### PR TITLE
DATAREDIS-242 - Listener Container start() Returns Before Container is R...

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/ConnectionUtils.java
+++ b/src/main/java/org/springframework/data/redis/connection/ConnectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.data.redis.connection.srp.SrpConnectionFactory;
  * Utilities for examining a {@link RedisConnection}
  *
  * @author Jennifer Hickey
+ * @author Thomas Darimont
  *
  */
 public abstract class ConnectionUtils {

--- a/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
@@ -172,4 +172,27 @@ public class PubSubTests<T> {
 		// DATREDIS-207 This test previously took 5 seconds on start due to monitor wait
 		container.start();
 	}
+	
+	
+	/**
+	 * @see DATAREDIS-251
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testStartListenersToNoSpecificChannelTest() throws InterruptedException {
+		container.removeMessageListener(adapter, new ChannelTopic(CHANNEL));
+		container.addMessageListener(adapter, Arrays.asList(new PatternTopic("*")));
+		container.start();
+		
+		Thread.sleep(1000); //give the container a little time to recover
+		
+		T payload = getT();
+		
+		template.convertAndSend(CHANNEL, payload);
+		
+		Set<T> set = new LinkedHashSet<T>();
+		set.add((T) bag.poll(3, TimeUnit.SECONDS));
+
+		assertThat(set, hasItems(payload));
+	}
 }


### PR DESCRIPTION
...eally Started.

We now wait for the subscription to be present in the connection in case of async connections by periodically checking whether the subscription is available in 100ms intervals. The max time to wait for the async subscription can be configured and is set to 2 seconds by default.

Moved SpinBarrier and TestCondition from test packages as static inner classes into RedisMessageListenerContainer. Included ConnectionUtils from tests into official API.
