### PR TITLE
DATAREDIS-82

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisUtils.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisUtils.java
@@ -90,7 +90,7 @@ public abstract class JedisUtils {
 			return convertJedisAccessException((JedisException) ex);
 		}
 
-		return new RedisSystemException("Unknown exception", ex);
+		return null;
 	}
 
 	static DataAccessException convertJedisAccessException(IOException ex) {


### PR DESCRIPTION
PersistenceExceptionTranslator wraps unknow exceptions in a
RedisSystemException, this causes other spring data projects like JPA
to have some of their exceptions wrapped.

https://jira.springsource.org/browse/DATAREDIS-82
