### PR TITLE
DATAREDIS-523 - Read back TTL into property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-523-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -453,6 +453,7 @@ public class TimeToLiveOnMethod {
 ----
 ====
 
+NOTE: Annotating a property explicitly with `@TimeToLive` will read back the actual `TTL` or `PTTL` value from Redis. -1 indicates that the object has no expire associated.
 
 The repository implementation ensures subscription to http://redis.io/topics/notifications[Redis keyspace notifications] via `RedisMessageListenerContainer`.
 

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -605,9 +605,9 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 				}
 			});
 
-			if (timeout != null || (timeout == null && !ttlProperty.getType().isPrimitive())) {
+			if (timeout != null || !ttlProperty.getType().isPrimitive()) {
 				entity.getPropertyAccessor(target).setProperty(ttlProperty,
-						NumberUtils.convertNumberToTargetClass(timeout, (Class) ttlProperty.getType()));
+						converter.getConversionService().convert(timeout, ttlProperty.getType()));
 			}
 		}
 

--- a/src/main/java/org/springframework/data/redis/core/mapping/BasicRedisPersistentEntity.java
+++ b/src/main/java/org/springframework/data/redis/core/mapping/BasicRedisPersistentEntity.java
@@ -20,6 +20,7 @@ import org.springframework.data.keyvalue.core.mapping.BasicKeyValuePersistentEnt
 import org.springframework.data.keyvalue.core.mapping.KeySpaceResolver;
 import org.springframework.data.keyvalue.core.mapping.KeyValuePersistentProperty;
 import org.springframework.data.mapping.model.MappingException;
+import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.TimeToLiveAccessor;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.util.Assert;
@@ -57,6 +58,24 @@ public class BasicRedisPersistentEntity<T> extends BasicKeyValuePersistentEntity
 	@Override
 	public TimeToLiveAccessor getTimeToLiveAccessor() {
 		return this.timeToLiveAccessor;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.mapping.RedisPersistentEntity#hasExplictTimeToLiveProperty()
+	 */
+	@Override
+	public boolean hasExplictTimeToLiveProperty() {
+		return getExplicitTimeToLiveProperty() != null;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.mapping.RedisPersistentEntity#getExplicitTimeToLiveProperty()
+	 */
+	@Override
+	public RedisPersistentProperty getExplicitTimeToLiveProperty() {
+		return (RedisPersistentProperty) this.getPersistentProperty(TimeToLive.class);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/mapping/RedisMappingContext.java
+++ b/src/main/java/org/springframework/data/redis/core/mapping/RedisMappingContext.java
@@ -282,9 +282,9 @@ public class RedisMappingContext extends KeyValueMappingContext {
 			} else if (ttlProperty != null) {
 
 				RedisPersistentEntity entity = mappingContext.getPersistentEntity(type);
-				Long timeout = (Long) entity.getPropertyAccessor(source).getProperty(ttlProperty);
+				Number timeout = (Number) entity.getPropertyAccessor(source).getProperty(ttlProperty);
 				if (timeout != null) {
-					return TimeUnit.SECONDS.convert(timeout, unit);
+					return TimeUnit.SECONDS.convert(timeout.longValue(), unit);
 				}
 
 			} else {

--- a/src/main/java/org/springframework/data/redis/core/mapping/RedisPersistentEntity.java
+++ b/src/main/java/org/springframework/data/redis/core/mapping/RedisPersistentEntity.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.core.mapping;
 
 import org.springframework.data.keyvalue.core.mapping.KeyValuePersistentEntity;
 import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.redis.core.TimeToLiveAccessor;
 
 /**
@@ -34,5 +35,19 @@ public interface RedisPersistentEntity<T> extends KeyValuePersistentEntity<T> {
 	 * @return never {@literal null}.
 	 */
 	TimeToLiveAccessor getTimeToLiveAccessor();
+
+	/**
+	 * @return {@literal true} when a property is annotated with {@link org.springframework.data.redis.core.TimeToLive}.
+	 * @since 1.8
+	 */
+	boolean hasExplictTimeToLiveProperty();
+
+	/**
+	 * Get the {@link PersistentProperty}
+	 *
+	 * @return can be {@null}.
+	 * @since 1.8
+	 */
+	PersistentProperty<? extends PersistentProperty<?>> getExplicitTimeToLiveProperty();
 
 }

--- a/src/main/java/org/springframework/data/redis/core/mapping/RedisPersistentEntity.java
+++ b/src/main/java/org/springframework/data/redis/core/mapping/RedisPersistentEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public interface RedisPersistentEntity<T> extends KeyValuePersistentEntity<T> {
 	boolean hasExplictTimeToLiveProperty();
 
 	/**
-	 * Get the {@link PersistentProperty}
+	 * Get the {@link PersistentProperty} that is annotated with {@link org.springframework.data.redis.core.TimeToLive}.
 	 *
 	 * @return can be {@null}.
 	 * @since 1.8

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,10 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
+ * Integration tests for {@link RedisKeyValueTemplate}.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(Parameterized.class)
 public class RedisKeyValueTemplateTests {
@@ -891,6 +894,25 @@ public class RedisKeyValueTemplateTests {
 	 * @see DATAREDIS-523
 	 */
 	@Test
+	public void shouldReadBackExplicitTimeToLiveToPrimitiveField() throws InterruptedException {
+
+		WithPrimitiveTtl source = new WithPrimitiveTtl();
+		source.id = "ttl-1";
+		source.ttl = 5;
+		source.value = "5 seconds";
+
+		template.insert(source);
+
+		Thread.sleep(1100);
+
+		WithPrimitiveTtl target = template.findById(source.id, WithPrimitiveTtl.class);
+		assertThat((double) target.ttl, is(closeTo(3D, 1D)));
+	}
+
+	/**
+	 * @see DATAREDIS-523
+	 */
+	@Test
 	public void shouldReadBackExplicitTimeToLiveWhenFetchingList() throws InterruptedException {
 
 		WithTtl source = new WithTtl();
@@ -1048,5 +1070,13 @@ public class RedisKeyValueTemplateTests {
 		@Id String id;
 		String value;
 		@TimeToLive Long ttl;
+	}
+
+	@Data
+	static class WithPrimitiveTtl {
+
+		@Id String id;
+		String value;
+		@TimeToLive int ttl;
 	}
 }


### PR DESCRIPTION
We now read back `TTL` value from Redis for explicitly `@TimeToLive` annotated properties.