### PR TITLE
DATAREDIS-296 - Upgrade jedis to recent version.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 slf4jVersion=1.7.5
 junitVersion=4.11
 jredisVersion=06052013
-jedisVersion=2.4.1
+jedisVersion=2.5.0
 springVersion=3.2.9.RELEASE
 log4jVersion=1.2.17
 version=1.4.0.DATAREDIS-296-SNAPSHOT

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -2975,11 +2975,8 @@ public class JedisConnection implements RedisConnection {
 
 				ScanParams params = prepareScanParams(options);
 
-				// TODO: use binary version of jedis.sscan (in v.2.4.3) to avoid potentially invalid representations.
-				redis.clients.jedis.ScanResult<String> result = jedis.sscan(JedisConverters.toString(key),
-						Long.toString(cursorId), params);
-				return new ScanIteration<byte[]>(Long.valueOf(result.getStringCursor()), JedisConverters.stringListToByteList()
-						.convert(result.getResult()));
+				redis.clients.jedis.ScanResult<byte[]> result = jedis.sscan(key, JedisConverters.toBytes(cursorId), params);
+				return new ScanIteration<byte[]>(Long.valueOf(result.getStringCursor()), result.getResult());
 			}
 		}.open();
 	}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -48,6 +48,7 @@ import redis.clients.util.SafeEncoder;
  * 
  * @author Jennifer Hickey
  * @author Christoph Strobl
+ * @author Thomas Darimont
  */
 abstract public class JedisConverters extends Converters {
 
@@ -114,6 +115,10 @@ abstract public class JedisConverters extends Converters {
 	}
 
 	public static byte[] toBytes(Integer source) {
+		return String.valueOf(source).getBytes();
+	}
+
+	public static byte[] toBytes(Long source) {
 		return String.valueOf(source).getBytes();
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
@@ -24,6 +24,7 @@ import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.connection.AbstractConnectionPipelineIntegrationTests;
 import org.springframework.data.redis.connection.DefaultStringRedisConnection;
@@ -39,6 +40,7 @@ import redis.clients.jedis.JedisPoolConfig;
  * 
  * @author Jennifer Hickey
  * @author Christoph Strobl
+ * @author Thomas Darimont
  */
 @RunWith(RelaxedJUnit4ClassRunner.class)
 @ContextConfiguration("JedisConnectionIntegrationTests-context.xml")
@@ -262,5 +264,13 @@ public class JedisConnectionPipelineIntegrationTests extends AbstractConnectionP
 	@Test(expected = UnsupportedOperationException.class)
 	public void testListClientsContainsAtLeastOneElement() {
 		super.testListClientsContainsAtLeastOneElement();
+	}
+
+	/**
+	 * @see DATAREDIS-296
+	 */
+	@Test(expected = InvalidDataAccessApiUsageException.class)
+	public void testExecWithoutMulti() {
+		super.testExecWithoutMulti();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsTests.java
@@ -38,7 +38,6 @@ import org.junit.runners.Parameterized.Parameters;
 import org.springframework.data.redis.ObjectFactory;
 import org.springframework.data.redis.RedisTestProfileValueSource;
 import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.data.redis.test.util.MinimumRedisVersionRule;
 import org.springframework.test.annotation.IfProfileValue;
 
@@ -47,6 +46,7 @@ import org.springframework.test.annotation.IfProfileValue;
  * 
  * @author Jennifer Hickey
  * @author Christoph Strobl
+ * @author Thomas Darimont
  */
 @RunWith(Parameterized.class)
 public class DefaultSetOperationsTests<K, V> {
@@ -208,8 +208,6 @@ public class DefaultSetOperationsTests<K, V> {
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	public void testSSCanReadsValuesFully() {
 
-		// TODO: remove this when upgrading to jedis v.2.4.3 as this guard to avoids key serialization
-		assumeThat(redisTemplate.getKeySerializer(), instanceOf(StringRedisSerializer.class));
 		K key = keyFactory.instance();
 		V v1 = valueFactory.instance();
 		V v2 = valueFactory.instance();


### PR DESCRIPTION
Upgrading to latest jedis version 2.5.0. Added new conversion for Long to byte[] in JedisConverters to be able to convert long cursorIds to byte[].
