### PR TITLE
Fixed NOSCRIPT error for another exception type

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/script/DefaultScriptExecutor.java
+++ b/src/main/java/org/springframework/data/redis/core/script/DefaultScriptExecutor.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.UncategorizedDataAccessException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.ReturnType;
@@ -147,8 +148,7 @@ public class DefaultScriptExecutor<K> implements ScriptExecutor<K> {
 	}
 
 	private boolean expectionContainsNoScriptError(Exception e) {
-
-		if (!(e instanceof UncategorizedDataAccessException)) {
+		if (!(e instanceof UncategorizedDataAccessException) && !(e instanceof InvalidDataAccessApiUsageException)) {
 			return false;
 		}
 


### PR DESCRIPTION
EVERE: Servlet.service() for servlet [restDispatcher] in context with path [/bird-mobile-backend] threw exception
org.springframework.dao.InvalidDataAccessApiUsageException: NOSCRIPT No matching script. Please use EVAL.; nested exception is redis.clients.jedis.exceptions.JedisDataException: NOSCRIPT No matching script. Please use EVAL.
    at org.springframework.data.redis.connection.jedis.JedisExceptionConverter.convert(JedisExceptionConverter.java:44)
    at org.springframework.data.redis.connection.jedis.JedisExceptionConverter.convert(JedisExceptionConverter.java:36)
    at org.springframework.data.redis.PassThroughExceptionTranslationStrategy.translate(PassThroughExceptionTranslationStrategy.java:37)
    at org.springframework.data.redis.FallbackExceptionTranslationStrategy.translate(FallbackExceptionTranslationStrategy.java:37)
    at org.springframework.data.redis.connection.jedis.JedisConnection.convertJedisAccessException(JedisConnection.java:195)
    at org.springframework.data.redis.connection.jedis.JedisConnection.evalSha(JedisConnection.java:2814)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.springframework.data.redis.core.CloseSuppressingInvocationHandler.invoke(CloseSuppressingInvocationHandler.java:57)
    at com.sun.proxy.$Proxy23.evalSha(Unknown Source)
    at org.springframework.data.redis.core.script.DefaultScriptExecutor.eval(DefaultScriptExecutor.java:81)
    at org.springframework.data.redis.core.script.DefaultScriptExecutor$1.doInRedis(DefaultScriptExecutor.java:71)
    at org.springframework.data.redis.core.RedisTemplate.execute(RedisTemplate.java:190)
    at org.springframework.data.redis.core.RedisTemplate.execute(RedisTemplate.java:152)
    at org.springframework.data.redis.core.RedisTemplate.execute(RedisTemplate.java:140)
    at org.springframework.data.redis.core.script.DefaultScriptExecutor.execute(DefaultScriptExecutor.java:60)
    at org.springframework.data.redis.core.script.DefaultScriptExecutor.execute(DefaultScriptExecutor.java:54)
    at org.springframework.data.redis.core.RedisTemplate.execute(RedisTemplate.java:288)
    at com.kartaca.bird.mobile.session.ApiSessionProvider.getSession(ApiSessionProvider.java:67)
    at com.kartaca.bird.mobile.session.ApiSessionRequestWrapper.<init>(ApiSessionRequestWrapper.java:33)
    at com.kartaca.bird.mobile.session.ApiSessionFilter.doFilter(ApiSessionFilter.java:42)
    at com.kartaca.bird.mobile.servlet.BirdApiFilter.lambda$0(BirdApiFilter.java:31)
    at com.kartaca.bird.mobile.servlet.BirdApiFilter$$Lambda$8/696754265.doFilter(Unknown Source)
    at com.kartaca.bird.mobile.servlet.BufferedServletInputFilter.doFilter(BufferedServletInputFilter.java:35)
    at com.kartaca.bird.mobile.servlet.BirdApiFilter.doFilter(BirdApiFilter.java:30)
    at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:344)
    at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:261)
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
    at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
    at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:219)
    at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:106)
    at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:505)
    at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:142)
    at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:79)
    at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:610)
    at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:88)
    at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:534)
    at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1081)
    at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:658)
    at org.apache.coyote.http11.Http11NioProtocol$Http11ConnectionHandler.process(Http11NioProtocol.java:222)
    at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1566)
    at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1523)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
    at java.lang.Thread.run(Thread.java:745)
Caused by: redis.clients.jedis.exceptions.JedisDataException: NOSCRIPT No matching script. Please use EVAL.
    at redis.clients.jedis.Protocol.processError(Protocol.java:115)
    at redis.clients.jedis.Protocol.process(Protocol.java:133)
    at redis.clients.jedis.Protocol.read(Protocol.java:202)
    at redis.clients.jedis.Connection.readProtocolWithCheckingBroken(Connection.java:285)
    at redis.clients.jedis.Connection.getOne(Connection.java:267)
    at redis.clients.jedis.BinaryJedis.evalsha(BinaryJedis.java:3345)
    at org.springframework.data.redis.connection.jedis.JedisConnection.evalSha(JedisConnection.java:2811)
    ... 45 more
