### PR TITLE
DATAREDIS-531 - Fix deferred ScanCursor command execution using Jedis.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-531-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -341,8 +341,8 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 		}
 
 		Jedis jedis = fetchJedisConnector();
-		JedisConnection connection = (usePool ? new JedisConnection(jedis, pool, dbIndex)
-				: new JedisConnection(jedis, null, dbIndex));
+		JedisConnection connection = (usePool ? new JedisConnection(jedis, pool, this, dbIndex)
+				: new JedisConnection(jedis, null, this, dbIndex));
 		connection.setConvertPipelineAndTxResults(convertPipelineAndTxResults);
 		return postProcessConnection(connection);
 	}


### PR DESCRIPTION
Previously, `ScanCursor` held a reference to the Jedis connection which was used during ScanCursor creation. Cursors can be used outside RedisTemplate that leads to releasing/closing the initial connection. The retained reference used a released connection.

We now check whether the connection is still open. If so, we reuse the connection. If the connection is closed, we use the associated connection factory to obtain a connection to invoke `SCAN` and release the reference after command execution.

----

Related ticket: [DATAREDIS-531](https://jira.spring.io/browse/DATAREDIS-531)