### PR TITLE
DATAREDIS-316 - Add EX/PX, NX/XX options to SET command.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAREDIS-316-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.data.redis.connection.convert.SetConverter;
 import org.springframework.data.redis.core.ConvertingCursor;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -728,6 +729,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection {
 
 	public void set(byte[] key, byte[] value) {
 		delegate.set(key, value);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#set(byte[], byte[], org.springframework.data.redis.core.types.Expiration, org.springframework.data.redis.connection.RedisStringCommands.SetOptions)
+	 */
+	@Override
+	public void set(byte[] key, byte[] value, Expiration expiration, SetOption option) {
+		delegate.set(key, value, expiration, option);
 	}
 
 	public Boolean setBit(byte[] key, long offset, boolean value) {
@@ -1858,6 +1868,14 @@ public class DefaultStringRedisConnection implements StringRedisConnection {
 
 	public void set(String key, String value) {
 		delegate.set(serialize(key), serialize(value));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#set(java.lang.String, java.lang.String, org.springframework.data.redis.core.types.Expiration, org.springframework.data.redis.connection.RedisStringCommands.SetOptions)
+	 */
+	public void set(String key, String value, Expiration expiration, SetOption option) {
+		set(serialize(key), serialize(value), expiration, option);
 	}
 
 	public Boolean setBit(String key, long offset, boolean value) {

--- a/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package org.springframework.data.redis.connection;
 
 import java.util.List;
 import java.util.Map;
+
+import org.springframework.data.redis.core.types.Expiration;
 
 /**
  * String/Value-specific commands supported by Redis.
@@ -70,6 +72,18 @@ public interface RedisStringCommands {
 	 * @param value
 	 */
 	void set(byte[] key, byte[] value);
+
+	/**
+	 * Set {@code value} for {@code key} applying timeouts from {@code expiration} if set and inserting/updating values
+	 * depending on {@code options}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @param expiration can be {@literal null}. Defaulted to {@link Expiration#persistent()}.
+	 * @param option can be {@literal null}. Defaulted to {@link SetOption#UPSERT}.
+	 * @since 1.7
+	 */
+	void set(byte[] key, byte[] value, Expiration expiration, SetOption option);
 
 	/**
 	 * Set {@code value} for {@code key}, only if {@code key} does not exist.
@@ -278,4 +292,61 @@ public interface RedisStringCommands {
 	 * @return
 	 */
 	Long strLen(byte[] key);
+
+	/**
+	 * {@code SET} command arguments for {@code NX}, {@code XX}.
+	 * 
+	 * @author Christoph Strobl
+	 * @since 1.7
+	 */
+	public static enum SetOption {
+
+		/**
+		 * Do not set any additional command argument.
+		 * 
+		 * @return
+		 */
+		UPSERT,
+
+		/**
+		 * {@code NX}
+		 * 
+		 * @return
+		 */
+		SET_IF_ABSENT,
+
+		/**
+		 * {@code XX}
+		 * 
+		 * @return
+		 */
+		SET_IF_PRESENT;
+
+		/**
+		 * Do not set any additional command argument.
+		 * 
+		 * @return
+		 */
+		public static SetOption upsert() {
+			return UPSERT;
+		}
+
+		/**
+		 * {@code XX}
+		 * 
+		 * @return
+		 */
+		public static SetOption ifPresent() {
+			return SET_IF_PRESENT;
+		}
+
+		/**
+		 * {@code NX}
+		 * 
+		 * @return
+		 */
+		public static SetOption ifAbsent() {
+			return SET_IF_ABSENT;
+		}
+	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
@@ -75,8 +75,10 @@ public interface RedisStringCommands {
 
 	/**
 	 * Set {@code value} for {@code key} applying timeouts from {@code expiration} if set and inserting/updating values
-	 * depending on {@code options}.
-	 * 
+	 * depending on {@code option}.
+	 * <p>
+	 * See http://redis.io/commands/set
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @param expiration can be {@literal null}. Defaulted to {@link Expiration#persistent()}.

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -98,7 +98,9 @@ public interface StringRedisConnection extends RedisConnection {
 
 	/**
 	 * Set {@code value} for {@code key} applying timeouts from {@code expiration} if set and inserting/updating values
-	 * depending on {@code options}.
+	 * depending on {@code option}.
+	 * <p>
+	 * See http://redis.io/commands/set
 	 * 
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -24,6 +24,7 @@ import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.data.redis.serializer.RedisSerializer;
 
@@ -94,6 +95,18 @@ public interface StringRedisConnection extends RedisConnection {
 	List<String> mGet(String... keys);
 
 	void set(String key, String value);
+
+	/**
+	 * Set {@code value} for {@code key} applying timeouts from {@code expiration} if set and inserting/updating values
+	 * depending on {@code options}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @param expiration can be {@literal null}. Defaulted to {@link Expiration#persistent()}.
+	 * @param option can be {@literal null}. Defaulted to {@link SetOption#UPSERT}.
+	 * @since 1.7
+	 */
+	void set(String key, String value, Expiration expiration, SetOption option);
 
 	Boolean setNX(String key, String value);
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -604,7 +604,7 @@ public class JedisClusterConnection implements RedisClusterConnection {
 	@Override
 	public void set(byte[] key, byte[] value, Expiration expiration, SetOption option) {
 
-		if (expiration == null || expiration.isPersitent()) {
+		if (expiration == null || expiration.isPersistent()) {
 
 			if (option == null || ObjectUtils.nullSafeEquals(SetOption.UPSERT, option)) {
 				set(key, value);

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -1147,7 +1147,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	@Override
 	public void set(byte[] key, byte[] value, Expiration expiration, SetOption option) {
 
-		if (expiration == null || expiration.isPersitent()) {
+		if (expiration == null || expiration.isPersistent()) {
 
 			if (option == null || ObjectUtils.nullSafeEquals(SetOption.UPSERT, option)) {
 				set(key, value);
@@ -1194,7 +1194,7 @@ public class JedisConnection extends AbstractRedisConnection {
 						if (expiration.getExpirationTime() > Integer.MAX_VALUE) {
 
 							throw new IllegalArgumentException(
-									"Expiration.exprirationTime must be less than equals Integer.MAX_VALUE for pipeline in Jedis.");
+									"Expiration.expirationTime must be less than Integer.MAX_VALUE for pipeline in Jedis.");
 						}
 
 						pipeline(new JedisStatusResult(pipeline.set(key, value, nxxx, expx, (int) expiration.getExpirationTime())));
@@ -1204,7 +1204,7 @@ public class JedisConnection extends AbstractRedisConnection {
 
 						if (expiration.getExpirationTime() > Integer.MAX_VALUE) {
 							throw new IllegalArgumentException(
-									"Expiration.exprirationTime must be less than equals Integer.MAX_VALUE for transactions in Jedis.");
+									"Expiration.expirationTime must be less than Integer.MAX_VALUE for transactions in Jedis.");
 						}
 
 						transaction(new JedisStatusResult(transaction.set(key, value, nxxx, expx,

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ import org.springframework.data.redis.core.KeyBoundCursor;
 import org.springframework.data.redis.core.ScanCursor;
 import org.springframework.data.redis.core.ScanIteration;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -1136,6 +1137,87 @@ public class JedisConnection extends AbstractRedisConnection {
 			jedis.set(key, value);
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#set(byte[], byte[], org.springframework.data.redis.core.types.Expiration, org.springframework.data.redis.connection.RedisStringCommands.SetOption)
+	 */
+	@Override
+	public void set(byte[] key, byte[] value, Expiration expiration, SetOption option) {
+
+		if (expiration == null || expiration.isPersitent()) {
+
+			if (option == null || ObjectUtils.nullSafeEquals(SetOption.UPSERT, option)) {
+				set(key, value);
+			} else {
+
+				try {
+
+					byte[] nxxx = JedisConverters.toSetCommandNxXxArgument(option);
+
+					if (isPipelined()) {
+
+						pipeline(new JedisStatusResult(pipeline.set(key, value, nxxx)));
+						return;
+					}
+					if (isQueueing()) {
+
+						transaction(new JedisStatusResult(transaction.set(key, value, nxxx)));
+						return;
+					}
+
+					jedis.set(key, value, nxxx);
+				} catch (Exception ex) {
+					throw convertJedisAccessException(ex);
+				}
+			}
+
+		} else {
+
+			if (option == null || ObjectUtils.nullSafeEquals(SetOption.UPSERT, option)) {
+
+				if (ObjectUtils.nullSafeEquals(TimeUnit.MILLISECONDS, expiration.getTimeUnit())) {
+					pSetEx(key, expiration.getExpirationTime(), value);
+				} else {
+					setEx(key, expiration.getExpirationTime(), value);
+				}
+			} else {
+
+				byte[] nxxx = JedisConverters.toSetCommandNxXxArgument(option);
+				byte[] expx = JedisConverters.toSetCommandExPxArgument(expiration);
+
+				try {
+					if (isPipelined()) {
+
+						if (expiration.getExpirationTime() > Integer.MAX_VALUE) {
+
+							throw new IllegalArgumentException(
+									"Expiration.exprirationTime must be less than equals Integer.MAX_VALUE for pipeline in Jedis.");
+						}
+
+						pipeline(new JedisStatusResult(pipeline.set(key, value, nxxx, expx, (int) expiration.getExpirationTime())));
+						return;
+					}
+					if (isQueueing()) {
+
+						if (expiration.getExpirationTime() > Integer.MAX_VALUE) {
+							throw new IllegalArgumentException(
+									"Expiration.exprirationTime must be less than equals Integer.MAX_VALUE for transactions in Jedis.");
+						}
+
+						transaction(new JedisStatusResult(transaction.set(key, value, nxxx, expx,
+								(int) expiration.getExpirationTime())));
+						return;
+					}
+
+					jedis.set(key, value, nxxx, expx, expiration.getExpirationTime());
+
+				} catch (Exception ex) {
+					throw convertJedisAccessException(ex);
+				}
+			}
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -131,7 +131,7 @@ abstract public class JedisConverters extends Converters {
 			@Override
 			public byte[] convert(Expiration source) {
 
-				if (source == null || source.isPersitent()) {
+				if (source == null || source.isPersistent()) {
 					return new byte[0];
 				}
 

--- a/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnection.java
@@ -47,6 +47,7 @@ import org.springframework.data.redis.connection.SortParameters;
 import org.springframework.data.redis.connection.Subscription;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -468,6 +469,16 @@ public class JredisConnection extends AbstractRedisConnection {
 		} catch (Exception ex) {
 			throw convertJredisAccessException(ex);
 		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#set(byte[], byte[], org.springframework.data.redis.core.types.Expiration, org.springframework.data.redis.connection.RedisStringCommands.SetOption)
+	 */
+	@Override
+	public void set(byte[] key, byte[] value, Expiration expiration, SetOption option) {
+		throw new UnsupportedOperationException(
+				"SET with options is not supported for JRedis. Please use SETNX, SETEX, PSETEX.");
 	}
 
 	public byte[] getSet(byte[] key, byte[] value) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -628,7 +628,7 @@ abstract public class LettuceConverters extends Converters {
 	public static SetArgs toSetArgs(Expiration expiration, SetOption option) {
 
 		SetArgs args = new SetArgs();
-		if (expiration != null && !expiration.isPersitent()) {
+		if (expiration != null && !expiration.isPersistent()) {
 
 			switch (expiration.getTimeUnit()) {
 				case SECONDS:

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
@@ -39,6 +40,7 @@ import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.RedisNode.NodeType;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisServer;
+import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range.Boundary;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 import org.springframework.data.redis.connection.ReturnType;
@@ -47,6 +49,7 @@ import org.springframework.data.redis.connection.SortParameters.Order;
 import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.connection.convert.LongToBooleanConverter;
 import org.springframework.data.redis.connection.convert.StringToRedisClientInfoConverter;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -60,6 +63,7 @@ import com.lambdaworks.redis.SortArgs;
 import com.lambdaworks.redis.cluster.models.partitions.Partitions;
 import com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode.NodeFlag;
 import com.lambdaworks.redis.protocol.LettuceCharsets;
+import com.lambdaworks.redis.protocol.SetArgs;
 
 /**
  * Lettuce type converters
@@ -612,6 +616,45 @@ abstract public class LettuceConverters extends Converters {
 	public static RedisClusterNode toRedisClusterNode(
 			com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode source) {
 		return CLUSTER_NODE_TO_CLUSTER_NODE_CONVERTER.convert(source);
+	}
+
+	/**
+	 * Converts a given {@link Expiration} and {@link SetOption} to the according {@link SetArgs}.<br />
+	 * 
+	 * @param expiration can be {@literal null}.
+	 * @param option can be {@literal null}.
+	 * @since 1.7
+	 */
+	public static SetArgs toSetArgs(Expiration expiration, SetOption option) {
+
+		SetArgs args = new SetArgs();
+		if (expiration != null && !expiration.isPersitent()) {
+
+			switch (expiration.getTimeUnit()) {
+				case SECONDS:
+					args.ex(expiration.getExpirationTime());
+					break;
+				default:
+					args.px(expiration.getConverted(TimeUnit.MILLISECONDS));
+					break;
+			}
+		}
+
+		if (option != null) {
+
+			switch (option) {
+				case SET_IF_ABSENT:
+					args.nx();
+					break;
+				case SET_IF_PRESENT:
+					args.xx();
+					break;
+				default:
+					break;
+			}
+		}
+
+		return args;
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
@@ -46,6 +46,7 @@ import org.springframework.data.redis.connection.SortParameters;
 import org.springframework.data.redis.connection.Subscription;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.util.Assert;
 
@@ -873,6 +874,16 @@ public class SrpConnection extends AbstractRedisConnection {
 		} catch (Exception ex) {
 			throw convertSrpAccessException(ex);
 		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#set(byte[], byte[], org.springframework.data.redis.core.types.Expiration, org.springframework.data.redis.connection.RedisStringCommands.SetOption)
+	 */
+	@Override
+	public void set(byte[] key, byte[] value, Expiration expiration, SetOption option) {
+		throw new UnsupportedOperationException(
+				"SET with options is not supported for Srp. Please use SETNX, SETEX, PSETEX.");
 	}
 
 	public byte[] getSet(byte[] key, byte[] value) {

--- a/src/main/java/org/springframework/data/redis/core/types/Expiration.java
+++ b/src/main/java/org/springframework/data/redis/core/types/Expiration.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.types;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.util.Assert;
+
+/**
+ * Expiration holds a value with its associated {@link TimeUnit}.
+ * 
+ * @author Christoph Strobl
+ * @since 1.7
+ */
+public class Expiration {
+
+	private long expirationTime;
+	private TimeUnit timeUnit;
+
+	/**
+	 * Creates new {@link Expiration}.
+	 * 
+	 * @param expirationTime can be {@literal null}. Defaulted to {@link TimeUnit#SECONDS}
+	 * @param timeUnit
+	 */
+	protected Expiration(long expirationTime, TimeUnit timeUnit) {
+
+		this.expirationTime = expirationTime;
+		this.timeUnit = timeUnit != null ? timeUnit : TimeUnit.SECONDS;
+	}
+
+	/**
+	 * Get the expiration time converted into {@link TimeUnit#MILLISECONDS}.
+	 * 
+	 * @return
+	 */
+	public long getExpirationTimeInMilliseconds() {
+		return getConverted(TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Get the expiration time converted into {@link TimeUnit#SECONDS}.
+	 * 
+	 * @return
+	 */
+	public long getExpirationTimeInSeconds() {
+		return getConverted(TimeUnit.SECONDS);
+	}
+
+	/**
+	 * Get the expiration time.
+	 * 
+	 * @return
+	 */
+	public long getExpirationTime() {
+		return expirationTime;
+	}
+
+	/**
+	 * Get the time unit for the expiration time.
+	 * 
+	 * @return
+	 */
+	public TimeUnit getTimeUnit() {
+		return this.timeUnit;
+	}
+
+	/**
+	 * Get the expiration time converted into the desired {@code targetTimeUnit}.
+	 * 
+	 * @param targetTimeUnit must not {@literal null}.
+	 * @return
+	 * @throws IllegalArgumentException
+	 */
+	public long getConverted(TimeUnit targetTimeUnit) {
+
+		Assert.notNull(targetTimeUnit, "TargetTimeUnit must not be null!");
+		return targetTimeUnit.convert(expirationTime, timeUnit);
+	}
+
+	/**
+	 * Creates new {@link Expiration} with {@link TimeUnit#SECONDS}.
+	 * 
+	 * @param expirationTime
+	 * @return
+	 */
+	public static Expiration seconds(long expirationTime) {
+		return new Expiration(expirationTime, TimeUnit.SECONDS);
+	}
+
+	/**
+	 * Creates new {@link Expiration} with {@link TimeUnit#MILLISECONDS}.
+	 * 
+	 * @param expirationTime
+	 * @return
+	 */
+	public static Expiration milliseconds(long expirationTime) {
+		return new Expiration(expirationTime, TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Creates new persistent {@link Expiration}.
+	 * 
+	 * @return
+	 */
+	public static Expiration persistent() {
+		return new Expiration(-1, TimeUnit.SECONDS);
+	}
+
+	/**
+	 * @return {@literal true} if {@link Expiration} is set to persistent.
+	 */
+	public boolean isPersitent() {
+		return expirationTime == -1;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/types/Expiration.java
+++ b/src/main/java/org/springframework/data/redis/core/types/Expiration.java
@@ -18,11 +18,13 @@ package org.springframework.data.redis.core.types;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Expiration holds a value with its associated {@link TimeUnit}.
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.7
  */
 public class Expiration {
@@ -112,6 +114,31 @@ public class Expiration {
 	}
 
 	/**
+	 * Creates new {@link Expiration} with the provided {@link TimeUnit}. Greater units than {@link TimeUnit#SECONDS} are
+	 * converted to {@link TimeUnit#SECONDS}. Units smaller than {@link TimeUnit#MILLISECONDS} are converted to
+	 * {@link TimeUnit#MILLISECONDS} and can lose precision since {@link TimeUnit#MILLISECONDS} is the smallest granularity
+	 * supported by Redis.
+	 *
+	 * @param expirationTime
+	 * @param timeUnit can be {@literal null}. Defaulted to {@link TimeUnit#SECONDS}
+	 * @return
+	 */
+	public static Expiration from(long expirationTime, TimeUnit timeUnit) {
+
+		if (ObjectUtils.nullSafeEquals(timeUnit, TimeUnit.MICROSECONDS)
+				|| ObjectUtils.nullSafeEquals(timeUnit, TimeUnit.NANOSECONDS)
+				|| ObjectUtils.nullSafeEquals(timeUnit, TimeUnit.MILLISECONDS)) {
+			return new Expiration(timeUnit.toMillis(expirationTime), TimeUnit.MILLISECONDS);
+		}
+
+		if (timeUnit != null) {
+			return new Expiration(timeUnit.toSeconds(expirationTime), TimeUnit.SECONDS);
+		}
+
+		return new Expiration(expirationTime, TimeUnit.SECONDS);
+	}
+
+	/**
 	 * Creates new persistent {@link Expiration}.
 	 * 
 	 * @return
@@ -123,7 +150,7 @@ public class Expiration {
 	/**
 	 * @return {@literal true} if {@link Expiration} is set to persistent.
 	 */
-	public boolean isPersitent() {
+	public boolean isPersistent() {
 		return expirationTime == -1;
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.redis.connection;
 
+/**
+ * @author Christoph Strobl
+ */
 public interface ClusterConnectionTests {
 
 	/**
@@ -892,5 +895,45 @@ public interface ClusterConnectionTests {
 	 * @see DATAREDIS-315
 	 */
 	void clusterGetMasterSlaveMapShouldListMastersAndSlavesCorrectly();
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	void setWithExpirationInSecondsShouldWorkCorrectly();
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	void setWithExpirationInMillisecondsShouldWorkCorrectly();
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	void setWithOptionIfPresentShouldWorkCorrectly();
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	void setWithOptionIfAbsentShouldWorkCorrectly();
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	void setWithExpirationAndIfAbsentShouldWorkCorrectly();
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	void setWithExpirationAndIfAbsentShouldNotBeAppliedWhenKeyExists();
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	void setWithExpirationAndIfPresentShouldWorkCorrectly();
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	void setWithExpirationAndIfPresentShouldNotBeAppliedWhenKeyDoesNotExists();
 
 }

--- a/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
@@ -30,6 +30,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.RedisNode.RedisNodeBuilder;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.util.ObjectUtils;
 
@@ -890,6 +891,11 @@ public class RedisConnectionUnitTests {
 		@Override
 		public void migrate(byte[] key, RedisNode target, int dbIndex, MigrateOption option, long timeout) {
 			delegate.migrate(key, target, dbIndex, option, timeout);
+		}
+
+		@Override
+		public void set(byte[] key, byte[] value, Expiration expiration, SetOption options) {
+			delegate.set(key, value, expiration, options);
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.springframework.data.redis.connection.RedisServer;
+import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 
 /**
@@ -255,6 +257,56 @@ public class JedisConvertersUnitTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void boundaryToBytesForZRangeByShouldThrowExceptionWhenBoundaryHoldsUnknownType() {
 		JedisConverters.boundaryToBytesForZRange(Range.range().gt(new Date()).getMin(), null);
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void toSetCommandExPxOptionShouldReturnEXforSeconds() {
+		assertThat(JedisConverters.toSetCommandExPxArgument(Expiration.seconds(100)), equalTo(JedisConverters.toBytes("EX")));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void toSetCommandExPxOptionShouldReturnEXforMilliseconds() {
+
+		assertThat(JedisConverters.toSetCommandExPxArgument(Expiration.milliseconds(100)),
+				equalTo(JedisConverters.toBytes("PX")));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void toSetCommandExPxOptionShouldReturnEmptyArrayForNull() {
+		assertThat(JedisConverters.toSetCommandExPxArgument(null), equalTo(new byte[] {}));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void toSetCommandNxXxOptionShouldReturnNXforAbsent() {
+		assertThat(JedisConverters.toSetCommandNxXxArgument(SetOption.ifAbsent()), equalTo(JedisConverters.toBytes("NX")));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void toSetCommandNxXxOptionShouldReturnXXforAbsent() {
+		assertThat(JedisConverters.toSetCommandNxXxArgument(SetOption.ifPresent()), equalTo(JedisConverters.toBytes("XX")));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void toSetCommandNxXxOptionShouldReturnEmptyArrayforUpsert() {
+		assertThat(JedisConverters.toSetCommandNxXxArgument(SetOption.upsert()), equalTo(new byte[] {}));
 	}
 
 	private void verifyRedisServerInfo(RedisServer server, Map<String, String> values) {

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.number.IsCloseTo.*;
 import static org.junit.Assert.*;
 import static org.springframework.data.redis.connection.ClusterTestVariables.*;
 
@@ -44,11 +45,13 @@ import org.springframework.data.redis.connection.RedisClusterNode;
 import org.springframework.data.redis.connection.RedisListCommands.Position;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
+import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 import org.springframework.data.redis.connection.jedis.JedisConverters;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.test.util.RedisClusterRule;
 
 import com.lambdaworks.redis.RedisURI.Builder;
@@ -2297,5 +2300,106 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItem(new RedisClusterNode(CLUSTER_HOST, SLAVEOF_NODE_1_PORT)));
 		assertThat(masterSlaveMap.get(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT)).isEmpty(), is(true));
 		assertThat(masterSlaveMap.get(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_3_PORT)).isEmpty(), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void setWithExpirationInSecondsShouldWorkCorrectly() {
+
+		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.upsert());
+
+		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.ttl(KEY_1), is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void setWithExpirationInMillisecondsShouldWorkCorrectly() {
+
+		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.milliseconds(500), SetOption.upsert());
+
+		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.pttl(KEY_1).doubleValue(), is(closeTo(500d, 499d)));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void setWithOptionIfPresentShouldWorkCorrectly() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+		clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.persistent(), SetOption.ifPresent());
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void setWithOptionIfAbsentShouldWorkCorrectly() {
+
+		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.persistent(), SetOption.ifAbsent());
+
+		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.ttl(KEY_1), is(-1L));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void setWithExpirationAndIfAbsentShouldWorkCorrectly() {
+
+		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifAbsent());
+
+		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.ttl(KEY_1), is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void setWithExpirationAndIfAbsentShouldNotBeAppliedWhenKeyExists() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+
+		clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.seconds(1), SetOption.ifAbsent());
+
+		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.ttl(KEY_1), is(-1L));
+		assertThat(nativeConnection.get(KEY_1), is(equalTo(VALUE_1)));
+
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void setWithExpirationAndIfPresentShouldWorkCorrectly() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+
+		clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.seconds(1), SetOption.ifPresent());
+
+		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.ttl(KEY_1), is(1L));
+		assertThat(nativeConnection.get(KEY_1), is(equalTo(VALUE_2)));
+
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void setWithExpirationAndIfPresentShouldNotBeAppliedWhenKeyDoesNotExists() {
+
+		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifPresent());
+
+		assertThat(nativeConnection.exists(KEY_1), is(false));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/types/ExpirationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/types/ExpirationUnitTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.core.types;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+/**
+ * @author Mark Paluch
+ */
+public class ExpirationUnitTests {
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void fromDefault() throws Exception {
+
+		Expiration expiration = Expiration.from(5, null);
+
+		assertThat(expiration.getExpirationTime(), is(5L));
+		assertThat(expiration.getTimeUnit(), is(TimeUnit.SECONDS));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void fromNanos() throws Exception {
+
+		Expiration expiration = Expiration.from(5L * 1000 * 1000, TimeUnit.NANOSECONDS);
+
+		assertThat(expiration.getExpirationTime(), is(5L));
+		assertThat(expiration.getTimeUnit(), is(TimeUnit.MILLISECONDS));
+	}
+
+	/**
+	 * @see DATAREDIS-316
+	 */
+	@Test
+	public void fromMinutes() throws Exception {
+
+		Expiration expiration = Expiration.from(5, TimeUnit.MINUTES);
+
+		assertThat(expiration.getExpirationTime(), is(5L * 60));
+		assertThat(expiration.getTimeUnit(), is(TimeUnit.SECONDS));
+	}
+}


### PR DESCRIPTION
We now support `EX`/`PX` and `NX`/`XX` arguments along with the `SET` command for both [xetorthio/jedis](https://github.com/xetorthio/jedis) and [mp911de/lettuce](https://github.com/mp911de/lettuce). 

Jedis 2.8 does not support all combinations of `EX`/`PX` and `NX`/`XX`. To work around those limitations we delegate to the according set methods to execute related commands or fail fast if there is no way for delegation.