### PR TITLE
Changed weights from ints to doubles

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -978,7 +978,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection {
 		return result;
 	}
 
-	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zInterStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		Long result = delegate.zInterStore(destKey, aggregate, weights, sets);
 		if (isFutureConversion()) {
 			addResultConverter(identityConverter);
@@ -1138,7 +1138,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection {
 		return result;
 	}
 
-	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zUnionStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		Long result = delegate.zUnionStore(destKey, aggregate, weights, sets);
 		if (isFutureConversion()) {
 			addResultConverter(identityConverter);
@@ -1935,7 +1935,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection {
 		return result;
 	}
 
-	public Long zInterStore(String destKey, Aggregate aggregate, int[] weights, String... sets) {
+	public Long zInterStore(String destKey, Aggregate aggregate, double[] weights, String... sets) {
 		Long result = delegate.zInterStore(serialize(destKey), aggregate, weights, serializeMulti(sets));
 		if (isFutureConversion()) {
 			addResultConverter(identityConverter);
@@ -2095,7 +2095,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection {
 		return result;
 	}
 
-	public Long zUnionStore(String destKey, Aggregate aggregate, int[] weights, String... sets) {
+	public Long zUnionStore(String destKey, Aggregate aggregate, double[] weights, String... sets) {
 		Long result = delegate.zUnionStore(serialize(destKey), aggregate, weights, serializeMulti(sets));
 		if (isFutureConversion()) {
 			addResultConverter(identityConverter);

--- a/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
@@ -314,7 +314,7 @@ public interface RedisZSetCommands {
 	 * @param sets
 	 * @return
 	 */
-	Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets);
+	Long zUnionStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets);
 
 	/**
 	 * Intersect sorted {@code sets} and store result in destination {@code key}.
@@ -334,7 +334,7 @@ public interface RedisZSetCommands {
 	 * @param sets
 	 * @return
 	 */
-	Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets);
+	Long zInterStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets);
 
 	/**
 	 * Use a {@link Cursor} to iterate over elements in sorted set at {@code key}.

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -260,11 +260,11 @@ public interface StringRedisConnection extends RedisConnection {
 
 	Long zUnionStore(String destKey, String... sets);
 
-	Long zUnionStore(String destKey, Aggregate aggregate, int[] weights, String... sets);
+	Long zUnionStore(String destKey, Aggregate aggregate, double[] weights, String... sets);
 
 	Long zInterStore(String destKey, String... sets);
 
-	Long zInterStore(String destKey, Aggregate aggregate, int[] weights, String... sets);
+	Long zInterStore(String destKey, Aggregate aggregate, double[] weights, String... sets);
 
 	Boolean hSet(String key, String field, String value);
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -2070,9 +2070,9 @@ public class JedisConnection extends AbstractRedisConnection {
 		}
 	}
 
-	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zInterStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		try {
-			ZParams zparams = new ZParams().weights(weights).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
+			ZParams zparams = new ZParams().weights(intWeights(weights)).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
 
 			if (isPipelined()) {
 				pipeline(new JedisResult(pipeline.zinterstore(destKey, zparams, sets)));
@@ -2400,9 +2400,9 @@ public class JedisConnection extends AbstractRedisConnection {
 		}
 	}
 
-	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zUnionStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		try {
-			ZParams zparams = new ZParams().weights(weights).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
+			ZParams zparams = new ZParams().weights(intWeights(weights)).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
 
 			if (isPipelined()) {
 				pipeline(new JedisResult(pipeline.zunionstore(destKey, zparams, sets)));
@@ -3146,5 +3146,22 @@ public class JedisConnection extends AbstractRedisConnection {
 
 	protected Jedis getJedis(RedisNode node) {
 		return new Jedis(node.getHost(), node.getPort());
+	}
+	
+	/**
+	 * Convert double weights to ints.
+	 * TODO Remove asap jedis supports double weights.
+	 * 
+	 * @param weights
+	 *            Double weights.
+	 * @return Int weights.
+	 */
+	@Deprecated
+	private int[] intWeights(double[] weights) {
+		int[] result = new int[weights.length];
+		for (int i = 0; i < weights.length; i++) {
+			result[i] = (int) weights[i];
+		}
+		return result;
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnection.java
@@ -913,7 +913,7 @@ public class JredisConnection extends AbstractRedisConnection {
 		}
 	}
 
-	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zInterStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -1036,7 +1036,7 @@ public class JredisConnection extends AbstractRedisConnection {
 	// Hash commands
 	//
 
-	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zUnionStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -2140,7 +2140,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
-	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zInterStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		ZStoreArgs storeArgs = zStoreArgs(aggregate, weights);
 
 		try {
@@ -2486,7 +2486,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
-	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zUnionStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		ZStoreArgs storeArgs = zStoreArgs(aggregate, weights);
 
 		try {
@@ -3371,7 +3371,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 		return new byte[0][0];
 	}
 
-	private ZStoreArgs zStoreArgs(Aggregate aggregate, int[] weights) {
+	private ZStoreArgs zStoreArgs(Aggregate aggregate, double[] weights) {
 		ZStoreArgs args = new ZStoreArgs();
 		if (aggregate != null) {
 			switch (aggregate) {

--- a/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
@@ -1596,7 +1596,7 @@ public class SrpConnection extends AbstractRedisConnection {
 		}
 	}
 
-	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zInterStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -1838,7 +1838,7 @@ public class SrpConnection extends AbstractRedisConnection {
 		}
 	}
 
-	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+	public Long zUnionStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 
 /**
@@ -83,6 +84,21 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 			public Long doInRedis(RedisConnection connection) {
 				return connection.zInterStore(rawDestKey, rawKeys);
+			}
+		}, true);
+	}
+
+	public Long intersectAndStore(K key, K otherKey, Aggregate aggregate, double weight, K destKey) {
+		return intersectAndStore(key, Collections.singleton(otherKey), aggregate, new double[]{ weight }, destKey);
+	}
+
+	public Long intersectAndStore(K key, Collection<K> otherKeys, final Aggregate aggregate, final double[] weights, K destKey) {
+		final byte[][] rawKeys = rawKeys(key, otherKeys);
+		final byte[] rawDestKey = rawKey(destKey);
+		return execute(new RedisCallback<Long>() {
+
+			public Long doInRedis(RedisConnection connection) {
+				return connection.zInterStore(rawDestKey, aggregate, weights, rawKeys);
 			}
 		}, true);
 	}
@@ -364,6 +380,21 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 			public Long doInRedis(RedisConnection connection) {
 				return connection.zUnionStore(rawDestKey, rawKeys);
+			}
+		}, true);
+	}
+
+	public Long unionAndStore(K key, K otherKey, Aggregate aggregate, double weight, K destKey) {
+		return unionAndStore(key, Collections.singleton(otherKey), aggregate, new double[]{ weight }, destKey);
+	}
+
+	public Long unionAndStore(K key, Collection<K> otherKeys, final Aggregate aggregate, final double[] weights, K destKey) {
+		final byte[][] rawKeys = rawKeys(key, otherKeys);
+		final byte[] rawDestKey = rawKey(destKey);
+		return execute(new RedisCallback<Long>() {
+
+			public Long doInRedis(RedisConnection connection) {
+				return connection.zUnionStore(rawDestKey, aggregate, weights, rawKeys);
 			}
 		}, true);
 	}

--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -19,6 +19,8 @@ package org.springframework.data.redis.core;
 import java.util.Collection;
 import java.util.Set;
 
+import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
+
 /**
  * Redis ZSet/sorted set specific operations.
  * 
@@ -40,9 +42,17 @@ public interface ZSetOperations<K, V> {
 
 	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey);
 
+	Long intersectAndStore(K key, K otherKey, Aggregate aggregat, double weight, K destKey);
+
+	Long intersectAndStore(K key, Collection<K> otherKeys, Aggregate aggregate, double[] weights, K destKey);
+
 	Long unionAndStore(K key, K otherKey, K destKey);
 
 	Long unionAndStore(K key, Collection<K> otherKeys, K destKey);
+
+	Long unionAndStore(K key, K otherKey, Aggregate aggregat, double weight, K destKey);
+
+	Long unionAndStore(K key, Collection<K> otherKeys, Aggregate aggregat, double[] weights, K destKey);
 
 	Set<V> range(K key, long start, long end);
 

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -1520,7 +1520,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		actual.add(connection.zAdd("myset", 4, "Joe"));
 		actual.add(connection.zAdd("otherset", 1, "Bob"));
 		actual.add(connection.zAdd("otherset", 4, "James"));
-		actual.add(connection.zInterStore("thirdset", Aggregate.MAX, new int[] { 2, 3 }, "myset", "otherset"));
+		actual.add(connection.zInterStore("thirdset", Aggregate.MAX, new double[] { 2, 3 }, "myset", "otherset"));
 
 		actual.add(connection.zRangeWithScores("thirdset", 0, -1));
 		verifyResults(Arrays.asList(new Object[] {
@@ -1745,7 +1745,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		actual.add(connection.zAdd("myset", 4, "Joe"));
 		actual.add(connection.zAdd("otherset", 1, "Bob"));
 		actual.add(connection.zAdd("otherset", 4, "James"));
-		actual.add(connection.zUnionStore("thirdset", Aggregate.MAX, new int[] { 2, 3 }, "myset", "otherset"));
+		actual.add(connection.zUnionStore("thirdset", Aggregate.MAX, new double[] { 2, 3 }, "myset", "otherset"));
 		actual.add(connection.zRangeWithScores("thirdset", 0, -1));
 		verifyResults(Arrays.asList(new Object[] {
 				true,

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
@@ -1263,15 +1263,15 @@ public class DefaultStringRedisConnectionTests {
 
 	@Test
 	public void testZInterStoreAggWeightsBytes() {
-		doReturn(5l).when(nativeConnection).zInterStore(fooBytes, Aggregate.MAX, new int[0], fooBytes);
-		actual.add(connection.zInterStore(fooBytes, Aggregate.MAX, new int[0], fooBytes));
+		doReturn(5l).when(nativeConnection).zInterStore(fooBytes, Aggregate.MAX, new double[0], fooBytes);
+		actual.add(connection.zInterStore(fooBytes, Aggregate.MAX, new double[0], fooBytes));
 		verifyResults(Arrays.asList(new Object[] { 5l }));
 	}
 
 	@Test
 	public void testZInterStoreAggWeights() {
-		doReturn(5l).when(nativeConnection).zInterStore(fooBytes, Aggregate.MAX, new int[0], fooBytes);
-		actual.add(connection.zInterStore(foo, Aggregate.MAX, new int[0], foo));
+		doReturn(5l).when(nativeConnection).zInterStore(fooBytes, Aggregate.MAX, new double[0], fooBytes);
+		actual.add(connection.zInterStore(foo, Aggregate.MAX, new double[0], foo));
 		verifyResults(Arrays.asList(new Object[] { 5l }));
 	}
 
@@ -1543,15 +1543,15 @@ public class DefaultStringRedisConnectionTests {
 
 	@Test
 	public void testZUnionStoreAggWeightsBytes() {
-		doReturn(5l).when(nativeConnection).zUnionStore(fooBytes, Aggregate.MAX, new int[0], fooBytes);
-		actual.add(connection.zUnionStore(fooBytes, Aggregate.MAX, new int[0], fooBytes));
+		doReturn(5l).when(nativeConnection).zUnionStore(fooBytes, Aggregate.MAX, new double[0], fooBytes);
+		actual.add(connection.zUnionStore(fooBytes, Aggregate.MAX, new double[0], fooBytes));
 		verifyResults(Arrays.asList(new Object[] { 5l }));
 	}
 
 	@Test
 	public void testZUnionStoreAggWeights() {
-		doReturn(5l).when(nativeConnection).zUnionStore(fooBytes, Aggregate.MAX, new int[0], fooBytes);
-		actual.add(connection.zUnionStore(foo, Aggregate.MAX, new int[0], foo));
+		doReturn(5l).when(nativeConnection).zUnionStore(fooBytes, Aggregate.MAX, new double[0], fooBytes);
+		actual.add(connection.zUnionStore(foo, Aggregate.MAX, new double[0], foo));
 		verifyResults(Arrays.asList(new Object[] { 5l }));
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
@@ -757,7 +757,7 @@ public class RedisConnectionUnitTests {
 			return delegate.zUnionStore(destKey, sets);
 		}
 
-		public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+		public Long zUnionStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 			return delegate.zUnionStore(destKey, aggregate, weights, sets);
 		}
 
@@ -765,7 +765,7 @@ public class RedisConnectionUnitTests {
 			return delegate.zInterStore(destKey, sets);
 		}
 
-		public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+		public Long zInterStore(byte[] destKey, Aggregate aggregate, double[] weights, byte[]... sets) {
 			return delegate.zInterStore(destKey, aggregate, weights, sets);
 		}
 


### PR DESCRIPTION
ZUNIONSTORE supports double weights, but the api just provides ints for the weights. This is changed by this pull request. Sadly all java redis clients use ints/longs for the weights by now, but even though the clients do not support double weights yet, this should be changed to be able to support double weights in the future. Because double is a superset of int this should not have any negative side effects.

I created a pull request for jedis too, which supports double weights in jedis. A test cases in jedis proves that redis supports double weights. When this pull request has been accepted, the workaround which converts double weights back to ints in the spring jedis adapter has to be removed.
