### PR TITLE
Make RedisCache public

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -37,7 +37,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  */
 @SuppressWarnings("unchecked")
-class RedisCache implements Cache {
+public class RedisCache implements Cache {
 
 	private static final int PAGE_SIZE = 128;
 	private final String name;


### PR DESCRIPTION
Making this class public allows users to implement their own
RedisCacheManager without having to duplicate the whole logic.