### PR TITLE
DATAREDIS-551 - Fix pageable query execution when derived criteria is empty.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-551-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/RedisQueryEngine.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisQueryEngine.java
@@ -40,6 +40,7 @@ import org.springframework.util.CollectionUtils;
  * Redis specific {@link QueryEngine} implementation.
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.7
  */
 class RedisQueryEngine extends QueryEngine<RedisKeyValueAdapter, RedisOperationChain, Comparator<?>> {
@@ -155,6 +156,10 @@ class RedisQueryEngine extends QueryEngine<RedisKeyValueAdapter, RedisOperationC
 	 */
 	@Override
 	public long count(final RedisOperationChain criteria, final Serializable keyspace) {
+
+		if(criteria == null) {
+			return this.getAdapter().count(keyspace);
+		}
 
 		return this.getAdapter().execute(new RedisCallback<Long>() {
 

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
@@ -223,6 +223,24 @@ public abstract class RedisRepositoryIntegrationTestBase {
 	}
 
 	/**
+	 * @see DATAREDIS-551
+	 */
+	@Test
+	public void shouldApplyPageableCorrectlyWhenUsingFindByWithoutCriteria() {
+
+		Person eddard = new Person("eddard", "stark");
+		Person robb = new Person("robb", "stark");
+		Person jon = new Person("jon", "snow");
+
+		repo.save(Arrays.asList(eddard, robb, jon));
+
+		Page<Person> firstPage = repo.findBy(new PageRequest(0, 2));
+ 		assertThat(firstPage.getContent(), hasSize(2));
+ 		assertThat(firstPage.getTotalElements(), is(equalTo(3L)));
+ 		assertThat(repo.findBy(firstPage.nextPageable()).getContent(), hasSize(1));
+	}
+
+	/**
 	 * @see DATAREDIS-547
 	 */
 	@Test
@@ -317,6 +335,8 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		List<Person> findTop2By();
 
 		List<Person> findTop2ByLastname(String lastname);
+
+		Page<Person> findBy(Pageable page);
 	}
 
 	/**


### PR DESCRIPTION
We now make sure to count records without using criteria when derived criteria is empty. This allows usage of declared query methods using `Pageable` without criteria like `findBy(Pageable page)`.

----

Related ticket: [DATAREDIS-551](https://jira.spring.io/browse/DATAREDIS-551)