### PR TITLE
DATAREDIS-452 Improve thread synchronization in RedisCacheTest.testCacheGetSynchronized

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAREDIS-452-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<jedis>2.7.3</jedis>
 		<srp>0.7</srp>
 		<jredis>06052013</jredis>
+		<multithreadedtc>1.01</multithreadedtc>
 	</properties>
 
 	<dependencyManagement>
@@ -179,6 +180,13 @@
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<version>${xstream}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>edu.umd.cs.mtc</groupId>
+			<artifactId>multithreadedtc</artifactId>
+			<version>${multithreadedtc}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
The current implementation of the Thread synchronization does not guarantee the overlap of threads. This change improves Thread synchronization to guarantee that two threads call `RedisCache.get(...)` concurrently.