### PR TITLE
DATAREDIS-352: Enhance range options for zSetOperations.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/AbstractRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/AbstractRedisConnection.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.dao.DataAccessException;
@@ -118,12 +117,11 @@ public abstract class AbstractRedisConnection implements RedisConnection {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public Set<Object> zRange(byte[] key, TargetMethod method) {
-		String keyStr;
+	public Object zRange(byte[] key, TargetMethod method) {
 		try {
 			method.getValueList().add(0, key);
 			Method targetMethod = this.getClass().getMethod(method.getMethodName(), method.getTypeList());
-			return (Set<Object>) targetMethod.invoke(this, method.getValueList().toArray(new Object[0]));
+			return targetMethod.invoke(this, method.getValueList().toArray(new Object[0]));
 		}
 		catch (NoSuchMethodException e) {
 			// TODO Auto-generated catch block

--- a/src/main/java/org/springframework/data/redis/connection/AbstractRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/AbstractRedisConnection.java
@@ -16,6 +16,10 @@
 package org.springframework.data.redis.connection;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.dao.DataAccessException;
@@ -110,6 +114,39 @@ public abstract class AbstractRedisConnection implements RedisConnection {
 				}
 			}
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Set<Object> zRange(byte[] key, TargetMethod method) {
+		String keyStr;
+		try {
+			method.getValueList().add(0, key);
+			Method targetMethod = this.getClass().getMethod(method.getMethodName(), method.getTypeList());
+			return (Set<Object>) targetMethod.invoke(this, method.getValueList().toArray(new Object[0]));
+		}
+		catch (NoSuchMethodException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		catch (SecurityException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		catch (IllegalAccessException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		catch (IllegalArgumentException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		catch (InvocationTargetException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return new HashSet<Object>();
+
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.convert.ListConverter;
@@ -2430,6 +2431,20 @@ public class DefaultStringRedisConnection implements StringRedisConnection {
 			addResultConverter(identityConverter);
 		}
 		
+		return results;
+	}
+
+	@Override
+	public Object zRange(String string, TargetMethod method) {
+		return zRange(serialize(string), method);
+	}
+
+	@Override
+	public Object zRange(byte[] key, TargetMethod method) {
+		Object results = delegate.zRange(key, method);
+		if (isFutureConversion()) {
+			addResultConverter(identityConverter);
+		}
 		return results;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
@@ -373,4 +373,14 @@ public interface RedisZSetCommands {
 	 * @return
 	 */
 	Set<byte[]> zRangeByScore(byte[] key, String min, String max, long offset, long count);
+
+	/**
+	 * Get elements using ZRangeOptions.
+	 * 
+	 * @param key
+	 * @param method
+	 * @return
+	 */
+
+	Object zRange(byte[] key, TargetMethod method);
 }

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -368,4 +368,11 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @return
 	 */
 	Set<byte[]> zRangeByScore(String key, String min, String max, long offset, long count);
+	
+	/**
+	* @param string
+	* @param count
+	* @return
+	*/
+	Object zRange(String string, TargetMethod count);
 }

--- a/src/main/java/org/springframework/data/redis/connection/TargetMethod.java
+++ b/src/main/java/org/springframework/data/redis/connection/TargetMethod.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.util.List;
+
+/**
+ * @author David Liu
+ * @since 1.2
+ *
+ */
+public class TargetMethod {
+
+	private String methodName;
+	private List<Class> typeList;
+	private List<Object> valueList;
+
+	/**
+	 * @return the methodName
+	 */
+	public String getMethodName() {
+		return methodName;
+	}
+
+	/**
+	 * @param methodName
+	 *            the methodName to set
+	 */
+	public void setMethodName(String methodName) {
+		this.methodName = methodName;
+	}
+
+	/**
+	 * @return the typeList
+	 */
+	public Class[] getTypeList() {
+		return typeList.toArray(new Class[0]);
+	}
+
+	/**
+	 * @param typeList
+	 *            the typeList to set
+	 */
+	public void setTypeList(List<Class> typeList) {
+		this.typeList = typeList;
+	}
+
+	/**
+	 * @return the valueList
+	 */
+	public List<Object> getValueList() {
+		return valueList;
+	}
+
+	/**
+	 * @param valueList
+	 *            the valueList to set
+	 */
+	public void setValueList(List<Object> valueList) {
+		this.valueList = valueList;
+	}
+
+	public TargetMethod(String methodName, List<Class> typeList,
+			List<Object> valueList) {
+		this.methodName = methodName;
+		this.typeList = typeList;
+		this.valueList = valueList;
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ZRangeOptions.java
+++ b/src/main/java/org/springframework/data/redis/connection/ZRangeOptions.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+
+/**
+ * ZRangeOptions is to provide user add options to zRange related methods programmatically. like this new
+ * ZRangeOptions().score().greaterThanInclusive(1.1)
+ * lessThanInclusive(4.0).withScores().limitedTo().offset(1).count(1).build());
+ * 
+ * @author David Liu
+ * @since 1.2
+ *
+ */
+public class ZRangeOptions {
+
+	private boolean score = false;
+	private Object min;
+	private Object max;
+	private boolean inclusiveMax = false;
+	private boolean inclusiveMin = false;
+	private boolean limited = false;
+	private boolean withScores = false;
+	private boolean rev = false;
+	private List<Object> valueList = new ArrayList<Object>();
+	private List<Class> typeList = new ArrayList<Class>();
+	private List<Param> paramList = new ArrayList<Param>();
+	public static final int STARTINDEX = 1;
+	public static final int ENDINDEX = 2;
+	public static final int OFFSETINDEX = 3;
+	public static final int COUNTINDEX = 4;
+	private enum Type{
+		DOUBLE,STRING
+	}
+	private Type type;
+
+	public ZRangeOptions start(long value) {
+		paramList.add(new Param(STARTINDEX, value, long.class));
+		return this;
+	}
+
+	public ZRangeOptions end(long value) {
+		paramList.add(new Param(ENDINDEX, value, long.class));
+		return this;
+	}
+
+	private class Param {
+		private int index;
+		private Object value;
+		private Class type;
+
+		public Param(int index, Object value, Class type) {
+			this.index = index;
+			this.value = value;
+			this.type = type;
+		}
+		/**
+		 * @return the index
+		 */
+		public int getIndex() {
+			return index;
+		}
+		/**
+		 * @param index the index to set
+		 */
+		public void setIndex(int index) {
+			this.index = index;
+		}
+		/**
+		 * @return the value
+		 */
+		public Object getValue() {
+			return value;
+		}
+		/**
+		 * @param value the value to set
+		 */
+		public void setValue(Object value) {
+			this.value = value;
+		}
+		/**
+		 * @return the type
+		 */
+		public Class getType() {
+			return type;
+		}
+		/**
+		 * @param type the type to set
+		 */
+		public void setType(Class type) {
+			this.type = type;
+		}
+		
+	}
+
+
+	public ZRangeOptions withScores() {
+		this.withScores = true;
+		return this;
+	}
+
+	public ZRangeOptions rev() {
+		this.rev = true;
+		return this;
+	}
+
+	public ZRangeOptions limitedTo() {
+		this.limited = true;
+		return this;
+	}
+
+	public ZRangeOptions offset(long value) {
+		if (this.limited) {
+			paramList.add(new Param(OFFSETINDEX, value, long.class));
+		}
+		else {
+			throw new IllegalStateException("limited is not set");
+		}
+		return this;
+	}
+
+	public ZRangeOptions count(long value) {
+		if (this.limited) {
+			paramList.add(new Param(COUNTINDEX, value, long.class));
+		}
+		else {
+			throw new IllegalStateException("limited is not set");
+		}
+		return this;
+	}
+
+	public ZRangeOptions score() {
+		this.score = true;
+		return this;
+	}
+
+	public ZRangeOptions lessThanInclusive(double value) {
+		if(this.type == null) {
+			this.type = Type.DOUBLE;
+		}
+		this.max = value;
+		this.inclusiveMax = true;
+		return this;
+	}
+
+	public ZRangeOptions lessThanExclusive(double value) {
+		this.type = Type.STRING;
+		this.max = value;
+		return this;
+	}
+
+	public ZRangeOptions greaterThanInclusive(double value) {
+		if(this.type == null) {
+			this.type = Type.DOUBLE;
+		}
+		this.min = value;
+		this.inclusiveMin = true;
+		return this;
+	}
+
+	public ZRangeOptions greaterThanExclusive(double value) {
+		this.type = Type.STRING;
+		this.min = value;
+		return this;
+	}
+
+	public ZRangeOptions greaterThanInfinite() {
+		this.paramList.add(new Param(STARTINDEX, Double.MIN_VALUE, double.class));
+		return this;
+	}
+
+	public ZRangeOptions lessThanInfinite() {
+		this.paramList.add(new Param(ENDINDEX, Double.MAX_VALUE, double.class));
+		return this;
+	}
+
+	public TargetMethod build() {
+		StringBuilder sb = new StringBuilder();
+		if (this.rev) {
+			sb.append("zRevRange");
+		} else {
+			sb.append("zRange");
+		}
+		if (this.score) {
+			sb.append("ByScore");
+		}
+		if (this.withScores) {
+			sb.append("WithScores");
+		}
+
+		generateParamAndValueList();
+		return new TargetMethod(sb.toString(), this.typeList, this.valueList);
+	}
+	
+	public class ComparatorParam implements Comparator{
+
+		 public int compare(Object arg0, Object arg1) {
+			 Param user0 = (Param)arg0;
+			 Param user1 = (Param)arg1;
+		  return user0.getIndex()-user1.getIndex();
+		 }
+	}
+
+	@SuppressWarnings("unchecked")
+	private void generateParamAndValueList() {
+		this.typeList.add(byte[].class);
+		if (this.type != null) {
+			if (this.type.equals(Type.DOUBLE)) {
+				this.paramList.add(new Param(ENDINDEX, this.max, double.class));
+				this.paramList.add(new Param(STARTINDEX, this.min, double.class));
+			}
+			else if (this.type.equals(Type.STRING)) {
+				if (this.inclusiveMax) {
+					this.paramList.add(new Param(ENDINDEX, this.max.toString(), String.class));
+				}
+				else {
+					this.paramList.add(new Param(ENDINDEX, "(" + this.max, String.class));
+				}
+				if (this.inclusiveMin) {
+					this.paramList.add(new Param(STARTINDEX, this.min.toString(), String.class));
+				}
+				else {
+					this.paramList.add(new Param(STARTINDEX, "(" + this.min, String.class));
+				}
+			}
+		}
+		ComparatorParam comparator=new ComparatorParam();
+		Collections.sort(this.paramList,comparator);
+		for (Param param : this.paramList) {
+			this.typeList.add(param.getType());
+			this.valueList.add(param.getValue());
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -15,11 +15,22 @@
  */
 package org.springframework.data.redis.connection;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
-import static org.springframework.data.redis.SpinBarrier.*;
-import static org.springframework.data.redis.core.ScanOptions.*;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+import static org.springframework.data.redis.SpinBarrier.waitFor;
+import static org.springframework.data.redis.core.ScanOptions.scanOptions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +38,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +55,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.internal.AssumptionViolatedException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.RedisSystemException;
@@ -55,6 +68,7 @@ import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 import org.springframework.data.redis.connection.SortParameters.Order;
 import org.springframework.data.redis.connection.StringRedisConnection.StringTuple;
+import org.springframework.data.redis.connection.jedis.JedisConverters;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -2090,4 +2104,20 @@ public abstract class AbstractConnectionIntegrationTests {
 			return (!connection.exists(key));
 		}
 	}
+
+
+	@Test
+	public void zRangeOptionIndex() {
+
+		connection.zAdd("myzset", 1, "one");
+		connection.zAdd("myzset", 2, "two");
+		connection.zAdd("myzset", 3, "three");
+
+		Set<byte[]> zRangeByScore = (Set<byte[]>) connection.zRange("myzset", new ZRangeOptions().start(1).end(3).build());
+		Iterator<byte[]> iterator = zRangeByScore.iterator();
+		assertEquals("two", JedisConverters.toString(iterator.next()));
+		assertEquals("three", JedisConverters.toString(iterator.next()));
+	}
+
+
 }

--- a/src/test/java/org/springframework/data/redis/connection/jredis/JRedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jredis/JRedisConnectionIntegrationTests.java
@@ -16,12 +16,16 @@
 
 package org.springframework.data.redis.connection.jredis;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.hamcrest.core.IsCollectionContaining;
@@ -33,6 +37,7 @@ import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.SettingsUtils;
@@ -42,6 +47,8 @@ import org.springframework.data.redis.connection.DefaultStringRedisConnection;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.SortParameters.Order;
 import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.connection.ZRangeOptions;
+import org.springframework.data.redis.connection.jedis.JedisConverters;
 import org.springframework.data.redis.test.util.RelaxedJUnit4ClassRunner;
 import org.springframework.test.annotation.IfProfileValue;
 import org.springframework.test.context.ContextConfiguration;
@@ -833,4 +840,19 @@ public class JRedisConnectionIntegrationTests extends AbstractConnectionIntegrat
 	public void testListClientsContainsAtLeastOneElement() {
 		super.testListClientsContainsAtLeastOneElement();
 	}
+
+	@Test
+	public void zRangeOptionScoreInclusiveTest() {
+
+		connection.zAdd("myzset", 1, "one");
+		connection.zAdd("myzset", 2, "two");
+		connection.zAdd("myzset", 3, "three");
+
+		Set<byte[]> zRangeByScore = (Set<byte[]>) connection.zRange("myzset", new ZRangeOptions().score().greaterThanInclusive(1.1)
+				.lessThanInclusive(3.0).build());
+		Iterator<byte[]> iterator = zRangeByScore.iterator();
+		assertEquals("two", JedisConverters.toString(iterator.next()));
+		assertEquals("three", JedisConverters.toString(iterator.next()));
+	}
+
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/DATAREDIS-352

we now support programmatic range options like this: new ZRangeOptions().score().rev().greaterThanInclusive(1.1)
.lessThanInclusive(3.0).limitedTo().offset(0).count(2).build()
