### PR TITLE
DATAREDIS-299 - Assert compatibility with Spring IO.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     dependencies {
         classpath 'org.springframework.build.gradle:bundlor-plugin:0.1.2'
         classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.4'
+        classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
         classpath 'me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1'
     }
 }
@@ -26,6 +27,18 @@ apply plugin: 'docbook-reference'
 apply plugin: 'bundlor'
 apply plugin: 'javadocHotfix'
 
+if (project.hasProperty('platformVersion')) {
+    apply plugin: 'spring-io'
+
+    repositories {
+        maven { url "https://repo.spring.io/libs-snapshot" }
+    }
+
+    dependencies {
+        springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+    }
+}
+
 [compileJava, compileTestJava]*.options*.compilerArgs = ["-Xlint:-serial"]
 [compileJava, compileTestJava]*.options*.compilerArgs = ["-Xlint:-serial", "-Xlint:deprecation"]
 
@@ -44,7 +57,7 @@ dependencies {
 
     // Spring Framework
     compile("org.springframework:spring-core:$springVersion") {
-        exclude module: "commons-logging"
+        exclude group: "commons-logging", module: "commons-logging"
     }
     compile "org.springframework:spring-context-support:$springVersion"
     compile "org.springframework:spring-context:$springVersion"
@@ -72,7 +85,7 @@ dependencies {
     testCompile "junit:junit:$junitVersion"
     testCompile "org.springframework:spring-test:$springVersion"
     testCompile "org.springframework:spring-jdbc:$springVersion"
-    testCompile "org.mockito:mockito-all:$mockitoVersion"
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile("javax.annotation:jsr250-api:1.0", optional)
     testCompile("com.thoughtworks.xstream:xstream:1.4.4", optional)
     testCompile("javax.transaction:jta:1.1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 slf4jVersion=1.7.5
-junitVersion=4.10
+junitVersion=4.11
 jredisVersion=06052013
 jedisVersion=2.4.1
 springVersion=3.2.8.RELEASE

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
@@ -27,9 +27,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.hamcrest.core.IsCollectionContaining;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.matchers.IsCollectionContaining;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
@@ -27,10 +27,10 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsCollectionContaining;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.After;
 import org.junit.Test;
-import org.junit.internal.matchers.IsCollectionContaining;
 import org.junit.runner.RunWith;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.SettingsUtils;
@@ -331,7 +331,7 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 		connection.set("redis", "supercalifragilisticexpialidocious");
 
 		assertThat(
-				connection.execute("MGET", "spring".getBytes(), "data".getBytes(), "redis".getBytes()),
+				(Iterable<byte[]>)connection.execute("MGET", "spring".getBytes(), "data".getBytes(), "redis".getBytes()),
 				AllOf.allOf(IsInstanceOf.instanceOf(List.class), IsCollectionContaining.hasItems("awesome".getBytes(),
 						"cool".getBytes(), "supercalifragilisticexpialidocious".getBytes())));
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jredis/JRedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jredis/JRedisConnectionIntegrationTests.java
@@ -25,13 +25,13 @@ import java.util.List;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.hamcrest.core.IsInstanceOf;
+import org.hamcrest.core.IsCollectionContaining;
 import org.jredis.JRedis;
 import org.jredis.protocol.BulkResponse;
 import org.jredis.ri.alphazero.protocol.SyncProtocol.SyncMultiBulkResponse;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.internal.matchers.IsCollectionContaining;
 import org.junit.runner.RunWith;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.RedisConnectionFailureException;

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsCollectionContaining;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
-import org.junit.internal.matchers.IsCollectionContaining;
 import org.junit.runner.RunWith;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.RedisSystemException;
@@ -293,7 +293,7 @@ public class LettuceConnectionIntegrationTests extends AbstractConnectionIntegra
 		connection.set("redis", "supercalifragilisticexpialidocious");
 
 		assertThat(
-				connection.execute("MGET", "spring".getBytes(), "data".getBytes(), "redis".getBytes()),
+				(Iterable<byte[]>)connection.execute("MGET", "spring".getBytes(), "data".getBytes(), "redis".getBytes()),
 				AllOf.allOf(IsInstanceOf.instanceOf(List.class), IsCollectionContaining.hasItems("awesome".getBytes(),
 						"cool".getBytes(), "supercalifragilisticexpialidocious".getBytes())));
 	}

--- a/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsTests.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.data.redis.core;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.either;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import static org.junit.matchers.JUnitMatchers.hasItem;
-import static org.junit.matchers.JUnitMatchers.hasItems;
-import static org.junit.matchers.JUnitMatchers.either;
 import static org.springframework.data.redis.matcher.RedisTestMatchers.isEqual;
 
 import java.util.Collection;
@@ -31,6 +31,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.core.CombinableMatcher;
+import org.hamcrest.core.CombinableMatcher.CombinableEitherMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -115,7 +118,8 @@ public class DefaultSetOperationsTests<K, V> {
 		setOps.add(setKey, v2);
 		List<V> members = setOps.randomMembers(setKey, 2);
 		assertEquals(2, members.size());
-		assertThat(members, either(hasItem(v1)).or(hasItem(v2)));
+		
+		assertThat(members, CoreMatchers.<Iterable<? super V>>either(hasItem(v1)).or(hasItem(v2)));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.data.redis.listener;
 
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
-import static org.junit.matchers.JUnitMatchers.hasItems;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/org/springframework/data/redis/matcher/Equals.java
+++ b/src/test/java/org/springframework/data/redis/matcher/Equals.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.matcher;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -27,7 +29,6 @@ import java.util.Set;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import static org.junit.matchers.JUnitMatchers.hasItems;
 
 /**
  * Custom JUnit {@link Matcher} that exists to properly compare byte arrays, either as individual results or members of

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisCollectionTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisCollectionTests.java
@@ -16,6 +16,8 @@
 package org.springframework.data.redis.support.collections;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertArrayEquals;
@@ -24,8 +26,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.matchers.JUnitMatchers.hasItem;
-import static org.junit.matchers.JUnitMatchers.hasItems;
 import static org.springframework.data.redis.matcher.RedisTestMatchers.isEqual;
 
 import java.util.Arrays;

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisListTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisListTests.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.data.redis.support.collections;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import static org.junit.matchers.JUnitMatchers.hasItem;
-import static org.junit.matchers.JUnitMatchers.hasItems;
 import static org.springframework.data.redis.matcher.RedisTestMatchers.isEqual;
 
 import java.util.ArrayList;

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisMapTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisMapTests.java
@@ -16,6 +16,8 @@
 package org.springframework.data.redis.support.collections;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -24,8 +26,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
-import static org.junit.matchers.JUnitMatchers.hasItem;
-import static org.junit.matchers.JUnitMatchers.hasItems;
 import static org.springframework.data.redis.matcher.RedisTestMatchers.isEqual;
 
 import java.text.DecimalFormat;

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisSetTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisSetTests.java
@@ -17,7 +17,6 @@ package org.springframework.data.redis.support.collections;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
-import static org.junit.matchers.JUnitMatchers.*;
 import static org.springframework.data.redis.matcher.RedisTestMatchers.isEqual;
 
 import java.util.ArrayList;

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisZSetTest.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisZSetTest.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.data.redis.support.collections;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
-import static org.junit.matchers.JUnitMatchers.hasItem;
-import static org.junit.matchers.JUnitMatchers.hasItems;
 import static org.springframework.data.redis.matcher.RedisTestMatchers.isEqual;
 
 import java.util.Arrays;

--- a/src/test/java/org/springframework/data/redis/support/collections/RedisCollectionFactoryBeanTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/RedisCollectionFactoryBeanTests.java
@@ -115,15 +115,15 @@ public class RedisCollectionFactoryBeanTests {
 
 		template.boundSetOps(key).add(val);
 		RedisStore col = createCollection(key);
-		assertThat(col, is(DefaultRedisSet.class));
+		assertThat(col, instanceOf(DefaultRedisSet.class));
 
 		key = "map";
 		template.boundHashOps(key).put(val, val);
 		col = createCollection(key);
-		assertThat(col, is(DefaultRedisMap.class));
+		assertThat(col, instanceOf(DefaultRedisMap.class));
 
 		col = createCollection(key, CollectionType.PROPERTIES);
-		assertThat(col, is(RedisProperties.class));
+		assertThat(col, instanceOf(RedisProperties.class));
 
 	}
 }


### PR DESCRIPTION
Upgrade to JUnit 4.11

Upgrade to JUnit 4.11 and remove use of a matcher in an internal
package in favour of the Hamcrest equivalent. To avoid a clash between
JUnit 4.11's Hamcrest dependency and the version of Hamcrest that's
bundled in mockito-all, use of mockito-all has been replaced with
mockito-core.

Fixed deprecation warnings caused by Junit upgrade.

Add and configure the Spring IO plugin such that it's only applied when the
build is run with -PplatformVersion=<version>. This platformVersion
property is used to determine the version of the Platform that will
be used when running the springIoCheck task. The plugin can be used
by running a build as follows:

./gradlew clean springIoCheck -PplatformVersion=1.0.0.BUILD-SNAPSHOT -PJDK7_HOME=… -PJDK8_HOME=…

This will test the project on JDK7 and JDK 8 using the dependencies
defined in the latest snapshot of Spring IO Platform 1.0.0.
