### PR TITLE
DATAREDIS-514 - Unify geoRadius capitalization. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-514-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -2499,10 +2499,10 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.StringRedisConnection#georadius(java.lang.String, org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#geoRadius(java.lang.String, org.springframework.data.geo.Circle)
 	 */
 	@Override
-	public GeoResults<GeoLocation<String>> georadius(String key, Circle within) {
+	public GeoResults<GeoLocation<String>> geoRadius(String key, Circle within) {
 
 		GeoResults<GeoLocation<byte[]>> result = delegate.geoRadius(serialize(key), within);
 		if (isFutureConversion()) {
@@ -2514,10 +2514,10 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.StringRedisConnection#georadius(java.lang.String, org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#geoRadius(java.lang.String, org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<String>> georadius(String key, Circle within, GeoRadiusCommandArgs args) {
+	public GeoResults<GeoLocation<String>> geoRadius(String key, Circle within, GeoRadiusCommandArgs args) {
 
 		GeoResults<GeoLocation<byte[]>> result = delegate.geoRadius(serialize(key), within, args);
 		if (isFutureConversion()) {
@@ -2528,19 +2528,19 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.StringRedisConnection#georadiusByMember(java.lang.String, java.lang.String, double)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#geoRadiusByMember(java.lang.String, java.lang.String, double)
 	 */
 	@Override
-	public GeoResults<GeoLocation<String>> georadiusByMember(String key, String member, double radius) {
-		return georadiusByMember(key, member, new Distance(radius, DistanceUnit.METERS));
+	public GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, double radius) {
+		return geoRadiusByMember(key, member, new Distance(radius, DistanceUnit.METERS));
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.StringRedisConnection#georadiusByMember(java.lang.String, java.lang.String, org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#geoRadiusByMember(java.lang.String, java.lang.String, org.springframework.data.geo.Distance)
 	 */
 	@Override
-	public GeoResults<GeoLocation<String>> georadiusByMember(String key, String member, Distance radius) {
+	public GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, Distance radius) {
 
 		GeoResults<GeoLocation<byte[]>> result = delegate.geoRadiusByMember(serialize(key), serialize(member), radius);
 		if (isFutureConversion()) {
@@ -2551,10 +2551,10 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.StringRedisConnection#georadiusByMember(java.lang.String, java.lang.String, org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#geoRadiusByMember(java.lang.String, java.lang.String, org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<String>> georadiusByMember(String key, String member, Distance radius,
+	public GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, Distance radius,
 			GeoRadiusCommandArgs args) {
 
 		GeoResults<GeoLocation<byte[]>> result = delegate.geoRadiusByMember(serialize(key), serialize(member), radius,
@@ -2567,7 +2567,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within) {
@@ -2581,7 +2581,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args) {
@@ -2595,7 +2595,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], double)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], double)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, double radius) {
@@ -2604,7 +2604,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius) {
@@ -2618,7 +2618,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -732,7 +732,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
 	 * @since 1.8
 	 */
-	GeoResults<GeoLocation<String>> georadius(String key, Circle within);
+	GeoResults<GeoLocation<String>> geoRadius(String key, Circle within);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying {@link GeoRadiusCommandArgs}.
@@ -744,7 +744,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
 	 * @since 1.8
 	 */
-	GeoResults<GeoLocation<String>> georadius(String key, Circle within, GeoRadiusCommandArgs args);
+	GeoResults<GeoLocation<String>> geoRadius(String key, Circle within, GeoRadiusCommandArgs args);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -757,7 +757,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 * @since 1.8
 	 */
-	GeoResults<GeoLocation<String>> georadiusByMember(String key, String member, double radius);
+	GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, double radius);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -770,7 +770,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 * @since 1.8
 	 */
-	GeoResults<GeoLocation<String>> georadiusByMember(String key, String member, Distance radius);
+	GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, Distance radius);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -784,7 +784,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 * @since 1.8
 	 */
-	GeoResults<GeoLocation<String>> georadiusByMember(String key, String member, Distance radius,
+	GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, Distance radius,
 			GeoRadiusCommandArgs args);
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -2675,7 +2675,7 @@ public class JedisClusterConnection implements RedisClusterConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within) {
@@ -2694,7 +2694,7 @@ public class JedisClusterConnection implements RedisClusterConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args) {
@@ -2717,7 +2717,7 @@ public class JedisClusterConnection implements RedisClusterConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], double)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], double)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, double radius) {
@@ -2726,7 +2726,7 @@ public class JedisClusterConnection implements RedisClusterConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius) {
@@ -2746,7 +2746,7 @@ public class JedisClusterConnection implements RedisClusterConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -3321,7 +3321,7 @@ public class JedisConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within) {
@@ -3358,7 +3358,7 @@ public class JedisConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args) {
@@ -3394,7 +3394,7 @@ public class JedisConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], double)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], double)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, double radius) {
@@ -3403,7 +3403,7 @@ public class JedisConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius) {
@@ -3432,6 +3432,10 @@ public class JedisConnection extends AbstractRedisConnection {
 		}
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs)
+	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,
 			GeoRadiusCommandArgs args) {

--- a/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnection.java
@@ -1275,7 +1275,7 @@ public class JredisConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within) {
@@ -1284,7 +1284,7 @@ public class JredisConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args) {
@@ -1293,7 +1293,7 @@ public class JredisConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], double)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], double)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, double radius) {
@@ -1302,7 +1302,7 @@ public class JredisConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius) {
@@ -1311,7 +1311,7 @@ public class JredisConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -3301,7 +3301,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within) {
@@ -3337,7 +3337,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args) {
@@ -3373,7 +3373,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], double)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], double)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, double radius) {
@@ -3382,7 +3382,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], double, org.springframework.data.geo.Metric)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], double, org.springframework.data.geo.Metric)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius) {
@@ -3414,7 +3414,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,

--- a/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
@@ -2321,7 +2321,7 @@ public class SrpConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within) {
@@ -2330,7 +2330,7 @@ public class SrpConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadius(byte[], org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args) {
@@ -2339,7 +2339,7 @@ public class SrpConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], double)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], double)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, double radius) {
@@ -2348,7 +2348,7 @@ public class SrpConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius) {
@@ -2357,7 +2357,7 @@ public class SrpConnection extends AbstractRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisGeoCommands#georadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.connection.RedisGeoCommands#geoRadiusByMember(byte[], byte[], org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
 	public GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,

--- a/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
@@ -118,7 +118,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
 	 */
-	GeoResults<GeoLocation<M>> georadius(Circle within);
+	GeoResults<GeoLocation<M>> geoRadius(Circle within);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying {@link GeoRadiusCommandArgs}.
@@ -128,7 +128,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
 	 */
-	GeoResults<GeoLocation<M>> georadius(Circle within, GeoRadiusCommandArgs args);
+	GeoResults<GeoLocation<M>> geoRadius(Circle within, GeoRadiusCommandArgs args);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -139,7 +139,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 */
-	GeoResults<GeoLocation<M>> georadiusByMember(K key, M member, double radius);
+	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -150,7 +150,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 */
-	GeoResults<GeoLocation<M>> georadiusByMember(M member, Distance distance);
+	GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -162,7 +162,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 */
-	GeoResults<GeoLocation<M>> georadiusByMember(M member, Distance distance, GeoRadiusCommandArgs args);
+	GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance, GeoRadiusCommandArgs args);
 
 	/**
 	 * Remove the {@literal member}s.

--- a/src/main/java/org/springframework/data/redis/core/DefaultBoundGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultBoundGeoOperations.java
@@ -124,47 +124,47 @@ class DefaultBoundGeoOperations<K, M> extends DefaultBoundKeyOperations<K> imple
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#georadius(org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadius(org.springframework.data.geo.Circle)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadius(Circle within) {
-		return ops.georadius(getKey(), within);
+	public GeoResults<GeoLocation<M>> geoRadius(Circle within) {
+		return ops.geoRadius(getKey(), within);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#georadius(org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadius(org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadius(Circle within, GeoRadiusCommandArgs param) {
-		return ops.georadius(getKey(), within, param);
+	public GeoResults<GeoLocation<M>> geoRadius(Circle within, GeoRadiusCommandArgs param) {
+		return ops.geoRadius(getKey(), within, param);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#georadiusByMember(java.lang.Object, java.lang.Object, double)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, double)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadiusByMember(K key, M member, double radius) {
-		return ops.georadiusByMember(getKey(), member, radius);
+	public GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius) {
+		return ops.geoRadiusByMember(getKey(), member, radius);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#georadiusByMember(java.lang.Object, org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadiusByMember(java.lang.Object, org.springframework.data.geo.Distance)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadiusByMember(M member, Distance distance) {
-		return ops.georadiusByMember(getKey(), member, distance);
+	public GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance) {
+		return ops.geoRadiusByMember(getKey(), member, distance);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#georadiusByMember(java.lang.Object, org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadiusByMember(java.lang.Object, org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadiusByMember(M member, Distance distance, GeoRadiusCommandArgs param) {
-		return ops.georadiusByMember(getKey(), member, distance, param);
+	public GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance, GeoRadiusCommandArgs param) {
+		return ops.geoRadiusByMember(getKey(), member, distance, param);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultGeoOperations.java
@@ -187,10 +187,10 @@ public class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> impleme
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#georadius(java.lang.Object, org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.core.GeoOperations#geoRadius(java.lang.Object, org.springframework.data.geo.Circle)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadius(K key, final Circle within) {
+	public GeoResults<GeoLocation<M>> geoRadius(K key, final Circle within) {
 
 		final byte[] rawKey = rawKey(key);
 
@@ -206,10 +206,10 @@ public class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> impleme
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#georadius(java.lang.Object, org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.core.GeoOperations#geoRadius(java.lang.Object, org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadius(K key, final Circle within, final GeoRadiusCommandArgs args) {
+	public GeoResults<GeoLocation<M>> geoRadius(K key, final Circle within, final GeoRadiusCommandArgs args) {
 
 		final byte[] rawKey = rawKey(key);
 
@@ -225,10 +225,10 @@ public class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> impleme
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#georadiusByMember(java.lang.Object, java.lang.Object, double)
+	 * @see org.springframework.data.redis.core.GeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, double)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadiusByMember(K key, M member, final double radius) {
+	public GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, final double radius) {
 
 		final byte[] rawKey = rawKey(key);
 		final byte[] rawMember = rawValue(member);
@@ -244,10 +244,10 @@ public class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> impleme
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#georadiusByMember(java.lang.Object, java.lang.Object, org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.core.GeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, org.springframework.data.geo.Distance)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadiusByMember(K key, M member, final Distance distance) {
+	public GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, final Distance distance) {
 
 		final byte[] rawKey = rawKey(key);
 		final byte[] rawMember = rawValue(member);
@@ -264,10 +264,10 @@ public class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> impleme
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#georadiusByMember(java.lang.Object, java.lang.Object, double, org.springframework.data.geo.Metric, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.core.GeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, double, org.springframework.data.geo.Metric, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> georadiusByMember(K key, M member, final Distance distance,
+	public GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, final Distance distance,
 			final GeoRadiusCommandArgs param) {
 
 		final byte[] rawKey = rawKey(key);

--- a/src/main/java/org/springframework/data/redis/core/GeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/GeoOperations.java
@@ -128,7 +128,7 @@ public interface GeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
 	 */
-	GeoResults<GeoLocation<M>> georadius(K key, Circle within);
+	GeoResults<GeoLocation<M>> geoRadius(K key, Circle within);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying {@link GeoRadiusCommandArgs}.
@@ -139,7 +139,7 @@ public interface GeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
 	 */
-	GeoResults<GeoLocation<M>> georadius(K key, Circle within, GeoRadiusCommandArgs args);
+	GeoResults<GeoLocation<M>> geoRadius(K key, Circle within, GeoRadiusCommandArgs args);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -151,7 +151,7 @@ public interface GeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 */
-	GeoResults<GeoLocation<M>> georadiusByMember(K key, M member, double radius);
+	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -163,7 +163,7 @@ public interface GeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 */
-	GeoResults<GeoLocation<M>> georadiusByMember(K key, M member, Distance distance);
+	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -176,7 +176,7 @@ public interface GeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 */
-	GeoResults<GeoLocation<M>> georadiusByMember(K key, M member, Distance distance, GeoRadiusCommandArgs args);
+	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance, GeoRadiusCommandArgs args);
 
 	/**
 	 * Remove the {@literal member}s.

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -2660,8 +2660,8 @@ public abstract class AbstractConnectionIntegrationTests {
 		String key = "geo-" + UUID.randomUUID();
 		actual.add(connection.geoAdd(key, Arrays.asList(ARIGENTO, CATANIA, PALERMO)));
 
-		actual.add(connection.georadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS))));
-		actual.add(connection.georadius(key, new Circle(new Point(15D, 37D), new Distance(150D, KILOMETERS))));
+		actual.add(connection.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS))));
+		actual.add(connection.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(150D, KILOMETERS))));
 
 		List<Object> results = getResults();
 		assertThat(((GeoResults<GeoLocation<String>>) results.get(1)).getContent(), hasSize(3));
@@ -2679,7 +2679,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		String key = "geo-" + UUID.randomUUID();
 		actual.add(connection.geoAdd(key, Arrays.asList(ARIGENTO, CATANIA, PALERMO)));
 
-		actual.add(connection.georadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)),
+		actual.add(connection.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)),
 				newGeoRadiusArgs().includeDistance()));
 
 		List<Object> results = getResults();
@@ -2701,7 +2701,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		String key = "geo-" + UUID.randomUUID();
 		actual.add(connection.geoAdd(key, Arrays.asList(ARIGENTO, CATANIA, PALERMO)));
 
-		actual.add(connection.georadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)),
+		actual.add(connection.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)),
 				newGeoRadiusArgs().limit(2)));
 
 		List<Object> results = getResults();
@@ -2719,7 +2719,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		String key = "geo-" + UUID.randomUUID();
 		actual.add(connection.geoAdd(key, Arrays.asList(ARIGENTO, CATANIA, PALERMO)));
 
-		actual.add(connection.georadiusByMember(key, PALERMO.getName(), new Distance(100, KILOMETERS),
+		actual.add(connection.geoRadiusByMember(key, PALERMO.getName(), new Distance(100, KILOMETERS),
 				newGeoRadiusArgs().sortAscending()));
 
 		List<Object> results = getResults();
@@ -2740,7 +2740,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		String key = "geo-" + UUID.randomUUID();
 		actual.add(connection.geoAdd(key, Arrays.asList(ARIGENTO, CATANIA, PALERMO)));
 
-		actual.add(connection.georadiusByMember(key, PALERMO.getName(), new Distance(100, KILOMETERS),
+		actual.add(connection.geoRadiusByMember(key, PALERMO.getName(), new Distance(100, KILOMETERS),
 				newGeoRadiusArgs().includeDistance()));
 
 		List<Object> results = getResults();
@@ -2762,7 +2762,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		String key = "geo-" + UUID.randomUUID();
 		actual.add(connection.geoAdd(key, Arrays.asList(ARIGENTO, CATANIA, PALERMO)));
 
-		actual.add(connection.georadiusByMember(key, PALERMO.getName(), new Distance(200, KILOMETERS),
+		actual.add(connection.geoRadiusByMember(key, PALERMO.getName(), new Distance(200, KILOMETERS),
 				newGeoRadiusArgs().limit(2)));
 
 		List<Object> results = getResults();

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
@@ -1977,7 +1977,7 @@ public class DefaultStringRedisConnectionTests {
 		doReturn(geoResults).when(nativeConnection).geoRadius(eq(fooBytes), any(Circle.class));
 
 		actual.add(
-				connection.georadius(foo, new Circle(new Point(13.361389, 38.115556), new Distance(10, DistanceUnit.FEET))));
+				connection.geoRadius(foo, new Circle(new Point(13.361389, 38.115556), new Distance(10, DistanceUnit.FEET))));
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
 
@@ -2004,7 +2004,7 @@ public class DefaultStringRedisConnectionTests {
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeDistance();
 		doReturn(geoResults).when(nativeConnection).geoRadius(eq(fooBytes), any(Circle.class), eq(geoRadiusParam));
 
-		actual.add(connection.georadius(foo,
+		actual.add(connection.geoRadius(foo,
 				new Circle(new Point(13.361389, 38.115556), new Distance(10, DistanceUnit.FEET)), geoRadiusParam));
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
@@ -2031,7 +2031,7 @@ public class DefaultStringRedisConnectionTests {
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeCoordinates().sortDescending();
 		doReturn(geoResults).when(nativeConnection).geoRadius(eq(fooBytes), any(Circle.class), eq(geoRadiusParam));
 
-		actual.add(connection.georadius(foo,
+		actual.add(connection.geoRadius(foo,
 				new Circle(new Point(13.361389, 38.115556), new Distance(10, DistanceUnit.FEET)), geoRadiusParam));
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
@@ -2058,7 +2058,7 @@ public class DefaultStringRedisConnectionTests {
 		doReturn(geoResults).when(nativeConnection).geoRadiusByMember(fooBytes, barBytes,
 				new Distance(38.115556, DistanceUnit.FEET));
 
-		actual.add(connection.georadiusByMember(foo, bar, new Distance(38.115556, DistanceUnit.FEET)));
+		actual.add(connection.geoRadiusByMember(foo, bar, new Distance(38.115556, DistanceUnit.FEET)));
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
 
@@ -2087,7 +2087,7 @@ public class DefaultStringRedisConnectionTests {
 		doReturn(geoResults).when(nativeConnection).geoRadiusByMember(fooBytes, barBytes,
 				new Distance(38.115556, DistanceUnit.FEET), geoRadiusParam);
 
-		actual.add(connection.georadiusByMember(foo, bar, new Distance(38.115556, DistanceUnit.FEET), geoRadiusParam));
+		actual.add(connection.geoRadiusByMember(foo, bar, new Distance(38.115556, DistanceUnit.FEET), geoRadiusParam));
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
 
@@ -2116,7 +2116,7 @@ public class DefaultStringRedisConnectionTests {
 		doReturn(geoResults).when(nativeConnection).geoRadiusByMember(fooBytes, barBytes,
 				new Distance(38.115556, DistanceUnit.FEET), geoRadiusParam);
 
-		actual.add(connection.georadiusByMember(foo, bar, new Distance(38.115556, DistanceUnit.FEET), geoRadiusParam));
+		actual.add(connection.geoRadiusByMember(foo, bar, new Distance(38.115556, DistanceUnit.FEET), geoRadiusParam));
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
@@ -272,7 +272,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1);
 		geoOperations.geoAdd(key, POINT_CATANIA, member2);
 
-		GeoResults<GeoLocation<M>> result = geoOperations.georadius(key,
+		GeoResults<GeoLocation<M>> result = geoOperations.geoRadius(key,
 				new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)));
 
 		assertThat(result.getContent(), hasSize(2));
@@ -291,7 +291,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1);
 		geoOperations.geoAdd(key, POINT_CATANIA, member2);
 
-		GeoResults<GeoLocation<M>> result = geoOperations.georadius(key,
+		GeoResults<GeoLocation<M>> result = geoOperations.geoRadius(key,
 				new Circle(new Point(15, 37), new Distance(200, KILOMETERS)),
 				newGeoRadiusArgs().includeDistance().sortDescending());
 
@@ -318,7 +318,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1);
 		geoOperations.geoAdd(key, POINT_CATANIA, member2);
 
-		GeoResults<GeoLocation<M>> result = geoOperations.georadius(key,
+		GeoResults<GeoLocation<M>> result = geoOperations.geoRadius(key,
 				new Circle(new Point(15, 37), new Distance(200, KILOMETERS)),
 				newGeoRadiusArgs().includeCoordinates().sortAscending());
 
@@ -345,7 +345,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1);
 		geoOperations.geoAdd(key, POINT_CATANIA, member2);
 
-		GeoResults<GeoLocation<M>> result = geoOperations.georadius(key,
+		GeoResults<GeoLocation<M>> result = geoOperations.geoRadius(key,
 				new Circle(new Point(15, 37), new Distance(200, KILOMETERS)),
 				newGeoRadiusArgs().includeCoordinates().includeDistance().sortAscending());
 		assertThat(result.getContent(), hasSize(2));
@@ -378,7 +378,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		geoOperations.geoAdd(key, POINT_CATANIA, member2);
 		geoOperations.geoAdd(key, POINT_ARIGENTO, member3);
 
-		GeoResults<GeoLocation<M>> result = geoOperations.georadiusByMember(key, member3, new Distance(200, KILOMETERS));
+		GeoResults<GeoLocation<M>> result = geoOperations.geoRadiusByMember(key, member3, new Distance(200, KILOMETERS));
 		assertThat(result.getContent(), hasSize(3));
 	}
 
@@ -397,7 +397,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		geoOperations.geoAdd(key, POINT_CATANIA, member2);
 		geoOperations.geoAdd(key, POINT_ARIGENTO, member3);
 
-		GeoResults<GeoLocation<M>> result = geoOperations.georadiusByMember(key, member3, new Distance(100, KILOMETERS),
+		GeoResults<GeoLocation<M>> result = geoOperations.geoRadiusByMember(key, member3, new Distance(100, KILOMETERS),
 				newGeoRadiusArgs().includeDistance().sortDescending());
 
 		assertThat(result.getContent(), hasSize(2));
@@ -422,7 +422,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		geoOperations.geoAdd(key, POINT_CATANIA, member2);
 		geoOperations.geoAdd(key, POINT_ARIGENTO, member3);
 
-		GeoResults<GeoLocation<M>> result = geoOperations.georadiusByMember(key, member3,
+		GeoResults<GeoLocation<M>> result = geoOperations.geoRadiusByMember(key, member3,
 				new Distance(100, DistanceUnit.KILOMETERS), newGeoRadiusArgs().includeCoordinates().sortAscending());
 
 		assertThat(result.getContent(), hasSize(2));
@@ -451,7 +451,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		geoOperations.geoAdd(key, POINT_ARIGENTO, member3);
 
 		// with coord and dist, ascending
-		GeoResults<GeoLocation<M>> result = geoOperations.georadiusByMember(key, member1, new Distance(100, KILOMETERS),
+		GeoResults<GeoLocation<M>> result = geoOperations.geoRadiusByMember(key, member1, new Distance(100, KILOMETERS),
 				newGeoRadiusArgs().includeCoordinates().includeDistance().sortAscending());
 		assertThat(result.getContent(), hasSize(2));
 


### PR DESCRIPTION
Unify capitalization of `geoRadius` to match other `geo` prefixed operations.