### PR TITLE
ScanCursor throw " java.util.NoSuchElementException"

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/ScanCursor.java
+++ b/src/main/java/org/springframework/data/redis/core/ScanCursor.java
@@ -164,7 +164,7 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 
 		assertCursorIsOpen();
 
-		if (!delegate.hasNext() && !CursorState.FINISHED.equals(state)) {
+		while (!delegate.hasNext() && !CursorState.FINISHED.equals(state)) {
 			scan(cursorId);
 		}
 


### PR DESCRIPTION
when scan big key with "match" options, redis server continuous return empty result，
ScanCursor throw " java.util.NoSuchElementException"