### PR TITLE
DATAREDIS-479 - Upgrade to jedis to 2.8.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<xstream>1.4.8</xstream>
 		<pool>2.2</pool>
 		<lettuce>3.4.2.Final</lettuce>
-		<jedis>2.8.0</jedis>
+		<jedis>2.8.1</jedis>
 		<srp>0.7</srp>
 		<jredis>06052013</jredis>
 		<multithreadedtc>1.01</multithreadedtc>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAREDIS-479-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -42,6 +42,7 @@ import org.springframework.data.redis.connection.convert.ListConverter;
 import org.springframework.data.redis.connection.convert.MapConverter;
 import org.springframework.data.redis.connection.convert.SetConverter;
 import org.springframework.data.redis.connection.convert.StringToRedisClientInfoConverter;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.util.Assert;
@@ -51,6 +52,7 @@ import org.springframework.util.StringUtils;
 
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
 import redis.clients.jedis.BitOP;
+import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.SortingParams;
 import redis.clients.util.SafeEncoder;
 
@@ -432,4 +434,26 @@ abstract public class JedisConverters extends Converters {
 		return buffer.array();
 
 	}
+
+	/**
+	 * Convert {@link ScanOptions} to Jedis {@link ScanParams}.
+	 *
+	 * @param options
+	 * @return
+	 */
+	public static ScanParams toScanParams(ScanOptions options) {
+		
+		ScanParams sp = new ScanParams();
+		
+		if (!options.equals(ScanOptions.NONE)) {
+			if (options.getCount() != null) {
+				sp.count(options.getCount().intValue());
+			}
+			if (StringUtils.hasText(options.getPattern())) {
+				sp.match(options.getPattern());
+			}
+		}
+		return sp;
+	}
+
 }


### PR DESCRIPTION
Update jedis driver to 2.8.1. Use binary method for sscan and implement zscan and hscan methods. Move ScanOptions to ScanParams conversion to JedisConverters.