### PR TITLE
Move serialization out of doInRedis calls.

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheKey.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheKey.java
@@ -27,90 +27,97 @@ import org.springframework.data.redis.serializer.RedisSerializer;
  */
 public class RedisCacheKey {
 
-	private final Object keyElement;
-	private byte[] prefix;
-	@SuppressWarnings("rawtypes")//
-	private RedisSerializer serializer;
+	private final byte[] keyBytes;
+	private final boolean hasPrefix;
 
-	/**
-	 * @param keyElement must not be {@literal null}.
-	 */
-	public RedisCacheKey(Object keyElement) {
-
-		notNull(keyElement, "KeyElement must not be null!");
-		this.keyElement = keyElement;
+	private RedisCacheKey(byte[] keyBytes, boolean hasPrefix) {
+		this.keyBytes = keyBytes;
+		this.hasPrefix = hasPrefix;
 	}
 
 	/**
 	 * Get the {@link Byte} representation of the given key element using prefix if available.
 	 */
 	public byte[] getKeyBytes() {
-
-		byte[] rawKey = serializeKeyElement();
-		if (!hasPrefix()) {
-			return rawKey;
-		}
-
-		byte[] prefixedKey = Arrays.copyOf(prefix, prefix.length + rawKey.length);
-		System.arraycopy(rawKey, 0, prefixedKey, prefix.length, rawKey.length);
-
-		return prefixedKey;
-	}
-
-	/**
-	 * @return
-	 */
-	public Object getKeyElement() {
-		return keyElement;
-	}
-
-	@SuppressWarnings("unchecked")
-	private byte[] serializeKeyElement() {
-
-		if (serializer == null && keyElement instanceof byte[]) {
-			return (byte[]) keyElement;
-		}
-
-		return serializer.serialize(keyElement);
-	}
-
-	/**
-	 * Set the {@link RedisSerializer} used for converting the key into its {@link Byte} representation.
-	 * 
-	 * @param serializer can be {@literal null}.
-	 */
-	public void setSerializer(RedisSerializer<?> serializer) {
-		this.serializer = serializer;
+		return keyBytes;
 	}
 
 	/**
 	 * @return true if prefix is not empty.
 	 */
 	public boolean hasPrefix() {
-		return (prefix != null && prefix.length > 0);
+		return hasPrefix;
 	}
 
 	/**
-	 * Use the given prefix when generating key.
-	 * 
-	 * @param prefix can be {@literal null}.
-	 * @return
+	 * @param keyElement must not be {@literal null}.
 	 */
-	public RedisCacheKey usePrefix(byte[] prefix) {
-		this.prefix = prefix;
-		return this;
+	public static RedisCacheKeyBuilder builder(final Object keyElement) {
+		notNull(keyElement, "KeyElement must not be null!");
+		return new RedisCacheKeyBuilder(keyElement);
 	}
 
-	/**
-	 * Use {@link RedisSerializer} for converting the key into its {@link Byte} representation.
-	 * 
-	 * @param serializer can be {@literal null}.
-	 * @return
-	 */
-	public RedisCacheKey withKeySerializer(RedisSerializer serializer) {
+	public static class RedisCacheKeyBuilder {
+		private Object keyElement;
+		@SuppressWarnings("rawtypes")//
+		private RedisSerializer serializer;
+		private byte[] prefix;
 
-		this.serializer = serializer;
-		return this;
+		private RedisCacheKeyBuilder(Object keyElement) {
+			this.keyElement = keyElement;
+		}
+
+		/**
+		 * Use the given prefix when generating key.
+		 *
+		 * @param prefix can be {@literal null}.
+		 * @return
+		 */
+		public RedisCacheKeyBuilder usePrefix(byte[] prefix) {
+			this.prefix = prefix;
+			return this;
+		}
+
+		/**
+		 * Use {@link RedisSerializer} for converting the key into its {@link Byte} representation.
+		 *
+		 * @param serializer can be {@literal null}.
+		 * @return
+		 */
+		public RedisCacheKeyBuilder withKeySerializer(RedisSerializer<?> serializer) {
+			this.serializer = serializer;
+			return this;
+		}
+
+		public RedisCacheKey build() {
+			return new RedisCacheKey(getKeyBytes(), hasPrefix());
+		}
+
+		private boolean hasPrefix() {
+			return (prefix != null && prefix.length > 0);
+		}
+
+		private byte[] getKeyBytes() {
+
+			byte[] rawKey = serializeKeyElement();
+			if (!hasPrefix()) {
+				return rawKey;
+			}
+
+			byte[] prefixedKey = Arrays.copyOf(prefix, prefix.length + rawKey.length);
+			System.arraycopy(rawKey, 0, prefixedKey, prefix.length, rawKey.length);
+
+			return prefixedKey;
+		}
+
+		@SuppressWarnings("unchecked")
+		private byte[] serializeKeyElement() {
+
+			if (serializer == null && keyElement instanceof byte[]) {
+				return (byte[]) keyElement;
+			}
+
+			return serializer.serialize(keyElement);
+		}
 	}
-
 }


### PR DESCRIPTION
This allows the pooled connection to be returned quicker so more threads can be
serviced.

This change adds RedisCacheKeyBuilder and makes RedisCacheKey fully immutable. This eager serialization of the key avoids calling it multiple times and ensures this work is done while not holding onto a connection.

The putIfAbsent call was not changed to deserialize outside the redis call. It would require a bit more rearrangement. Let me know if you'd like me to give that a go.

See also https://jira.spring.io/browse/DATAREDIS-414.