### PR TITLE
DATAREDIS-427 - Allow construction of customized JdkSerializationRedisSerializer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAREDIS-427-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/serializer/JdkSerializationRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/JdkSerializationRedisSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,53 @@ package org.springframework.data.redis.serializer;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.serializer.support.DeserializingConverter;
 import org.springframework.core.serializer.support.SerializingConverter;
+import org.springframework.util.Assert;
 
 /**
- * Java Serialization Redis serializer. Delegates to the default (Java based) serializer in Spring 3.
+ * Java Serialization Redis serializer. Delegates to the default (Java based) {@link DefaultSerializer serializer} and
+ * {@link DefaultDeserializer}. This {@link RedisSerializer serializer} can be constructed with either custom
+ * {@link ClassLoader} or own {@link Converter converters}.
  * 
  * @author Mark Pollack
  * @author Costin Leau
+ * @author Mark Paluch
  */
 public class JdkSerializationRedisSerializer implements RedisSerializer<Object> {
 
-	private Converter<Object, byte[]> serializer = new SerializingConverter();
-	private Converter<byte[], Object> deserializer = new DeserializingConverter();
+	private final Converter<Object, byte[]> serializer;
+	private final Converter<byte[], Object> deserializer;
+
+	/**
+	 * Creates a new {@link JdkSerializationRedisSerializer} using the default class loader.
+	 */
+	public JdkSerializationRedisSerializer() {
+		this(new SerializingConverter(), new DeserializingConverter());
+	}
+
+	/**
+	 * Creates a new {@link JdkSerializationRedisSerializer} using a {@link ClassLoader}.
+	 *
+	 * @param classLoader
+	 */
+	public JdkSerializationRedisSerializer(ClassLoader classLoader) {
+		this(new SerializingConverter(), new DeserializingConverter(classLoader));
+	}
+
+	/**
+	 * Creates a new {@link JdkSerializationRedisSerializer} using a {@link Converter converters} to serialize and
+	 * deserialize objects.
+	 * 
+	 * @param serializer must not be {@literal null}
+	 * @param deserializer must not be {@literal null}
+	 */
+	public JdkSerializationRedisSerializer(Converter<Object, byte[]> serializer, Converter<byte[], Object> deserializer) {
+
+		Assert.notNull("Serializer must not be null!");
+		Assert.notNull("Deserializer must not be null!");
+
+		this.serializer = serializer;
+		this.deserializer = deserializer;
+	}
 
 	public Object deserialize(byte[] bytes) {
 		if (SerializationUtils.isEmpty(bytes)) {

--- a/src/test/java/org/springframework/data/redis/serializer/SerializableDomainClass.java
+++ b/src/test/java/org/springframework/data/redis/serializer/SerializableDomainClass.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.serializer;
+
+import java.io.Serializable;
+
+/**
+ * @author Mark Paluch
+ */
+public class SerializableDomainClass implements Serializable {
+
+}


### PR DESCRIPTION
We now allow constructing JdkSerializationRedisSerializer using an own class loader and by specifying custom converters.

Using an own class-loader: `new JdkSerializationRedisSerializer(classLoader)`

Using own serializers: `new JdkSerializationRedisSerializer(new SerializingConverter(), new DeserializingConverter(new DefaultDeserializer(classLoader)))`

----

Related ticket: [DATAREDIS-427](https://jira.spring.io/browse/DATAREDIS-427)