### PR TITLE
DATAREDIS-77 Fix for pubsub channel pattern not being passed to message listeners.

### DIFF
--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -721,7 +721,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 				taskExecutor.execute(new Runnable() {
 					
 					public void run() {
-						processMessage(messageListener, message, null);
+						processMessage(messageListener, message, message.getChannel());
 					}
 				});
 			}


### PR DESCRIPTION
The call to handle an incoming message was hard-coded to pass null for the channel pattern. I changed this to pass `message.getChannel()` instead, so message listeners would receive the pattern in their handlers rather than `null`, which is what they receive now.
