### PR TITLE
DATAREDIS-492 - Handle serializing arrays and collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-492-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 


### PR DESCRIPTION
When serializing complex structures that include lists AND arrays, Spring Data Redis breaks down by assuming all "collectionLike" structures implement the Collection interface. This commit includes a test case that reproduces this problem along with a patch to handle both collections and arrays that both identify as "collectionLike".