### PR TITLE
DATAREDIS-333 Use binary version of Jedis.evalsha()

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -2803,8 +2803,8 @@ public class JedisConnection implements RedisConnection {
 			throw new UnsupportedOperationException();
 		}
 		try {
-			return (T) new JedisScriptReturnConverter(returnType).convert(jedis.evalsha(scriptSha1, numKeys,
-					JedisConverters.toStrings(keysAndArgs)));
+			return (T) new JedisScriptReturnConverter(returnType).convert(jedis.evalsha(
+                    JedisConverters.toBytes(scriptSha1), numKeys, keysAndArgs));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -135,6 +135,8 @@ abstract public class JedisConverters extends Converters {
 		return String.valueOf(source).getBytes();
 	}
 
+    public static byte[] toBytes(String source) { return SafeEncoder.encode(source); }
+
 	public static String toString(byte[] source) {
 		return source == null ? null : SafeEncoder.encode(source);
 	}


### PR DESCRIPTION
Please see https://jira.spring.io/browse/DATAREDIS-333 for details.
- JedisConnection.eval() uses binary version of Jedis.eval()
- but JedisConnection.evalsha() uses string version of Jedis.evalsha()
- this commit changes JedisConnection.evalsha() to use binary version of Jedis.evalsha()

Please let me know that something is wrong (commit log styles, code styles, etc).

Thanks!
