### PR TITLE
Setup the right version range of spring framework packages that  spring-data-redis can import

### DIFF
--- a/template.mf
+++ b/template.mf
@@ -2,27 +2,27 @@ Bundle-SymbolicName: org.springframework.data.redis
 Bundle-Name: Spring Data Redis Support
 Bundle-Vendor: Pivotal Software, Inc.
 Bundle-ManifestVersion: 2
-Import-Package: 
+Import-Package:
  sun.reflect;version="0";resolution:=optional
-Import-Template: 
- org.springframework.beans.*;version="[4.0.6, 4.0.6)",
- org.springframework.cache.*;version="[4.0.6, 4.0.6)",
- org.springframework.context.*;version="[4.0.6, 4.0.6)",
- org.springframework.core.*;version="[4.0.6, 4.0.6)",
- org.springframework.dao.*;version="[4.0.6, 4.0.6)",
- org.springframework.scheduling.*;resolution:="optional";version="[4.0.6, 4.0.6)",
- org.springframework.scripting.*;resolution:="optional";version="[4.0.6, 4.0.6)",
- org.springframework.util.*;version="[4.0.6, 4.0.6)",
- org.springframework.aop.*;version="[4.0.6, 4.0.6)",
- org.springframework.cglib.*;version="[4.0.6, 4.0.6)",
- org.springframework.oxm.*;resolution:="optional";version="[4.0.6, 4.0.6)",
- org.springframework.transaction.support.*;version="[4.0.6, 4.0.6)",
+Import-Template:
+ org.springframework.beans.*;version="[3.2.9, 4.1)",
+ org.springframework.cache.*;version="[3.2.9, 4.1)",
+ org.springframework.context.*;version="[3.2.9, 4.1)",
+ org.springframework.core.*;version="[3.2.9, 4.1)",
+ org.springframework.dao.*;version="[3.2.9, 4.1)",
+ org.springframework.scheduling.*;resolution:="optional";version="[3.2.9, 4.1)",
+ org.springframework.scripting.*;resolution:="optional";version="[3.2.9, 4.1)",
+ org.springframework.util.*;version="[3.2.9, 4.1)",
+ org.springframework.aop.*;version="[3.2.9, 4.1)",
+ org.springframework.cglib.*;version="[3.2.9, 4.1)",
+ org.springframework.oxm.*;resolution:="optional";version="[3.2.9, 4.1)",
+ org.springframework.transaction.support.*;version="[3.2.9, 4.1)",
  org.aopalliance.*;version="[1.0.0, 2.0.0)";resolution:=optional,
  org.apache.commons.logging.*;version="[1.1.1, 2.0.0)",
  org.w3c.dom.*;version="0",
  javax.xml.transform.*;resolution:="optional";version="0",
  org.jredis.*;resolution:="optional";version="[1.0.0, 2.0.0)",
- redis.clients.*;resolution:="optional";version="[2.5.2, 2.5.2)",
+ redis.clients.*;resolution:="optional";version="[2.1.0, 2.6)",
  org.apache.commons.pool2.*;resolution:="optional";version="[1.0, 2.2)",
  org.codehaus.jackson.*;resolution:="optional";version="[1.6, 2.0.0)",
  com.fasterxml.jackson.*;resolution:="optional";version="[2.0.0, 3.0.0)",


### PR DESCRIPTION
org.springframework.beans.*;version="[4.0.6, 4.0.6)", means we can only import the package with version is >= 4.0.6 and version < 4.0.6.  It makes spring-data-redis  bundle cannot import any version of spring beans packages. 

So I just change the bundle template file to let spring-data-redis can work with a rang of spring framework in the OSGi platform.