### PR TITLE
DATAREDIS-249 - Improve logging for tests in Gradle build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,6 +208,10 @@ task distZip(type: Zip, dependsOn: [jar, docsZip, schemaZip, sourcesJar, javadoc
 
 tasks.withType(Test) {
     systemProperty 'runLongTests', System.getProperty('runLongTests')
+
+    testLogging {
+        exceptionFormat = 'full'
+    }
 }
 
 artifacts {


### PR DESCRIPTION
Changed exceptionFormat to full in order to get more detail StackTrace information for exceptions during test execution.
