### PR TITLE
Update ScanCursor.java

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/ScanCursor.java
+++ b/src/main/java/org/springframework/data/redis/core/ScanCursor.java
@@ -82,8 +82,10 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 
 	private void scan(long cursorId) {
 
-		ScanIteration<T> result = doScan(cursorId, this.scanOptions);
-		processScanResult(result);
+		do{
+			ScanIteration<T> result = doScan(cursorId, this.scanOptions);
+			processScanResult(result);
+		} while (cursorId > 0 && !delegate.hasNext());
 	}
 
 	/**


### PR DESCRIPTION
fix bug:when scan big key with "match" options, ScanCursor throw " java.util.NoSuchElementException"