### PR TITLE
Fix for (hash) increment treats long values as int [replaced PR7]

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -1048,14 +1048,14 @@ public class JedisConnection implements RedisConnection {
 	public Long decrBy(byte[] key, long value) {
 		try {
 			if (isQueueing()) {
-				transaction.decrBy(key, (int) value);
+				transaction.decrBy(key, value);
 				return null;
 			}
 			if (isPipelined()) {
-				pipeline.decrBy(key, (int) value);
+				pipeline.decrBy(key, value);
 				return null;
 			}
-			return jedis.decrBy(key, (int) value);
+			return jedis.decrBy(key, value);
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}
@@ -1082,14 +1082,14 @@ public class JedisConnection implements RedisConnection {
 	public Long incrBy(byte[] key, long value) {
 		try {
 			if (isQueueing()) {
-				transaction.incrBy(key, (int) value);
+				transaction.incrBy(key, value);
 				return null;
 			}
 			if (isPipelined()) {
-				pipeline.incrBy(key, (int) value);
+				pipeline.incrBy(key, value);
 				return null;
 			}
-			return jedis.incrBy(key, (int) value);
+			return jedis.incrBy(key, value);
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}
@@ -2254,14 +2254,14 @@ public class JedisConnection implements RedisConnection {
 	public Long hIncrBy(byte[] key, byte[] field, long delta) {
 		try {
 			if (isQueueing()) {
-				transaction.hincrBy(key, field, (int) delta);
+				transaction.hincrBy(key, field, delta);
 				return null;
 			}
 			if (isPipelined()) {
-				pipeline.hincrBy(key, field, (int) delta);
+				pipeline.hincrBy(key, field, delta);
 				return null;
 			}
-			return jedis.hincrBy(key, field, (int) delta);
+			return jedis.hincrBy(key, field, delta);
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheTest.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheTest.java
@@ -76,7 +76,6 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 	public void setUp() throws Exception {
 		ConnectionFactoryTracker.add(template.getConnectionFactory());
 		super.setUp();
-
 	}
 
 	@AfterClass

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -141,7 +141,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		try {
 			connection.decr((String) null);
 		} catch (Exception ex) {
-			// excepted
+			// expected
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.data.redis.connection.jedis;
 
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.connection.AbstractConnectionIntegrationTests;
@@ -58,6 +59,32 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 		connection.multi();
 		connection.set(value, key);
 		System.out.println(connection.exec());
+	}
+
+	@Test
+	public void testIncrDecrBy() {
+		String key = "test.count";
+		long largeNumber = 0x123456789L; // > 32bits
+		connection.set(key.getBytes(), "0".getBytes());
+		connection.incrBy(key.getBytes(), largeNumber);
+		assertEquals(largeNumber, Long.valueOf(new String(connection.get(key.getBytes()))).longValue());
+		connection.decrBy(key.getBytes(), largeNumber);
+		assertEquals(0, Long.valueOf(new String(connection.get(key.getBytes()))).longValue());
+		connection.decrBy(key.getBytes(), 2*largeNumber);
+		assertEquals(-2*largeNumber, Long.valueOf(new String(connection.get(key.getBytes()))).longValue());
+	}
+
+	@Test
+	public void testHashIncrDecrBy() {
+		byte[] key = "test.hcount".getBytes();
+		byte[] hkey = "hashkey".getBytes();
+
+		long largeNumber = 0x123456789L; // > 32bits
+		connection.hSet(key, hkey, "0".getBytes());
+		connection.hIncrBy(key, hkey, largeNumber);
+		assertEquals(largeNumber, Long.valueOf(new String(connection.hGet(key, hkey))).longValue());
+		connection.hIncrBy(key, hkey, -2*largeNumber);
+		assertEquals(-largeNumber, Long.valueOf(new String(connection.hGet(key, hkey))).longValue());
 	}
 
 //	@Test

--- a/src/test/java/org/springframework/data/redis/support/collections/CollectionTestParams.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/CollectionTestParams.java
@@ -169,7 +169,7 @@ public abstract class CollectionTestParams {
 		lettuceConnFactory.setHostName(SettingsUtils.getHost());
 		lettuceConnFactory.afterPropertiesSet();
 
-		RedisTemplate<String, String> stringTemplateLtc = new StringRedisTemplate(srConnFactory);
+		RedisTemplate<String, String> stringTemplateLtc = new StringRedisTemplate(lettuceConnFactory);
 		RedisTemplate<String, Person> personTemplateLtc = new RedisTemplate<String, Person>();
 		personTemplateLtc.setConnectionFactory(lettuceConnFactory);
 		personTemplateLtc.afterPropertiesSet();


### PR DESCRIPTION
While the (hash) increment() method accepts a long argument (and Redis
HINCRBY/INCRBY/DECRBY treats arguments as 64 bits), it is cast to a
32bits signed int in the JedisConnection class.
- Removed offensive (& unnecessary) casts
- Extended integration tests with incrBy, decrBy and hIncrBy to
  demonstrate handling of large numbers
- Fixed typos in test support
  (CollectionTestParams, AbstractConnectionIntegrationTests)

Issue: DATAREDIS-117
