### PR TITLE
DATAREDIS-510 - Fix caching of null values. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-510-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -686,10 +686,14 @@ public class RedisCache implements Cache {
 				connection.multi();
 			}
 
-			connection.set(element.getKeyBytes(), element.get());
+			if (element.get().length == 0) {
+				connection.del(element.getKeyBytes());
+			} else {
+				connection.set(element.getKeyBytes(), element.get());
 
-			processKeyExpiration(element, connection);
-			maintainKnownKeys(element, connection);
+				processKeyExpiration(element, connection);
+				maintainKnownKeys(element, connection);
+			}
 
 			if (!isClusterConnection(connection)) {
 				connection.exec();

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheTest.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheTest.java
@@ -17,6 +17,7 @@
 package org.springframework.data.redis.cache;
 
 import static edu.umd.cs.mtc.TestFramework.*;
+import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsEqual.*;
 import static org.hamcrest.core.IsInstanceOf.*;
 import static org.hamcrest.core.IsNot.*;
@@ -279,6 +280,38 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		}
 
 		assertThat(wrapper.get(), equalTo(value));
+	}
+
+	/**
+	 * @see DATAREDIS-510
+	 */
+	@Test
+	public void cachePutWithNullShouldNotAddStuffToRedis() {
+
+		Object key = getKey();
+		Object value = getValue();
+
+		cache.put(key, null);
+
+		assertThat(cache.get(key), is(nullValue()));
+	}
+
+	/**
+	 * @see DATAREDIS-510
+	 */
+	@Test
+	public void cachePutWithNullShouldRemoveKeyIfExists() {
+
+		Object key = getKey();
+		Object value = getValue();
+
+		cache.put(key, value);
+
+		assertThat(cache.get(key).get(), is(equalTo(value)));
+
+		cache.put(key, null);
+
+		assertThat(cache.get(key), is(nullValue()));
 	}
 
 	/**


### PR DESCRIPTION
We now no longer add empty `byte[]` as cache value but return `null` instead.