### PR TITLE
DATAREDIS-471 - Add support for partial updates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-471-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -487,6 +487,44 @@ mother = persons:a9d4b3a0-50d3-4538-a2fc-f7fc2581ee56      <1>
 WARNING: Referenced Objects are not subject of persisting changes when saving the referencing object. Please make sure to persist changes on referenced objects separately, since only the reference will be stored. 
 Indexes set on properties of referenced types will not be resolved.
 
+[[redis.repositories.partial-updates]]
+== Persisting Partial Updates
+In some cases it is not necessary to load and rewrite the entire entity just to set a new value within it. A session timestamp for last active time might be such a scenario where you just want to alter one property.
+`PartialUpdate` allows to define `set`, `delete` actions on existing objects while taking care of updating potential expiration times of the entity itself as well as index structures.
+
+.Sample Partial Update
+====
+[source,java]
+----
+PartialUpdate<Person> update = new PartialUpdate<Person>("e2c7dcee", Person.class)
+  .set("firstname", "mat")                                                           <1>
+  .set("address.city", "emond's field")                                              <2>
+  .del("age");                                                                       <3>
+
+template.update(update);
+
+update = new PartialUpdate<Person>("e2c7dcee", Person.class)
+  .set("address", new Address("caemlyn", "andor"))                                   <4>
+  .set("attributes", singletonMap("eye-color", "grey"));                             <5>
+
+template.update(update);
+
+update = new PartialUpdate<Person>("e2c7dcee", Person.class)
+  .refreshTtl(true);                                                                 <6>
+  .set("expiration", 1000);
+
+template.update(update);
+----
+<1> Set the simple property _firstname_ to _mat_
+<2> Set the simple property _address.city_ to _emond's field_ without having to pass in the entire object. This does not work when a custom conversion is registered.
+<3> Remove the property _age_.
+<4> Set complex property _address_.
+<5> Set a map/collection of values removes the previously existing map/collection and replaces the values with the given ones.
+<6> Automatically update the server expiration time when altering <<redis.repositories.expirations>>.
+====
+
+NOTE: Updating complex objects as well as map/collection structures requires further interaction with Redis to determine existing values which means that it might turn out that rewriting the entire entity might be faster.
+
 [[redis.repositories.queries]]
 == Queries and Query Methods
 Query methods allow automatic derivation of simple finder queries from the method name. 

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -490,7 +490,7 @@ Indexes set on properties of referenced types will not be resolved.
 [[redis.repositories.partial-updates]]
 == Persisting Partial Updates
 In some cases it is not necessary to load and rewrite the entire entity just to set a new value within it. A session timestamp for last active time might be such a scenario where you just want to alter one property.
-`PartialUpdate` allows to define `set`, `delete` actions on existing objects while taking care of updating potential expiration times of the entity itself as well as index structures.
+`PartialUpdate` allows to define `set` and `delete` actions on existing objects while taking care of updating potential expiration times of the entity itself as well as index structures.
 
 .Sample Partial Update
 ====
@@ -515,7 +515,7 @@ update = new PartialUpdate<Person>("e2c7dcee", Person.class)
 
 template.update(update);
 ----
-<1> Set the simple property _firstname_ to _mat_
+<1> Set the simple property _firstname_ to _mat_.
 <2> Set the simple property _address.city_ to _emond's field_ without having to pass in the entire object. This does not work when a custom conversion is registered.
 <3> Remove the property _age_.
 <4> Set complex property _address_.

--- a/src/main/java/org/springframework/data/redis/core/IndexWriter.java
+++ b/src/main/java/org/springframework/data/redis/core/IndexWriter.java
@@ -21,6 +21,7 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.convert.IndexedData;
 import org.springframework.data.redis.core.convert.RedisConverter;
+import org.springframework.data.redis.core.convert.RemoveIndexedData;
 import org.springframework.data.redis.core.convert.SimpleIndexedPropertyValue;
 import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.util.Assert;
@@ -32,7 +33,7 @@ import org.springframework.util.ObjectUtils;
  * Redis. Depending on the type of {@link IndexedData} it uses eg. Sets with specific names to add actually referenced
  * keys to. While doing so {@link IndexWriter} also keeps track of all indexes associated with the root types key, which
  * allows to remove the root key from all indexes in case of deletion.
- * 
+ *
  * @author Christoph Strobl
  * @author Rob Winch
  * @since 1.7
@@ -44,7 +45,7 @@ class IndexWriter {
 
 	/**
 	 * Creates new {@link IndexWriter}.
-	 * 
+	 *
 	 * @param keyspace The key space to write index values to. Must not be {@literal null}.
 	 * @param connection must not be {@literal null}.
 	 * @param converter must not be {@literal null}.
@@ -104,7 +105,7 @@ class IndexWriter {
 
 	/**
 	 * Removes a key from all available indexes.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 */
 	public void removeKeyFromIndexes(String keyspace, Object key) {
@@ -142,7 +143,7 @@ class IndexWriter {
 
 	/**
 	 * Remove given key from all indexes matching {@link IndexedData#getIndexName()}:
-	 * 
+	 *
 	 * @param key
 	 * @param indexedData
 	 */
@@ -168,7 +169,7 @@ class IndexWriter {
 
 	/**
 	 * Adds a given key to the index for {@link IndexedData#getIndexName()}.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param indexedData must not be {@literal null}.
 	 */
@@ -177,7 +178,11 @@ class IndexWriter {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(indexedData, "IndexedData must not be null!");
 
-		if (indexedData instanceof SimpleIndexedPropertyValue) {
+		if (indexedData instanceof RemoveIndexedData) {
+			return;
+		}
+
+		else if (indexedData instanceof SimpleIndexedPropertyValue) {
 
 			Object value = ((SimpleIndexedPropertyValue) indexedData).getValue();
 

--- a/src/main/java/org/springframework/data/redis/core/IndexWriter.java
+++ b/src/main/java/org/springframework/data/redis/core/IndexWriter.java
@@ -150,6 +150,7 @@ class IndexWriter {
 	protected void removeKeyFromExistingIndexes(byte[] key, IndexedData indexedData) {
 
 		Assert.notNull(indexedData, "IndexedData must not be null!");
+
 		Set<byte[]> existingKeys = connection
 				.keys(toBytes(indexedData.getKeyspace() + ":" + indexedData.getIndexName() + ":*"));
 
@@ -217,7 +218,8 @@ class IndexWriter {
 		}
 
 		throw new InvalidDataAccessApiUsageException(String.format(
-				"Cannot convert %s to binary representation for index key generation. Are you missing a Converter? Did you register a non PathBasedRedisIndexDefinition that might apply to a complex type?",
+				"Cannot convert %s to binary representation for index key generation. "
+						+ "Are you missing a Converter? Did you register a non PathBasedRedisIndexDefinition that might apply to a complex type?",
 				source.getClass()));
 	}
 

--- a/src/main/java/org/springframework/data/redis/core/PartialUpdate.java
+++ b/src/main/java/org/springframework/data/redis/core/PartialUpdate.java
@@ -114,6 +114,7 @@ public class PartialUpdate<T> {
 		PartialUpdate<T> update = new PartialUpdate<T>(this.id, this.target, this.value, this.refreshTtl,
 				this.propertyUpdates);
 		update.propertyUpdates.add(new PropertyUpdate(UpdateCommand.SET, path, value));
+
 		return update;
 	}
 
@@ -130,6 +131,7 @@ public class PartialUpdate<T> {
 		PartialUpdate<T> update = new PartialUpdate<T>(this.id, this.target, this.value, this.refreshTtl,
 				this.propertyUpdates);
 		update.propertyUpdates.add(new PropertyUpdate(UpdateCommand.DEL, path));
+
 		return update;
 	}
 

--- a/src/main/java/org/springframework/data/redis/core/PartialUpdate.java
+++ b/src/main/java/org/springframework/data/redis/core/PartialUpdate.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * {@link PartialUpdate} allows to issue individual property updates without the need of rewriting the whole entity. It
+ * allows to define {@literal set}, {@literal delete} actions on existing objects while taking care of updating
+ * potential expiration times of the entity itself as well as index structures.
+ *
+ * @author Christoph Strobl
+ * @param <T>
+ * @since 1.8
+ */
+public class PartialUpdate<T> {
+
+	private final Object id;
+	private final Class<T> target;
+	private final T value;
+	private boolean refreshTtl = false;
+
+	private final List<PropertyUpdate> propertyUpdates = new ArrayList<PropertyUpdate>();
+
+	private PartialUpdate(Object id, Class<T> target, T value, boolean refreshTtl, List<PropertyUpdate> propertyUpdates) {
+
+		this.id = id;
+		this.target = target;
+		this.value = value;
+		this.refreshTtl = refreshTtl;
+		this.propertyUpdates.addAll(propertyUpdates);
+	}
+
+	/**
+	 * Create new {@link PartialUpdate} for given id and type.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @param targetType must not be {@literal null}.
+	 */
+	@SuppressWarnings("unchecked")
+	public PartialUpdate(Object id, Class<T> targetType) {
+
+		Assert.notNull(id, "Id must not be null!");
+		Assert.notNull(targetType, "TargetType must not be null!");
+
+		this.id = id;
+		this.target = (Class<T>) ClassUtils.getUserClass(targetType);
+		this.value = null;
+	}
+
+	/**
+	 * Create new {@link PartialUpdate} for given id and object.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 */
+	@SuppressWarnings("unchecked")
+	public PartialUpdate(Object id, T value) {
+
+		Assert.notNull(id, "Id must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+
+		this.id = id;
+		this.target = (Class<T>) ClassUtils.getUserClass(value.getClass());
+		this.value = value;
+	}
+
+	/**
+	 * Create new {@link PartialUpdate} for given id and type.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @param targetType must not be {@literal null}.
+	 */
+	public static <S> PartialUpdate<S> newPartialUpdate(Object id, Class<S> targetType) {
+		return new PartialUpdate<S>(id, targetType);
+	}
+
+	/**
+	 * @return can be {@literal null}.
+	 */
+	public T getValue() {
+		return value;
+	}
+
+	/**
+	 * Set the value of a simple or complex {@literal value} reachable via given {@literal path}.
+	 *
+	 * @param path must not be {@literal null}.
+	 * @param value must not be {@literal null}. If you want to remove a value use {@link #del(String)}.
+	 * @return a new {@link PartialUpdate}.
+	 */
+	public PartialUpdate<T> set(String path, Object value) {
+
+		Assert.hasText(path, "Path to set must not be null or empty!");
+
+		PartialUpdate<T> update = new PartialUpdate<T>(this.id, this.target, this.value, this.refreshTtl,
+				this.propertyUpdates);
+		update.propertyUpdates.add(new PropertyUpdate(UpdateCommand.SET, path, value));
+		return update;
+	}
+
+	/**
+	 * Remove the value reachable via given {@literal path}.
+	 *
+	 * @param path path must not be {@literal null}.
+	 * @return a new {@link PartialUpdate}.
+	 */
+	public PartialUpdate<T> del(String path) {
+
+		Assert.hasText(path, "Path to remove must not be null or empty!");
+
+		PartialUpdate<T> update = new PartialUpdate<T>(this.id, this.target, this.value, this.refreshTtl,
+				this.propertyUpdates);
+		update.propertyUpdates.add(new PropertyUpdate(UpdateCommand.DEL, path));
+		return update;
+	}
+
+	/**
+	 * Get the target type.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public Class<T> getTarget() {
+		return target;
+	}
+
+	/**
+	 * Get the id of the element to update.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public Object getId() {
+		return id;
+	}
+
+	/**
+	 * Get the list of individual property updates.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public List<PropertyUpdate> getPropertyUpdates() {
+		return Collections.unmodifiableList(propertyUpdates);
+	}
+
+	/**
+	 * @return true if expiration time of target should be updated.
+	 */
+	public boolean isRefreshTtl() {
+		return refreshTtl;
+	}
+
+	/**
+	 * Set indicator for updating expiration time of target.
+	 *
+	 * @param refreshTtl
+	 * @return a new {@link PartialUpdate}.
+	 */
+	public PartialUpdate<T> refreshTtl(boolean refreshTtl) {
+		return new PartialUpdate<T>(this.id, this.target, this.value, refreshTtl, this.propertyUpdates);
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 * @since 1.8
+	 */
+	public static class PropertyUpdate {
+
+		private final UpdateCommand cmd;
+		private final String propertyPath;
+		private final Object value;
+
+		private PropertyUpdate(UpdateCommand cmd, String propertyPath) {
+			this(cmd, propertyPath, null);
+		}
+
+		private PropertyUpdate(UpdateCommand cmd, String propertyPath, Object value) {
+
+			this.cmd = cmd;
+			this.propertyPath = propertyPath;
+			this.value = value;
+		}
+
+		/**
+		 * Get the associated {@link UpdateCommand}.
+		 *
+		 * @return never {@literal null}.
+		 */
+		public UpdateCommand getCmd() {
+			return cmd;
+		}
+
+		/**
+		 * Get the target path.
+		 *
+		 * @return never {@literal null}.
+		 */
+		public String getPropertyPath() {
+			return propertyPath;
+		}
+
+		/**
+		 * Get the value to set.
+		 *
+		 * @return can be {@literal null}.
+		 */
+		public Object getValue() {
+			return value;
+		}
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 * @since 1.8
+	 */
+	public static enum UpdateCommand {
+		SET, DEL
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueTemplate.java
@@ -140,29 +140,6 @@ public class RedisKeyValueTemplate extends KeyValueTemplate {
 		super.update(objectToUpdate);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.keyvalue.core.KeyValueTemplate#destroy()
-	 */
-	@Override
-	public void destroy() throws Exception {
-
-		execute(new RedisKeyValueCallback<Void>() {
-
-			@Override
-			public Void doInRedis(RedisKeyValueAdapter adapter) {
-
-				try {
-					adapter.destroy();
-				} catch (Exception e) {
-					throw new RedisSystemException(e.getMessage(), e);
-				}
-				return null;
-			}
-		});
-
-	}
-
 	protected void doPartialUpdate(final PartialUpdate<?> update) {
 
 		execute(new RedisKeyValueCallback<Void>() {

--- a/src/main/java/org/springframework/data/redis/core/convert/CompositeIndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/CompositeIndexResolver.java
@@ -72,4 +72,15 @@ public class CompositeIndexResolver implements IndexResolver {
 		return data;
 	}
 
+	@Override
+	public Set<IndexedData> resolveIndexesFor(String keyspace, String path, TypeInformation<?> typeInformation,
+			Object value) {
+
+		Set<IndexedData> data = new LinkedHashSet<IndexedData>();
+		for (IndexResolver resolver : resolvers) {
+			data.addAll(resolver.resolveIndexesFor(keyspace, path, typeInformation, value));
+		}
+		return data;
+	}
+
 }

--- a/src/main/java/org/springframework/data/redis/core/convert/CompositeIndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/CompositeIndexResolver.java
@@ -72,6 +72,9 @@ public class CompositeIndexResolver implements IndexResolver {
 		return data;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.core.convert.IndexResolver#resolveIndexesFor(java.lang.String, java.lang.String, org.springframework.data.util.TypeInformation, java.lang.Object)
+	 */
 	@Override
 	public Set<IndexedData> resolveIndexesFor(String keyspace, String path, TypeInformation<?> typeInformation,
 			Object value) {

--- a/src/main/java/org/springframework/data/redis/core/convert/IndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/IndexResolver.java
@@ -23,7 +23,7 @@ import org.springframework.data.util.TypeInformation;
 /**
  * {@link IndexResolver} extracts secondary index structures to be applied on a given path, {@link PersistentProperty}
  * and value.
- * 
+ *
  * @author Christoph Strobl
  * @since 1.7
  */
@@ -31,13 +31,22 @@ public interface IndexResolver {
 
 	/**
 	 * Resolves all indexes for given type information / value combination.
-	 * 
+	 *
 	 * @param typeInformation must not be {@literal null}.
 	 * @param value the actual value. Can be {@literal null}.
 	 * @return never {@literal null}.
 	 */
 	Set<IndexedData> resolveIndexesFor(TypeInformation<?> typeInformation, Object value);
 
+	/**
+	 * Resolves all indexes for given type information / value combination.
+	 *
+	 * @param keyspace must not be {@literal null}.
+	 * @param path must not be {@literal null}.
+	 * @param typeInformation must not be {@literal null}.
+	 * @param value the actual value. Can be {@literal null}.
+	 * @return never {@literal null}.
+	 */
 	Set<IndexedData> resolveIndexesFor(String keyspace, String path, TypeInformation<?> typeInformation, Object value);
 
 }

--- a/src/main/java/org/springframework/data/redis/core/convert/IndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/IndexResolver.java
@@ -38,4 +38,6 @@ public interface IndexResolver {
 	 */
 	Set<IndexedData> resolveIndexesFor(TypeInformation<?> typeInformation, Object value);
 
+	Set<IndexedData> resolveIndexesFor(String keyspace, String path, TypeInformation<?> typeInformation, Object value);
+
 }

--- a/src/main/java/org/springframework/data/redis/core/convert/PathIndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/PathIndexResolver.java
@@ -62,7 +62,7 @@ public class PathIndexResolver implements IndexResolver {
 	/**
 	 * Creates new {@link PathIndexResolver} with given {@link IndexConfiguration}.
 	 *
-	 * @param mapppingContext must not be {@literal null}.
+	 * @param mappingContext must not be {@literal null}.
 	 */
 	public PathIndexResolver(RedisMappingContext mappingContext) {
 
@@ -80,6 +80,9 @@ public class PathIndexResolver implements IndexResolver {
 				null, value);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.core.convert.IndexResolver#resolveIndexesFor(java.lang.String, java.lang.String, org.springframework.data.util.TypeInformation, java.lang.Object)
+	 */
 	@Override
 	public Set<IndexedData> resolveIndexesFor(String keyspace, String path, TypeInformation<?> typeInformation,
 			Object value) {
@@ -134,7 +137,7 @@ public class PathIndexResolver implements IndexResolver {
 						final Iterable<?> iterable;
 
 						if (Iterable.class.isAssignableFrom(propertyValue.getClass())) {
-							iterable = (Iterable) propertyValue;
+							iterable = (Iterable<?>) propertyValue;
 						} else if (propertyValue.getClass().isArray()) {
 							iterable = CollectionUtils.arrayToList(propertyValue);
 						} else {

--- a/src/main/java/org/springframework/data/redis/core/convert/RedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/RedisConverter.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.core.convert;
 import org.springframework.data.convert.EntityConverter;
 import org.springframework.data.keyvalue.core.mapping.KeyValuePersistentEntity;
 import org.springframework.data.keyvalue.core.mapping.KeyValuePersistentProperty;
+import org.springframework.data.redis.core.mapping.RedisMappingContext;
 
 /**
  * Redis specific {@link EntityConverter}.
@@ -25,7 +26,13 @@ import org.springframework.data.keyvalue.core.mapping.KeyValuePersistentProperty
  * @author Christoph Strobl
  * @since 1.7
  */
-public interface RedisConverter extends
-		EntityConverter<KeyValuePersistentEntity<?>, KeyValuePersistentProperty, Object, RedisData> {
+public interface RedisConverter
+		extends EntityConverter<KeyValuePersistentEntity<?>, KeyValuePersistentProperty, Object, RedisData> {
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.convert.EntityConverter#getMappingContext()
+	 */
+	@Override
+	RedisMappingContext getMappingContext();
 }

--- a/src/main/java/org/springframework/data/redis/core/convert/RedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/RedisConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.data.redis.core.mapping.RedisMappingContext;
 
 /**
  * Redis specific {@link EntityConverter}.
- * 
+ *
  * @author Christoph Strobl
  * @since 1.7
  */

--- a/src/main/java/org/springframework/data/redis/core/convert/RedisData.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/RedisData.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.core.convert;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -94,12 +95,21 @@ public class RedisData {
 	}
 
 	/**
-	 * @param index
+	 * @param index must not be {@literal null}.
 	 */
 	public void addIndexedData(IndexedData index) {
 
 		Assert.notNull(index, "IndexedData to add must not be null!");
 		this.indexedData.add(index);
+	}
+
+	/**
+	 * @param indexes must not be {@literal null}.
+	 */
+	public void addIndexedData(Collection<IndexedData> indexes) {
+
+		Assert.notNull(indexes, "IndexedData to add must not be null!");
+		this.indexedData.addAll(indexes);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/core/convert/RedisData.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/RedisData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.springframework.util.Assert;
 /**
  * Data object holding {@link Bucket} representing the domain object to be stored in a Redis hash. Index information
  * points to additional structures holding the objects is for searching.
- * 
+ *
  * @author Christoph Strobl
  * @since 1.7
  */
@@ -50,7 +50,7 @@ public class RedisData {
 
 	/**
 	 * Creates new {@link RedisData} with {@link Bucket} holding provided values.
-	 * 
+	 *
 	 * @param raw should not be {@literal null}.
 	 */
 	public RedisData(Map<byte[], byte[]> raw) {
@@ -59,7 +59,7 @@ public class RedisData {
 
 	/**
 	 * Creates new {@link RedisData} with {@link Bucket}
-	 * 
+	 *
 	 * @param bucket must not be {@literal null}.
 	 */
 	public RedisData(Bucket bucket) {
@@ -71,7 +71,7 @@ public class RedisData {
 
 	/**
 	 * Set the id to be used as part of the key.
-	 * 
+	 *
 	 * @param id
 	 */
 	public void setId(String id) {
@@ -87,7 +87,7 @@ public class RedisData {
 
 	/**
 	 * Get the time before expiration in seconds.
-	 * 
+	 *
 	 * @return {@literal null} if not set.
 	 */
 	public Long getTimeToLive() {
@@ -142,7 +142,7 @@ public class RedisData {
 
 	/**
 	 * Set the time before expiration in {@link TimeUnit#SECONDS}.
-	 * 
+	 *
 	 * @param timeToLive can be {@literal null}.
 	 */
 	public void setTimeToLive(Long timeToLive) {
@@ -151,7 +151,7 @@ public class RedisData {
 
 	/**
 	 * Set the time before expiration converting the given arguments to {@link TimeUnit#SECONDS}.
-	 * 
+	 *
 	 * @param timeToLive must not be {@literal null}
 	 * @param timeUnit must not be {@literal null}
 	 */

--- a/src/main/java/org/springframework/data/redis/core/convert/RemoveIndexedData.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/RemoveIndexedData.java
@@ -16,7 +16,10 @@
 package org.springframework.data.redis.core.convert;
 
 /**
+ * {@link RemoveIndexedData} represents a removed index entry from a secondary index for a property path in a given keyspace.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class RemoveIndexedData implements IndexedData {
 

--- a/src/main/java/org/springframework/data/redis/core/convert/RemoveIndexedData.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/RemoveIndexedData.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.convert;
+
+/**
+ * @author Christoph Strobl
+ */
+public class RemoveIndexedData implements IndexedData {
+
+	private final IndexedData delegate;
+
+	RemoveIndexedData(IndexedData delegate) {
+		super();
+		this.delegate = delegate;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.convert.IndexedData#getIndexName()
+	 */
+	@Override
+	public String getIndexName() {
+		return delegate.getIndexName();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.convert.IndexedData#getKeyspace()
+	 */
+	@Override
+	public String getKeyspace() {
+		return delegate.getKeyspace();
+	}
+
+	@Override
+	public String toString() {
+		return "RemoveIndexedData [indexName=" + getIndexName() + ", keyspace()=" + getKeyspace() + "]";
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/core/convert/SpelIndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/SpelIndexResolver.java
@@ -119,6 +119,12 @@ public class SpelIndexResolver implements IndexResolver {
 		return indexes;
 	}
 
+	@Override
+	public Set<IndexedData> resolveIndexesFor(String keyspace, String path, TypeInformation<?> typeInformation,
+			Object value) {
+		return Collections.emptySet();
+	}
+
 	private Expression getAndCacheIfAbsent(SpelIndexDefinition indexDefinition) {
 
 		if (expressionCache.containsKey(indexDefinition)) {

--- a/src/main/java/org/springframework/data/redis/core/convert/SpelIndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/SpelIndexResolver.java
@@ -119,6 +119,9 @@ public class SpelIndexResolver implements IndexResolver {
 		return indexes;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.core.convert.IndexResolver#resolveIndexesFor(java.lang.String, java.lang.String, org.springframework.data.util.TypeInformation, java.lang.Object)
+	 */
 	@Override
 	public Set<IndexedData> resolveIndexesFor(String keyspace, String path, TypeInformation<?> typeInformation,
 			Object value) {

--- a/src/main/java/org/springframework/data/redis/hash/ObjectHashMapper.java
+++ b/src/main/java/org/springframework/data/redis/hash/ObjectHashMapper.java
@@ -143,6 +143,10 @@ public class ObjectHashMapper implements HashMapper<Object, byte[], byte[]> {
 
 		private static final Map<byte[], byte[]> NO_REFERENCE = Collections.emptyMap();
 
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.core.convert.ReferenceResolver#resolveReference(java.io.Serializable, java.lang.String)
+		 */
 		@Override
 		public Map<byte[], byte[]> resolveReference(Serializable id, String keyspace) {
 			return NO_REFERENCE;
@@ -158,8 +162,22 @@ public class ObjectHashMapper implements HashMapper<Object, byte[], byte[]> {
 
 		private static final Set<IndexedData> NO_INDEXES = Collections.emptySet();
 
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.core.convert.IndexResolver#resolveIndexesFor(org.springframework.data.util.TypeInformation, java.lang.Object)
+		 */
 		@Override
 		public Set<IndexedData> resolveIndexesFor(TypeInformation<?> typeInformation, Object value) {
+			return NO_INDEXES;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.core.convert.IndexResolver#resolveIndexesFor(java.lang.String, java.lang.String, org.springframework.data.util.TypeInformation, java.lang.Object)
+		 */
+		@Override
+		public Set<IndexedData> resolveIndexesFor(String keyspace, String path, TypeInformation<?> typeInformation,
+				Object value) {
 			return NO_INDEXES;
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -21,22 +21,30 @@ import static org.hamcrest.core.IsInstanceOf.*;
 import static org.hamcrest.core.IsNot.*;
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.DisposableBean;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Reference;
 import org.springframework.data.keyvalue.annotation.KeySpace;
+import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.convert.Bucket;
 import org.springframework.data.redis.core.convert.KeyspaceConfiguration;
 import org.springframework.data.redis.core.convert.MappingConfiguration;
@@ -48,18 +56,34 @@ import org.springframework.data.redis.core.mapping.RedisMappingContext;
  * @author Christoph Strobl
  * @author Mark Paluch
  */
+@RunWith(Parameterized.class)
 public class RedisKeyValueAdapterTests {
 
 	RedisKeyValueAdapter adapter;
 	StringRedisTemplate template;
 	RedisConnectionFactory connectionFactory;
 
+	public RedisKeyValueAdapterTests(RedisConnectionFactory connectionFactory) throws Exception {
+
+		if (connectionFactory instanceof InitializingBean) {
+			((InitializingBean) connectionFactory).afterPropertiesSet();
+		}
+		this.connectionFactory = connectionFactory;
+		ConnectionFactoryTracker.add(connectionFactory);
+	}
+
+	@Parameters
+	public static List<RedisConnectionFactory> params() {
+		return Arrays.<RedisConnectionFactory> asList(new JedisConnectionFactory(), new LettuceConnectionFactory());
+	}
+
+	@AfterClass
+	public static void cleanUp() {
+		ConnectionFactoryTracker.cleanUp();
+	}
+
 	@Before
 	public void setUp() {
-
-		JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory();
-		jedisConnectionFactory.afterPropertiesSet();
-		connectionFactory = jedisConnectionFactory;
 
 		template = new StringRedisTemplate(connectionFactory);
 		template.afterPropertiesSet();
@@ -85,14 +109,6 @@ public class RedisKeyValueAdapterTests {
 
 		try {
 			adapter.destroy();
-		} catch (Exception e) {
-			// ignore
-		}
-
-		try {
-			if (connectionFactory instanceof DisposableBean) {
-				((DisposableBean) connectionFactory).destroy();
-			}
 		} catch (Exception e) {
 			// ignore
 		}
@@ -309,6 +325,191 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.hasKey("persons:rand:idx"), is(true));
 		assertThat(template.opsForSet().isMember("persons:rand:idx", "persons:firstname:frodo"), is(true));
 		assertThat(template.opsForSet().isMember("persons:mat:idx", "persons:firstname:mat"), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void updateShouldAlterIndexDataCorrectly() {
+
+		Person rand = new Person();
+		rand.firstname = "rand";
+
+		adapter.put("1", rand, "persons");
+
+		assertThat(template.hasKey("persons:firstname:rand"), is(true));
+
+		PartialUpdate<Person> update = new PartialUpdate<Person>("1", Person.class) //
+				.set("firstname", "mat");
+
+		adapter.update(update);
+
+		assertThat(template.hasKey("persons:firstname:rand"), is(false));
+		assertThat(template.hasKey("persons:firstname:mat"), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void updateShouldAlterIndexDataOnNestedObjectCorrectly() {
+
+		Person rand = new Person();
+		rand.address = new Address();
+		rand.address.country = "andor";
+
+		adapter.put("1", rand, "persons");
+
+		assertThat(template.hasKey("persons:address.country:andor"), is(true));
+
+		PartialUpdate<Person> update = new PartialUpdate<Person>("1", Person.class);
+		Address addressUpdate = new Address();
+		addressUpdate.country = "tear";
+
+		update = update.set("address", addressUpdate);
+
+		adapter.update(update);
+
+		assertThat(template.hasKey("persons:address.country:andor"), is(false));
+		assertThat(template.hasKey("persons:address.country:tear"), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void updateShouldAlterIndexDataOnNestedObjectPathCorrectly() {
+
+		Person rand = new Person();
+		rand.address = new Address();
+		rand.address.country = "andor";
+
+		adapter.put("1", rand, "persons");
+
+		assertThat(template.hasKey("persons:address.country:andor"), is(true));
+
+		PartialUpdate<Person> update = new PartialUpdate<Person>("1", Person.class) //
+				.set("address.country", "tear");
+
+		adapter.update(update);
+
+		assertThat(template.hasKey("persons:address.country:andor"), is(false));
+		assertThat(template.hasKey("persons:address.country:tear"), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void updateShouldRemoveComplexObjectCorrectly() {
+
+		Person rand = new Person();
+		rand.address = new Address();
+		rand.address.country = "andor";
+		rand.address.city = "emond's field";
+
+		adapter.put("1", rand, "persons");
+
+		PartialUpdate<Person> update = new PartialUpdate<Person>("1", Person.class) //
+				.del("address");
+
+		adapter.update(update);
+
+		assertThat(template.opsForHash().hasKey("persons:1", "address.country"), is(false));
+		assertThat(template.opsForHash().hasKey("persons:1", "address.city"), is(false));
+		assertThat(template.opsForSet().isMember("persons:address.country:andor", "1"), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void updateShouldRemoveSimpleListValuesCorrectly() {
+
+		Person rand = new Person();
+		rand.nicknames = Arrays.asList("lews therin", "dragon reborn");
+
+		adapter.put("1", rand, "persons");
+
+		PartialUpdate<Person> update = new PartialUpdate<Person>("1", Person.class) //
+				.del("nicknames");
+
+		adapter.update(update);
+
+		assertThat(template.opsForHash().hasKey("persons:1", "nicknames.[0]"), is(false));
+		assertThat(template.opsForHash().hasKey("persons:1", "nicknames.[1]"), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void updateShouldRemoveComplexListValuesCorrectly() {
+
+		Person mat = new Person();
+		mat.firstname = "mat";
+		mat.nicknames = Collections.singletonList("prince of ravens");
+
+		Person perrin = new Person();
+		perrin.firstname = "mat";
+		perrin.nicknames = Collections.singletonList("lord of the two rivers");
+
+		Person rand = new Person();
+		rand.coworkers = Arrays.asList(mat, perrin);
+
+		adapter.put("1", rand, "persons");
+
+		PartialUpdate<Person> update = new PartialUpdate<Person>("1", Person.class) //
+				.del("coworkers");
+
+		adapter.update(update);
+
+		assertThat(template.opsForHash().hasKey("persons:1", "coworkers.[0].firstname"), is(false));
+		assertThat(template.opsForHash().hasKey("persons:1", "coworkers.[0].nicknames.[0]"), is(false));
+		assertThat(template.opsForHash().hasKey("persons:1", "coworkers.[1].firstname"), is(false));
+		assertThat(template.opsForHash().hasKey("persons:1", "coworkers.[1].nicknames.[0]"), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void updateShouldRemoveSimpleMapValuesCorrectly() {
+
+		Person rand = new Person();
+		rand.physicalAttributes = Collections.singletonMap("eye-color", "grey");
+
+		adapter.put("1", rand, "persons");
+
+		PartialUpdate<Person> update = new PartialUpdate<Person>("1", Person.class) //
+				.del("physicalAttributes");
+
+		adapter.update(update);
+
+		assertThat(template.opsForHash().hasKey("persons:1", "physicalAttributes.[eye-color]"), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void updateShouldRemoveComplexMapValuesCorrectly() {
+
+		Person tam = new Person();
+		tam.firstname = "tam";
+
+		Person rand = new Person();
+		rand.relatives = Collections.singletonMap("stepfather", tam);
+
+		adapter.put("1", rand, "persons");
+
+		PartialUpdate<Person> update = new PartialUpdate<Person>("1", Person.class) //
+				.del("relatives");
+
+		adapter.update(update);
+
+		assertThat(template.opsForHash().hasKey("persons:1", "relatives.[stepfather].firstname"), is(false));
 	}
 
 	@KeySpace("persons")

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -15,10 +15,7 @@
  */
 package org.springframework.data.redis.core;
 
-import static org.hamcrest.core.Is.*;
-import static org.hamcrest.core.IsCollectionContaining.*;
-import static org.hamcrest.core.IsInstanceOf.*;
-import static org.hamcrest.core.IsNot.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.data.redis.core;
 
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueTemplateTests.java
@@ -109,6 +109,7 @@ public class RedisKeyValueTemplateTests {
 		});
 
 		template.destroy();
+		adapter.destroy();
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -16,10 +16,7 @@
 package org.springframework.data.redis.core.convert;
 
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.hamcrest.core.Is.*;
-import static org.hamcrest.core.IsCollectionContaining.*;
-import static org.hamcrest.core.IsInstanceOf.*;
-import static org.hamcrest.core.IsNull.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
@@ -1586,8 +1583,7 @@ public class MappingRedisConverterUnitTests {
 	}
 
 	/**
-	 * <<<<<<< HEAD
-	 * 
+	 *
 	 * @see DATAREDIS-509
 	 */
 	@Test

--- a/src/test/java/org/springframework/data/redis/core/convert/PathIndexResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/PathIndexResolverUnitTests.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -223,6 +224,7 @@ public class PathIndexResolverUnitTests {
 
 	/**
 	 * @see DATAREDIS-425
+	 * @see DATAREDIS-471
 	 */
 	@Test
 	public void shouldIgnoreConfiguredIndexesInMapWhenValueIsNull() {
@@ -235,7 +237,8 @@ public class PathIndexResolverUnitTests {
 
 		Set<IndexedData> indexes = indexResolver.resolveIndexesFor(ClassTypeInformation.from(Person.class), rand);
 
-		assertThat(indexes.size(), is(0));
+		assertThat(indexes.size(), is(1));
+		assertThat(indexes.iterator().next(), IsInstanceOf.instanceOf(RemoveIndexedData.class));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareTimeToLiveAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareTimeToLiveAccessorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,7 @@
  */
 package org.springframework.data.redis.core.mapping;
 
-import static org.hamcrest.core.Is.*;
-import static org.hamcrest.core.IsNull.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import org.junit.Before;

--- a/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareTimeToLiveAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareTimeToLiveAccessorUnitTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.data.redis.core.PartialUpdate;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.convert.KeyspaceConfiguration;
@@ -174,6 +175,55 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		config.addKeyspaceSettings(setting);
 
 		assertThat(accessor.getTimeToLive(new TypeWithTtlOnMethod(100L)), is(100L));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void getTimeToLiveShouldReturnDefaultValue() {
+
+		Long ttl = accessor
+				.getTimeToLive(new PartialUpdate<TypeWithRedisHashAnnotation>("123", new TypeWithRedisHashAnnotation()));
+
+		assertThat(ttl, is(5L));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void getTimeToLiveShouldReturnValueWhenUpdateModifiesTtlProperty() {
+
+		Long ttl = accessor
+				.getTimeToLive(new PartialUpdate<SimpleTypeWithTTLProperty>("123", new SimpleTypeWithTTLProperty())
+						.set("ttl", 100).refreshTtl(true));
+
+		assertThat(ttl, is(100L));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void getTimeToLiveShouldReturnPropertyValueWhenUpdateModifiesTtlProperty() {
+
+		Long ttl = accessor.getTimeToLive(new PartialUpdate<TypeWithRedisHashAnnotationAndTTLProperty>("123",
+				new TypeWithRedisHashAnnotationAndTTLProperty()).set("ttl", 100).refreshTtl(true));
+
+		assertThat(ttl, is(100L));
+	}
+
+	/**
+	 * @see DATAREDIS-471
+	 */
+	@Test
+	public void getTimeToLiveShouldReturnDefaultValueWhenUpdateDoesNotModifyTtlProperty() {
+
+		Long ttl = accessor.getTimeToLive(new PartialUpdate<TypeWithRedisHashAnnotationAndTTLProperty>("123",
+				new TypeWithRedisHashAnnotationAndTTLProperty()).refreshTtl(true));
+
+		assertThat(ttl, is(10L));
 	}
 
 	static class SimpleType {}


### PR DESCRIPTION
We now allow partial update of domain types via PartialUpdate. The according expiration times and secondary index structures are updated accordingly.

In some cases it is not necessary to load and rewrite the entire entity just to set a new value within it. A session timestamp for last active time might be such a scenario where you just want to alter one property.
`PartialUpdate` allows to define `set`, `delete` actions on existing objects while taking care of updating potential expiration times of the entity itself as well as index structures.

```java
PartialUpdate<Person> update = new PartialUpdate<Person>("e2c7dcee", Person.class)
  .set("firstname", "mat")                                                           <1>
  .set("address.city", "emond's field")                                              <2>
  .del("age");                                                                       <3>

template.update(update);

update = new PartialUpdate<Person>("e2c7dcee", Person.class)
  .set("address", new Address("caemlyn", "andor"))                                   <4>
  .set("attributes", singletonMap("eye-color", "grey"));                             <5>

template.update(update);

update = new PartialUpdate<Person>("e2c7dcee", Person.class)
  .refreshTtl(true);                                                                 <6>
  .set("expiration", 1000);

template.update(update);
```

```bash
<1> Set the simple property _firstname_ to _mat_
<2> Set the simple property _address.city_ to _emond's field_ without having to pass in the entire object. This does not work when a custom conversion is registered.
<3> Remove the property _age_.
<4> Set complex property _address_.
<5> Set a map/collection of values removes the previously existing map/collection and replaces the values with the given ones.
<6> Automatically update the server expiration time when altering time to live.
```

**NOTE:** Updating complex objects as well as map/collection structures requires further interaction with Redis to determine existing values which means that it might turn out that rewriting the entire entity might be faster.