### PR TITLE
DATAREDIS-505 - Allow configuration of Redis Keyspace events config value.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-505-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -108,6 +107,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 	private ApplicationEventPublisher eventPublisher;
 
 	private EnableKeyspaceEvents enableKeyspaceEvents = EnableKeyspaceEvents.OFF;
+	private String keyspaceNotificationsConfigParameter = null;
 
 	/**
 	 * Creates new {@link RedisKeyValueAdapter} with default {@link RedisMappingContext} and default
@@ -590,6 +590,17 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 	}
 
 	/**
+	 * Configure the {@literal notify-keyspace-events} property if not already set. Use an empty {@link String} or
+	 * {@literal null} to retain existing server settings.
+	 *
+	 * @param keyspaceNotificationsConfigParameter can be {@literal null}.
+	 * @since 1.8
+	 */
+	public void setKeyspaceNotificationsConfigParameter(String keyspaceNotificationsConfigParameter) {
+		this.keyspaceNotificationsConfigParameter = keyspaceNotificationsConfigParameter;
+	}
+
+	/**
 	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
 	 * @since 1.8
 	 */
@@ -611,7 +622,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 			this.expirationListener.get().destroy();
 		}
 
-		if(this.messageListenerContainer != null){
+		if (this.messageListenerContainer != null) {
 			this.messageListenerContainer.destroy();
 		}
 	}
@@ -669,6 +680,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 
 			MappingExpirationListener listener = new MappingExpirationListener(this.messageListenerContainer, this.redisOps,
 					this.converter);
+			listener.setKeyspaceNotificationsConfigParameter(keyspaceNotificationsConfigParameter);
 
 			if (this.eventPublisher != null) {
 				listener.setApplicationEventPublisher(this.eventPublisher);

--- a/src/main/java/org/springframework/data/redis/listener/KeyspaceEventMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/listener/KeyspaceEventMessageListener.java
@@ -35,6 +35,7 @@ public abstract class KeyspaceEventMessageListener implements MessageListener, I
 
 	private final RedisMessageListenerContainer listenerContainer;
 	private static final Topic TOPIC_ALL_KEYEVENTS = new PatternTopic("__keyevent@*");
+	private String keyspaceNotificationsConfigParameter = "EA";
 
 	/**
 	 * Creates new {@link KeyspaceEventMessageListener}.
@@ -77,12 +78,11 @@ public abstract class KeyspaceEventMessageListener implements MessageListener, I
 		RedisConnection connection = listenerContainer.getConnectionFactory().getConnection();
 		List<String> config = connection.getConfig("notify-keyspace-events");
 
-		if (config.size() == 2) {
-
-			if (!StringUtils.hasText(config.get(1))) {
-
-				// TODO more fine grained reaction on event configuration
-				connection.setConfig("notify-keyspace-events", "KEA");
+		if (StringUtils.hasText(keyspaceNotificationsConfigParameter)) {
+			if (config.size() == 2) {
+				if (!StringUtils.hasText(config.get(1))) {
+					connection.setConfig("notify-keyspace-events", keyspaceNotificationsConfigParameter);
+				}
 			}
 		}
 		connection.close();
@@ -106,6 +106,16 @@ public abstract class KeyspaceEventMessageListener implements MessageListener, I
 	@Override
 	public void destroy() throws Exception {
 		listenerContainer.removeMessageListener(this);
+	}
+
+	/**
+	 * Set the configuration string to use for {@literal notify-keyspace-events}.
+	 *
+	 * @param keyspaceNotificationsConfigParameter can be {@literal null}.
+	 * @since 1.8
+	 */
+	public void setKeyspaceNotificationsConfigParameter(String keyspaceNotificationsConfigParameter) {
+		this.keyspaceNotificationsConfigParameter = keyspaceNotificationsConfigParameter;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/repository/configuration/EnableRedisRepositories.java
+++ b/src/main/java/org/springframework/data/redis/repository/configuration/EnableRedisRepositories.java
@@ -166,4 +166,13 @@ public @interface EnableRedisRepositories {
 	 */
 	EnableKeyspaceEvents enableKeyspaceEvents() default EnableKeyspaceEvents.OFF;
 
+	/**
+	 * Configure the {@literal notify-keyspace-events} property if not already set. <br />
+	 * Use an empty {@link String} to keep <b>not</b> alter existing server configuration.
+	 *
+	 * @return {@literal Ex} by default.
+	 * @since 1.8
+	 */
+	String keyspaceNotificationsConfigParameter() default "Ex";
+
 }

--- a/src/main/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtension.java
@@ -128,6 +128,8 @@ public class RedisRepositoryConfigurationExtension extends KeyValueRepositoryCon
 
 		MutablePropertyValues redisKeyValueAdapterProps = new MutablePropertyValues();
 		redisKeyValueAdapterProps.add("enableKeyspaceEvents", attributes.getEnum("enableKeyspaceEvents"));
+		redisKeyValueAdapterProps.add("keyspaceNotificationsConfigParameter",
+				attributes.getString("keyspaceNotificationsConfigParameter"));
 		redisKeyValueAdapterDefinition.setPropertyValues(redisKeyValueAdapterProps);
 
 		registerIfNotAlreadyRegistered(redisKeyValueAdapterDefinition, registry, REDIS_ADAPTER_BEAN_NAME,

--- a/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtensionUnitTests.java
@@ -93,8 +93,7 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 		metadata = new StandardAnnotationMetadata(Config.class, true);
 		BeanDefinitionRegistry beanDefintionRegistry = getBeanDefinitionRegistry();
 
-		assertThat(getEnableKeyspaceEvents(beanDefintionRegistry),
-				equalTo((Object) EnableKeyspaceEvents.ON_STARTUP));
+		assertThat(getEnableKeyspaceEvents(beanDefintionRegistry), equalTo((Object) EnableKeyspaceEvents.ON_STARTUP));
 	}
 
 	/**
@@ -106,8 +105,31 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 		metadata = new StandardAnnotationMetadata(ConfigWithKeyspaceEventsDisabled.class, true);
 		BeanDefinitionRegistry beanDefintionRegistry = getBeanDefinitionRegistry();
 
-		assertThat(getEnableKeyspaceEvents(beanDefintionRegistry),
-				equalTo((Object) EnableKeyspaceEvents.OFF));
+		assertThat(getEnableKeyspaceEvents(beanDefintionRegistry), equalTo((Object) EnableKeyspaceEvents.OFF));
+	}
+
+	/**
+	 * @see DATAREDIS-505
+	 */
+	@Test
+	public void picksUpDefaultKeyspaceNotificationsConfigParameterCorrectly() {
+
+		metadata = new StandardAnnotationMetadata(Config.class, true);
+		BeanDefinitionRegistry beanDefintionRegistry = getBeanDefinitionRegistry();
+
+		assertThat(getKeyspaceNotificationsConfigParameter(beanDefintionRegistry), equalTo((Object) "Ex"));
+	}
+
+	/**
+	 * @see DATAREDIS-505
+	 */
+	@Test
+	public void picksUpCustomKeyspaceNotificationsConfigParameterCorrectly() {
+
+		metadata = new StandardAnnotationMetadata(ConfigWithKeyspaceEventsEnabledAndCustomEventConfig.class, true);
+		BeanDefinitionRegistry beanDefintionRegistry = getBeanDefinitionRegistry();
+
+		assertThat(getKeyspaceNotificationsConfigParameter(beanDefintionRegistry), equalTo((Object) "KEA"));
 	}
 
 	private static void assertDoesNotHaveRepo(Class<?> repositoryInterface,
@@ -153,6 +175,11 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 				.getPropertyValue("enableKeyspaceEvents").getValue();
 	}
 
+	private Object getKeyspaceNotificationsConfigParameter(BeanDefinitionRegistry beanDefintionRegistry) {
+		return beanDefintionRegistry.getBeanDefinition("redisKeyValueAdapter").getPropertyValues()
+				.getPropertyValue("keyspaceNotificationsConfigParameter").getValue();
+	}
+
 	@EnableRedisRepositories(considerNestedRepositories = true, enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP)
 	static class Config {
 
@@ -160,6 +187,12 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 
 	@EnableRedisRepositories(considerNestedRepositories = true)
 	static class ConfigWithKeyspaceEventsDisabled {
+
+	}
+
+	@EnableRedisRepositories(considerNestedRepositories = true, enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP,
+			keyspaceNotificationsConfigParameter = "KEA")
+	static class ConfigWithKeyspaceEventsEnabledAndCustomEventConfig {
 
 	}
 


### PR DESCRIPTION
We now allow setting the desired `notify-keyspace-events` server configuration via `@EnableRedisRepsoitories`. Use `null` or an empty String for not touching the server’s config. The default is `Ex`.