### PR TITLE
DATAREDIS-538 - Allow @TimeToLive methods that are not accessible by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-538-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/mapping/RedisMappingContext.java
+++ b/src/main/java/org/springframework/data/redis/core/mapping/RedisMappingContext.java
@@ -53,6 +53,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Mark Paluch
  * @since 1.7
  */
 public class RedisMappingContext extends KeyValueMappingContext<RedisPersistentEntity<?>, RedisPersistentProperty> {
@@ -255,6 +256,10 @@ public class RedisMappingContext extends KeyValueMappingContext<RedisPersistentE
 
 				Method timeoutMethod = resolveTimeMethod(type);
 				if (timeoutMethod != null) {
+
+					if (!timeoutMethod.isAccessible()) {
+						ReflectionUtils.makeAccessible(timeoutMethod);
+					}
 
 					TimeToLive ttl = AnnotationUtils.findAnnotation(timeoutMethod, TimeToLive.class);
 					try {

--- a/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareTimeToLiveAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareTimeToLiveAccessorUnitTests.java
@@ -28,7 +28,10 @@ import org.springframework.data.redis.core.convert.KeyspaceConfiguration.Keyspac
 import org.springframework.data.redis.core.mapping.RedisMappingContext.ConfigAwareTimeToLiveAccessor;
 
 /**
+ * Unit tests for {@link ConfigAwareTimeToLiveAccessor}.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class ConfigAwareTimeToLiveAccessorUnitTests {
 
@@ -137,6 +140,11 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(accessor.getTimeToLive(new TypeWithTtlOnMethod(100L))).isEqualTo(100L);
 	}
 
+	@Test // DATAREDIS-538
+	public void getTimeToLiveShouldReturnMethodLevelTimeToLiveOfNonPublicTypeIfPresent() {
+		assertThat(accessor.getTimeToLive(new PrivateTypeWithTtlOnMethod(10L))).isEqualTo(10L);
+	}
+
 	@Test // DATAREDIS-471
 	public void getTimeToLiveShouldReturnDefaultValue() {
 
@@ -209,6 +217,22 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		Long value;
 
 		public TypeWithTtlOnMethod(Long value) {
+			this.value = value;
+		}
+
+		@TimeToLive
+		private Long getTimeToLive() {
+			return value;
+		}
+	}
+
+	// Type must be private so it does not fall in the
+	// package-default scope like the types from above
+	private static class PrivateTypeWithTtlOnMethod {
+
+		Long value;
+
+		public PrivateTypeWithTtlOnMethod(Long value) {
 			this.value = value;
 		}
 


### PR DESCRIPTION
We allow now the use of non-public classes with a @TimeToLive method and @TimeToLive on non-public methods.

---

Related ticket: [DATAREDIS-538](https://jira.spring.io/browse/DATAREDIS-538)
