### PR TITLE
Update JedisConnection.java

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -806,8 +806,11 @@ public class JedisConnection extends AbstractRedisConnection {
 		 *  fix for: https://github.com/xetorthio/jedis/pull/575
 		 */
 		if (seconds > Integer.MAX_VALUE) {
-
-			return pExpireAt(key, time() + TimeUnit.SECONDS.toMillis(seconds));
+			final Long time = time();
+			if (time == null) {
+				return null;
+			}
+			return pExpireAt(key, time + TimeUnit.SECONDS.toMillis(seconds));
 		}
 
 		try {


### PR DESCRIPTION
Handling of a `NULL` result on invocation of the `Long time()` method.

NB: Feel free to merge or steal the change into a PR that follows the contribution guidelines to the letter.