### PR TITLE
DATAREDIS-399 Make RedisCache easier for extending

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -210,6 +210,14 @@ public class RedisCache implements Cache {
 				template.getKeySerializer());
 	}
 
+    protected RedisCacheMetadata getCacheMetadata() {
+        return cacheMetadata;
+    }
+
+    protected CacheValueAccessor getCacheValueAccessor() {
+        return cacheValueAccessor;
+    }
+
 	private ValueWrapper toWrapper(Object value) {
 		return (value != null ? new SimpleValueWrapper(value) : null);
 	}


### PR DESCRIPTION
This change is setting visibility of RedisCache inner classes to
protected, thus making them more accessible for subclassing. Also,
generation of RedisCacheKey object has been moved to separate method so
that it can be reused from subclasses.
