### PR TITLE
DATAREDIS-524 - Use password to connect Redis nodes using Sentinel.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-524-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.redis.connection.PoolException;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import com.lambdaworks.redis.RedisAsyncConnection;
 import com.lambdaworks.redis.RedisClient;
@@ -120,7 +121,13 @@ public class DefaultLettucePool implements LettucePool, InitializingBean {
 	private RedisURI getRedisURI() {
 
 		if (isRedisSentinelAware()) {
-			return LettuceConverters.sentinelConfigurationToRedisURI(sentinelConfiguration);
+			RedisURI redisURI = LettuceConverters.sentinelConfigurationToRedisURI(sentinelConfiguration);
+
+			if (StringUtils.hasText(password)) {
+				redisURI.setPassword(password);
+			}
+
+			return redisURI;
 		}
 
 		return createSimpleHostRedisURI();

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -607,7 +607,14 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	}
 
 	private RedisURI getSentinelRedisURI() {
-		return LettuceConverters.sentinelConfigurationToRedisURI(sentinelConfiguration);
+
+		RedisURI redisURI = LettuceConverters.sentinelConfigurationToRedisURI(sentinelConfiguration);
+
+		if (StringUtils.hasText(password)) {
+			redisURI.setPassword(password);
+		}
+
+		return redisURI;
 	}
 
 	/**


### PR DESCRIPTION
LettuceConnectionFactory and DefaultLettucePool now use the configured password to authenticate with Redis. Authentication is applied when connecting to nodes that were obtained from Redis Sentinel.

----

Related ticket: [DATAREDIS-524](https://jira.spring.io/browse/DATAREDIS-524)