### PR TITLE
DATAREDIS-526

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -715,11 +715,14 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 		return execute(new RedisCallback<Long>() {
 
 			public Long doInRedis(RedisConnection connection) {
+				Long expire;
 				try {
-					return timeUnit.convert(connection.pTtl(rawKey), TimeUnit.MILLISECONDS);
+					expire = connection.pTtl(rawKey);
+					return expire < 0 ? expire : timeUnit.convert(expire, TimeUnit.MILLISECONDS);
 				} catch (Exception e) {
 					// Driver may not support pTtl or we may be running on Redis 2.4
-					return timeUnit.convert(connection.ttl(rawKey), TimeUnit.SECONDS);
+					expire = connection.ttl(rawKey);
+					return expire < 0 ? expire : timeUnit.convert(expire, TimeUnit.SECONDS);
 				}
 			}
 		}, true);

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -531,6 +531,39 @@ public class RedisTemplateTests<K, V> {
 	}
 
 	@Test
+	public void testGetExpireSecondsForKeyDoesNotExist() {
+		final K key1 = keyFactory.instance();
+		Long expire = redisTemplate.getExpire(key1, TimeUnit.SECONDS);
+		assertTrue(expire < 0l);
+	}
+
+	@Test
+	public void testGetExpireSecondsForKeyExistButHasNoAssociatedExpire() {
+		final K key1 = keyFactory.instance();
+		V value1 = valueFactory.instance();
+		redisTemplate.boundValueOps(key1).set(value1);
+		Long expire = redisTemplate.getExpire(key1, TimeUnit.SECONDS);
+		assertTrue(expire < 0l);
+	}
+
+
+	@Test
+	public void testGetExpireMillisForKeyDoesNotExist() {
+		final K key1 = keyFactory.instance();
+		Long expire = redisTemplate.getExpire(key1, TimeUnit.MILLISECONDS);
+		assertTrue(expire < 0l);
+	}
+
+	@Test
+	public void testGetExpireMillisForKeyExistButHasNoAssociatedExpire() {
+		final K key1 = keyFactory.instance();
+		V value1 = valueFactory.instance();
+		redisTemplate.boundValueOps(key1).set(value1);
+		Long expire = redisTemplate.getExpire(key1, TimeUnit.MILLISECONDS);
+		assertTrue(expire < 0l);
+	}
+
+	@Test
 	public void testGetExpireMillisNotSupported() {
 
 		assumeTrue(redisTemplate.getConnectionFactory() instanceof JedisConnectionFactory);


### PR DESCRIPTION
The redis command TTL and PTTL should return negative number(-1 or -2) when the key does not exist or the key exist but has no associated expire.
But the function getExpire like this: redisTemplate.getExpire(key1, TimeUnit.SECONDS),the return value will be 0 and redisTemplate.getExpire(key1) will be -1 or -2.