### PR TITLE
DATAREDIS-552-Support setting client name for connection with redis server

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -63,6 +63,7 @@ import redis.clients.util.Pool;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Fu Jian
  */
 public class JedisConnectionFactory implements InitializingBean, DisposableBean, RedisConnectionFactory {
 
@@ -101,6 +102,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	private Pool<Jedis> pool;
 	private JedisPoolConfig poolConfig = new JedisPoolConfig();
 	private int dbIndex = 0;
+	private String clientName;
 	private boolean convertPipelineAndTxResults = true;
 	private RedisSentinelConfiguration sentinelConfig;
 	private RedisClusterConfiguration clusterConfig;
@@ -255,7 +257,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	protected Pool<Jedis> createRedisSentinelPool(RedisSentinelConfiguration config) {
 		return new JedisSentinelPool(config.getMaster().getName(), convertToJedisSentinelSet(config.getSentinels()),
 				getPoolConfig() != null ? getPoolConfig() : new JedisPoolConfig(), getTimeoutFrom(getShardInfo()),
-				getShardInfo().getPassword());
+				getShardInfo().getPassword(), Protocol.DEFAULT_DATABASE, clientName);
 	}
 
 	/**
@@ -267,7 +269,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	protected Pool<Jedis> createRedisPool() {
 
 		return new JedisPool(getPoolConfig(), getShardInfo().getHost(), getShardInfo().getPort(),
-				getTimeoutFrom(getShardInfo()), getShardInfo().getPassword(), useSsl);
+				getTimeoutFrom(getShardInfo()), getShardInfo().getPassword(), Protocol.DEFAULT_DATABASE, clientName, useSsl);
 	}
 
 	private JedisCluster createCluster() {
@@ -529,6 +531,24 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	public void setDatabase(int index) {
 		Assert.isTrue(index >= 0, "invalid DB index (a positive index required)");
 		this.dbIndex = index;
+	}
+	
+	/**
+	 * Returns the client name.
+	 * 
+	 * @return Returns the client name
+	 */
+	public String getClientName() {
+		return clientName;
+	}
+
+	/**
+	 * Sets the client name used by this connection factory. Default is empty.
+	 * 
+	 * @param clientName client name
+	 */
+	public void setClientName(String clientName) {
+		this.clientName = clientName;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryTests.java
@@ -39,6 +39,7 @@ public class JedisConnectionFactoryTests {
 	@Before
 	public void setUp() {
 		factory = new JedisConnectionFactory(SENTINEL_CONFIG);
+		factory.setClientName("clientName");
 		factory.afterPropertiesSet();
 	}
 
@@ -53,5 +54,10 @@ public class JedisConnectionFactoryTests {
 	@Test
 	public void shouldSendCommandCorrectlyViaConnectionFactoryUsingSentinel() {
 		assertThat(factory.getConnection().ping(), equalTo("PONG"));
+	}
+	
+	@Test
+	public void getClientNameShouldEqualWithFactorySetting() {
+		assertThat(factory.getConnection().getClientName(), equalTo("clientName"));
 	}
 }


### PR DESCRIPTION
Motivation:

JedisConnectionFactory should support setting clientName into Jedis so
that we can trouble shooting easier by client name.

now no client name be showed for client list:
id=18 addr=10.140.201.34:51637 fd=12 name= age=85650 idle=85619 flags=N
db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0
events=r cmd=scan

Modifications:

add private member: clientName and use it in constructor for Jedis Pool.

Result:

easier to trouble shooting with connection name:

id=2 addr=10.224.38.23:33652 fd=5 name=sentinel-164682c3-cmd age=1350882
idle=1 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0
omem=0 events=r cmd=ping
