### PR TITLE
DATAREDIS-537 - Add support for Redis Cluster and SSL.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-537-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -565,6 +565,10 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 
 				RedisURI redisURI = new RedisURI(node.getHost(), node.getPort(), timeout, TimeUnit.MILLISECONDS);
 
+				redisURI.setSsl(useSsl);
+				redisURI.setVerifyPeer(verifyPeer);
+				redisURI.setStartTls(startTls);
+
 				if (StringUtils.hasText(password)) {
 					redisURI.setPassword(password);
 				}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -28,6 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.data.redis.ConnectionFactoryTracker;
+import org.springframework.data.redis.connection.ClusterTestVariables;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 
@@ -243,4 +244,69 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(connectionFactory.isStartTls(), is(true));
 	}
 
+	/**
+	 * @see DATAREDIS-537
+	 */
+	@Test
+	public void sslShouldBeSetCorrectlyOnClusterClient() {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisClusterConfiguration().clusterNode(ClusterTestVariables.CLUSTER_NODE_1));
+		connectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		connectionFactory.setUseSsl(true);
+		connectionFactory.afterPropertiesSet();
+		ConnectionFactoryTracker.add(connectionFactory);
+
+		AbstractRedisClient client = (AbstractRedisClient) getField(connectionFactory, "client");
+		assertThat(client, instanceOf(RedisClusterClient.class));
+
+		Iterable<RedisURI> initialUris = (Iterable<RedisURI>) getField(client, "initialUris");
+
+		for (RedisURI uri : initialUris) {
+			assertThat(uri.isSsl(), is(true));
+		}
+	}
+
+	/**
+	 * @see DATAREDIS-537
+	 */
+	@Test
+	public void startTLSOptionShouldBeSetCorrectlyOnClusterClient() {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisClusterConfiguration().clusterNode(ClusterTestVariables.CLUSTER_NODE_1));
+		connectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		connectionFactory.setStartTls(true);
+		connectionFactory.afterPropertiesSet();
+		ConnectionFactoryTracker.add(connectionFactory);
+
+		AbstractRedisClient client = (AbstractRedisClient) getField(connectionFactory, "client");
+		assertThat(client, instanceOf(RedisClusterClient.class));
+
+		Iterable<RedisURI> initialUris = (Iterable<RedisURI>) getField(client, "initialUris");
+
+		for (RedisURI uri : initialUris) {
+			assertThat(uri.isStartTls(), is(true));
+		}
+	}
+
+	/**
+	 * @see DATAREDIS-537
+	 */
+	@Test
+	public void verifyPeerTLSOptionShouldBeSetCorrectlyOnClusterClient() {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisClusterConfiguration().clusterNode(ClusterTestVariables.CLUSTER_NODE_1));
+		connectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		connectionFactory.setVerifyPeer(true);
+		connectionFactory.afterPropertiesSet();
+		ConnectionFactoryTracker.add(connectionFactory);
+
+		AbstractRedisClient client = (AbstractRedisClient) getField(connectionFactory, "client");
+		assertThat(client, instanceOf(RedisClusterClient.class));
+
+		Iterable<RedisURI> initialUris = (Iterable<RedisURI>) getField(client, "initialUris");
+
+		for (RedisURI uri : initialUris) {
+			assertThat(uri.isVerifyPeer(), is(true));
+		}
+	}
 }


### PR DESCRIPTION
Support SSL, StartTLS and VerifyPeer flags.

----

Related ticket: [DATAREDIS-537](https://jira.spring.io/browse/DATAREDIS-537)