### PR TITLE
Shutdown the client when pool is destroyed

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
@@ -29,9 +29,9 @@ import com.lambdaworks.redis.RedisClient;
 
 /**
  * Default implementation of {@link LettucePool}
- * 
+ *
  * @author Jennifer Hickey
- * 
+ *
  */
 public class DefaultLettucePool implements LettucePool, InitializingBean {
 	private GenericObjectPool internalPool;
@@ -53,7 +53,7 @@ public class DefaultLettucePool implements LettucePool, InitializingBean {
 	/**
 	 * Uses the {@link Config} and {@link RedisClient} defaults for configuring
 	 * the connection pool
-	 * 
+	 *
 	 * @param hostName
 	 *            The Redis host
 	 * @param port
@@ -66,7 +66,7 @@ public class DefaultLettucePool implements LettucePool, InitializingBean {
 
 	/**
 	 * Uses the {@link RedisClient} defaults for configuring the connection pool
-	 * 
+	 *
 	 * @param hostName
 	 *            The Redis host
 	 * @param port
@@ -114,6 +114,7 @@ public class DefaultLettucePool implements LettucePool, InitializingBean {
 
 	public void destroy() {
 		try {
+			client.shutdown();
 			internalPool.close();
 		} catch (Exception e) {
 			throw new PoolException("Could not destroy the pool", e);


### PR DESCRIPTION
DefaultLettucePool manages a RedisClient instance that's created
when afterPropertiesSet is called. The client was not being shutdown
as part of the pool's destroy() processing leading to a resource leak.
On OS X this would manifest itself as a growing number of kqueue file
descriptors being consumed eventually leading to a failure when
something tries to get a file descriptor and is unable to do so.

This commit updates destroy() to call the client's shutdown() method.
