### PR TITLE
use delimiter specified from constructor if possible, othe...

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/DefaultRedisCachePrefix.java
+++ b/src/main/java/org/springframework/data/redis/cache/DefaultRedisCachePrefix.java
@@ -38,6 +38,6 @@ public class DefaultRedisCachePrefix implements RedisCachePrefix {
 	}
 
 	public byte[] prefix(String cacheName) {
-		return serializer.serialize((delimiter != null ? cacheName.concat(":") : cacheName));
+		return serializer.serialize((delimiter != null ? cacheName.concat(delimiter) : cacheName.concat(":")));
 	}
 }


### PR DESCRIPTION
...rwise default to using a colon as the delimiter
