### PR TITLE
DATAREDIS-251 - Fix tests to work against Redis 2.8.x.

### DIFF
--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
@@ -16,15 +16,15 @@
 
 package org.springframework.data.redis.connection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.test.annotation.IfProfileValue;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.springframework.test.annotation.IfProfileValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Base test class for integration tests that execute each operation of a
@@ -151,6 +151,14 @@ abstract public class AbstractConnectionPipelineIntegrationTests extends
 	}
 
 	protected List<Object> getResults() {
-		return connection.closePipeline();
+
+        try {
+            //we give redis some time to keep up
+            Thread.sleep(10);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        return connection.closePipeline();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/support/BoundKeyOperationsTest.java
+++ b/src/test/java/org/springframework/data/redis/support/BoundKeyOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2014 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,6 @@
  */
 package org.springframework.data.redis.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
-
-import java.util.Collection;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
@@ -35,9 +27,19 @@ import org.springframework.data.redis.connection.ConnectionUtils;
 import org.springframework.data.redis.core.BoundKeyOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
 /**
  * @author Costin Leau
  * @author Jennifer Hickey
+ * @author Thomas Darimont
  */
 @RunWith(Parameterized.class)
 public class BoundKeyOperationsTest {
@@ -90,8 +92,18 @@ public class BoundKeyOperationsTest {
 		assertEquals(key, keyOps.getKey());
 	}
 
+    /**
+     * @see DATAREDIS-251
+     */
 	@Test
 	public void testExpire() throws Exception {
+
+        if(keyOps instanceof List || keyOps instanceof Set){
+            ((Collection) keyOps).add("dummy");
+        }else if(keyOps instanceof Map){
+            ((Map)keyOps).put("dummy","dummy");
+        }
+
 		assertEquals(Long.valueOf(-1), keyOps.getExpire());
 		if (keyOps.expire(10, TimeUnit.SECONDS)) {
 			long expire = keyOps.getExpire().longValue();
@@ -99,9 +111,19 @@ public class BoundKeyOperationsTest {
 		}
 	}
 
+    /**
+     * @see DATAREDIS-251
+     */
 	@Test
 	public void testPersist() throws Exception {
 		assumeTrue(!ConnectionUtils.isJredis(template.getConnectionFactory()));
+
+        if(keyOps instanceof List || keyOps instanceof Set){
+            ((Collection) keyOps).add("dummy");
+        }else if(keyOps instanceof Map){
+            ((Map)keyOps).put("dummy","dummy");
+        }
+
 		keyOps.persist();
 		assertEquals(Long.valueOf(-1), keyOps.getExpire());
 		if (keyOps.expire(10, TimeUnit.SECONDS)) {


### PR DESCRIPTION
Since Redis 2.8.x keyOps#getExpire() now returns -2 for empty collections (RedisList/RedisSet/RedisMap) we add a dummy entry to keep the test version agnostic. Previously getExpire() returned -1.

For reference see the discussion in http://redis.io/commands/ttl
