### PR TITLE
DATAREDIS-530 - Fix PartialUpdate removing existing indexes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-530-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/IndexWriter.java
+++ b/src/main/java/org/springframework/data/redis/core/IndexWriter.java
@@ -76,6 +76,16 @@ class IndexWriter {
 	 * @param indexValues can be {@literal null}.
 	 */
 	public void updateIndexes(Object key, Iterable<IndexedData> indexValues) {
+		createOrUpdateIndexes(key, indexValues, IndexWriteMode.PARTIAL_UPDATE);
+	}
+
+	/**
+	 * Updates indexes by first removing key from existing one and then persisting new index data.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param indexValues can be {@literal null}.
+	 */
+	public void deleteAndUpdateIndexes(Object key, Iterable<IndexedData> indexValues) {
 		createOrUpdateIndexes(key, indexValues, IndexWriteMode.UPDATE);
 	}
 
@@ -96,7 +106,7 @@ class IndexWriter {
 					removeKeyFromIndexes(data.getKeyspace(), binKey);
 				}
 			}
-
+		} else if (ObjectUtils.nullSafeEquals(IndexWriteMode.PARTIAL_UPDATE, writeMode)) {
 			removeKeyFromExistingIndexes(binKey, indexValues);
 		}
 
@@ -229,6 +239,6 @@ class IndexWriter {
 	 */
 	private static enum IndexWriteMode {
 
-		CREATE, UPDATE
+		CREATE, UPDATE, PARTIAL_UPDATE
 	}
 }

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -236,7 +236,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 				if (isNew) {
 					indexWriter.createIndexes(key, rdo.getIndexedData());
 				} else {
-					indexWriter.updateIndexes(key, rdo.getIndexedData());
+					indexWriter.deleteAndUpdateIndexes(key, rdo.getIndexedData());
 				}
 				return null;
 			}

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueTemplate.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.springframework.data.keyvalue.core.KeyValueAdapter;
 import org.springframework.data.keyvalue.core.KeyValueCallback;
 import org.springframework.data.keyvalue.core.KeyValueTemplate;
-import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.mapping.RedisMappingContext;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -135,6 +134,7 @@ public class RedisKeyValueTemplate extends KeyValueTemplate {
 
 		if (objectToUpdate instanceof PartialUpdate) {
 			doPartialUpdate((PartialUpdate<?>) objectToUpdate);
+			return;
 		}
 
 		super.update(objectToUpdate);

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
@@ -19,7 +19,6 @@ package org.springframework.data.redis.core;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
@@ -98,6 +97,7 @@ public class RedisKeyValueAdapterUnitTests {
 
 	/**
 	 * @see DATAREDIS-512
+	 * @see DATAREDIS-530
 	 */
 	@Test
 	public void putShouldRemoveExistingIndexValuesWhenUpdating() {
@@ -105,13 +105,14 @@ public class RedisKeyValueAdapterUnitTests {
 		RedisData rd = new RedisData(Bucket.newBucketFromStringMap(Collections.singletonMap("_id", "1")));
 		rd.addIndexedData(new SimpleIndexedPropertyValue("persons", "firstname", "rand"));
 
-		when(redisConnectionMock.keys(any(byte[].class)))
+		when(redisConnectionMock.sMembers(org.mockito.Matchers.any(byte[].class)))
 				.thenReturn(new LinkedHashSet<byte[]>(Arrays.asList("persons:firstname:rand".getBytes())));
 		when(redisConnectionMock.del((byte[][]) anyVararg())).thenReturn(1L);
 
 		adapter.put("1", rd, "persons");
 
-		verify(redisConnectionMock, times(1)).sRem(any(byte[].class), any(byte[].class));
+		verify(redisConnectionMock, times(1)).sRem(org.mockito.Matchers.any(byte[].class),
+				org.mockito.Matchers.any(byte[].class));
 	}
 
 	/**
@@ -123,20 +124,20 @@ public class RedisKeyValueAdapterUnitTests {
 		RedisData rd = new RedisData(Bucket.newBucketFromStringMap(Collections.singletonMap("_id", "1")));
 		rd.addIndexedData(new SimpleIndexedPropertyValue("persons", "firstname", "rand"));
 
-		when(redisConnectionMock.sMembers(any(byte[].class)))
+		when(redisConnectionMock.sMembers(org.mockito.Matchers.any(byte[].class)))
 				.thenReturn(new LinkedHashSet<byte[]>(Arrays.asList("persons:firstname:rand".getBytes())));
 		when(redisConnectionMock.del((byte[][]) anyVararg())).thenReturn(0L);
 
 		adapter.put("1", rd, "persons");
 
-		verify(redisConnectionMock, never()).sRem(any(byte[].class), (byte[][]) anyVararg());
+		verify(redisConnectionMock, never()).sRem(org.mockito.Matchers.any(byte[].class), (byte[][]) anyVararg());
 	}
 
 	/**
 	 * @see DATAREDIS-491
 	 */
 	@Test
-	public void shouldInitKeyExpirationListenerOnStartup() throws Exception{
+	public void shouldInitKeyExpirationListenerOnStartup() throws Exception {
 
 		adapter.destroy();
 


### PR DESCRIPTION
We now make sure to leave existing indexes untouched when using `PartialUpdate`. 
We also fixed a glitch, where index values have not been removed correctly when saving entities with `null` values, along the way.