### PR TITLE
Fixed SrpConverter to return null for unknown exceptions. Issue: DATARED...

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/srp/SrpConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/srp/SrpConverters.java
@@ -362,7 +362,7 @@ abstract public class SrpConverters extends Converters {
 			return new RedisConnectionFailureException("Redis connection failed", (IOException) ex);
 		}
 
-		return new RedisSystemException("Unknown SRP exception", ex);
+		return null;
 	}
 
 	public static byte[][] toByteArrays(Map<byte[], byte[]> source) {


### PR DESCRIPTION
The PersistenceExceptionTranslator javadoc states
"Do not translate exceptions that are not understand by this translator:    for example, if coming from another persistence framework, or resulting from user code and unrelated to persistence."
However the SrpConverters class will wrap unknown exceptions in a RedisSystemException

This is a similar issue that was fixed for the JEDIS connector in DATAREDIS-82
