### PR TITLE
Add alternate constructor to MessageListenerAdapter

### DIFF
--- a/src/main/java/org/springframework/data/redis/listener/adapter/MessageListenerAdapter.java
+++ b/src/main/java/org/springframework/data/redis/listener/adapter/MessageListenerAdapter.java
@@ -105,6 +105,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Juergen Hoeller
  * @author Costin Leau
+ * @author Greg Turnquist
  * @see org.springframework.jms.listener.adapter.MessageListenerAdapter
  */
 public class MessageListenerAdapter implements InitializingBean, MessageListener {
@@ -205,6 +206,19 @@ public class MessageListenerAdapter implements InitializingBean, MessageListener
 	public MessageListenerAdapter(Object delegate) {
 		initDefaultStrategies();
 		setDelegate(delegate);
+	}
+	
+	/**
+	 * Create a new {@link MessageListenerAdapter} for the given delegate.
+	 * 
+	 * @param delegate the delegate object
+	 * @param defaultListenerMethod method to call when a message comes
+	 * 
+	 * @see #getListenerMethodName
+	 */
+	public MessageListenerAdapter(Object delegate, String defaultListenerMethod) {
+		this(delegate);
+		setDefaultListenerMethod(defaultListenerMethod);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/listener/adapter/MessageListenerTest.java
+++ b/src/test/java/org/springframework/data/redis/listener/adapter/MessageListenerTest.java
@@ -27,17 +27,17 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.data.redis.connection.DefaultMessage;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
-import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 /**
  * Unit test for MessageListenerAdapter.
  * 
  * @author Costin Leau
+ * @author Greg Turnquist
  */
 public class MessageListenerTest {
 
-	private static final RedisSerializer serializer = new StringRedisSerializer();
+	private static final StringRedisSerializer serializer = new StringRedisSerializer();
 	private static final String CHANNEL = "some::test:";
 	private static final byte[] RAW_CHANNEL = serializer.serialize(CHANNEL);
 	private static final String PAYLOAD = "do re mi";
@@ -108,9 +108,29 @@ public class MessageListenerTest {
 	}
 
 	@Test
+	public void testCustomMethodWithAlternateConstructor() throws Exception {
+		MessageListenerAdapter adapter = new MessageListenerAdapter(target, "customMethod");
+		adapter.afterPropertiesSet();
+
+		adapter.onMessage(STRING_MSG, null);
+
+		verify(target).customMethod(PAYLOAD);
+	}
+
+	@Test
 	public void testCustomMethodWithChannel() throws Exception {
 		MessageListenerAdapter adapter = new MessageListenerAdapter(target);
 		adapter.setDefaultListenerMethod("customMethodWithChannel");
+		adapter.afterPropertiesSet();
+
+		adapter.onMessage(STRING_MSG, RAW_CHANNEL);
+
+		verify(target).customMethodWithChannel(PAYLOAD, CHANNEL);
+	}
+
+	@Test
+	public void testCustomMethodWithChannelAndAlternateConstructor() throws Exception {
+		MessageListenerAdapter adapter = new MessageListenerAdapter(target, "customMethodWithChannel");
 		adapter.afterPropertiesSet();
 
 		adapter.onMessage(STRING_MSG, RAW_CHANNEL);


### PR DESCRIPTION
As a convenience when configuring with Java, added another constructor
call that allows setting the delegate and the default listener method
in one line of code.

``` java
    public MessageListenerAdapter(Object delegate, String defaultListenerMethod) {
        this(delegate);
        setDefaultListenerMethod(defaultListenerMethod);
    }
```

This supports configuring a POJO-based listener with a single step:

``` java
    @Test
    public void testCustomMethodWithAlternateConstructor() throws Exception {
        MessageListenerAdapter adapter = new MessageListenerAdapter(target, "customMethod");
        adapter.afterPropertiesSet();

        adapter.onMessage(STRING_MSG, null);

        verify(target).customMethod(PAYLOAD);
    }
```

A pure Java configuration bean can now look like this:

``` java
     @Bean
     MessageListenerAdapter listenerAdapter(Receiver receiver) {
         return new MessageListenerAdapter(receiver, "pojoMethod");
     }
     @Bean
     Receiver receiver() {
         return new Receiver();
     }
```

No longer do we have to A) assign the adapter to a variable and B) call
setDefaultListenerMethod, slimming down POJO configuration with pure
Java.

P.S. Added automated tests everywhere that setDefaultListenerMethod was used.
