### PR TITLE
DATAREDIS-468 - Guard muli/exec bocks in RedisCache to allow usage with cluster.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAREDIS-468-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/DecoratedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DecoratedRedisConnection.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * Specifies that the connection decorates another {@link RedisConnection}.
+ *
+ * @author Mark Paluch
+ * @since 1.7
+ */
+public interface DecoratedRedisConnection {
+
+	/**
+	 * Gets the underlying {@link RedisConnection}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	RedisConnection getDelegate();
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -49,8 +49,9 @@ import org.springframework.util.Assert;
  * @author Jennifer Hickey
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
-public class DefaultStringRedisConnection implements StringRedisConnection {
+public class DefaultStringRedisConnection implements StringRedisConnection, DecoratedRedisConnection {
 
 	private static final byte[][] EMPTY_2D_BYTE_ARRAY = new byte[0][];
 
@@ -2722,6 +2723,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection {
 	@Override
 	public void migrate(byte[] key, RedisNode target, int dbIndex, MigrateOption option, long timeout) {
 		delegate.migrate(key, target, dbIndex, option, timeout);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.DecoratedRedisConnection#getDelegate()
+	 */
+	@Override
+	public RedisConnection getDelegate() {
+		return delegate;
 	}
 
 }


### PR DESCRIPTION
We now guard `muli` / `exec` blocks by checking the connection type. This allows to skip those commands when running in cluster.