### PR TITLE
DATAREDIS-501 - Use application context ClassLoader as default for JdkSerializationRedisSerializer in RedisTemplate.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-501-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 


### PR DESCRIPTION
We now pick up the `ClassLoader` from the `ApplicationContext` and use the latter as default in `RedisTemplate` for initializing the `JdkSerializationRedisSerializer`. We only do this in case the default serializer has not been set explicitly.

----

Should also be back ported to `1.7.x` which might require updating javadoc `@since` which currently states 1.8.0