### PR TITLE
DATAREDIS-507 - Do not destroy RedisConnectionFactory in RedisKeyValueAdapter.destroy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-507-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -84,6 +84,7 @@ import org.springframework.util.Assert;
  * Please use {@link RedisTemplate} for this purpose.
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.7
  */
 public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
@@ -446,13 +447,6 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 	 * @see org.springframework.beans.factory.DisposableBean#destroy()
 	 */
 	public void destroy() throws Exception {
-
-		if (redisOps instanceof RedisTemplate) {
-			RedisConnectionFactory connectionFactory = ((RedisTemplate<?, ?>) redisOps).getConnectionFactory();
-			if (connectionFactory instanceof DisposableBean) {
-				((DisposableBean) connectionFactory).destroy();
-			}
-		}
 
 		this.expirationListener.destroy();
 		this.messageListenerContainer.destroy();

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Reference;
@@ -83,6 +84,14 @@ public class RedisKeyValueAdapterTests {
 
 		try {
 			adapter.destroy();
+		} catch (Exception e) {
+			// ignore
+		}
+
+		try {
+			if (connectionFactory instanceof DisposableBean) {
+				((DisposableBean) connectionFactory).destroy();
+			}
 		} catch (Exception e) {
 			// ignore
 		}

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.core;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+
+/**
+ * Unit tests for {@link RedisKeyValueAdapter}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RedisKeyValueAdapterUnitTests {
+
+	RedisTemplate<?, ?> redisTemplate;
+	RedisKeyValueAdapter redisKeyValueAdapter;
+
+	@Mock JedisConnectionFactory jedisConnectionFactoryMock;
+	@Mock RedisConnection redisConnectionMock;
+
+	@Before
+	public void setUp() throws Exception {
+
+		redisTemplate = new RedisTemplate<Object, Object>();
+		redisTemplate.setConnectionFactory(jedisConnectionFactoryMock);
+		redisTemplate.afterPropertiesSet();
+
+		when(jedisConnectionFactoryMock.getConnection()).thenReturn(redisConnectionMock);
+		when(redisConnectionMock.getConfig("notify-keyspace-events"))
+				.thenReturn(Arrays.asList("notify-keyspace-events", "KEA"));
+
+		redisKeyValueAdapter = new RedisKeyValueAdapter(redisTemplate);
+	}
+
+	@Test
+	public void destroyShouldNotDestroyConnectionFactory() throws Exception {
+
+		redisKeyValueAdapter.destroy();
+
+		verify(jedisConnectionFactoryMock, never()).destroy();
+	}
+}


### PR DESCRIPTION
Do not destroy `RedisConnectionFactory` which is likely managed outside of `RedisKeyValueAdapter`. This change also retains a working connection factory while shutting down message listeners as those try to unsubscribe on shutdown.

----

Related ticket: [DATAREDIS-507](https://jira.spring.io/browse/DATAREDIS-507)