### PR TITLE
DATAREDIS-506 - Upgrade to Jedis 2.9.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ work/sentinel-%.conf:
 
 	echo port $* >> $@
 	echo daemonize yes >> $@
+	echo bind 0.0.0.0 >> $@
 	echo pidfile $(shell pwd)/work/sentinel-$*.pid >> $@
 	echo logfile $(shell pwd)/work/sentinel-$*.log >> $@
 	echo save \"\" >> $@

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<xstream>1.4.8</xstream>
 		<pool>2.2</pool>
 		<lettuce>3.4.2.Final</lettuce>
-		<jedis>2.8.1</jedis>
+		<jedis>2.9.0</jedis>
 		<srp>0.7</srp>
 		<jredis>06052013</jredis>
 		<multithreadedtc>1.01</multithreadedtc>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-506-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -770,7 +770,7 @@ public class JedisConnection extends AbstractRedisConnection {
 				throw new InvalidDataAccessApiUsageException("No ongoing transaction. Did you forget to call multi?");
 			}
 			List<Object> results = transaction.exec();
-			return convertPipelineAndTxResults
+			return convertPipelineAndTxResults && results != null && !results.isEmpty()
 					? new TransactionResultConverter<Response<?>>(txResults, JedisConverters.exceptionConverter())
 							.convert(results)
 					: results;

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -71,6 +71,7 @@ import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 import org.springframework.data.redis.connection.SortParameters.Order;
 import org.springframework.data.redis.connection.StringRedisConnection.StringTuple;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -830,7 +831,12 @@ public abstract class AbstractConnectionIntegrationTests {
 		connection.set("testitnow", "somethingelse");
 		actual.add(connection.exec());
 		actual.add(connection.get("testitnow"));
-		verifyResults(Arrays.asList(new Object[] { null, "something" }));
+
+		if (connectionFactory instanceof JedisConnectionFactory) {
+			verifyResults(Arrays.asList(new Object[] { Collections.emptyList(), "something" }));
+		} else {
+			verifyResults(Arrays.asList(new Object[] { null, "something" }));
+		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -761,6 +761,9 @@ public class RedisTemplateTests<K, V> {
 		assertEquals(DataType.STRING, redisTemplate.type(key1));
 	}
 
+	/**
+	 * @see DATAREDIS-506
+	 */
 	@Test
 	public void testWatch() {
 		final K key1 = keyFactory.instance();
@@ -768,19 +771,24 @@ public class RedisTemplateTests<K, V> {
 		final V value2 = valueFactory.instance();
 		final V value3 = valueFactory.instance();
 		redisTemplate.opsForValue().set(key1, value1);
+
 		final Thread th = new Thread(new Runnable() {
 			public void run() {
 				redisTemplate.opsForValue().set(key1, value2);
 			}
 		});
+
 		List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
 			@SuppressWarnings({ "unchecked", "rawtypes" })
 			public List<Object> execute(RedisOperations operations) throws DataAccessException {
+
 				operations.watch(key1);
+
 				th.start();
 				try {
 					th.join();
 				} catch (InterruptedException e) {}
+
 				operations.multi();
 				operations.opsForValue().set(key1, value3);
 				return operations.exec();
@@ -792,11 +800,13 @@ public class RedisTemplateTests<K, V> {
 		} else {
 			assertNull(results);
 		}
+
 		assertThat(redisTemplate.opsForValue().get(key1), isEqual(value2));
 	}
 
 	@Test
 	public void testUnwatch() {
+
 		final K key1 = keyFactory.instance();
 		V value1 = valueFactory.instance();
 		final V value2 = valueFactory.instance();
@@ -807,48 +817,62 @@ public class RedisTemplateTests<K, V> {
 				redisTemplate.opsForValue().set(key1, value2);
 			}
 		});
+
 		List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
 			@SuppressWarnings({ "unchecked", "rawtypes" })
 			public List<Object> execute(RedisOperations operations) throws DataAccessException {
+
 				operations.watch(key1);
+
 				th.start();
 				try {
 					th.join();
 				} catch (InterruptedException e) {}
+
 				operations.unwatch();
 				operations.multi();
 				operations.opsForValue().set(key1, value3);
 				return operations.exec();
 			}
 		});
+
 		assertTrue(results.isEmpty());
 		assertThat(redisTemplate.opsForValue().get(key1), isEqual(value3));
 	}
 
+	/**
+	 * @see DATAREDIS-506
+	 */
 	@Test
 	public void testWatchMultipleKeys() {
+
 		final K key1 = keyFactory.instance();
 		final K key2 = keyFactory.instance();
 		V value1 = valueFactory.instance();
 		final V value2 = valueFactory.instance();
 		final V value3 = valueFactory.instance();
 		redisTemplate.opsForValue().set(key1, value1);
+
 		final Thread th = new Thread(new Runnable() {
 			public void run() {
 				redisTemplate.opsForValue().set(key1, value2);
 			}
 		});
+
 		List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
 			@SuppressWarnings({ "unchecked", "rawtypes" })
 			public List<Object> execute(RedisOperations operations) throws DataAccessException {
+
 				List<K> keys = new ArrayList<K>();
 				keys.add(key1);
 				keys.add(key2);
 				operations.watch(keys);
+
 				th.start();
 				try {
 					th.join();
 				} catch (InterruptedException e) {}
+
 				operations.multi();
 				operations.opsForValue().set(key1, value3);
 				return operations.exec();

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -72,6 +72,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * @author Christoph Strobl
  * @author Anqing Shao
  * @author Duobiao Ou
+ * @author Mark Paluch
  */
 @RunWith(Parameterized.class)
 public class RedisTemplateTests<K, V> {
@@ -785,7 +786,12 @@ public class RedisTemplateTests<K, V> {
 				return operations.exec();
 			}
 		});
-		assertNull(results);
+
+		if (redisTemplate.getConnectionFactory() instanceof JedisConnectionFactory) {
+			assertThat(results, is(empty()));
+		} else {
+			assertNull(results);
+		}
 		assertThat(redisTemplate.opsForValue().get(key1), isEqual(value2));
 	}
 
@@ -848,7 +854,13 @@ public class RedisTemplateTests<K, V> {
 				return operations.exec();
 			}
 		});
-		assertNull(results);
+
+		if (redisTemplate.getConnectionFactory() instanceof JedisConnectionFactory) {
+			assertThat(results, is(empty()));
+		} else {
+			assertNull(results);
+		}
+
 		assertThat(redisTemplate.opsForValue().get(key1), isEqual(value2));
 	}
 


### PR DESCRIPTION
We now support Jedis 2.9.0 with Redis Standalone SSL and Redis Cluster with passwords. The code is compatible with Jedis 2.8.0 when not using SSL or Redis Cluster with passwords.

----

Related ticket: [DATAREDIS-506](https://jira.spring.io/browse/DATAREDIS-506)