### PR TITLE
DATAREDIS-548 - Release connection after command execution in read-only transactions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-548-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -74,6 +74,7 @@ import org.springframework.util.CollectionUtils;
  * @author Christoph Strobl
  * @author Ninad Divadkar
  * @author Anqing Shao
+ * @author Mark Paluch
  * @param <K> the Redis key type against which the template works (usually a String)
  * @param <V> the Redis value type against which the template works
  * @see StringRedisTemplate
@@ -212,10 +213,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 			// TODO: any other connection processing?
 			return postProcessResult(result, connToUse, existingConnection);
 		} finally {
-
-			if (!enableTransactionSupport) {
-				RedisConnectionUtils.releaseConnection(conn, factory);
-			}
+			RedisConnectionUtils.releaseConnection(conn, factory);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/AbstractTransactionalTestBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractTransactionalTestBase.java
@@ -39,6 +39,13 @@ import org.springframework.test.context.transaction.AfterTransaction;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Base class with integration tests for transactional use.
+ *
+ * @author Thomas Darimont
+ * @author Christoph Strobl
+ * @author Mark Paluch
+ */
 @RunWith(RelaxedJUnit4ClassRunner.class)
 @Transactional(transactionManager = "transactionManager")
 public abstract class AbstractTransactionalTestBase {
@@ -130,6 +137,19 @@ public abstract class AbstractTransactionalTestBase {
 	}
 
 	/**
+	 * @see DATAREDIS-548
+	 */
+	@Test
+	@Transactional(readOnly = true)
+	public void valueOperationShouldWorkWithReadOnlyTransactions() {
+
+		this.valuesShouldHaveBeenPersisted = false;
+		for (String key : KEYS) {
+			template.opsForValue().get(key);
+		}
+	}
+
+	/**
 	 * @see DATAREDIS-73
 	 */
 	@Rollback(true)
@@ -146,7 +166,7 @@ public abstract class AbstractTransactionalTestBase {
 	 */
 	@Rollback(false)
 	@Test
-	public void listOperationLPushShoudBeCommittedCorrectly() {
+	public void listOperationLPushShouldBeCommittedCorrectly() {
 
 		this.valuesShouldHaveBeenPersisted = true;
 		for (String key : KEYS) {


### PR DESCRIPTION
Previously, RedisConnection's were bound as transactional resource when used in the scope of a `@Transactional(readOnly = true)` method but not released on transaction completion. This was, because connections are not registered with a transaction synchronizer.

We now unbind and release the connection from the transaction resources after a Redis command is invoked. Redis read operations return always null while using RedisTemplate in a transaction so Redis read transactions are not useful.

----

Related ticket: [DATAREDIS-548](https://jira.spring.io/browse/DATAREDIS-548)
Related PR: #209 