### PR TITLE
DATAREDIS-578 - made default hash/list/set/value/zset ops public

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
@@ -33,7 +33,7 @@ import org.springframework.data.redis.connection.RedisConnection;
  * @author Costin Leau
  * @author Christoph Strobl
  */
-class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> implements HashOperations<K, HK, HV> {
+public class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> implements HashOperations<K, HK, HV> {
 
 	@SuppressWarnings("unchecked")
 	DefaultHashOperations(RedisTemplate<K, ?> template) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
@@ -27,7 +27,7 @@ import org.springframework.util.CollectionUtils;
  * 
  * @author Costin Leau
  */
-class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements ListOperations<K, V> {
+public class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements ListOperations<K, V> {
 
 	DefaultListOperations(RedisTemplate<K, V> template) {
 		super(template);

--- a/src/main/java/org/springframework/data/redis/core/DefaultSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultSetOperations.java
@@ -31,7 +31,7 @@ import org.springframework.data.redis.connection.RedisConnection;
  * @author Costin Leau
  * @author Christoph Strobl
  */
-class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements SetOperations<K, V> {
+public class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements SetOperations<K, V> {
 
 	public DefaultSetOperations(RedisTemplate<K, V> template) {
 		super(template);

--- a/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
@@ -32,7 +32,7 @@ import org.springframework.data.redis.connection.RedisConnection;
  * @author Jennifer Hickey
  * @author Christoph Strobl
  */
-class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements ValueOperations<K, V> {
+public class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements ValueOperations<K, V> {
 
 	DefaultValueOperations(RedisTemplate<K, V> template) {
 		super(template);

--- a/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
@@ -30,7 +30,7 @@ import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
  * @author Costin Leau
  * @author Christoph Strobl
  */
-class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZSetOperations<K, V> {
+public class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZSetOperations<K, V> {
 
 	DefaultZSetOperations(RedisTemplate<K, V> template) {
 		super(template);


### PR DESCRIPTION
The behavior of the Default Hash/Set.List/Value/ZSet Operations can only be customized by creating classes in the org.springframework.data.redis.core package.

Making these classes public will allow people to customize the behavior using their own package structure.
