### PR TITLE
DATAREDIS-564 - Delegate expire(…) to pExpire if timeout exceeds Integer.MAX_VALUE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-564-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -801,15 +801,10 @@ public class JedisConnection extends AbstractRedisConnection {
 
 	public Boolean expire(byte[] key, long seconds) {
 
-		/*
-		 *  @see DATAREDIS-286 to avoid overflow in Jedis
-		 *  
-		 *  TODO Remove this workaround when we upgrade to a Jedis version that contains a 
-		 *  fix for: https://github.com/xetorthio/jedis/pull/575
-		 */
-		if (seconds > Integer.MAX_VALUE) {
+		Assert.notNull(key, "Key must not be null!");
 
-			return pExpireAt(key, time() + TimeUnit.SECONDS.toMillis(seconds));
+		if (seconds > Integer.MAX_VALUE) {
+			return pExpire(key, TimeUnit.SECONDS.toMillis(seconds));
 		}
 
 		try {
@@ -828,6 +823,9 @@ public class JedisConnection extends AbstractRedisConnection {
 	}
 
 	public Boolean expireAt(byte[] key, long unixTime) {
+
+		Assert.notNull(key, "Key must not be null!");
+
 		try {
 			if (isPipelined()) {
 				pipeline(new JedisResult(pipeline.expireAt(key, unixTime), JedisConverters.longToBoolean()));
@@ -1021,6 +1019,8 @@ public class JedisConnection extends AbstractRedisConnection {
 	}
 
 	public Boolean pExpire(byte[] key, long millis) {
+		
+		Assert.notNull(key, "Key must not be null!");
 
 		try {
 			if (isPipelined()) {
@@ -1038,6 +1038,9 @@ public class JedisConnection extends AbstractRedisConnection {
 	}
 
 	public Boolean pExpireAt(byte[] key, long unixTimeInMillis) {
+		
+		Assert.notNull(key, "Key must not be null!");
+		
 		try {
 			if (isPipelined()) {
 				pipeline(new JedisResult(pipeline.pexpireAt(key, unixTimeInMillis), JedisConverters.longToBoolean()));


### PR DESCRIPTION
Remove `pExpireAt` workaround that can lead to `NullPointerException` if called within a transaction/pipeline. Calls to `expire(…)` with a timeout greater `Integer.MAX_VALUE` are delegated to `pExpire` converting seconds to milliseconds.

---

Related ticket: [DATAREDIS-564](https://jira.spring.io/browse/DATAREDIS-564).
