### PR TITLE
DATAREDIS-383 - Improve JavaDoc of RedisCacheManager.

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
@@ -106,7 +106,9 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 	/**
 	 * Specify the set of cache names for this CacheManager's 'static' mode. <br>
 	 * The number of caches and their names will be fixed after a call to this method, with no creation of further cache
-	 * regions at runtime.
+	 * regions at runtime. <br>
+	 * Calling this with a {@code null} or empty collection argument resets the mode to 'dynamic', allowing for further
+	 * creation of caches again.
 	 */
 	public void setCacheNames(Collection<String> cacheNames) {
 


### PR DESCRIPTION
`setCacheNames` allow to restore the mode to dynamic with a null/empty collection argument but the javadoc does not state that.