### PR TITLE
DATAREDIS-289 - Avoid NPE in append() in case of pipelining or/and multi/exec calls.

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
@@ -83,7 +83,8 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 		return execute(new RedisCallback<Integer>() {
 
 			public Integer doInRedis(RedisConnection connection) {
-				return connection.append(rawKey, rawString).intValue();
+				final Long result = connection.append(rawKey, rawString); 				
+				return ( result != null ) ? result.intValue() : null; 
 			}
 		}, true);
 	}

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -221,6 +221,7 @@ public class RedisTemplateTests<K, V> {
 				operations.multi();
 				operations.opsForValue().set("foo", "5");
 				operations.opsForValue().get("foo");
+				operations.opsForValue().append("foo1", "5");
 				operations.opsForList().leftPush("foolist", "6");
 				operations.opsForList().range("foolist", 0l, 1l);
 				operations.opsForSet().add("fooset", "7");
@@ -242,7 +243,7 @@ public class RedisTemplateTests<K, V> {
 		Map<Long, Long> map = new LinkedHashMap<Long, Long>();
 		map.put(10l, 11l);
 		assertThat(results,
-				isEqual(Arrays.asList(new Object[] { 5l, 1l, list, 1l, longSet, true, tupleSet, zSet, true, map })));
+				isEqual(Arrays.asList(new Object[] { 5l, 1L, 1l, list, 1l, longSet, true, tupleSet, zSet, true, map })));
 	}
 
 	@Test


### PR DESCRIPTION
Fix for NullPointerException in append() in case of pipelining or/and multi/exec calls.
