### PR TITLE
DATAREDIS-542 - Expire keys in RedisCache.putIfAbsent.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-542-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 


### PR DESCRIPTION
RedisCache now expires keys using putIfAbsent if the key was set. Previously, the key was only expired if the value was already present and the value matched the value stored inside of Redis.

----

Should be backported to _1.6.x_ and _1.7.x_.

Related ticket: [DATAREDIS-542](https://jira.spring.io/browse/DATAREDIS-542)
See also: https://github.com/spring-projects/spring-data-redis/pull/150