### PR TITLE
Clean up documentation

### DIFF
--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -8,7 +8,7 @@ New and noteworthy in the latest releases.
 
 * The `Lettuce` Redis driver switched from https://github.com/wg/lettuce[wg/lettuce] to https://github.com/mp911de/lettuce[mp911de/lettuce].
 * Support for `ZRANGEBYLEX`.
-* Enhanced range operations for `ZSET`s including `+inf` / `-inf`.
+* Enhanced range operations for `ZSET` s including `+inf` / `-inf`.
 * Performance improvements in `RedisCache` now releasing connections earlier.
 * Generic Jackson2 `RedisSerializer` making use of Jackson's polymorphic deserialization.
 

--- a/src/main/asciidoc/reference/redis-messaging.adoc
+++ b/src/main/asciidoc/reference/redis-messaging.adoc
@@ -10,7 +10,7 @@ The package `org.springframework.data.redis.connection` and `org.springframework
 [[redis:pubsub:publish]]
 == Sending/Publishing messages
 
-To publish a message, one can use, as with the other operations, either the low-level `RedisConnection` or the high-level `RedisTemplate`. Both entities offer the `publish` method that accepts as argument the message that needs to be sent as well as the destination channel. While `RedisConnection` requires raw-data (array of bytes), the `RedisTemplate` allow arbitrary objects to be passed in as messages:
+To publish a message, one can use, as with the other operations, either the low-level `RedisConnection` or the high-level `RedisTemplate`. Both entities offer the `publish` method that accepts as an argument the message that needs to be sent as well as the destination channel. While `RedisConnection` requires raw-data (array of bytes), the `RedisTemplate` allow arbitrary objects to be passed in as messages:
 
 [source,java]
 ----
@@ -40,7 +40,7 @@ In order to subscribe for messages, one needs to implement the `MessageListener`
 
 Due to its blocking nature, low-level subscription is not attractive as it requires connection and thread management for every single listener. To alleviate this problem, Spring Data offers `RedisMessageListenerContainer` which does all the heavy lifting on behalf of the user - users familiar with EJB and JMS should find the concepts familiar as it is designed as close as possible to the support in Spring Framework and its message-driven POJOs (MDPs)
 
-`RedisMessageListenerContainer` acts as a message listener container; it is used to receive messages from a Redis channel and drive the MessageListeners that are injected into it. The listener container is responsible for all threading of message reception and dispatches into the listener for processing. A message listener container is the intermediary between an MDP and a messaging provider, and takes care of registering to receive messages, resource acquisition and release, exception conversion and the like. This allows you as an application developer to write the (possibly complex) business logic associated with receiving a message (and reacting to it), and delegates boilerplate Redis infrastructure concerns to the framework.
+`RedisMessageListenerContainer` acts as a message listener container; it is used to receive messages from a Redis channel and drive the `MessageListener` s that are injected into it. The listener container is responsible for all threading of message reception and dispatches into the listener for processing. A message listener container is the intermediary between an MDP and a messaging provider, and takes care of registering to receive messages, resource acquisition and release, exception conversion and the like. This allows you as an application developer to write the (possibly complex) business logic associated with receiving a message (and reacting to it), and delegates boilerplate Redis infrastructure concerns to the framework.
 
 Furthermore, to minimize the application footprint, `RedisMessageListenerContainer` allows one connection and one thread to be shared by multiple listeners even though they do not share a subscription. Thus no matter how many listeners or channels an application tracks, the runtime cost will remain the same through out its lifetime. Moreover, the container allows runtime configuration changes so one can add or remove listeners while an application is running without the need for restart. Additionally, the container uses a lazy subscription approach, using a `RedisConnection` only when needed - if all the listeners are unsubscribed, cleanup is automatically performed and the used thread released.
 
@@ -51,7 +51,7 @@ To help with the asynch manner of messages, the container requires a `java.util.
 
 The `MessageListenerAdapter` class is the final component in Spring's asynchronous messaging support: in a nutshell, it allows you to expose almost *any* class as a MDP (there are of course some constraints).
 
-Consider the following interface definition. Notice that although the interface extends the `MessageListener` interface, it can still be used as a MDP via the use of the `MessageListenerAdapter` class. Notice also how the various message handling methods are strongly typed according to the *contents* of the various `Message` types that they can receive and handle. In addition, the channel or pattern to which a message is sent can be passed in to the method as the second argument of type String:
+Consider the following interface definition. Notice that although the interface doesn't extend the `MessageListener` interface, it can still be used as a MDP via the use of the `MessageListenerAdapter` class. Notice also how the various message handling methods are strongly typed according to the *contents* of the various `Message` types that they can receive and handle. In addition, the channel or pattern to which a message is sent can be passed in to the method as the second argument of type String:
 
 [source,java]
 ----

--- a/src/main/asciidoc/reference/redis-scripting.adoc
+++ b/src/main/asciidoc/reference/redis-scripting.adoc
@@ -41,7 +41,7 @@ public class Example {
  return false 
 ----
 
-The XML above configures a `DefaultRedisScript` pointing to a file called `checkandset.lua`, which is expected to return a boolean value. The script `resultType` should be one of Long, Boolean, List, or deserialized value type. It can also be null if the script returns a throw-away status (i.e "OK"). It is ideal to configure a single instance of `DefaultRedisScript` in your application context to avoid re-calculation of the script's SHA1 on every script execution.
+The XML above configures a `DefaultRedisScript` pointing to a file called `checkandset.lua`, which is expected to return a boolean value. The script `resultType` should be one of `Long`, `Boolean`, `List`, or deserialized value type. It can also be null if the script returns a throw-away status (i.e "OK"). It is ideal to configure a single instance of `DefaultRedisScript` in your application context to avoid re-calculation of the script's SHA1 on every script execution.
 
 The checkAndSet method above then executes th
 Scripts can be executed within a `SessionCallback` as part of a transaction or pipeline. See <<tx>> and <<pipeline>> for more information.

--- a/src/main/asciidoc/reference/redis-transactions.adoc
+++ b/src/main/asciidoc/reference/redis-transactions.adoc
@@ -27,7 +27,7 @@ NOTE: An important change has been made to the `exec` methods of `RedisConnectio
 [[tx.spring]]
 == @Transactional Support
 
-Transaction Support is disabled by default and has explicitly to be enabled for each `RedisTemplate` in use by setting `setEnableTransactionSupport(true)`. This will force binding the `RedisConnection` in use to the current `Thread` triggering `MULTI`. If the transaction finishes without errors, `EXEC` is called, otherwise `DISCARD`. Once in `MULTI`, `RedisConnection` would queue write operations, all `readonly` operations, such as `KEYS` are piped to a fresh (non thread bound) `RedisConnection`.
+Transaction Support is disabled by default and has to be explicitly enabled for each `RedisTemplate` in use by setting `setEnableTransactionSupport(true)`. This will force binding the `RedisConnection` in use to the current `Thread` triggering `MULTI`. If the transaction finishes without errors, `EXEC` is called, otherwise `DISCARD`. Once in `MULTI`, `RedisConnection` would queue write operations, all `readonly` operations, such as `KEYS` are piped to a fresh (non thread bound) `RedisConnection`.
 
 [source,java]
 ----

--- a/src/main/asciidoc/reference/redis.adoc
+++ b/src/main/asciidoc/reference/redis.adoc
@@ -39,7 +39,7 @@ NOTE: Depending on the underlying configuration, the factory can return a new co
 
 The easiest way to work with a `RedisConnectionFactory` is to configure the appropriate connector through the IoC container and inject it into the using class.
 
-IMPORTANT: Unfortunately, currently, not all connectors support all Redis features.  When invoking a method on the Connection` API that is unsupported by the underlying library, an `UnsupportedOperationException is thrown.
+IMPORTANT: Unfortunately, currently, not all connectors support all Redis features.  When invoking a method on the Connection API that is unsupported by the underlying library, an `UnsupportedOperationException is thrown.
   This situation is likely to be fixed in the future, as the various connectors mature.
 
 [[redis:connectors:jedis]]
@@ -95,7 +95,7 @@ A typical JRedis configuration can looks like this:
 </beans>
 ----
 
-The configuration is quite similar to Jedis, with one notable exception. By default, the `JredisConnectionFactory` pools connections. In order to use a connection pool with JRedis, configure the `JredisConnectionFactory` with an instance of `JredisPool`. For example:
+The configuration is quite similar to Jedis, with one notable exception. By default, the `JedisConnectionFactory` pools connections. In order to use a connection pool with JRedis, configure the `JredisConnectionFactory` with an instance of `JredisPool`. For example:
 
 [source,xml]
 ----
@@ -158,7 +158,7 @@ Its configuration is probably easy to guess:
 </beans>
 ----
 
-There are also a few Lettuce-specific connection parameters that can be tweaked. By default, all `LettuceConnections` created by the `LettuceConnectionFactory` share the same thread-safe native connection for all non-blocking and non-transactional operations. Set `shareNativeConnection` to false to use a dedicated connection each time. `LettuceConnectionFactory` can also be configured with a `LettucePool` to use for pooling blocking and transactional connections, or all connections if `shareNativeConnection` is set to false.
+There are also a few Lettuce-specific connection parameters that can be tweaked. By default, all `LettuceConnection` s created by the `LettuceConnectionFactory` share the same thread-safe native connection for all non-blocking and non-transactional operations. Set `shareNativeConnection` to false to use a dedicated connection each time. `LettuceConnectionFactory` can also be configured with a `LettucePool` to use for pooling blocking and transactional connections, or all connections if `shareNativeConnection` is set to false.
 
 [[redis:sentinel]]
 == Redis Sentinel Support
@@ -255,7 +255,7 @@ Moreover, the template provides operations views (following the grouping from Re
 
 Once configured, the template is thread-safe and can be reused across multiple instances.
 
-Out of the box, `RedisTemplate` uses a Java-based serializer for most of its operations. This means that any object written or read by the template will be serializer/deserialized through Java. The serialization mechanism can be easily changed on the template, and the Redis module offers several implementations available in the `org.springframework.data.redis.serializer` package - see <<redis:serializer>> for more information. You can also set any of the serializers to null and use RedisTemplate with raw `byte` arrays by setting the `enableDefaultSerializer` property to false. Note that the template requires all keys to be non-null - values can be null as long as the underlying serializer accepts them; read the javadoc of each serializer for more information.
+Out of the box, `RedisTemplate` uses a Java-based serializer for most of its operations. This means that any object written or read by the template will be serialized/deserialized through Java. The serialization mechanism can be easily changed on the template, and the Redis module offers several implementations available in the `org.springframework.data.redis.serializer` package - see <<redis:serializer>> for more information. You can also set any of the serializers to null and use RedisTemplate with raw `byte` arrays by setting the `enableDefaultSerializer` property to false. Note that the template requires all keys to be non-null - values can be null as long as the underlying serializer accepts them; read the javadoc of each serializer for more information.
 
 For cases where a certain template *view* is needed, declare the view as a dependency and inject the template: the container will automatically perform the conversion eliminating the `opsFor[X]` calls:
 
@@ -281,8 +281,9 @@ public class Example {
   
   // inject the actual template 
   @Autowired 
-  private RedisTemplate<String, String> template; // inject the template as ListOperations
-  
+  private RedisTemplate<String, String> template; 
+
+  // inject the template as ListOperations
   @Resource(name="redisTemplate") 
   private ListOperations<String, String> listOps;
 


### PR DESCRIPTION
There was a mistake in the documentation where it referenced
`JRedisConnectionFactory` having a default pooling. It should have
been `JedisConnectionFactory` instead. 

That was the only fix I initially  intended to make, but decided to do some
proof reading. I cleaned up some spelling and grammatical errors, and fixed
some highlighting.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.

Note: I just realized I didn't create a different branch. Let me know if it's a problem. I can remedy that.