### PR TITLE
DATAREDIS-469 - Throw DataRetrievalFailureException for atomic numbers when key is removed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.7.0.BUILD-SNAPSHOT</version>
+	<version>1.7.0.DATAREDIS-469-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -36,10 +36,11 @@ import org.springframework.util.Assert;
 /**
  * Atomic double backed by Redis. Uses Redis atomic increment/decrement and watch/multi/exec operations for CAS
  * operations.
- * 
+ *
  * @author Jennifer Hickey
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class RedisAtomicDouble extends Number implements Serializable, BoundKeyOperations<String> {
 
@@ -51,7 +52,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Constructs a new <code>RedisAtomicDouble</code> instance. Uses the value existing in Redis or 0 if none is found.
-	 * 
+	 *
 	 * @param redisCounter redis counter
 	 * @param factory connection factory
 	 */
@@ -61,7 +62,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Constructs a new <code>RedisAtomicDouble</code> instance.
-	 * 
+	 *
 	 * @param redisCounter
 	 * @param factory
 	 * @param initialValue
@@ -96,7 +97,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Constructs a new <code>RedisAtomicDouble</code> instance. Uses the value existing in Redis or 0 if none is found.
-	 * 
+	 *
 	 * @param redisCounter the redis counter
 	 * @param template the template
 	 * @see #RedisAtomicDouble(String, RedisConnectionFactory, double)
@@ -110,7 +111,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 	 * with appropriate {@link RedisSerializer} for the key and value. As an alternative one could use the
 	 * {@link #RedisAtomicDouble(String, RedisConnectionFactory, Double)} constructor which uses appropriate default
 	 * serializers.
-	 * 
+	 *
 	 * @param redisCounter the redis counter
 	 * @param template the template
 	 * @param initialValue the initial value
@@ -141,7 +142,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Gets the current value.
-	 * 
+	 *
 	 * @return the current value
 	 */
 	public double get() {
@@ -156,7 +157,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Sets to the given value.
-	 * 
+	 *
 	 * @param newValue the new value
 	 */
 	public void set(double newValue) {
@@ -165,17 +166,23 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Atomically sets to the given value and returns the old value.
-	 * 
+	 *
 	 * @param newValue the new value
 	 * @return the previous value
 	 */
 	public double getAndSet(double newValue) {
-		return operations.getAndSet(key, newValue);
+
+		Double value = operations.getAndSet(key, newValue);
+		if (value != null) {
+			return value.doubleValue();
+		}
+
+		return 0;
 	}
 
 	/**
 	 * Atomically sets the value to the given updated value if the current value {@code ==} the expected value.
-	 * 
+	 *
 	 * @param expect the expected value
 	 * @param update the new value
 	 * @return true if successful. False return indicates that the actual value was not equal to the expected value.
@@ -204,7 +211,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Atomically increments by one the current value.
-	 * 
+	 *
 	 * @return the previous value
 	 */
 	public double getAndIncrement() {
@@ -213,7 +220,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Atomically decrements by one the current value.
-	 * 
+	 *
 	 * @return the previous value
 	 */
 	public double getAndDecrement() {
@@ -222,7 +229,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Atomically adds the given value to the current value.
-	 * 
+	 *
 	 * @param delta the value to add
 	 * @return the previous value
 	 */
@@ -232,7 +239,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Atomically increments by one the current value.
-	 * 
+	 *
 	 * @return the updated value
 	 */
 	public double incrementAndGet() {
@@ -241,7 +248,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Atomically decrements by one the current value.
-	 * 
+	 *
 	 * @return the updated value
 	 */
 	public double decrementAndGet() {
@@ -250,7 +257,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Atomically adds the given value to the current value.
-	 * 
+	 *
 	 * @param delta the value to add
 	 * @return the updated value
 	 */
@@ -260,7 +267,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 	/**
 	 * Returns the String representation of the current value.
-	 * 
+	 *
 	 * @return the String representation of the current value.
 	 */
 	public String toString() {

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.BoundKeyOperations;
@@ -38,6 +39,7 @@ import org.springframework.util.Assert;
  * 
  * @author Jennifer Hickey
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 public class RedisAtomicDouble extends Number implements Serializable, BoundKeyOperations<String> {
 
@@ -143,7 +145,13 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 	 * @return the current value
 	 */
 	public double get() {
-		return operations.get(key);
+
+		Double value = operations.get(key);
+		if (value != null) {
+			return value.doubleValue();
+		}
+
+		throw new DataRetrievalFailureException(String.format("The key '%s' seems to no longer exist.", key));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.BoundKeyOperations;
@@ -39,6 +40,7 @@ import org.springframework.util.Assert;
  * @see java.util.concurrent.atomic.AtomicInteger
  * @author Costin Leau
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 public class RedisAtomicInteger extends Number implements Serializable, BoundKeyOperations<String> {
 
@@ -141,7 +143,13 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	 * @return the current value
 	 */
 	public int get() {
-		return Integer.valueOf(operations.get(key));
+
+		Integer value = operations.get(key);
+		if (value != null) {
+			return value.intValue();
+		}
+
+		throw new DataRetrievalFailureException(String.format("The key '%s' seems to no longer exist.", key));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011-2016 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,11 +36,12 @@ import org.springframework.util.Assert;
 /**
  * Atomic integer backed by Redis. Uses Redis atomic increment/decrement and watch/multi/exec operations for CAS
  * operations.
- * 
+ *
  * @see java.util.concurrent.atomic.AtomicInteger
  * @author Costin Leau
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class RedisAtomicInteger extends Number implements Serializable, BoundKeyOperations<String> {
 
@@ -52,7 +53,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Constructs a new <code>RedisAtomicInteger</code> instance. Uses the value existing in Redis or 0 if none is found.
-	 * 
+	 *
 	 * @param redisCounter redis counter
 	 * @param factory connection factory
 	 */
@@ -62,7 +63,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Constructs a new <code>RedisAtomicInteger</code> instance.
-	 * 
+	 *
 	 * @param redisCounter the redis counter
 	 * @param factory the factory
 	 * @param initialValue the initial value
@@ -73,7 +74,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Constructs a new <code>RedisAtomicInteger</code> instance. Uses the value existing in Redis or 0 if none is found.
-	 * 
+	 *
 	 * @param redisCounter the redis counter
 	 * @param template the template
 	 * @see #RedisAtomicInteger(String, RedisConnectionFactory, int)
@@ -87,7 +88,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	 * with appropriate {@link RedisSerializer} for the key and value. As an alternative one could use the
 	 * {@link #RedisAtomicInteger(String, RedisConnectionFactory, Integer)} constructor which uses appropriate default
 	 * serializers.
-	 * 
+	 *
 	 * @param redisCounter the redis counter
 	 * @param template the template
 	 * @param initialValue the initial value
@@ -139,7 +140,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Get the current value.
-	 * 
+	 *
 	 * @return the current value
 	 */
 	public int get() {
@@ -154,7 +155,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Set to the given value.
-	 * 
+	 *
 	 * @param newValue the new value
 	 */
 	public void set(int newValue) {
@@ -163,17 +164,23 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Set to the give value and return the old value.
-	 * 
+	 *
 	 * @param newValue the new value
 	 * @return the previous value
 	 */
 	public int getAndSet(int newValue) {
-		return operations.getAndSet(key, newValue);
+
+		Integer value = operations.getAndSet(key, newValue);
+		if (value != null) {
+			return value.intValue();
+		}
+
+		return 0;
 	}
 
 	/**
 	 * Atomically set the value to the given updated value if the current value <tt>==</tt> the expected value.
-	 * 
+	 *
 	 * @param expect the expected value
 	 * @param update the new value
 	 * @return true if successful. False return indicates that the actual value was not equal to the expected value.
@@ -202,7 +209,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Atomically increment by one the current value.
-	 * 
+	 *
 	 * @return the previous value
 	 */
 	public int getAndIncrement() {
@@ -211,7 +218,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Atomically decrement by one the current value.
-	 * 
+	 *
 	 * @return the previous value
 	 */
 	public int getAndDecrement() {
@@ -220,7 +227,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Atomically add the given value to current value.
-	 * 
+	 *
 	 * @param delta the value to add
 	 * @return the previous value
 	 */
@@ -230,7 +237,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Atomically increment by one the current value.
-	 * 
+	 *
 	 * @return the updated value
 	 */
 	public int incrementAndGet() {
@@ -239,7 +246,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Atomically decrement by one the current value.
-	 * 
+	 *
 	 * @return the updated value
 	 */
 	public int decrementAndGet() {
@@ -248,7 +255,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Atomically add the given value to current value.
-	 * 
+	 *
 	 * @param delta the value to add
 	 * @return the updated value
 	 */
@@ -258,7 +265,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 	/**
 	 * Returns the String representation of the current value.
-	 * 
+	 *
 	 * @return the String representation of the current value.
 	 */
 	public String toString() {

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.BoundKeyOperations;
@@ -39,6 +40,7 @@ import org.springframework.util.Assert;
  * @see java.util.concurrent.atomic.AtomicLong
  * @author Costin Leau
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 public class RedisAtomicLong extends Number implements Serializable, BoundKeyOperations<String> {
 
@@ -149,7 +151,13 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 	 * @return the current value
 	 */
 	public long get() {
-		return operations.get(key);
+
+		Long value = operations.get(key);
+		if (value != null) {
+			return value.longValue();
+		}
+
+		throw new DataRetrievalFailureException(String.format("The key '%s' seems to no longer exist.", key));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011-2016 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,11 +36,12 @@ import org.springframework.util.Assert;
 /**
  * Atomic long backed by Redis. Uses Redis atomic increment/decrement and watch/multi/exec operations for CAS
  * operations.
- * 
+ *
  * @see java.util.concurrent.atomic.AtomicLong
  * @author Costin Leau
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class RedisAtomicLong extends Number implements Serializable, BoundKeyOperations<String> {
 
@@ -52,7 +53,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Constructs a new <code>RedisAtomicLong</code> instance. Uses the value existing in Redis or 0 if none is found.
-	 * 
+	 *
 	 * @param redisCounter redis counter
 	 * @param factory connection factory
 	 */
@@ -62,7 +63,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Constructs a new <code>RedisAtomicLong</code> instance.
-	 * 
+	 *
 	 * @param redisCounter
 	 * @param factory
 	 * @param initialValue
@@ -97,7 +98,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Constructs a new <code>RedisAtomicLong</code> instance. Uses the value existing in Redis or 0 if none is found.
-	 * 
+	 *
 	 * @param redisCounter the redis counter
 	 * @param template the template
 	 * @see #RedisAtomicLong(String, RedisConnectionFactory, long)
@@ -116,7 +117,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 	 * As an alternative one could use the {@link #RedisAtomicLong(String, RedisConnectionFactory, Long)} constructor
 	 * which uses appropriate default serializers, in this case {@link StringRedisSerializer} for the key and
 	 * {@link GenericToStringSerializer} for the value.
-	 * 
+	 *
 	 * @param redisCounter the redis counter
 	 * @param template the template
 	 * @param initialValue the initial value
@@ -147,7 +148,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Gets the current value.
-	 * 
+	 *
 	 * @return the current value
 	 */
 	public long get() {
@@ -162,7 +163,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Sets to the given value.
-	 * 
+	 *
 	 * @param newValue the new value
 	 */
 	public void set(long newValue) {
@@ -171,17 +172,23 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Atomically sets to the given value and returns the old value.
-	 * 
+	 *
 	 * @param newValue the new value
 	 * @return the previous value
 	 */
 	public long getAndSet(long newValue) {
-		return operations.getAndSet(key, newValue);
+
+		Long value = operations.getAndSet(key, newValue);
+		if (value != null) {
+			return value.longValue();
+		}
+
+		return 0;
 	}
 
 	/**
 	 * Atomically sets the value to the given updated value if the current value {@code ==} the expected value.
-	 * 
+	 *
 	 * @param expect the expected value
 	 * @param update the new value
 	 * @return true if successful. False return indicates that the actual value was not equal to the expected value.
@@ -210,7 +217,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Atomically increments by one the current value.
-	 * 
+	 *
 	 * @return the previous value
 	 */
 	public long getAndIncrement() {
@@ -219,7 +226,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Atomically decrements by one the current value.
-	 * 
+	 *
 	 * @return the previous value
 	 */
 	public long getAndDecrement() {
@@ -228,7 +235,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Atomically adds the given value to the current value.
-	 * 
+	 *
 	 * @param delta the value to add
 	 * @return the previous value
 	 */
@@ -238,7 +245,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Atomically increments by one the current value.
-	 * 
+	 *
 	 * @return the updated value
 	 */
 	public long incrementAndGet() {
@@ -247,7 +254,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Atomically decrements by one the current value.
-	 * 
+	 *
 	 * @return the updated value
 	 */
 	public long decrementAndGet() {
@@ -256,7 +263,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Atomically adds the given value to the current value.
-	 * 
+	 *
 	 * @param delta the value to add
 	 * @return the updated value
 	 */
@@ -266,7 +273,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 	/**
 	 * Returns the String representation of the current value.
-	 * 
+	 *
 	 * @return the String representation of the current value.
 	 */
 	public String toString() {

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicIntegerTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicIntegerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.connection.ConnectionUtils;
 import org.springframework.data.redis.connection.RedisConnection;
@@ -44,6 +45,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * @author Costin Leau
  * @author Jennifer Hickey
  * @author Thomas Darimont
+ * @author Christoph Strobl
  */
 @RunWith(Parameterized.class)
 public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
@@ -179,5 +181,29 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		ral.set(32);
 
 		assertThat(ral.get(), is(32));
+	}
+
+	/**
+	 * @see DATAREDIS-469
+	 */
+	@Test
+	public void getThrowsExceptionWhenKeyHasBeenRemoved() {
+
+		expectedException.expect(DataRetrievalFailureException.class);
+		expectedException.expectMessage("'test' seems to no longer exist");
+
+		// setup long
+		RedisAtomicInteger test = new RedisAtomicInteger("test", factory, 1);
+		assertThat(test.get(), equalTo(1)); // this passes
+
+		RedisTemplate<String, Long> template = new RedisTemplate<String, Long>();
+		template.setConnectionFactory(factory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GenericToStringSerializer<Long>(Long.class));
+		template.afterPropertiesSet();
+
+		template.delete("test");
+
+		test.get();
 	}
 }


### PR DESCRIPTION
We now throw `DataRetrievalFailureException` in case of `get()` when the underlying key storing the value of an `AtomicInteger`, `AtomicLong` or `AtomicDouble` is removed from Redis.