### PR TITLE
DATAREDIS-547 - Fix query execution when derived criteria is empty.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-547-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 
@@ -17,7 +17,7 @@
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.0.BUILD-SNAPSHOT</springdata.keyvalue>
+		<springdata.keyvalue>1.2.0.DATAKV-142-SNAPSHOT</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -579,6 +579,7 @@ Here's an overview of the keywords supported for Redis and what a method contain
 |`And`|`findByLastnameAndFirstname`|`SINTER …:firstname:rand …:lastname:al’thor`
 |`Or`|`findByLastnameOrFirstname`|`SUNION …:firstname:rand …:lastname:al’thor`
 |`Is,Equals`|`findByFirstname`,`findByFirstnameIs`,`findByFirstnameEquals`|`SINTER …:firstname:rand`
+|`Top,First`|`findFirst10ByFirstname`,`findTop5ByFirstname`|
 |===============
 ====
 

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.core;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -363,6 +364,11 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 		List<Object> result = new ArrayList<Object>();
 
 		List<byte[]> keys = new ArrayList<byte[]>(ids);
+
+
+		if (keys.isEmpty() || keys.size() < offset) {
+			return Collections.emptyList();
+		}
 
 		offset = Math.max(0, offset);
 		if (offset >= 0 && rows > 0) {

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -60,7 +60,6 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.data.util.CloseableIterator;
 import org.springframework.util.Assert;
-import org.springframework.util.NumberUtils;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -346,6 +345,10 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 	 * @see org.springframework.data.keyvalue.core.KeyValueAdapter#getAllOf(java.io.Serializable)
 	 */
 	public List<?> getAllOf(final Serializable keyspace) {
+		return getAllOf(keyspace, -1, -1);
+	}
+
+	public List<?> getAllOf(final Serializable keyspace, int offset, int rows) {
 
 		final byte[] binKeyspace = toBytes(keyspace);
 
@@ -358,7 +361,15 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 		});
 
 		List<Object> result = new ArrayList<Object>();
-		for (byte[] key : ids) {
+
+		List<byte[]> keys = new ArrayList<byte[]>(ids);
+
+		offset = Math.max(0, offset);
+		if (offset >= 0 && rows > 0) {
+			keys = keys.subList(offset, Math.min(offset + rows, keys.size()));
+		}
+
+		for (byte[] key : keys) {
 			result.add(get(key, keyspace));
 		}
 		return result;

--- a/src/main/java/org/springframework/data/redis/core/RedisQueryEngine.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisQueryEngine.java
@@ -102,7 +102,7 @@ class RedisQueryEngine extends QueryEngine<RedisKeyValueAdapter, RedisOperationC
 
 				final Map<byte[], Map<byte[], byte[]>> rawData = new LinkedHashMap<byte[], Map<byte[], byte[]>>();
 
-				if (allKeys.size() == 0 || allKeys.size() < offset) {
+				if (allKeys.isEmpty() || allKeys.size() < offset) {
 					return Collections.emptyMap();
 				}
 

--- a/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
+++ b/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.data.repository.query.parser.Part;
 import org.springframework.data.repository.query.parser.PartTree;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Redis specific query creator.
@@ -87,11 +88,13 @@ public class RedisQueryCreator extends AbstractQueryCreator<KeyValueQuery<RedisO
 
 		KeyValueQuery<RedisOperationChain> query = new KeyValueQuery<RedisOperationChain>(criteria);
 
-		if (query.getCritieria().getSismember().size() == 1 && query.getCritieria().getOrSismember().size() == 1) {
+		if (query.getCritieria() != null && !CollectionUtils.isEmpty(query.getCritieria().getSismember())
+				&& !CollectionUtils.isEmpty(query.getCritieria().getOrSismember()))
+			if (query.getCritieria().getSismember().size() == 1 && query.getCritieria().getOrSismember().size() == 1) {
 
-			query.getCritieria().getOrSismember().add(query.getCritieria().getSismember().iterator().next());
-			query.getCritieria().getSismember().clear();
-		}
+				query.getCritieria().getOrSismember().add(query.getCritieria().getSismember().iterator().next());
+				query.getCritieria().getSismember().clear();
+			}
 
 		if (sort != null) {
 			query.setSort(sort);

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
@@ -47,6 +47,7 @@ import org.springframework.data.repository.PagingAndSortingRepository;
  * Base for testing Redis repository support in different configurations.
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public abstract class RedisRepositoryIntegrationTestBase {
 
@@ -217,8 +218,49 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		repo.save(Arrays.asList(eddard, robb, jon));
 
 		Page<Person> firstPage = repo.findAll(new PageRequest(0, 2));
-		assertThat(firstPage.getContent(), hasSize(2));
-		assertThat(repo.findAll(firstPage.nextPageable()).getContent(), hasSize(1));
+ 		assertThat(firstPage.getContent(), hasSize(2));
+ 		assertThat(repo.findAll(firstPage.nextPageable()).getContent(), hasSize(1));
+	}
+
+	/**
+	 * @see DATAREDIS-547
+	 */
+	@Test
+	public void shouldReturnEmptyListWhenPageableOutOfBoundsUsingFindAll() {
+
+		Person eddard = new Person("eddard", "stark");
+		Person robb = new Person("robb", "stark");
+		Person jon = new Person("jon", "snow");
+
+		repo.save(Arrays.asList(eddard, robb, jon));
+
+		Page<Person> firstPage = repo.findAll(new PageRequest(100, 2));
+		assertThat(firstPage.getContent(), hasSize(0));
+	}
+
+	/**
+	 * @see DATAREDIS-547
+	 */
+	@Test
+	public void shouldReturnEmptyListWhenPageableOutOfBoundsUsingQueryMethod() {
+
+		Person eddard = new Person("eddard", "stark");
+		Person robb = new Person("robb", "stark");
+		Person sansa = new Person("sansa", "stark");
+
+		repo.save(Arrays.asList(eddard, robb, sansa));
+
+		Page<Person> page1 = repo.findPersonByLastname("stark", new PageRequest(1, 3));
+
+		assertThat(page1.getNumberOfElements(), is(0));
+		assertThat(page1.getContent(), hasSize(0));
+		assertThat(page1.getTotalElements(), is(3L));
+
+		Page<Person> page2 = repo.findPersonByLastname("stark", new PageRequest(2, 3));
+
+		assertThat(page2.getNumberOfElements(), is(0));
+		assertThat(page2.getContent(), hasSize(0));
+		assertThat(page2.getTotalElements(), is(3L));
 	}
 
 	/**


### PR DESCRIPTION
We now make sure to pipe finder queries without any criteria to the according find all method. This allows usage of `PagingAndSortingRepository.findAllBy(Pageable page)` as well as finders without any criteria like `findTop3By()`.

---

Depends on: spring-projects/spring-data-keyvalue#22