### PR TITLE
DATAREDIS-533 - Add support for geo indexes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-533-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -7,6 +7,7 @@ New and noteworthy in the latest releases.
 == New in Spring Data Redis 1.8
 
 * Support for Redis http://redis.io/commands#geo[GEO] commands.
+* Support for Geospatial Indexes using Spring Data Repository abstractions (see <<redis.repositories.indexes.geospatial>>).
 
 [[new-in-1.7.0]]
 == New in Spring Data Redis 1.7

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -310,6 +310,8 @@ public class ApplicationConfig {
 == Secondary Indexes
 http://redis.io/topics/indexes[Secondary indexes] are used to enable lookup operations based on native Redis structures. Values are written to the according indexes on every save and are removed when objects are deleted or <<redis.repositories.expirations,expire>>.
 
+=== Simple Property Index
+
 Given the sample `Person` entity we can create an index for _firstname_ by annotating the property with `@Indexed`.
 
 .Annotation driven indexing
@@ -418,6 +420,51 @@ public class ApplicationConfig {
 }
 ----
 ====
+
+=== Geospatial Index
+
+Assume the `Address` type contains a property `location` of type `Point` that holds the geo coordinates of the particular address. By annotating the property with `@GeoIndexed` those values will be added using  Redis `GEO` commands.
+
+====
+[source,java]
+----
+@RedisHash("persons")
+public class Person {
+
+  Address address;
+
+  // ... other properties omitted
+}
+
+public class Address {
+
+  @GeoIndexed Point location;
+
+  // ... other properties omitted
+}
+
+public interface PersonRepository extends CrudRepository<Person, String> {
+
+  List<Person> findByAddressLocationNear(Point point, Distance distance);     <1>
+  List<Person> findByAddressLocationWithin(Circle circle);                    <2>
+}
+
+Person rand = new Person("rand", "al'thor");
+rand.setAddress(new Address(new Point(13.361389D, 38.115556D)));
+
+repository.save(rand);                                                        <3>
+
+repository.findByAddressLocationNear(new Point(15D, 37D), new Distance(200)); <4>
+----
+<1> finder declaration on nested property using Point and Distance.
+<2> finder declaration on nested property using Circle to search within.
+<3> `GEOADD persons:address:location 13.361389 38.115556 e2c7dcee-b8cd-4424-883e-736ce564363e`
+<4> `GEORADIUS persons:address:location 15.0 37.0 200.0 km`
+====
+
+In the above example the lon/lat values are stored using `GEOADD` using the objects `id` as the members name. The finder methods allow usage of `Circle` or `Point, Distance` combinations for querying those values.
+
+NOTE: It is **not** possible to combine `near`/`within` with other criteria.
 
 
 [[redis.repositories.expirations]]

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -310,6 +310,7 @@ public class ApplicationConfig {
 == Secondary Indexes
 http://redis.io/topics/indexes[Secondary indexes] are used to enable lookup operations based on native Redis structures. Values are written to the according indexes on every save and are removed when objects are deleted or <<redis.repositories.expirations,expire>>.
 
+[[redis.repositories.indexes.simple]]
 === Simple Property Index
 
 Given the sample `Person` entity we can create an index for _firstname_ by annotating the property with `@Indexed`.
@@ -421,9 +422,10 @@ public class ApplicationConfig {
 ----
 ====
 
+[[redis.repositories.indexes.geospatial]]
 === Geospatial Index
 
-Assume the `Address` type contains a property `location` of type `Point` that holds the geo coordinates of the particular address. By annotating the property with `@GeoIndexed` those values will be added using  Redis `GEO` commands.
+Assume the `Address` type contains a property `location` of type `Point` that holds the geo coordinates of the particular address. By annotating the property with `@GeoIndexed` those values will be added using Redis `GEO` commands.
 
 ====
 [source,java]
@@ -456,13 +458,13 @@ repository.save(rand);                                                        <3
 
 repository.findByAddressLocationNear(new Point(15D, 37D), new Distance(200)); <4>
 ----
-<1> finder declaration on nested property using Point and Distance.
-<2> finder declaration on nested property using Circle to search within.
+<1> Query method declaration on nested property using Point and Distance.
+<2> Query method declaration on nested property using Circle to search within.
 <3> `GEOADD persons:address:location 13.361389 38.115556 e2c7dcee-b8cd-4424-883e-736ce564363e`
 <4> `GEORADIUS persons:address:location 15.0 37.0 200.0 km`
 ====
 
-In the above example the lon/lat values are stored using `GEOADD` using the objects `id` as the members name. The finder methods allow usage of `Circle` or `Point, Distance` combinations for querying those values.
+In the above example the lon/lat values are stored using `GEOADD` using the objects `id` as the member's name. The finder methods allow usage of `Circle` or `Point, Distance` combinations for querying those values.
 
 NOTE: It is **not** possible to combine `near`/`within` with other criteria.
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -2431,7 +2431,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 		Map<byte[], Point> byteMap = new HashMap<byte[], Point>();
 		for (Entry<String, Point> entry : memberCoordinateMap.entrySet()) {
-			byteMap.put(serialize(entry.getKey()), memberCoordinateMap.get(entry.getValue()));
+			byteMap.put(serialize(entry.getKey()), entry.getValue());
 		}
 
 		return geoAdd(serialize(key), byteMap);

--- a/src/main/java/org/springframework/data/redis/core/IndexWriter.java
+++ b/src/main/java/org/springframework/data/redis/core/IndexWriter.java
@@ -206,7 +206,7 @@ class IndexWriter {
 			return;
 		}
 
-		else if (indexedData instanceof SimpleIndexedPropertyValue) {
+		if (indexedData instanceof SimpleIndexedPropertyValue) {
 
 			Object value = ((SimpleIndexedPropertyValue) indexedData).getValue();
 
@@ -234,9 +234,7 @@ class IndexWriter {
 
 			// keep track of indexes used for the object
 			connection.sAdd(ByteUtils.concatAll(toBytes(indexedData.getKeyspace() + ":"), key, toBytes(":idx")), indexKey);
-		}
-
-		else {
+		} else {
 			throw new IllegalArgumentException(
 					String.format("Cannot write index data for unknown index type %s", indexedData.getClass()));
 		}

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -516,9 +516,9 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 					? ByteUtils.concatAll(toBytes(redisUpdateObject.keyspace), toBytes((":" + path)), toBytes(":"), value) : null;
 
 			if (connection.exists(existingValueIndexKey)) {
-
 				redisUpdateObject.addIndexToUpdate(new RedisUpdateObject.Index(existingValueIndexKey, DataType.SET));
 			}
+
 			return redisUpdateObject;
 		}
 
@@ -545,13 +545,11 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 		}
 
 		String pathToUse = GeoIndexedPropertyValue.geoIndexName(path);
-		if (connection.zRank(ByteUtils.concatAll(toBytes(redisUpdateObject.keyspace), toBytes(":"), toBytes(pathToUse)),
-				toBytes(redisUpdateObject.targetId)) != null) {
+		byte[] existingGeoIndexKey = ByteUtils.concatAll(toBytes(redisUpdateObject.keyspace), toBytes(":"),
+				toBytes(pathToUse));
 
-			redisUpdateObject
-					.addIndexToUpdate(new org.springframework.data.redis.core.RedisKeyValueAdapter.RedisUpdateObject.Index(
-							ByteUtils.concatAll(toBytes(redisUpdateObject.keyspace), toBytes(":"), toBytes(pathToUse)),
-							DataType.ZSET));
+		if (connection.zRank(existingGeoIndexKey, toBytes(redisUpdateObject.targetId)) != null) {
+			redisUpdateObject.addIndexToUpdate(new RedisUpdateObject.Index(existingGeoIndexKey, DataType.ZSET));
 		}
 
 		return redisUpdateObject;

--- a/src/main/java/org/springframework/data/redis/core/RedisQueryEngine.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisQueryEngine.java
@@ -90,18 +90,11 @@ class RedisQueryEngine extends QueryEngine<RedisKeyValueAdapter, RedisOperationC
 			@Override
 			public Map<byte[], Map<byte[], byte[]>> doInRedis(RedisConnection connection) throws DataAccessException {
 
-				String key = keyspace + ":";
-				byte[][] keys = new byte[criteria.getSismember().size()][];
-				int i = 0;
-				for (Object o : criteria.getSismember()) {
-					keys[i] = getAdapter().getConverter().getConversionService().convert(key + o, byte[].class);
-					i++;
-				}
-
 				List<byte[]> allKeys = new ArrayList<byte[]>();
 				if (!criteria.getSismember().isEmpty()) {
 					allKeys.addAll(connection.sInter(keys(keyspace + ":", criteria.getSismember())));
 				}
+
 				if (!criteria.getOrSismember().isEmpty()) {
 					allKeys.addAll(connection.sUnion(keys(keyspace + ":", criteria.getOrSismember())));
 				}
@@ -229,5 +222,4 @@ class RedisQueryEngine extends QueryEngine<RedisKeyValueAdapter, RedisOperationC
 			return (RedisOperationChain) query.getCritieria();
 		}
 	}
-
 }

--- a/src/main/java/org/springframework/data/redis/core/convert/GeoIndexedPropertyValue.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/GeoIndexedPropertyValue.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.convert;
+
+import org.springframework.data.geo.Point;
+
+import lombok.Data;
+
+/**
+ * {@link IndexedData} implementation indicating storage of data within a Redis GEO structure.
+ *
+ * @author Christoph Strobl
+ * @since 1.8
+ */
+@Data
+public class GeoIndexedPropertyValue implements IndexedData {
+
+	private final String keyspace;
+	private final String indexName;
+	private final Point value;
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.convert.IndexedData#getIndexName()
+	 */
+	@Override
+	public String getIndexName() {
+		return GeoIndexedPropertyValue.geoIndexName(indexName);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.convert.IndexedData#getKeyspace()
+	 */
+	@Override
+	public String getKeyspace() {
+		return keyspace;
+	}
+
+	public Point getPoint() {
+		return value;
+	}
+
+	public static String geoIndexName(String path) {
+
+		int index = path.lastIndexOf('.');
+		if (index == -1) {
+			return path;
+		}
+		StringBuilder sb = new StringBuilder(path);
+		sb.setCharAt(index, ':');
+		return sb.toString();
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/convert/IndexedDataFactoryProvider.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/IndexedDataFactoryProvider.java
@@ -81,5 +81,4 @@ class IndexedDataFactoryProvider {
 					(Point) indexDefinition.valueTransformer().convert(value));
 		}
 	}
-
 }

--- a/src/main/java/org/springframework/data/redis/core/convert/IndexedDataFactoryProvider.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/IndexedDataFactoryProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.convert;
+
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.core.index.GeoIndexDefinition;
+import org.springframework.data.redis.core.index.IndexDefinition;
+import org.springframework.data.redis.core.index.SimpleIndexDefinition;
+
+/**
+ * @author Christoph Strobl
+ * @since 1.8
+ */
+class IndexedDataFactoryProvider {
+
+	/**
+	 * @author Christoph Strobl
+	 * @since 1.8
+	 */
+	IndexedDataFactory getIndexedDataFactory(IndexDefinition definition) {
+
+		if (definition instanceof SimpleIndexDefinition) {
+			return new SimpleIndexedPropertyValueFactory((SimpleIndexDefinition) definition);
+		} else if (definition instanceof GeoIndexDefinition) {
+			return new GeoIndexedPropertyValueFactory(((GeoIndexDefinition) definition));
+		}
+		return null;
+	}
+
+	static interface IndexedDataFactory {
+		IndexedData createIndexedDataFor(Object value);
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 * @since 1.8
+	 */
+	static class SimpleIndexedPropertyValueFactory implements IndexedDataFactory {
+
+		final SimpleIndexDefinition indexDefinition;
+
+		public SimpleIndexedPropertyValueFactory(SimpleIndexDefinition indexDefinition) {
+			this.indexDefinition = indexDefinition;
+		}
+
+		public SimpleIndexedPropertyValue createIndexedDataFor(Object value) {
+
+			return new SimpleIndexedPropertyValue(indexDefinition.getKeyspace(), indexDefinition.getIndexName(),
+					indexDefinition.valueTransformer().convert(value));
+		}
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 * @since 1.8
+	 */
+	static class GeoIndexedPropertyValueFactory implements IndexedDataFactory {
+
+		final GeoIndexDefinition indexDefinition;
+
+		public GeoIndexedPropertyValueFactory(GeoIndexDefinition indexDefinition) {
+			this.indexDefinition = indexDefinition;
+		}
+
+		public GeoIndexedPropertyValue createIndexedDataFor(Object value) {
+
+			return new GeoIndexedPropertyValue(indexDefinition.getKeyspace(), indexDefinition.getPath(),
+					(Point) indexDefinition.valueTransformer().convert(value));
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/core/index/GeoIndexDefinition.java
+++ b/src/main/java/org/springframework/data/redis/core/index/GeoIndexDefinition.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.index;
+
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
+
+/**
+ * @author Christoph Strobl
+ * @since 1.8
+ */
+public class GeoIndexDefinition extends RedisIndexDefinition implements PathBasedRedisIndexDefinition {
+
+	/**
+	 * Creates new {@link GeoIndexDefinition}.
+	 *
+	 * @param keyspace must not be {@literal null}.
+	 * @param path
+	 */
+	public GeoIndexDefinition(String keyspace, String path) {
+		this(keyspace, path, path);
+	}
+
+	/**
+	 * Creates new {@link GeoIndexDefinition}.
+	 *
+	 * @param keyspace must not be {@literal null}.
+	 * @param path
+	 * @param name must not be {@literal null}.
+	 */
+	public GeoIndexDefinition(String keyspace, String path, String name) {
+		super(keyspace, path, name);
+		addCondition(new PathCondition(path));
+		setValueTransformer(new PointValueTransformer());
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 * @since 1.8
+	 */
+	static class PointValueTransformer implements IndexValueTransformer {
+
+		@Override
+		public Point convert(Object source) {
+
+			if (source == null || source instanceof Point) {
+				return (Point) source;
+			}
+
+			if (source instanceof GeoLocation<?>) {
+				return ((GeoLocation<?>) source).getPoint();
+			}
+
+			throw new IllegalArgumentException(
+					String.format("Cannot convert %s to %s. GeoIndexed property needs to be of type Point or GeoLocation!",
+							source.getClass(), Point.class));
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/index/GeoIndexed.java
+++ b/src/main/java/org/springframework/data/redis/core/index/GeoIndexed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,15 +23,15 @@ import java.lang.annotation.Target;
 
 /**
  * Mark properties value to be included in a secondary index. <br />
- * Uses Redis {@literal SET} for storage. <br />
+ * Uses Redis {@literal GEO} structures for storage. <br />
  * The value will be part of the key built for the index.
- * 
+ *
  * @author Christoph Strobl
- * @since 1.7
+ * @since 1.8
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
-public @interface Indexed {
+public @interface GeoIndexed {
 
 }

--- a/src/main/java/org/springframework/data/redis/repository/query/RedisOperationChain.java
+++ b/src/main/java/org/springframework/data/redis/repository/query/RedisOperationChain.java
@@ -27,7 +27,7 @@ import org.springframework.data.geo.Point;
 import org.springframework.util.ObjectUtils;
 
 /**
- * Simple set of operations requried to run queries against Redis.
+ * Simple set of operations required to run queries against Redis.
  * 
  * @author Christoph Strobl
  * @since 1.7
@@ -36,7 +36,6 @@ public class RedisOperationChain {
 
 	private Set<PathAndValue> sismember = new LinkedHashSet<PathAndValue>();
 	private Set<PathAndValue> orSismember = new LinkedHashSet<PathAndValue>();
-
 	private NearPath near;
 
 	public void sismember(String path, Object value) {
@@ -163,5 +162,4 @@ public class RedisOperationChain {
 			return (Distance) it.next();
 		}
 	}
-
 }

--- a/src/main/java/org/springframework/data/redis/repository/query/RedisOperationChain.java
+++ b/src/main/java/org/springframework/data/redis/repository/query/RedisOperationChain.java
@@ -15,11 +15,15 @@
  */
 package org.springframework.data.redis.repository.query;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Point;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -32,6 +36,8 @@ public class RedisOperationChain {
 
 	private Set<PathAndValue> sismember = new LinkedHashSet<PathAndValue>();
 	private Set<PathAndValue> orSismember = new LinkedHashSet<PathAndValue>();
+
+	private NearPath near;
 
 	public void sismember(String path, Object value) {
 		sismember(new PathAndValue(path, value));
@@ -59,6 +65,14 @@ public class RedisOperationChain {
 
 	public Set<PathAndValue> getOrSismember() {
 		return orSismember;
+	}
+
+	public void near(NearPath near) {
+		this.near = near;
+	}
+
+	public NearPath getNear() {
+		return near;
 	}
 
 	public static class PathAndValue {
@@ -126,6 +140,28 @@ public class RedisOperationChain {
 			return ObjectUtils.nullSafeEquals(this.values, that.values);
 		}
 
+	}
+
+	/**
+	 * @since 1.8
+	 * @author Christoph Strobl
+	 */
+	public static class NearPath extends PathAndValue {
+
+		public NearPath(String path, Point point, Distance distance) {
+			super(path, Arrays.<Object> asList(point, distance));
+		}
+
+		public Point getPoint() {
+			return (Point) getFirstValue();
+		}
+
+		public Distance getDistance() {
+
+			Iterator<Object> it = values().iterator();
+			it.next();
+			return (Distance) it.next();
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
+++ b/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
@@ -17,8 +17,14 @@ package org.springframework.data.redis.repository.query;
 
 import java.util.Iterator;
 
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Point;
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
+import org.springframework.data.redis.repository.query.RedisOperationChain.NearPath;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.data.repository.query.parser.Part;
@@ -35,6 +41,7 @@ public class RedisQueryCreator extends AbstractQueryCreator<KeyValueQuery<RedisO
 
 	public RedisQueryCreator(PartTree tree, ParameterAccessor parameters) {
 		super(tree, parameters);
+
 	}
 
 	/*
@@ -51,6 +58,10 @@ public class RedisQueryCreator extends AbstractQueryCreator<KeyValueQuery<RedisO
 		switch (part.getType()) {
 			case SIMPLE_PROPERTY:
 				sink.sismember(part.getProperty().toDotPath(), iterator.next());
+				break;
+			case WITHIN:
+			case NEAR:
+				sink.near(getNearPath(part, iterator));
 				break;
 			default:
 				throw new IllegalArgumentException(part.getType() + "is not supported for redis query derivation");
@@ -101,6 +112,43 @@ public class RedisQueryCreator extends AbstractQueryCreator<KeyValueQuery<RedisO
 		}
 
 		return query;
+	}
+
+	private NearPath getNearPath(Part part, Iterator<Object> iterator) {
+
+		Object o = iterator.next();
+
+		Point point = null;
+		Distance distance = null;
+
+		if (o instanceof Circle) {
+
+			point = ((Circle) o).getCenter();
+			distance = ((Circle) o).getRadius();
+		} else if (o instanceof Point) {
+
+			point = (Point) o;
+
+			if (!iterator.hasNext()) {
+				throw new InvalidDataAccessApiUsageException(
+						"Expected to find distance value for geo query. Are you missing a parameter?");
+			}
+
+			Object distObject = iterator.next();
+			if (distObject instanceof Distance) {
+				distance = (Distance) distObject;
+			} else if (distObject instanceof Number) {
+				distance = new Distance(((Number) distObject).doubleValue(), Metrics.KILOMETERS);
+			} else {
+				throw new InvalidDataAccessApiUsageException(String
+						.format("Expected to find Distance or Numeric value for geo query but was %s.", distObject.getClass()));
+			}
+		} else {
+			throw new InvalidDataAccessApiUsageException(
+					String.format("Expected to find a Circle or Point/Distance for geo query but was %s.", o.getClass()));
+		}
+
+		return new NearPath(part.getProperty().toDotPath(), point, distance);
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
+++ b/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
@@ -41,7 +41,6 @@ public class RedisQueryCreator extends AbstractQueryCreator<KeyValueQuery<RedisO
 
 	public RedisQueryCreator(PartTree tree, ParameterAccessor parameters) {
 		super(tree, parameters);
-
 	}
 
 	/*
@@ -68,7 +67,6 @@ public class RedisQueryCreator extends AbstractQueryCreator<KeyValueQuery<RedisO
 		}
 
 		return sink;
-
 	}
 
 	/*
@@ -150,5 +148,4 @@ public class RedisQueryCreator extends AbstractQueryCreator<KeyValueQuery<RedisO
 
 		return new NearPath(part.getProperty().toDotPath(), point, distance);
 	}
-
 }

--- a/src/test/java/org/springframework/data/redis/core/IndexWriterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/IndexWriterUnitTests.java
@@ -35,6 +35,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.convert.GeoIndexedPropertyValue;
 import org.springframework.data.redis.core.convert.IndexedData;
 import org.springframework.data.redis.core.convert.MappingRedisConverter;
 import org.springframework.data.redis.core.convert.PathIndexResolver;
@@ -213,6 +214,21 @@ public class IndexWriterUnitTests {
 		verify(connectionMock).sAdd(eq("persons:key-1:idx".getBytes(CHARSET)),
 				eq("persons:firstname:Rand".getBytes(CHARSET)));
 		verify(connectionMock, times(1)).sRem(any(byte[].class), eq(KEY_BIN));
+	}
+
+	/**
+	 * @see DATAREDIS-533
+	 */
+	@Test
+	public void removeGeoIndexShouldCallGeoRemove() {
+
+		byte[] indexKey1 = "persons:location".getBytes(CHARSET);
+
+		when(connectionMock.keys(any(byte[].class))).thenReturn(new LinkedHashSet<byte[]>(Arrays.asList(indexKey1)));
+
+		writer.removeKeyFromExistingIndexes(KEY_BIN, new GeoIndexedPropertyValue(KEYSPACE, "address.city", null));
+
+		verify(connectionMock).geoRemove(indexKey1, KEY_BIN);
 	}
 
 	static class StubIndxedData implements IndexedData {

--- a/src/test/java/org/springframework/data/redis/core/convert/PathIndexResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/PathIndexResolverUnitTests.java
@@ -637,5 +637,4 @@ public class PathIndexResolverUnitTests {
 	static class GeoIndexedOnArray {
 		@GeoIndexed double[] location;
 	}
-
 }

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryClusterIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryClusterIntegrationTests.java
@@ -51,8 +51,8 @@ public class RedisRepositoryClusterIntegrationTests extends RedisRepositoryInteg
 
 	@Configuration
 	@EnableRedisRepositories(considerNestedRepositories = true, indexConfiguration = MyIndexConfiguration.class,
-			keyspaceConfiguration = MyKeyspaceConfiguration.class,
-			includeFilters = { @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*PersonRepository") })
+			keyspaceConfiguration = MyKeyspaceConfiguration.class, includeFilters = {
+					@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*PersonRepository|.*CityRepository") })
 	static class Config {
 
 		@Bean

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
@@ -584,5 +584,4 @@ public abstract class RedisRepositoryIntegrationTestBase {
 			return true;
 		}
 	}
-
 }

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTests.java
@@ -35,8 +35,8 @@ public class RedisRepositoryIntegrationTests extends RedisRepositoryIntegrationT
 
 	@Configuration
 	@EnableRedisRepositories(considerNestedRepositories = true, indexConfiguration = MyIndexConfiguration.class,
-			keyspaceConfiguration = MyKeyspaceConfiguration.class,
-			includeFilters = { @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*PersonRepository") })
+			keyspaceConfiguration = MyKeyspaceConfiguration.class, includeFilters = {
+					@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*PersonRepository|.*CityRepository") })
 	static class Config {
 
 		@Bean

--- a/src/test/java/org/springframework/data/redis/repository/query/RedisQueryCreatorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/query/RedisQueryCreatorUnitTests.java
@@ -16,15 +16,26 @@
 package org.springframework.data.redis.repository.query;
 
 import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsCollectionContaining.*;
+import static org.hamcrest.core.IsNull.*;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.geo.Box;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Shape;
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
-import org.springframework.data.redis.core.convert.ConversionTestEntities;
+import org.springframework.data.redis.core.convert.ConversionTestEntities.Person;
 import org.springframework.data.redis.repository.query.RedisOperationChain.PathAndValue;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -36,6 +47,8 @@ import org.springframework.data.repository.query.parser.PartTree;
  * @author Christoph Strobl
  */
 public class RedisQueryCreatorUnitTests {
+
+	public @Rule ExpectedException exception = ExpectedException.none();
 
 	private @Mock RepositoryMetadata metadataMock;
 
@@ -61,8 +74,8 @@ public class RedisQueryCreatorUnitTests {
 	public void findByMultipleSimpleProperties() throws SecurityException, NoSuchMethodException {
 
 		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
-				SampleRepository.class.getMethod("findByFirstnameAndAge", String.class, Integer.class), new Object[] {
-						"eddard", 43 });
+				SampleRepository.class.getMethod("findByFirstnameAndAge", String.class, Integer.class),
+				new Object[] { "eddard", 43 });
 
 		KeyValueQuery<RedisOperationChain> query = creator.createQuery();
 
@@ -78,8 +91,8 @@ public class RedisQueryCreatorUnitTests {
 	public void findByMultipleSimplePropertiesUsingOr() throws SecurityException, NoSuchMethodException {
 
 		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
-				SampleRepository.class.getMethod("findByAgeOrFirstname", Integer.class, String.class), new Object[] { 43,
-						"eddard" });
+				SampleRepository.class.getMethod("findByAgeOrFirstname", Integer.class, String.class),
+				new Object[] { 43, "eddard" });
 
 		KeyValueQuery<RedisOperationChain> query = creator.createQuery();
 
@@ -88,21 +101,127 @@ public class RedisQueryCreatorUnitTests {
 		assertThat(query.getCritieria().getOrSismember(), hasItem(new PathAndValue("firstname", "eddard")));
 	}
 
+	/**
+	 * @see DATAREDIS-533
+	 */
+	@Test
+	public void findWithinCircle() throws SecurityException, NoSuchMethodException {
+
+		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
+				SampleRepository.class.getMethod("findByLocationWithin", Circle.class),
+				new Object[] { new Circle(new Point(1, 2), new Distance(200, Metrics.KILOMETERS)) });
+
+		KeyValueQuery<RedisOperationChain> query = creator.createQuery();
+
+		assertThat(query.getCritieria().getNear(), is(notNullValue()));
+		assertThat(query.getCritieria().getNear().getPoint(), is(new Point(1, 2)));
+		assertThat(query.getCritieria().getNear().getDistance(), is(new Distance(200, Metrics.KILOMETERS)));
+	}
+
+	/**
+	 * @see DATAREDIS-533
+	 */
+	@Test
+	public void findNearWithPointAndDistance() throws SecurityException, NoSuchMethodException {
+
+		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
+				SampleRepository.class.getMethod("findByLocationNear", Point.class, Distance.class),
+				new Object[] { new Point(1, 2), new Distance(200, Metrics.KILOMETERS) });
+
+		KeyValueQuery<RedisOperationChain> query = creator.createQuery();
+
+		assertThat(query.getCritieria().getNear(), is(notNullValue()));
+		assertThat(query.getCritieria().getNear().getPoint(), is(new Point(1, 2)));
+		assertThat(query.getCritieria().getNear().getDistance(), is(new Distance(200, Metrics.KILOMETERS)));
+	}
+
+	/**
+	 * @see DATAREDIS-533
+	 */
+	@Test
+	public void findNearWithPointAndNumericValueDefaultsToKilometers() throws SecurityException, NoSuchMethodException {
+
+		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
+				SampleRepository.class.getMethod("findByLocationNear", Shape.class, Object.class),
+				new Object[] { new Point(1, 2), 200F });
+
+		KeyValueQuery<RedisOperationChain> query = creator.createQuery();
+
+		assertThat(query.getCritieria().getNear(), is(notNullValue()));
+		assertThat(query.getCritieria().getNear().getPoint(), is(new Point(1, 2)));
+		assertThat(query.getCritieria().getNear().getDistance(), is(new Distance(200, Metrics.KILOMETERS)));
+	}
+
+	/**
+	 * @see DATAREDIS-533
+	 */
+	@Test
+	public void findNearWithInvalidShapeParameter() throws SecurityException, NoSuchMethodException {
+
+		exception.expect(InvalidDataAccessApiUsageException.class);
+		exception.expectMessage("Expected to find a Circle or Point/Distance");
+
+		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
+				SampleRepository.class.getMethod("findByLocationNear", Shape.class, Object.class),
+				new Object[] { new Box(new Point(0, 0), new Point(1, 1)), 200F });
+
+		creator.createQuery();
+	}
+
+	/**
+	 * @see DATAREDIS-533
+	 */
+	@Test
+	public void findNearWithInvalidDistanceParameter() throws SecurityException, NoSuchMethodException {
+
+		exception.expect(InvalidDataAccessApiUsageException.class);
+		exception.expectMessage("Expected to find Distance or Numeric value");
+
+		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
+				SampleRepository.class.getMethod("findByLocationNear", Shape.class, Object.class),
+				new Object[] { new Point(0, 0), "200" });
+
+		creator.createQuery();
+	}
+
+	/**
+	 * @see DATAREDIS-533
+	 */
+	@Test
+	public void findNearWithMissingDistanceParameter() throws SecurityException, NoSuchMethodException {
+
+		exception.expect(InvalidDataAccessApiUsageException.class);
+		exception.expectMessage("Are you missing a parameter?");
+
+		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
+				SampleRepository.class.getMethod("findByLocationNear", Shape.class), new Object[] { new Point(0, 0) });
+
+		creator.createQuery();
+	}
+
 	private RedisQueryCreator createQueryCreatorForMethodWithArgs(Method method, Object[] args) {
 
 		PartTree partTree = new PartTree(method.getName(), method.getReturnType());
-		RedisQueryCreator creator = new RedisQueryCreator(partTree, new ParametersParameterAccessor(new DefaultParameters(
-				method), args));
+		RedisQueryCreator creator = new RedisQueryCreator(partTree,
+				new ParametersParameterAccessor(new DefaultParameters(method), args));
 
 		return creator;
 	}
 
-	private interface SampleRepository extends Repository<ConversionTestEntities.Person, String> {
+	private interface SampleRepository extends Repository<Person, String> {
 
-		ConversionTestEntities.Person findByFirstname(String firstname);
+		Person findByFirstname(String firstname);
 
-		ConversionTestEntities.Person findByFirstnameAndAge(String firstname, Integer age);
+		Person findByFirstnameAndAge(String firstname, Integer age);
 
-		ConversionTestEntities.Person findByAgeOrFirstname(Integer age, String firstname);
+		Person findByAgeOrFirstname(Integer age, String firstname);
+
+		Person findByLocationWithin(Circle circle);
+
+		Person findByLocationNear(Point point, Distance distance);
+
+		Person findByLocationNear(Shape point, Object distance);
+
+		Person findByLocationNear(Shape point);
 	}
 }


### PR DESCRIPTION
We now allow usage of `@GeoIndexed` to mark `GeoLocation` or `Point` properties as candidates for secondary index creation. Non null values will be included in `GEOADD` command as follows:

```bash
GEOADD keyspace:property-path point.x point.y entity-id
```

`@GeoIndexed` can be used on top level as well as on nested properties.

```java
class Person {

	@Id String id;
    String firstname, lastname;
	Address hometown;
}

class Address {
    String city, street, housenumber;
    @GeoIndexed Point location;
}
```

The above allows us to derive geospatial queries from a given method like:

```java
interface PersonRepository extends CrudRepository<Person, String> {

	List<Person> findByAddressLocationNear(Point point, Distance distance);

	List<Person> findByAddressLocationWithin(Circle circle);
}
```

Partial updates on the `Point` itself also trigger an index refresh operation. So it is possible to alter existing entities via:

```java
template.save(new PartialUpdate<Person>("1", Person.class).set("address.location", new Point(17, 18));
```