### PR TITLE
DATAREDIS-438 Add support for geo commands.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -280,6 +280,14 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 		delegate.flushDb();
 	}
 
+    public Long geoAdd(byte[] key, double longitude, double latitude, byte[] member){
+        Long result = delegate.geoAdd(key, longitude, latitude, member);
+        if (isFutureConversion()){
+            addResultConverter(identityConverter);
+        }
+        return result;
+    }
+
 	public byte[] get(byte[] key) {
 		byte[] result = delegate.get(key);
 		if (isFutureConversion()) {
@@ -1506,6 +1514,10 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 		}
 		return result;
 	}
+
+    public Long geoAdd(String key, double longitude, double latitude, String member){
+        return delegate.geoAdd(serialize(key), longitude, latitude, serialize(member));
+    }
 
 	public String get(String key) {
 		byte[] result = delegate.get(serialize(key));

--- a/src/main/java/org/springframework/data/redis/connection/RedisCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisCommands.java
@@ -24,7 +24,7 @@ package org.springframework.data.redis.connection;
  */
 public interface RedisCommands extends RedisKeyCommands, RedisStringCommands, RedisListCommands, RedisSetCommands,
 		RedisZSetCommands, RedisHashCommands, RedisTxCommands, RedisPubSubCommands, RedisConnectionCommands,
-		RedisServerCommands, RedisScriptingCommands, HyperLogLogCommands {
+		RedisServerCommands, RedisScriptingCommands, RedisGeoCommands, HyperLogLogCommands {
 
 	/**
 	 * 'Native' or 'raw' execution of the given command along-side the given arguments. The command is executed as is,

--- a/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+/**
+ * Geo-specific Redis commands.
+ *
+ * @author Ninad Divadkar
+ */
+public interface RedisGeoCommands {
+    /**
+     * Add latitude and longitude for a given key with a name.
+     * Returns the number of elements added to the sorted set, not including elements already existing for which the
+     * score was updated.
+     * <p>
+     * @see http://redis.io/commands/geoadd
+     *
+     * @param key
+     * @param member
+     * @param longitude
+     * @param latitude
+     * @return
+     */
+    Long geoAdd(byte[] key, double longitude, double latitude, byte[] member);
+}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -2511,6 +2511,15 @@ public class JedisClusterConnection implements RedisClusterConnection {
 		}
 	}
 
+    @Override
+    public Long geoAdd(byte[] key, double longitude, double latitude, byte[] member){
+        try {
+            return cluster.geoadd(key, longitude, latitude, member);
+        } catch (Exception ex) {
+            throw convertJedisAccessException(ex);
+        }
+    }
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisConnectionCommands#select(int)

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -3078,6 +3078,28 @@ public class JedisConnection extends AbstractRedisConnection {
 		}
 	}
 
+    //
+    // Geo commands
+    //
+
+    public Long geoAdd(byte[] key, double longitude, double latitude, byte[] member){
+        try {
+            if (isPipelined()) {
+                pipeline(new JedisResult(pipeline.geoadd(key, longitude, latitude, member)));
+                return null;
+            }
+            if (isQueueing()) {
+                transaction(new JedisResult(transaction.geoadd(key, longitude, latitude, member)));
+                return null;
+            }
+
+            return jedis.geoadd(key, longitude, latitude, member);
+        } catch (Exception ex) {
+            throw convertJedisAccessException(ex);
+        }
+    }
+
+
 	//
 	// Scripting commands
 	//

--- a/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnection.java
@@ -1187,13 +1187,23 @@ public class JredisConnection extends AbstractRedisConnection {
 		throw new UnsupportedOperationException();
 	}
 
-	//
+    public void subscribe(MessageListener listener, byte[]... channels) {
+        throw new UnsupportedOperationException();
+    }
+
+    //
+    // Geo commands
+    //
+
+    @Override
+    public Long geoAdd(byte[] key, double longitude, double latitude, byte[] member) {
+        throw new UnsupportedOperationException();
+    }
+
+
+    //
 	// Scripting commands
 	//
-
-	public void subscribe(MessageListener listener, byte[]... channels) {
-		throw new UnsupportedOperationException();
-	}
 
 	public void scriptFlush() {
 		throw new UnsupportedOperationException();

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -3079,6 +3079,26 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
+    //
+    // Geo functionality
+    //
+    @Override
+    public Long geoAdd(byte[] key, double longitude, double latitude, byte[] member) {
+        try {
+            if (isPipelined()) {
+                pipeline(new LettuceResult(getAsyncConnection().geoadd(key, longitude, latitude, member)));
+                return null;
+            }
+            if (isQueueing()) {
+                transaction(new LettuceTxResult(getConnection().geoadd(key, longitude, latitude, member)));
+                return null;
+            }
+            return getConnection().geoadd(key, longitude, latitude, member);
+        } catch (Exception ex) {
+            throw convertLettuceAccessException(ex);
+        }
+    }
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisServerCommands#time()

--- a/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
@@ -2241,7 +2241,12 @@ public class SrpConnection extends AbstractRedisConnection {
 		}
 	}
 
-	/**
+    @Override
+    public Long geoAdd(byte[] key, double longitude, double latitude, byte[] member) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
 	 * Specifies if pipelined results should be converted to the expected data type. If false, results of
 	 * {@link #closePipeline()} and {@link #exec()} will be of the type returned by the Lettuce driver
 	 * 

--- a/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2011-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+/**
+ * Hash operations bound to a certain key.
+ *
+ * @author Ninad Divadkar
+ */
+public interface BoundGeoOperations<K,M> extends BoundKeyOperations<K> {
+    Long geoAdd(K key, double longitude, double latitude, M member);
+}

--- a/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
@@ -52,7 +52,7 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 
 	Long size();
 
-	void delete(Object... keys);
+	Long delete(Object... keys);
 
 	Map<HK, HV> entries();
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultBoundGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultBoundGeoOperations.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import org.springframework.data.redis.connection.DataType;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Ninad Divadkar
+ */
+class DefaultBoundGeoOperations<K, M> extends DefaultBoundKeyOperations<K> implements BoundGeoOperations<K, M> {
+
+	private final GeoOperations<K, M> ops;
+
+	/**
+	 * Constructs a new <code>DefaultBoundGeoOperations</code> instance.
+	 *
+	 * @param key
+	 * @param operations
+	 */
+	public DefaultBoundGeoOperations(K key, RedisOperations<K, M> operations) {
+		super(key, operations);
+		this.ops = operations.opsForGeo();
+	}
+
+    @Override
+    public Long geoAdd(K key, double longitude, double latitude, M member) {
+        return ops.geoAdd(key, longitude, latitude, member);
+    }
+
+    @Override
+    public DataType getType() {
+        return DataType.STRING;
+    }
+}

--- a/src/main/java/org/springframework/data/redis/core/DefaultBoundHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultBoundHashOperations.java
@@ -38,15 +38,15 @@ class DefaultBoundHashOperations<H, HK, HV> extends DefaultBoundKeyOperations<H>
 	 * Constructs a new <code>DefaultBoundHashOperations</code> instance.
 	 * 
 	 * @param key
-	 * @param template
+	 * @param operations
 	 */
 	public DefaultBoundHashOperations(H key, RedisOperations<H, ?> operations) {
 		super(key, operations);
 		this.ops = operations.opsForHash();
 	}
 
-	public void delete(Object... keys) {
-		ops.delete(getKey(), keys);
+	public Long delete(Object... keys) {
+		return ops.delete(getKey(), keys);
 	}
 
 	public HV get(Object key) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultGeoOperations.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2011-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import org.springframework.data.redis.connection.RedisConnection;
+
+/**
+ * Default implementation of {@link GeoOperations}.
+ *
+ * @author Ninad Divadkar
+ */
+public class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements GeoOperations<K, M> {
+    DefaultGeoOperations(RedisTemplate<K, M> template) {
+        super(template);
+    }
+
+    @Override
+    public Long geoAdd(K key, final double longitude, final double latitude, M member) {
+        final byte[] rawKey = rawKey(key);
+        final byte[] rawMember = rawValue(member);
+
+        return execute(new RedisCallback<Long>() {
+
+            public Long doInRedis(RedisConnection connection) {
+                return connection.geoAdd(rawKey, longitude, latitude, rawMember);
+            }
+        }, true);
+    }
+}

--- a/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
@@ -201,15 +201,14 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 		return deserializeHashValues(rawValues);
 	}
 
-	public void delete(K key, Object... hashKeys) {
+	public Long delete(K key, Object... hashKeys) {
 		final byte[] rawKey = rawKey(key);
 		final byte[][] rawHashKeys = rawHashKeys(hashKeys);
 
-		execute(new RedisCallback<Object>() {
+		return execute(new RedisCallback<Long>() {
 
-			public Object doInRedis(RedisConnection connection) {
-				connection.hDel(rawKey, rawHashKeys);
-				return null;
+			public Long doInRedis(RedisConnection connection) {
+				return connection.hDel(rawKey, rawHashKeys);
 			}
 		}, true);
 	}

--- a/src/main/java/org/springframework/data/redis/core/GeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/GeoOperations.java
@@ -16,7 +16,7 @@
 package org.springframework.data.redis.core;
 
 /**
- * Redis operations for simple (or in Redis terminology 'string') values.
+ * Redis operations for geo commands.
  *
  * @author Ninad Divadkar
  */

--- a/src/main/java/org/springframework/data/redis/core/GeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/GeoOperations.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2011-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+/**
+ * Redis operations for simple (or in Redis terminology 'string') values.
+ *
+ * @author Ninad Divadkar
+ */
+public interface GeoOperations<K, M> {
+    Long geoAdd(K key, double longitude, double latitude, M member);
+}

--- a/src/main/java/org/springframework/data/redis/core/GeoOperationsEditor.java
+++ b/src/main/java/org/springframework/data/redis/core/GeoOperationsEditor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import java.beans.PropertyEditorSupport;
+
+/**
+ * PropertyEditor allowing for easy injection of {@link org.springframework.data.redis.core.GeoOperations} from {@link org.springframework.data.redis.core.RedisOperations}.
+ *
+ * @author Ninad Divadkar
+ */
+class GeoOperationsEditor extends PropertyEditorSupport {
+
+	public void setValue(Object value) {
+		if (value instanceof RedisOperations) {
+			super.setValue(((RedisOperations) value).opsForGeo());
+		} else {
+			throw new IllegalArgumentException("Editor supports only conversion of type " + RedisOperations.class);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/HashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/HashOperations.java
@@ -28,7 +28,7 @@ import java.util.Set;
  */
 public interface HashOperations<H, HK, HV> {
 
-	void delete(H key, Object... hashKeys);
+	Long delete(H key, Object... hashKeys);
 
 	Boolean hasKey(H key, Object hashKey);
 

--- a/src/main/java/org/springframework/data/redis/core/RedisCommand.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisCommand.java
@@ -78,6 +78,7 @@ public enum RedisCommand {
 	GETBIT("r", 2, 2), //
 	GETRANGE("r", 3, 3), //
 	GETSET("rw", 2, 2), //
+    GEOADD("w", 3, 2),
 	// -- H
 	HDEL("rw", 2), //
 	HEXISTS("r", 2, 2), //

--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -283,6 +283,21 @@ public interface RedisOperations<K, V> {
 	 */
 	<HK, HV> BoundHashOperations<K, HK, HV> boundHashOps(K key);
 
+    /**
+     * Returns the operations performed on geo values.
+     *
+     * @return geo operations
+     */
+    GeoOperations<K, V> opsForGeo();
+
+    /**
+     * Returns the operations performed on hash values bound to the given key.
+     *
+     * @param key Redis key
+     * @return hash operations bound to the given key.
+     */
+    BoundGeoOperations<K, V> boundGeoOps(K key);
+
 	/**
 	 * Returns the cluster specific operations interface.
 	 * 

--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -291,10 +291,10 @@ public interface RedisOperations<K, V> {
     GeoOperations<K, V> opsForGeo();
 
     /**
-     * Returns the operations performed on hash values bound to the given key.
+     * Returns the operations performed on values bound to the given key.
      *
      * @param key Redis key
-     * @return hash operations bound to the given key.
+     * @return geo operations bound to the given key.
      */
     BoundGeoOperations<K, V> boundGeoOps(K key);
 

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -96,6 +96,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	private ListOperations<K, V> listOps;
 	private SetOperations<K, V> setOps;
 	private ZSetOperations<K, V> zSetOps;
+    private GeoOperations<K, V> geoOps;
 	private HyperLogLogOperations<K, V> hllOps;
 
 	/**
@@ -995,10 +996,23 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 		return zSetOps;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.RedisOperations#opsForHyperLogLog()
-	 */
+    @Override
+    public GeoOperations<K, V> opsForGeo() {
+        if (geoOps == null) {
+            geoOps = new DefaultGeoOperations<K, V>(this);
+        }
+        return geoOps;
+    }
+
+    @Override
+    public BoundGeoOperations<K, V> boundGeoOps(K key) {
+        return new DefaultBoundGeoOperations<K, V>(key, this);
+    }
+
+    /*
+         * (non-Javadoc)
+         * @see org.springframework.data.redis.core.RedisOperations#opsForHyperLogLog()
+         */
 	@Override
 	public HyperLogLogOperations<K, V> opsForHyperLogLog() {
 

--- a/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
@@ -260,7 +260,11 @@ public class RedisConnectionUnitTests {
 			delegate.subscribe(listener, channels);
 		}
 
-		public Set<byte[]> keys(byte[] pattern) {
+        public Long geoAdd(byte[] key, double longitude, double latitude, byte[] member) {
+            return delegate.geoAdd(key, longitude, latitude, member);
+        }
+
+        public Set<byte[]> keys(byte[] pattern) {
 			return delegate.keys(pattern);
 		}
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
@@ -36,26 +36,23 @@ import static org.springframework.data.redis.SpinBarrier.waitFor;
 import static org.springframework.data.redis.matcher.RedisTestMatchers.isEqual;
 
 /**
- * Integration test of {@link org.springframework.data.redis.core.DefaultValueOperations}
+ * Integration test of {@link org.springframework.data.redis.core.DefaultGeoOperations}
  *
- * @author Jennifer Hickey
- * @author Christoph Strobl
- * @author David Liu
- * @author Thomas Darimont
+ * @author Ninad Divadkar
  */
 @RunWith(Parameterized.class)
-public class DefaultGeoOperationsTests<K, V> {
+public class DefaultGeoOperationsTests<K, M> {
 
-	private RedisTemplate<K, V> redisTemplate;
+	private RedisTemplate<K, M> redisTemplate;
 
 	private ObjectFactory<K> keyFactory;
 
-	private ObjectFactory<V> valueFactory;
+	private ObjectFactory<M> valueFactory;
 
-	private GeoOperations<K, V> geoOperations;
+	private GeoOperations<K, M> geoOperations;
 
-	public DefaultGeoOperationsTests(RedisTemplate<K, V> redisTemplate, ObjectFactory<K> keyFactory,
-                                     ObjectFactory<V> valueFactory) {
+	public DefaultGeoOperationsTests(RedisTemplate<K, M> redisTemplate, ObjectFactory<K> keyFactory,
+                                     ObjectFactory<M> valueFactory) {
 		this.redisTemplate = redisTemplate;
 		this.keyFactory = keyFactory;
 		this.valueFactory = valueFactory;
@@ -84,7 +81,7 @@ public class DefaultGeoOperationsTests<K, V> {
 	@Test
 	public void testGeoAdd() throws Exception {
 		K key = keyFactory.instance();
-		V v1 = valueFactory.instance();
+        M v1 = valueFactory.instance();
 		Long numAdded = geoOperations.geoAdd(key, 13.361389, 38.115556, v1);
 		assertEquals(numAdded.longValue(), 1L);
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.data.redis.ObjectFactory;
+import org.springframework.data.redis.RedisTestProfileValueSource;
+import org.springframework.data.redis.TestCondition;
+import org.springframework.data.redis.connection.RedisConnection;
+
+import java.text.DecimalFormat;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+import static org.springframework.data.redis.SpinBarrier.waitFor;
+import static org.springframework.data.redis.matcher.RedisTestMatchers.isEqual;
+
+/**
+ * Integration test of {@link org.springframework.data.redis.core.DefaultValueOperations}
+ *
+ * @author Jennifer Hickey
+ * @author Christoph Strobl
+ * @author David Liu
+ * @author Thomas Darimont
+ */
+@RunWith(Parameterized.class)
+public class DefaultGeoOperationsTests<K, V> {
+
+	private RedisTemplate<K, V> redisTemplate;
+
+	private ObjectFactory<K> keyFactory;
+
+	private ObjectFactory<V> valueFactory;
+
+	private GeoOperations<K, V> geoOperations;
+
+	public DefaultGeoOperationsTests(RedisTemplate<K, V> redisTemplate, ObjectFactory<K> keyFactory,
+                                     ObjectFactory<V> valueFactory) {
+		this.redisTemplate = redisTemplate;
+		this.keyFactory = keyFactory;
+		this.valueFactory = valueFactory;
+	}
+
+	@Parameters
+	public static Collection<Object[]> testParams() {
+		return AbstractOperationsTestParams.testParams();
+	}
+
+	@Before
+	public void setUp() {
+		geoOperations = redisTemplate.opsForGeo();
+	}
+
+	@After
+	public void tearDown() {
+		redisTemplate.execute(new RedisCallback<Object>() {
+			public Object doInRedis(RedisConnection connection) {
+				connection.flushDb();
+				return null;
+			}
+		});
+	}
+
+	@Test
+	public void testGeoAdd() throws Exception {
+		K key = keyFactory.instance();
+		V v1 = valueFactory.instance();
+		Long numAdded = geoOperations.geoAdd(key, 13.361389, 38.115556, v1);
+		assertEquals(numAdded.longValue(), 1L);
+
+//        numAdded = geoOperations.geoAdd("Sicily", 15.087269, 37.502669, "Catania");
+//		assertEquals(numAdded.longValue(), 2L);
+	}
+}

--- a/src/test/java/org/springframework/data/redis/core/DefaultHashOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultHashOperationsTests.java
@@ -134,8 +134,9 @@ public class DefaultHashOperationsTests<K, HK, HV> {
 		HV val2 = hashValueFactory.instance();
 		hashOps.put(key, key1, val1);
 		hashOps.put(key, key2, val2);
-		hashOps.delete(key, key1, key2);
+		Long numDeleted = hashOps.delete(key, key1, key2);
 		assertTrue(hashOps.keys(key).isEmpty());
+        assertEquals(2L, numDeleted.longValue());
 	}
 
 	/**


### PR DESCRIPTION
Added support for Geo operations. Currently supports only the GEOADD command. If the pull request is up to standards, I can add other commands.
Major changes:
Added GeoOperations interface and RedisGeoCommands interface. 
RedisCommands interface now extends the RedisGeoCommands interface.
Added opsForGeo() to RedisTemplate.
Added DefaultGeoOperations and DefaultGeoOperationsTests