### PR TITLE
DATAREDIS-500 - executePipelined with RedisCallback uses wrong serializer (RedisTemplate.java)

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -273,7 +273,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 					}
 					List<Object> closePipeline = connection.closePipeline();
 					pipelinedClosed = true;
-					return deserializeMixedResults(closePipeline, resultSerializer, resultSerializer, resultSerializer);
+					return deserializeMixedResults(closePipeline, resultSerializer, hashKeySerializer, hashValueSerializer);
 				} finally {
 					if (!pipelinedClosed) {
 						connection.closePipeline();

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -317,7 +317,7 @@ public class RedisTemplateTests<K, V> {
 
 	@Test
 	public void testExecutePipelinedWidthDifferentHashKeySerializerAndHashValueSerializer() {
-		assumeFalse(redisTemplate.getConnectionFactory() instanceof JedisClusterConnection);
+		assumeTrue(redisTemplate instanceof StringRedisTemplate);
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashValueSerializer(new GenericToStringSerializer<Long>(Long.class));

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -314,6 +314,22 @@ public class RedisTemplateTests<K, V> {
 		assertEquals(Arrays.asList(new Object[] { 5l, 1l, 2l, Arrays.asList(new Long[] { 10l, 11l }) }), results);
 	}
 
+	@Test
+	public void testExecutePipelinedWidthDifferentHashKeySerializerAndHashValueSerializer() {
+		assumeTrue(redisTemplate instanceof RedisTemplate);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashValueSerializer(new GenericToStringSerializer<Long>(Long.class));
+		redisTemplate.opsForHash().put((K) "foo", "key", 1L);
+		List<Object> results = redisTemplate.executePipelined(new RedisCallback() {
+			public Object doInRedis(RedisConnection connection) throws DataAccessException {
+				connection.hGetAll(((StringRedisSerializer) redisTemplate.getKeySerializer()).serialize("foo"));
+				return null;
+			}
+		});
+		assertEquals(((Map) results.get(0)).get("key"), 1L);
+	}
+
 	@Test(expected = InvalidDataAccessApiUsageException.class)
 	public void testExecutePipelinedNonNullRedisCallback() {
 		redisTemplate.executePipelined(new RedisCallback<String>() {

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -51,6 +51,7 @@ import org.springframework.data.redis.TestCondition;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.connection.jedis.JedisClusterConnection;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.connection.jredis.JredisConnectionFactory;
 import org.springframework.data.redis.connection.srp.SrpConnectionFactory;
@@ -316,7 +317,7 @@ public class RedisTemplateTests<K, V> {
 
 	@Test
 	public void testExecutePipelinedWidthDifferentHashKeySerializerAndHashValueSerializer() {
-		assumeTrue(redisTemplate instanceof RedisTemplate);
+		assumeFalse(redisTemplate.getConnectionFactory() instanceof JedisClusterConnection);
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashValueSerializer(new GenericToStringSerializer<Long>(Long.class));


### PR DESCRIPTION
`RedisTemplate.java`: `executePipelined` with `RedisCallback` uses wrong `serializer` when `hashKeySerializer` is different from `hashValueSerializer`