### PR TITLE
DATAREDIS-525 - Add support for ReactiveRedisConnection & ReactiveRedisClusterConnection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,11 +134,6 @@
 			<optional>true</optional>
 		</dependency>
 
-		<dependency>
-			<groupId>io.reactivex</groupId>
-			<artifactId>rxjava</artifactId>
-			<version>1.1.1</version>
-		</dependency>
 		<!-- Pool -->
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-525-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 
@@ -39,6 +39,12 @@
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>${guava}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-commons</artifactId>
+				<version>2.0.0.DATACMNS-836-SNAPSHOT</version>
 			</dependency>
 
 		</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
 		<pool>2.2</pool>
-		<lettuce>4.2.2.Final</lettuce>
+		<lettuce>5.0.0.Beta1</lettuce>
 		<jedis>2.9.0</jedis>
 		<multithreadedtc>1.01</multithreadedtc>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,14 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- reactive -->
+		<dependency>
+		 	<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
+			<version>${reactor}</version>
+			<optional>true</optional>
+ 		</dependency>
+
 		<!--Mapper -->
 
 		<dependency>
@@ -126,6 +134,11 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>io.reactivex</groupId>
+			<artifactId>rxjava</artifactId>
+			<version>1.1.1</version>
+		</dependency>
 		<!-- Pool -->
 
 		<dependency>
@@ -212,7 +225,6 @@
 						<include>**/*Tests.java</include>
 						<include>**/*Test.java</include>
 					</includes>
-					<reuseForks>false</reuseForks>
 					<systemProperties>
 						<gemfire.disableShutdownHook>true</gemfire.disableShutdownHook>
 						<javax.net.ssl.keyStore>${basedir}/src/test/resources/trusted.keystore</javax.net.ssl.keyStore>
@@ -237,23 +249,6 @@
 
 		</plugins>
 	</build>
-
-	<profiles>
-		<profile>
-			<id>release</id>
-			<build>
-				<plugins>
-
-					<plugin>
-						<groupId>org.jfrog.buildinfo</groupId>
-						<artifactId>artifactory-maven-plugin</artifactId>
-						<inherited>false</inherited>
-					</plugin>
-
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 
 	<repositories>
 		<repository>

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -3,6 +3,14 @@
 
 New and noteworthy in the latest releases.
 
+[[new-in-2.0.0]]
+== New in Spring Data Redis 2.0
+
+* Upgrade to Java 8.
+* Removed support for SRP and JRedis drivers.
+* Upgrade to `Lettuce` 5.0.
+* Reactive connection support using https://github.com/mp911de/lettuce[mp911de/lettuce]
+
 [[new-in-1.8.0]]
 == New in Spring Data Redis 1.8
 

--- a/src/main/java/org/springframework/data/redis/connection/ClusterSlotHashUtil.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterSlotHashUtil.java
@@ -15,6 +15,10 @@
  */
 package org.springframework.data.redis.connection;
 
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.springframework.util.Assert;
 
 /**
@@ -50,6 +54,33 @@ public final class ClusterSlotHashUtil {
 
 	private ClusterSlotHashUtil() {
 
+	}
+
+	/**
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @since 2.0
+	 */
+	public static boolean isSameSlotForAllKeys(Collection<ByteBuffer> keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+
+		if (keys.size() <= 1) {
+			return true;
+		}
+
+		return isSameSlotForAllKeys((byte[][]) keys.stream().map(ByteBuffer::array).toArray(size -> new byte[size][]));
+	}
+
+	/**
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @since 2.0
+	 */
+	public static boolean isSameSlotForAllKeys(ByteBuffer... keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+		return isSameSlotForAllKeys(Arrays.asList(keys));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/ClusterSlotHashUtil.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterSlotHashUtil.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.util.Assert;
 
 /**
@@ -69,7 +70,10 @@ public final class ClusterSlotHashUtil {
 			return true;
 		}
 
-		return isSameSlotForAllKeys((byte[][]) keys.stream().map(ByteBuffer::array).toArray(size -> new byte[size][]));
+		return isSameSlotForAllKeys((byte[][]) keys.stream() //
+				.map(ByteBuffer::duplicate) //
+				.map(ByteUtils::getBytes) //
+				.toArray(byte[][]::new));
 	}
 
 	/**
@@ -164,5 +168,4 @@ public final class ClusterSlotHashUtil {
 		}
 		return crc & 0xFFFF;
 	}
-
 }

--- a/src/main/java/org/springframework/data/redis/connection/ClusterTopology.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterTopology.java
@@ -168,7 +168,7 @@ public class ClusterTopology {
 	 */
 	public RedisClusterNode lookup(String nodeId) {
 
-		Assert.notNull(nodeId, "NodeId must not be null");
+		Assert.notNull(nodeId, "NodeId must not be null!");
 
 		for (RedisClusterNode node : nodes) {
 			if (nodeId.equals(node.getId())) {
@@ -189,7 +189,7 @@ public class ClusterTopology {
 	 */
 	public RedisClusterNode lookup(RedisClusterNode node) {
 
-		Assert.notNull(node, "RedisClusterNode must not be null");
+		Assert.notNull(node, "RedisClusterNode must not be null!");
 
 		if(nodes.contains(node) && StringUtils.hasText(node.getHost()) && StringUtils.hasText(node.getId())){
 			return node;

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterGeoCommands.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveClusterGeoCommands extends ReactiveGeoCommands {
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterGeoCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection;
 
 /**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterHashCommands.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveClusterHashCommands extends ReactiveHashCommands {
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterHashCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection;
 
 /**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterHyperLogLogCommands.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveClusterHyperLogLogCommands extends ReactiveHyperLogLogCommands {
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterHyperLogLogCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection;
 
 /**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterKeyCommands.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveClusterKeyCommands extends ReactiveKeyCommands {
+
+	/**
+	 * Retrieve all {@literal keys} for a given {@literal pattern} from {@link RedisNode}.
+	 *
+	 * @param node must not be {@literal null}.
+	 * @param pattern must not be {@literal null}.
+	 * @return
+	 */
+	Mono<List<ByteBuffer>> keys(RedisClusterNode node, ByteBuffer pattern);
+
+	/**
+	 * Retrieve a random {@literal key} from {@link RedisNode}.
+	 *
+	 * @param node must not be {@literal null}.
+	 * @return
+	 */
+	Mono<ByteBuffer> randomKey(RedisClusterNode node);
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterKeyCommands.java
@@ -13,23 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Copyright 2016. the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.springframework.data.redis.connection;
 
 import java.nio.ByteBuffer;
@@ -59,5 +42,4 @@ public interface ReactiveClusterKeyCommands extends ReactiveKeyCommands {
 	 * @return
 	 */
 	Mono<ByteBuffer> randomKey(RedisClusterNode node);
-
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterListCommands.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveClusterListCommands extends ReactiveListCommands {
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterListCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection;
 
 /**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterNumberCommands.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveClusterNumberCommands extends ReactiveNumberCommands {
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterNumberCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection;
 
 /**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterSetCommands.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveClusterSetCommands extends ReactiveSetCommands {
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterSetCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection;
 
 /**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterStringCommands.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveClusterStringCommands extends ReactiveStringCommands {
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterStringCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection;
 
 /**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterZSetCommands.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveClusterZSetCommands extends ReactiveZSetCommands {
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterZSetCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection;
 
 /**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
@@ -1,0 +1,771 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.Metric;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.connection.RedisGeoCommands.DistanceUnit;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs.Flag;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveGeoCommands {
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class GeoAddCommand extends KeyCommand {
+
+		private final List<GeoLocation<ByteBuffer>> geoLocations;
+
+		public GeoAddCommand(ByteBuffer key, List<GeoLocation<ByteBuffer>> geoLocations) {
+
+			super(key);
+			this.geoLocations = geoLocations;
+		}
+
+		public static GeoAddCommand location(GeoLocation<ByteBuffer> geoLocation) {
+			return new GeoAddCommand(null, Collections.singletonList(geoLocation));
+		}
+
+		public static GeoAddCommand locations(List<GeoLocation<ByteBuffer>> geoLocations) {
+			return new GeoAddCommand(null, new ArrayList<>(geoLocations));
+		}
+
+		public GeoAddCommand to(ByteBuffer key) {
+			return new GeoAddCommand(key, geoLocations);
+		}
+
+		public List<GeoLocation<ByteBuffer>> getGeoLocations() {
+			return geoLocations;
+		}
+
+	}
+
+	/**
+	 * Add {@link Point} with given {@literal member} to {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param point must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> geoAdd(ByteBuffer key, Point point, ByteBuffer member) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(point, "point must not be null");
+		Assert.notNull(member, "member must not be null");
+
+		return geoAdd(key, new GeoLocation<>(member, point));
+	}
+
+	/**
+	 * Add {@link GeoLocation} to {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param location must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> geoAdd(ByteBuffer key, GeoLocation<ByteBuffer> location) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(location, "location must not be null");
+
+		return geoAdd(key, Collections.singletonList(location));
+	}
+
+	/**
+	 * Add {@link GeoLocation} to {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param locations must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> geoAdd(ByteBuffer key, List<GeoLocation<ByteBuffer>> locations) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(locations, "locations must not be null");
+
+		return geoAdd(Mono.just(GeoAddCommand.locations(locations).to(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Add {@link GeoLocation}s to {@literal key}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<GeoAddCommand, Long>> geoAdd(Publisher<GeoAddCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class GeoDistCommand extends KeyCommand {
+
+		private final ByteBuffer from;
+		private final ByteBuffer to;
+		private final Metric metric;
+
+		private GeoDistCommand(ByteBuffer key, ByteBuffer from, ByteBuffer to, Metric metric) {
+			super(key);
+			this.from = from;
+			this.to = to;
+			this.metric = metric;
+		}
+
+		static GeoDistCommand units(Metric unit) {
+			return new GeoDistCommand(null, null, null, unit);
+		}
+
+		public static GeoDistCommand meters() {
+			return units(DistanceUnit.METERS);
+		}
+
+		public static GeoDistCommand kiometers() {
+			return units(DistanceUnit.KILOMETERS);
+		}
+
+		public static GeoDistCommand miles() {
+			return units(DistanceUnit.MILES);
+		}
+
+		public static GeoDistCommand feet() {
+			return units(DistanceUnit.FEET);
+		}
+
+		public GeoDistCommand between(ByteBuffer from) {
+			return new GeoDistCommand(getKey(), from, to, metric);
+		}
+
+		public GeoDistCommand and(ByteBuffer to) {
+			return new GeoDistCommand(getKey(), from, to, metric);
+		}
+
+		public GeoDistCommand forKey(ByteBuffer key) {
+			return new GeoDistCommand(key, from, to, metric);
+		}
+
+		public ByteBuffer getFrom() {
+			return from;
+		}
+
+		public ByteBuffer getTo() {
+			return to;
+		}
+
+		public Optional<Metric> getMetric() {
+			return Optional.ofNullable(metric);
+		}
+	}
+
+	/**
+	 * Get the {@link Distance} between {@literal from} and {@literal to}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param from must not be {@literal null}.
+	 * @param to must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Distance> geoDist(ByteBuffer key, ByteBuffer from, ByteBuffer to) {
+		return geoDist(key, from, to, null);
+	}
+
+	/**
+	 * Get the {@link Distance} between {@literal from} and {@literal to}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param from must not be {@literal null}.
+	 * @param to must not be {@literal null}.
+	 * @param metric can be {@literal null} and defaults to {@link DistanceUnit#METERS}.
+	 * @return
+	 */
+	default Mono<Distance> geoDist(ByteBuffer key, ByteBuffer from, ByteBuffer to, Metric metric) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(from, "from must not be null");
+		Assert.notNull(to, "to must not be null");
+
+		return geoDist(Mono.just(GeoDistCommand.units(metric).between(from).and(to).forKey(key))).next()
+				.map(CommandResponse::getOutput);
+	}
+
+	/**
+	 * Get the {@link Distance} between {@literal from} and {@literal to}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<CommandResponse<GeoDistCommand, Distance>> geoDist(Publisher<GeoDistCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class GeoHashCommand extends KeyCommand {
+
+		private final List<ByteBuffer> members;
+
+		private GeoHashCommand(ByteBuffer key, List<ByteBuffer> members) {
+
+			super(key);
+			this.members = members;
+		}
+
+		public static GeoHashCommand member(ByteBuffer member) {
+			return new GeoHashCommand(null, Collections.singletonList(member));
+		}
+
+		public static GeoHashCommand members(List<ByteBuffer> members) {
+			return new GeoHashCommand(null, new ArrayList<>(members));
+		}
+
+		public GeoHashCommand of(ByteBuffer key) {
+			return new GeoHashCommand(key, members);
+		}
+
+		public List<ByteBuffer> getMembers() {
+			return members;
+		}
+	}
+
+	/**
+	 * Get geohash representation of the position for the one {@literal member}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<String> geoHash(ByteBuffer key, ByteBuffer member) {
+
+		Assert.notNull(member, "member must not be null");
+
+		return geoHash(key, Collections.singletonList(member)).map(vals -> vals.isEmpty() ? null : vals.iterator().next());
+	}
+
+	/**
+	 * Get geohash representation of the position for one or more {@literal member}s.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param members must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<String>> geoHash(ByteBuffer key, List<ByteBuffer> members) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(members, "members must not be null");
+
+		return geoHash(Mono.just(GeoHashCommand.members(members).of(key))).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get geohash representation of the position for one or more {@literal member}s.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<GeoHashCommand, String>> geoHash(Publisher<GeoHashCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class GeoPosCommand extends KeyCommand {
+
+		private final List<ByteBuffer> members;
+
+		private GeoPosCommand(ByteBuffer key, List<ByteBuffer> members) {
+
+			super(key);
+			this.members = members;
+		}
+
+		public static GeoPosCommand member(ByteBuffer member) {
+			return new GeoPosCommand(null, Collections.singletonList(member));
+		}
+
+		public static GeoPosCommand members(List<ByteBuffer> members) {
+			return new GeoPosCommand(null, new ArrayList<>(members));
+		}
+
+		public GeoPosCommand of(ByteBuffer key) {
+			return new GeoPosCommand(key, members);
+		}
+
+		public List<ByteBuffer> getMembers() {
+			return members;
+		}
+	}
+
+	/**
+	 * Get the {@link Point} representation of positions for the {@literal member}s.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Point> geoPos(ByteBuffer key, ByteBuffer member) {
+
+		Assert.notNull(member, "member must not be null");
+
+		return geoPos(key, Collections.singletonList(member)).map(vals -> vals.isEmpty() ? null : vals.iterator().next());
+	}
+
+	/**
+	 * Get the {@link Point} representation of positions for one or more {@literal member}s.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param members must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<Point>> geoPos(ByteBuffer key, List<ByteBuffer> members) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(members, "members must not be null");
+
+		return geoPos(Mono.just(GeoPosCommand.members(members).of(key))).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get the {@link Point} representation of positions for one or more {@literal member}s.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<GeoPosCommand, Point>> geoPos(Publisher<GeoPosCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class GeoRadiusCommand extends KeyCommand {
+
+		private final Distance distance;
+		private final Point point;
+		private final GeoRadiusCommandArgs args;
+		private final ByteBuffer store;
+		private final ByteBuffer storeDist;
+
+		private GeoRadiusCommand(ByteBuffer key, Point point, Distance distance, GeoRadiusCommandArgs args,
+				ByteBuffer store, ByteBuffer storeDist) {
+			super(key);
+			this.distance = distance;
+			this.point = point;
+			this.args = args == null ? GeoRadiusCommandArgs.newGeoRadiusArgs() : args;
+			this.store = store;
+			this.storeDist = storeDist;
+		}
+
+		public static GeoRadiusCommand within(Distance distance) {
+			return new GeoRadiusCommand(null, null, distance, null, null, null);
+		}
+
+		public static GeoRadiusCommand withinMeters(Double distance) {
+			return within(new Distance(distance, DistanceUnit.METERS));
+		}
+
+		public static GeoRadiusCommand withinKiometers(Double distance) {
+			return within(new Distance(distance, DistanceUnit.KILOMETERS));
+		}
+
+		public static GeoRadiusCommand withinMiles(Double distance) {
+			return within(new Distance(distance, DistanceUnit.MILES));
+		}
+
+		public static GeoRadiusCommand withinFeet(Double distance) {
+			return within(new Distance(distance, DistanceUnit.FEET));
+		}
+
+		public static GeoRadiusCommand within(Circle circle) {
+			return within(circle.getRadius()).from(circle.getCenter());
+		}
+
+		public GeoRadiusCommand from(Point center) {
+			return new GeoRadiusCommand(getKey(), center, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusCommand withFlag(Flag flag) {
+
+			GeoRadiusCommandArgs args = cloneArgs();
+			args.flags.add(flag);
+
+			return new GeoRadiusCommand(getKey(), point, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusCommand withCoord() {
+			return withFlag(Flag.WITHCOORD);
+		}
+
+		public GeoRadiusCommand withDist() {
+			return withFlag(Flag.WITHDIST);
+		}
+
+		public GeoRadiusCommand withArgs(GeoRadiusCommandArgs args) {
+			return new GeoRadiusCommand(getKey(), point, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusCommand limitTo(Long limit) {
+
+			GeoRadiusCommandArgs args = cloneArgs();
+			if (limit != null) {
+				args = args.limit(limit);
+			}
+
+			return new GeoRadiusCommand(getKey(), point, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusCommand sort(Direction direction) {
+
+			GeoRadiusCommandArgs args = cloneArgs();
+			args.sortDirection = direction;
+
+			return new GeoRadiusCommand(getKey(), point, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusCommand orderByDistanceAsc() {
+			return sort(Direction.ASC);
+		}
+
+		public GeoRadiusCommand orderByDistanceDesc() {
+			return sort(Direction.DESC);
+		}
+
+		public GeoRadiusCommand forKey(ByteBuffer key) {
+			return new GeoRadiusCommand(key, point, distance, args, store, storeDist);
+		}
+
+		/**
+		 * <b>NOTE:</b> STORE option is not compatible with WITHDIST, WITHHASH and WITHCOORDS options.
+		 *
+		 * @param key
+		 * @return
+		 */
+		public GeoRadiusCommand storeAt(ByteBuffer key) {
+			return new GeoRadiusCommand(getKey(), point, distance, args, key, storeDist);
+		}
+
+		/**
+		 * <b>NOTE:</b> STOREDIST option is not compatible with WITHDIST, WITHHASH and WITHCOORDS options.
+		 *
+		 * @param key
+		 * @return
+		 */
+		public GeoRadiusCommand storeDistAt(ByteBuffer key) {
+			return new GeoRadiusCommand(getKey(), point, distance, args, store, key);
+		}
+
+		public Optional<Direction> getDirection() {
+			return Optional.ofNullable(args.getSortDirection());
+		}
+
+		public Distance getDistance() {
+			return distance;
+		}
+
+		public Set<Flag> getFlags() {
+			return args.getFlags();
+		}
+
+		public Optional<Long> getLimit() {
+			return Optional.ofNullable(args.getLimit());
+		}
+
+		public Point getPoint() {
+			return point;
+		}
+
+		public Optional<ByteBuffer> getStore() {
+			return Optional.ofNullable(store);
+		}
+
+		public Optional<ByteBuffer> getStoreDist() {
+			return Optional.ofNullable(storeDist);
+		}
+
+		public Optional<GeoRadiusCommandArgs> getArgs() {
+			return Optional.ofNullable(args);
+		}
+
+		private GeoRadiusCommandArgs cloneArgs() {
+
+			if (args == null) {
+				return GeoRadiusCommandArgs.newGeoRadiusArgs();
+			}
+
+			return args.clone();
+		}
+	}
+
+	/**
+	 * Get the {@literal member}s within the boundaries of a given {@link Circle}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param circle must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<GeoLocation<ByteBuffer>>> geoRadius(ByteBuffer key, Circle circle) {
+		return geoRadius(key, circle, null)
+				.map(res -> res.getContent().stream().map(val -> val.getContent()).collect(Collectors.toList()));
+	}
+
+	/**
+	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying given parameters.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param circle must not be {@literal null}.
+	 * @param geoRadiusArgs can be {@literal null}.
+	 * @return
+	 */
+	default Mono<GeoResults<GeoLocation<ByteBuffer>>> geoRadius(ByteBuffer key, Circle circle,
+			GeoRadiusCommandArgs geoRadiusArgs) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(circle, "circle must not be null");
+
+		return geoRadius(Mono.just(GeoRadiusCommand.within(circle).withArgs(geoRadiusArgs).forKey(key))).next()
+				.map(CommandResponse::getOutput);
+	}
+
+	/**
+	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying given parameters.
+	 *
+	 * @param commands
+	 * @return
+	 */
+	Flux<CommandResponse<GeoRadiusCommand, GeoResults<GeoLocation<ByteBuffer>>>> geoRadius(
+			Publisher<GeoRadiusCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class GeoRadiusByMemberCommand extends KeyCommand {
+
+		private final Distance distance;
+		private final ByteBuffer member;
+		private final GeoRadiusCommandArgs args;
+		private final ByteBuffer store;
+		private final ByteBuffer storeDist;
+
+		private GeoRadiusByMemberCommand(ByteBuffer key, ByteBuffer member, Distance distance, GeoRadiusCommandArgs args,
+				ByteBuffer store, ByteBuffer storeDist) {
+
+			super(key);
+			this.distance = distance;
+			this.member = member;
+			this.args = args == null ? GeoRadiusCommandArgs.newGeoRadiusArgs() : args;
+			this.store = store;
+			this.storeDist = storeDist;
+		}
+
+		public static GeoRadiusByMemberCommand within(Distance distance) {
+			return new GeoRadiusByMemberCommand(null, null, distance, GeoRadiusCommandArgs.newGeoRadiusArgs(), null, null);
+		}
+
+		public static GeoRadiusByMemberCommand withinMeters(Double distance) {
+			return within(new Distance(distance, DistanceUnit.METERS));
+		}
+
+		public static GeoRadiusByMemberCommand withinKiometers(Double distance) {
+			return within(new Distance(distance, DistanceUnit.KILOMETERS));
+		}
+
+		public static GeoRadiusByMemberCommand withinMiles(Double distance) {
+			return within(new Distance(distance, DistanceUnit.MILES));
+		}
+
+		public static GeoRadiusByMemberCommand withinFeet(Double distance) {
+			return within(new Distance(distance, DistanceUnit.FEET));
+		}
+
+		public GeoRadiusByMemberCommand from(ByteBuffer member) {
+			return new GeoRadiusByMemberCommand(getKey(), member, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusByMemberCommand withArgs(GeoRadiusCommandArgs args) {
+			return new GeoRadiusByMemberCommand(getKey(), member, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusByMemberCommand withFlag(Flag flag) {
+
+			GeoRadiusCommandArgs args = cloneArgs();
+			args.flags.add(flag);
+
+			return new GeoRadiusByMemberCommand(getKey(), member, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusByMemberCommand withCoord() {
+			return withFlag(Flag.WITHCOORD);
+		}
+
+		public GeoRadiusByMemberCommand withDist() {
+			return withFlag(Flag.WITHDIST);
+		}
+
+		public GeoRadiusByMemberCommand limitTo(Long limit) {
+
+			GeoRadiusCommandArgs args = cloneArgs();
+			if (limit != null) {
+				args = args.limit(limit);
+			}
+
+			return new GeoRadiusByMemberCommand(getKey(), member, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusByMemberCommand sort(Direction direction) {
+
+			GeoRadiusCommandArgs args = cloneArgs();
+			args.sortDirection = direction;
+
+			return new GeoRadiusByMemberCommand(getKey(), member, distance, args, store, storeDist);
+		}
+
+		public GeoRadiusByMemberCommand orderByDistanceAsc() {
+			return sort(Direction.ASC);
+		}
+
+		public GeoRadiusByMemberCommand orderByDistanceDesc() {
+			return sort(Direction.DESC);
+		}
+
+		public GeoRadiusByMemberCommand forKey(ByteBuffer key) {
+			return new GeoRadiusByMemberCommand(key, member, distance, args, store, storeDist);
+		}
+
+		/**
+		 * <b>NOTE:</b> STORE option is not compatible with WITHDIST, WITHHASH and WITHCOORDS options.
+		 *
+		 * @param key
+		 * @return
+		 */
+		public GeoRadiusByMemberCommand storeAt(ByteBuffer key) {
+			return new GeoRadiusByMemberCommand(getKey(), member, distance, args, key, storeDist);
+		}
+
+		/**
+		 * <b>NOTE:</b> STOREDIST option is not compatible with WITHDIST, WITHHASH and WITHCOORDS options.
+		 *
+		 * @param key
+		 * @return
+		 */
+		public GeoRadiusByMemberCommand storeDistAt(ByteBuffer key) {
+			return new GeoRadiusByMemberCommand(getKey(), member, distance, args, store, key);
+		}
+
+		public Optional<Direction> getDirection() {
+			return Optional.ofNullable(args.getSortDirection());
+		}
+
+		public Distance getDistance() {
+			return distance;
+		}
+
+		public Set<Flag> getFlags() {
+			return args.getFlags();
+		}
+
+		public Optional<Long> getLimit() {
+			return Optional.ofNullable(args.getLimit());
+		}
+
+		public ByteBuffer getMember() {
+			return member;
+		}
+
+		public Optional<ByteBuffer> getStore() {
+			return Optional.ofNullable(store);
+		}
+
+		public Optional<ByteBuffer> getStoreDist() {
+			return Optional.ofNullable(storeDist);
+		}
+
+		public Optional<GeoRadiusCommandArgs> getArgs() {
+			return Optional.ofNullable(args);
+		}
+
+		private GeoRadiusCommandArgs cloneArgs() {
+
+			if (args == null) {
+				return GeoRadiusCommandArgs.newGeoRadiusArgs();
+			}
+
+			return args.clone();
+		}
+
+	}
+
+	/**
+	 * Get the {@literal member}s within given {@link Distance} from {@literal member} applying given parameters.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<GeoLocation<ByteBuffer>>> geoRadiusByMember(ByteBuffer key, ByteBuffer member, Distance distance) {
+		return geoRadiusByMember(key, member, distance, null)
+				.map(res -> res.getContent().stream().map(val -> val.getContent()).collect(Collectors.toList()));
+	}
+
+	/**
+	 * Get the {@literal member}s within given {@link Distance} from {@literal member} applying given parameters.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @param geoRadiusArgs can be {@literal null}.
+	 * @return
+	 */
+	default Mono<GeoResults<GeoLocation<ByteBuffer>>> geoRadiusByMember(ByteBuffer key, ByteBuffer member,
+			Distance distance, GeoRadiusCommandArgs geoRadiusArgs) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(member, "member must not be null");
+		Assert.notNull(distance, "distance must not be null");
+
+		return geoRadiusByMember(
+				Mono.just(GeoRadiusByMemberCommand.within(distance).from(member).forKey(key).withArgs(geoRadiusArgs))).next()
+						.map(CommandResponse::getOutput);
+	}
+
+	/**
+	 * Get the {@literal member}s within given {@link Distance} from {@literal member} applying given parameters.
+	 *
+	 * @param commands
+	 * @return
+	 */
+	Flux<CommandResponse<GeoRadiusByMemberCommand, GeoResults<GeoLocation<ByteBuffer>>>> geoRadiusByMember(
+			Publisher<GeoRadiusByMemberCommand> commands);
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveHashCommands {
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class HSetCommand extends KeyCommand {
+
+		private static final ByteBuffer SINGLE_VALUE_KEY = ByteBuffer.allocate(0);
+		private final Map<ByteBuffer, ByteBuffer> fieldValueMap;
+		private final Boolean upsert;
+
+		private HSetCommand(ByteBuffer key, Map<ByteBuffer, ByteBuffer> keyValueMap, Boolean upsert) {
+
+			super(key);
+			this.fieldValueMap = keyValueMap;
+			this.upsert = upsert;
+		}
+
+		public static HSetCommand value(ByteBuffer value) {
+			return new HSetCommand(null, Collections.singletonMap(SINGLE_VALUE_KEY, value), Boolean.TRUE);
+		}
+
+		public static HSetCommand fieldValues(Map<ByteBuffer, ByteBuffer> fieldValueMap) {
+			return new HSetCommand(null, fieldValueMap, Boolean.TRUE);
+		}
+
+		public HSetCommand ofField(ByteBuffer field) {
+
+			if (!fieldValueMap.containsKey(SINGLE_VALUE_KEY)) {
+				throw new InvalidDataAccessApiUsageException("Value has not been set.");
+			}
+
+			return new HSetCommand(getKey(), Collections.singletonMap(field, fieldValueMap.get(SINGLE_VALUE_KEY)), upsert);
+		}
+
+		public HSetCommand forKey(ByteBuffer key) {
+			return new HSetCommand(key, fieldValueMap, upsert);
+		}
+
+		public HSetCommand ifValueNotExists() {
+			return new HSetCommand(getKey(), fieldValueMap, Boolean.FALSE);
+		}
+
+		public Boolean isUpsert() {
+			return upsert;
+		}
+
+		public Map<ByteBuffer, ByteBuffer> getFieldValueMap() {
+			return fieldValueMap;
+		}
+	}
+
+	/**
+	 * Set the {@code value} of a hash {@code field}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> hSet(ByteBuffer key, ByteBuffer field, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(field, "field must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return hSet(Mono.just(HSetCommand.value(value).ofField(field).forKey(key))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set the {@code value} of a hash {@code field}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> hSetNX(ByteBuffer key, ByteBuffer field, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(field, "field must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return hSet(Mono.just(HSetCommand.value(value).ofField(field).forKey(key).ifValueNotExists())).next()
+				.map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set multiple hash fields to multiple values using data provided in {@code fieldValueMap}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param fieldValueMap must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> hMSet(ByteBuffer key, Map<ByteBuffer, ByteBuffer> fieldValueMap) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(fieldValueMap, "field must not be null");
+
+		return hSet(Mono.just(HSetCommand.fieldValues(fieldValueMap).forKey(key).ifValueNotExists())).next()
+				.map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set the {@code value} of a hash {@code field}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<HSetCommand>> hSet(Publisher<HSetCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class HGetCommand extends KeyCommand {
+
+		private List<ByteBuffer> fields;
+
+		private HGetCommand(ByteBuffer key, List<ByteBuffer> fields) {
+
+			super(key);
+			this.fields = fields;
+		}
+
+		public static HGetCommand field(ByteBuffer field) {
+			return new HGetCommand(null, Collections.singletonList(field));
+		}
+
+		public static HGetCommand fields(List<ByteBuffer> fields) {
+			return new HGetCommand(null, new ArrayList<>(fields));
+		}
+
+		public HGetCommand from(ByteBuffer key) {
+			return new HGetCommand(key, fields);
+		}
+
+		public List<ByteBuffer> getFields() {
+			return fields;
+		}
+	}
+
+	/**
+	 * Get value for given {@code field} from hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<ByteBuffer> hGet(ByteBuffer key, ByteBuffer field) {
+		return hMGet(key, Collections.singletonList(field)).map(val -> val.isEmpty() ? null : val.iterator().next());
+	}
+
+	/**
+	 * Get values for given {@code fields} from hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param fields must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> hMGet(ByteBuffer key, List<ByteBuffer> fields) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(fields, "fields must not be null");
+
+		return hMGet(Mono.just(HGetCommand.fields(fields).from(key))).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get values for given {@code fields} from hash at {@code key}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<HGetCommand, ByteBuffer>> hMGet(Publisher<HGetCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class HExistsCommand extends KeyCommand {
+
+		private final ByteBuffer field;
+
+		private HExistsCommand(ByteBuffer key, ByteBuffer field) {
+
+			super(key);
+			this.field = field;
+		}
+
+		public static HExistsCommand field(ByteBuffer field) {
+			return new HExistsCommand(null, field);
+		}
+
+		public HExistsCommand in(ByteBuffer key) {
+			return new HExistsCommand(key, field);
+		}
+
+		public ByteBuffer getField() {
+			return field;
+		}
+	}
+
+	/**
+	 * Determine if given hash {@code field} exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> hExists(ByteBuffer key, ByteBuffer field) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(field, "field must not be null");
+
+		return hExists(Mono.just(HExistsCommand.field(field).in(key))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Determine if given hash {@code field} exists.
+	 *
+	 * @param commands
+	 * @return
+	 */
+	Flux<BooleanResponse<HExistsCommand>> hExists(Publisher<HExistsCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class HDelCommand extends KeyCommand {
+
+		private final List<ByteBuffer> fields;
+
+		private HDelCommand(ByteBuffer key, List<ByteBuffer> fields) {
+			super(key);
+			this.fields = fields;
+		}
+
+		public static HDelCommand field(ByteBuffer field) {
+			return new HDelCommand(null, Collections.singletonList(field));
+		}
+
+		public static HDelCommand fields(List<ByteBuffer> fields) {
+			return new HDelCommand(null, new ArrayList<>(fields));
+		}
+
+		public HDelCommand from(ByteBuffer key) {
+			return new HDelCommand(key, fields);
+		}
+
+		public List<ByteBuffer> getFields() {
+			return fields;
+		}
+	}
+
+	/**
+	 * Delete given hash {@code field}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> hDel(ByteBuffer key, ByteBuffer field) {
+
+		Assert.notNull(field, "field must not be null");
+
+		return hDel(key, Collections.singletonList(field)).map(val -> val > 0 ? Boolean.TRUE : Boolean.FALSE);
+	}
+
+	/**
+	 * Delete given hash {@code fields}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param fields must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> hDel(ByteBuffer key, List<ByteBuffer> fields) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(fields, "fields must not be null");
+
+		return hDel(Mono.just(HDelCommand.fields(fields).from(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Delete given hash {@code fields}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<HDelCommand, Long>> hDel(Publisher<HDelCommand> commands);
+
+	/**
+	 * Get size of hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> hLen(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return hLen(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Get size of hash at {@code key}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<KeyCommand, Long>> hLen(Publisher<KeyCommand> commands);
+
+	/**
+	 * Get key set (fields) of hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> hKeys(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return hKeys(Mono.just(new KeyCommand(key))).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get key set (fields) of hash at {@code key}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<KeyCommand, ByteBuffer>> hKeys(Publisher<KeyCommand> commands);
+
+	/**
+	 * Get entry set (values) of hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> hVals(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return hVals(Mono.just(new KeyCommand(key))).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get entry set (values) of hash at {@code key}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<KeyCommand, ByteBuffer>> hVals(Publisher<KeyCommand> commands);
+
+	/**
+	 * Get entire hash stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Map<ByteBuffer, ByteBuffer>> hGetAll(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return hGetAll(Mono.just(new KeyCommand(key))).next().map(CommandResponse::getOutput);
+	}
+
+	/**
+	 * Get entire hash stored at {@code key}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<CommandResponse<KeyCommand, Map<ByteBuffer, ByteBuffer>>> hGetAll(Publisher<KeyCommand> commands);
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHyperLogLogCommands.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.Command;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveHyperLogLogCommands {
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class PfAddCommand extends KeyCommand {
+
+		private final List<ByteBuffer> values;
+
+		private PfAddCommand(ByteBuffer key, List<ByteBuffer> values) {
+
+			super(key);
+			this.values = values;
+		}
+
+		public static PfAddCommand value(ByteBuffer value) {
+			return values(Collections.singletonList(value));
+		}
+
+		public static PfAddCommand values(List<ByteBuffer> values) {
+			return new PfAddCommand(null, new ArrayList<>(values));
+		}
+
+		public PfAddCommand to(ByteBuffer key) {
+			return new PfAddCommand(key, values);
+		}
+
+		public List<ByteBuffer> getValues() {
+			return values;
+		}
+	}
+
+	/**
+	 * Adds given {@literal value} to the HyperLogLog stored at given {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> pfAdd(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(value, "value must not be null");
+
+		return pfAdd(key, Collections.singletonList(value));
+	}
+
+	/**
+	 * Adds given {@literal values} to the HyperLogLog stored at given {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> pfAdd(ByteBuffer key, List<ByteBuffer> values) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(values, "values must not be null");
+
+		return pfAdd(Mono.just(PfAddCommand.values(values).to(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Adds given {@literal values} to the HyperLogLog stored at given {@literal key}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<PfAddCommand, Long>> pfAdd(Publisher<PfAddCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class PfCountCommand implements Command {
+
+		private final List<ByteBuffer> keys;
+
+		private PfCountCommand(List<ByteBuffer> keys) {
+
+			super();
+			this.keys = keys;
+		}
+
+		public static PfCountCommand valueIn(ByteBuffer key) {
+			return valuesIn(Collections.singletonList(key));
+		}
+
+		public static PfCountCommand valuesIn(List<ByteBuffer> keys) {
+			return new PfCountCommand(keys);
+		}
+
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+
+		@Override
+		public ByteBuffer getKey() {
+			return null;
+		}
+
+	}
+
+	/**
+	 * Return the approximated cardinality of the structures observed by the HyperLogLog at {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> pfCount(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return pfCount(Collections.singletonList(key));
+	}
+
+	/**
+	 * Return the approximated cardinality of the structures observed by the HyperLogLog at {@literal key(s)}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> pfCount(List<ByteBuffer> keys) {
+
+		Assert.notNull(keys, "keys must not be null");
+
+		return pfCount(Mono.just(PfCountCommand.valuesIn(keys))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Return the approximated cardinality of the structures observed by the HyperLogLog at {@literal key(s)}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<PfCountCommand, Long>> pfCount(Publisher<PfCountCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class PfMergeCommand extends KeyCommand {
+
+		private final List<ByteBuffer> sourceKeys;
+
+		private PfMergeCommand(ByteBuffer key, List<ByteBuffer> sourceKeys) {
+
+			super(key);
+			this.sourceKeys = sourceKeys;
+		}
+
+		public static PfMergeCommand valuesIn(List<ByteBuffer> sourceKeys) {
+			return new PfMergeCommand(null, sourceKeys);
+		}
+
+		public PfMergeCommand into(ByteBuffer destinationKey) {
+			return new PfMergeCommand(destinationKey, sourceKeys);
+		}
+
+		public List<ByteBuffer> getSourceKeys() {
+			return sourceKeys;
+		}
+	}
+
+	/**
+	 * Merge N different HyperLogLogs at {@literal sourceKeys} into a single {@literal destinationKey}.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sourceKeys must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> pfMerge(ByteBuffer destinationKey, List<ByteBuffer> sourceKeys) {
+
+		Assert.notNull(destinationKey, "destinationKey must not be null");
+		Assert.notNull(sourceKeys, "sourceKeys must not be null");
+
+		return pfMerge(Mono.just(PfMergeCommand.valuesIn(sourceKeys).into(destinationKey))).next()
+				.map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Merge N different HyperLogLogs at {@literal sourceKeys} into a single {@literal destinationKey}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<PfMergeCommand>> pfMerge(Publisher<PfMergeCommand> commands);
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHyperLogLogCommands.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.connection;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,12 +32,17 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
+ * Redis HyperLogLog commands executed using reactive infrastructure.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 public interface ReactiveHyperLogLogCommands {
 
 	/**
+	 * {@code PFADD} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class PfAddCommand extends KeyCommand {
@@ -49,18 +55,48 @@ public interface ReactiveHyperLogLogCommands {
 			this.values = values;
 		}
 
+		/**
+		 * Creates a new {@link PfAddCommand} given a {@link ByteBuffer value}.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return a new {@link PfAddCommand} for {@link ByteBuffer value}.
+		 */
 		public static PfAddCommand value(ByteBuffer value) {
+
+			Assert.notNull(value, "Value must not be null!");
+
 			return values(Collections.singletonList(value));
 		}
 
-		public static PfAddCommand values(List<ByteBuffer> values) {
+		/**
+		 * Creates a new {@link PfAddCommand} given a {@link Collection} of {@link ByteBuffer values}.
+		 *
+		 * @param values must not be {@literal null}.
+		 * @return a new {@link PfAddCommand} for {@link ByteBuffer key}.
+		 */
+		public static PfAddCommand values(Collection<ByteBuffer> values) {
+
+			Assert.notNull(values, "Values must not be null!");
+
 			return new PfAddCommand(null, new ArrayList<>(values));
 		}
 
+		/**
+		 * Applies the {@literal key}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link PfAddCommand} with {@literal key} applied.
+		 */
 		public PfAddCommand to(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new PfAddCommand(key, values);
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getValues() {
 			return values;
 		}
@@ -75,7 +111,7 @@ public interface ReactiveHyperLogLogCommands {
 	 */
 	default Mono<Long> pfAdd(ByteBuffer key, ByteBuffer value) {
 
-		Assert.notNull(value, "value must not be null");
+		Assert.notNull(value, "Value must not be null!");
 
 		return pfAdd(key, Collections.singletonList(value));
 	}
@@ -87,10 +123,10 @@ public interface ReactiveHyperLogLogCommands {
 	 * @param values must not be {@literal null}.
 	 * @return
 	 */
-	default Mono<Long> pfAdd(ByteBuffer key, List<ByteBuffer> values) {
+	default Mono<Long> pfAdd(ByteBuffer key, Collection<ByteBuffer> values) {
 
-		Assert.notNull(key, "key must not be null");
-		Assert.notNull(values, "values must not be null");
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(values, "Values must not be null!");
 
 		return pfAdd(Mono.just(PfAddCommand.values(values).to(key))).next().map(NumericResponse::getOutput);
 	}
@@ -104,6 +140,8 @@ public interface ReactiveHyperLogLogCommands {
 	Flux<NumericResponse<PfAddCommand, Long>> pfAdd(Publisher<PfAddCommand> commands);
 
 	/**
+	 * {@code PFCOUNT} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class PfCountCommand implements Command {
@@ -116,23 +154,46 @@ public interface ReactiveHyperLogLogCommands {
 			this.keys = keys;
 		}
 
+		/**
+		 * Creates a new {@link PfCountCommand} given a {@link ByteBuffer key}.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link PfCountCommand} for {@link ByteBuffer key}.
+		 */
 		public static PfCountCommand valueIn(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return valuesIn(Collections.singletonList(key));
 		}
 
-		public static PfCountCommand valuesIn(List<ByteBuffer> keys) {
-			return new PfCountCommand(keys);
+		/**
+		 * Creates a new {@link PfCountCommand} given a {@link Collection} of {@literal keys}.
+		 *
+		 * @param keys must not be {@literal null}.
+		 * @return a new {@link PfCountCommand} for {@literal keys}.
+		 */
+		public static PfCountCommand valuesIn(Collection<ByteBuffer> keys) {
+
+			Assert.notNull(keys, "Keys must not be null!");
+
+			return new PfCountCommand(new ArrayList<>(keys));
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getKeys() {
 			return keys;
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.Command#getKey()
+		 */
 		@Override
 		public ByteBuffer getKey() {
 			return null;
 		}
-
 	}
 
 	/**
@@ -143,7 +204,7 @@ public interface ReactiveHyperLogLogCommands {
 	 */
 	default Mono<Long> pfCount(ByteBuffer key) {
 
-		Assert.notNull(key, "key must not be null");
+		Assert.notNull(key, "Key must not be null!");
 
 		return pfCount(Collections.singletonList(key));
 	}
@@ -154,9 +215,9 @@ public interface ReactiveHyperLogLogCommands {
 	 * @param keys must not be {@literal null}.
 	 * @return
 	 */
-	default Mono<Long> pfCount(List<ByteBuffer> keys) {
+	default Mono<Long> pfCount(Collection<ByteBuffer> keys) {
 
-		Assert.notNull(keys, "keys must not be null");
+		Assert.notNull(keys, "Keys must not be null!");
 
 		return pfCount(Mono.just(PfCountCommand.valuesIn(keys))).next().map(NumericResponse::getOutput);
 	}
@@ -170,6 +231,8 @@ public interface ReactiveHyperLogLogCommands {
 	Flux<NumericResponse<PfCountCommand, Long>> pfCount(Publisher<PfCountCommand> commands);
 
 	/**
+	 * {@code PFMERGE} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class PfMergeCommand extends KeyCommand {
@@ -182,14 +245,36 @@ public interface ReactiveHyperLogLogCommands {
 			this.sourceKeys = sourceKeys;
 		}
 
-		public static PfMergeCommand valuesIn(List<ByteBuffer> sourceKeys) {
-			return new PfMergeCommand(null, sourceKeys);
+		/**
+		 * Creates a new {@link PfMergeCommand} given a {@link Collection} of {@literal sourceKeys}.
+		 *
+		 * @param sourceKeys must not be {@literal null}.
+		 * @return a new {@link PfMergeCommand} for {@literal sourceKeys}.
+		 */
+		public static PfMergeCommand valuesIn(Collection<ByteBuffer> sourceKeys) {
+
+			Assert.notNull(sourceKeys, "Source keys must not be null!");
+
+			return new PfMergeCommand(null, new ArrayList<>(sourceKeys));
 		}
 
+		/**
+		 * Applies the {@literal destinationKey}. Constructs a new command instance with all previously configured
+		 * properties.
+		 *
+		 * @param destinationKey must not be {@literal null}.
+		 * @return a new {@link PfMergeCommand} with {@literal destinationKey} applied.
+		 */
 		public PfMergeCommand into(ByteBuffer destinationKey) {
+
+			Assert.notNull(destinationKey, "Destination key must not be null!");
+
 			return new PfMergeCommand(destinationKey, sourceKeys);
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getSourceKeys() {
 			return sourceKeys;
 		}
@@ -202,10 +287,10 @@ public interface ReactiveHyperLogLogCommands {
 	 * @param sourceKeys must not be {@literal null}.
 	 * @return
 	 */
-	default Mono<Boolean> pfMerge(ByteBuffer destinationKey, List<ByteBuffer> sourceKeys) {
+	default Mono<Boolean> pfMerge(ByteBuffer destinationKey, Collection<ByteBuffer> sourceKeys) {
 
-		Assert.notNull(destinationKey, "destinationKey must not be null");
-		Assert.notNull(sourceKeys, "sourceKeys must not be null");
+		Assert.notNull(destinationKey, "DestinationKey must not be null!");
+		Assert.notNull(sourceKeys, "SourceKeys must not be null!");
 
 		return pfMerge(Mono.just(PfMergeCommand.valuesIn(sourceKeys).into(destinationKey))).next()
 				.map(BooleanResponse::getOutput);
@@ -218,5 +303,4 @@ public interface ReactiveHyperLogLogCommands {
 	 * @return
 	 */
 	Flux<BooleanResponse<PfMergeCommand>> pfMerge(Publisher<PfMergeCommand> commands);
-
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveKeyCommands {
+
+	/**
+	 * Determine if given {@code key} exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> exists(ByteBuffer key) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return exists(Mono.just(new KeyCommand(key))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Determine if given {@code key} exists.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<KeyCommand>> exists(Publisher<KeyCommand> keys);
+
+	/**
+	 * Determine the type stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<DataType> type(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return type(Mono.just(new KeyCommand(key))).next().map(CommandResponse::getOutput);
+	}
+
+	/**
+	 * Determine the type stored at {@code key}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	Flux<CommandResponse<KeyCommand, DataType>> type(Publisher<KeyCommand> keys);
+
+	/**
+	 * Find all keys matching the given {@code pattern}.
+	 *
+	 * @param pattern must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> keys(ByteBuffer pattern) {
+
+		Assert.notNull(pattern, "pattern must not be null");
+
+		return keys(Mono.just(pattern)).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Return a random key from the keyspace.
+	 *
+	 * @return
+	 */
+	Mono<ByteBuffer> randomKey();
+
+	/**
+	 * Find all keys matching the given {@code pattern}.
+	 *
+	 * @param patterns must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<ByteBuffer, ByteBuffer>> keys(Publisher<ByteBuffer> patterns);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class RenameCommand extends KeyCommand {
+
+		private ByteBuffer newName;
+
+		private RenameCommand(ByteBuffer key, ByteBuffer newName) {
+
+			super(key);
+			this.newName = newName;
+		}
+
+		public static ReactiveKeyCommands.RenameCommand key(ByteBuffer key) {
+			return new RenameCommand(key, null);
+		}
+
+		public ReactiveKeyCommands.RenameCommand to(ByteBuffer newName) {
+			return new RenameCommand(getKey(), newName);
+		}
+
+		public ByteBuffer getNewName() {
+			return newName;
+		}
+	}
+
+	/**
+	 * Rename key {@code oleName} to {@code newName}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param newName must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> rename(ByteBuffer key, ByteBuffer newName) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return rename(Mono.just(RenameCommand.key(key).to(newName))).next().map(BooleanResponse::getOutput);
+	}
+
+	Flux<BooleanResponse<ReactiveKeyCommands.RenameCommand>> rename(Publisher<ReactiveKeyCommands.RenameCommand> cmd);
+
+	/**
+	 * Rename key {@code oleName} to {@code newName} only if {@code newName} does not exist.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param newName must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> renameNX(ByteBuffer key, ByteBuffer newName) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return renameNX(Mono.just(RenameCommand.key(key).to(newName))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Rename key {@code oleName} to {@code newName} only if {@code newName} does not exist.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param newName must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<ReactiveKeyCommands.RenameCommand>> renameNX(
+			Publisher<ReactiveKeyCommands.RenameCommand> command);
+
+	/**
+	 * Delete {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> del(ByteBuffer key) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return del(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Delete {@literal keys} one by one.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@link Flux} of {@link DelResponse} holding the {@literal key} removed along with the deletion result.
+	 */
+	Flux<NumericResponse<KeyCommand, Long>> del(Publisher<KeyCommand> keys);
+
+	/**
+	 * Delete multiple {@literal keys} one in one batch.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> mDel(List<ByteBuffer> keys) {
+
+		Assert.notEmpty(keys, "Keys must not be empty or null!");
+
+		return mDel(Mono.just(keys)).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Delete multiple {@literal keys} in batches.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@link Flux} of {@link MDelResponse} holding the {@literal keys} removed along with the deletion result.
+	 */
+	Flux<NumericResponse<List<ByteBuffer>, Long>> mDel(Publisher<List<ByteBuffer>> keys);
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
@@ -30,13 +30,16 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
+ * Redis Key commands executed using reactive infrastructure.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 public interface ReactiveKeyCommands {
 
 	/**
-	 * Determine if given {@code key} exists.
+	 * Determine if given {@literal key} exists.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
@@ -49,7 +52,7 @@ public interface ReactiveKeyCommands {
 	}
 
 	/**
-	 * Determine if given {@code key} exists.
+	 * Determine if given {@literal key} exists.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
@@ -57,20 +60,20 @@ public interface ReactiveKeyCommands {
 	Flux<BooleanResponse<KeyCommand>> exists(Publisher<KeyCommand> keys);
 
 	/**
-	 * Determine the type stored at {@code key}.
+	 * Determine the type stored at {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
 	 */
 	default Mono<DataType> type(ByteBuffer key) {
 
-		Assert.notNull(key, "key must not be null");
+		Assert.notNull(key, "Key must not be null!");
 
 		return type(Mono.just(new KeyCommand(key))).next().map(CommandResponse::getOutput);
 	}
 
 	/**
-	 * Determine the type stored at {@code key}.
+	 * Determine the type stored at {@literal key}.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
@@ -78,14 +81,14 @@ public interface ReactiveKeyCommands {
 	Flux<CommandResponse<KeyCommand, DataType>> type(Publisher<KeyCommand> keys);
 
 	/**
-	 * Find all keys matching the given {@code pattern}.
+	 * Find all keys matching the given {@literal pattern}.
 	 *
 	 * @param pattern must not be {@literal null}.
 	 * @return
 	 */
 	default Mono<List<ByteBuffer>> keys(ByteBuffer pattern) {
 
-		Assert.notNull(pattern, "pattern must not be null");
+		Assert.notNull(pattern, "Pattern must not be null!");
 
 		return keys(Mono.just(pattern)).next().map(MultiValueResponse::getOutput);
 	}
@@ -98,7 +101,7 @@ public interface ReactiveKeyCommands {
 	Mono<ByteBuffer> randomKey();
 
 	/**
-	 * Find all keys matching the given {@code pattern}.
+	 * Find all keys matching the given {@literal pattern}.
 	 *
 	 * @param patterns must not be {@literal null}.
 	 * @return
@@ -106,6 +109,8 @@ public interface ReactiveKeyCommands {
 	Flux<MultiValueResponse<ByteBuffer, ByteBuffer>> keys(Publisher<ByteBuffer> patterns);
 
 	/**
+	 * {@code RENAME} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class RenameCommand extends KeyCommand {
@@ -115,24 +120,46 @@ public interface ReactiveKeyCommands {
 		private RenameCommand(ByteBuffer key, ByteBuffer newName) {
 
 			super(key);
+
 			this.newName = newName;
 		}
 
-		public static ReactiveKeyCommands.RenameCommand key(ByteBuffer key) {
+		/**
+		 * Creates a new {@link RenameCommand} given a {@link ByteBuffer key}.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link RenameCommand} for {@link ByteBuffer key}.
+		 */
+		public static RenameCommand key(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new RenameCommand(key, null);
 		}
 
-		public ReactiveKeyCommands.RenameCommand to(ByteBuffer newName) {
+		/**
+		 * Applies the {@literal newName}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param newName must not be {@literal null}.
+		 * @return a new {@link RenameCommand} with {@literal newName} applied.
+		 */
+		public RenameCommand to(ByteBuffer newName) {
+
+			Assert.notNull(newName, "New name must not be null!");
+
 			return new RenameCommand(getKey(), newName);
 		}
 
+		/**
+		 * @return
+		 */
 		public ByteBuffer getNewName() {
 			return newName;
 		}
 	}
 
 	/**
-	 * Rename key {@code oleName} to {@code newName}.
+	 * Rename key {@literal oleName} to {@literal newName}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param newName must not be {@literal null}.
@@ -140,15 +167,15 @@ public interface ReactiveKeyCommands {
 	 */
 	default Mono<Boolean> rename(ByteBuffer key, ByteBuffer newName) {
 
-		Assert.notNull(key, "key must not be null");
+		Assert.notNull(key, "Key must not be null!");
 
 		return rename(Mono.just(RenameCommand.key(key).to(newName))).next().map(BooleanResponse::getOutput);
 	}
 
-	Flux<BooleanResponse<ReactiveKeyCommands.RenameCommand>> rename(Publisher<ReactiveKeyCommands.RenameCommand> cmd);
+	Flux<BooleanResponse<RenameCommand>> rename(Publisher<RenameCommand> cmd);
 
 	/**
-	 * Rename key {@code oleName} to {@code newName} only if {@code newName} does not exist.
+	 * Rename key {@literal oleName} to {@literal newName} only if {@literal newName} does not exist.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param newName must not be {@literal null}.
@@ -156,20 +183,18 @@ public interface ReactiveKeyCommands {
 	 */
 	default Mono<Boolean> renameNX(ByteBuffer key, ByteBuffer newName) {
 
-		Assert.notNull(key, "key must not be null");
+		Assert.notNull(key, "Key must not be null!");
 
 		return renameNX(Mono.just(RenameCommand.key(key).to(newName))).next().map(BooleanResponse::getOutput);
 	}
 
 	/**
-	 * Rename key {@code oleName} to {@code newName} only if {@code newName} does not exist.
+	 * Rename key {@literal oleName} to {@literal newName} only if {@literal newName} does not exist.
 	 *
-	 * @param keys must not be {@literal null}.
-	 * @param newName must not be {@literal null}.
+	 * @param command must not be {@literal null}.
 	 * @return
 	 */
-	Flux<BooleanResponse<ReactiveKeyCommands.RenameCommand>> renameNX(
-			Publisher<ReactiveKeyCommands.RenameCommand> command);
+	Flux<BooleanResponse<RenameCommand>> renameNX(Publisher<RenameCommand> command);
 
 	/**
 	 * Delete {@literal key}.
@@ -188,7 +213,7 @@ public interface ReactiveKeyCommands {
 	 * Delete {@literal keys} one by one.
 	 *
 	 * @param keys must not be {@literal null}.
-	 * @return {@link Flux} of {@link DelResponse} holding the {@literal key} removed along with the deletion result.
+	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} removed along with the deletion result.
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> del(Publisher<KeyCommand> keys);
 
@@ -209,7 +234,7 @@ public interface ReactiveKeyCommands {
 	 * Delete multiple {@literal keys} in batches.
 	 *
 	 * @param keys must not be {@literal null}.
-	 * @return {@link Flux} of {@link MDelResponse} holding the {@literal keys} removed along with the deletion result.
+	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal keys} removed along with the deletion result.
 	 */
 	Flux<NumericResponse<List<ByteBuffer>, Long>> mDel(Publisher<List<ByteBuffer>> keys);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveListCommands.java
@@ -1,0 +1,820 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.Command;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.RangeCommand;
+import org.springframework.data.redis.connection.RedisListCommands.Position;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveListCommands {
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	enum Direction {
+		LEFT, RIGHT
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class PushCommand extends KeyCommand {
+
+		private List<ByteBuffer> values;
+		private boolean upsert;
+		private Direction direction;
+
+		private PushCommand(ByteBuffer key, List<ByteBuffer> values, Direction direction, boolean upsert) {
+
+			super(key);
+			this.values = values;
+			this.upsert = upsert;
+			this.direction = direction;
+		}
+
+		public static PushCommand right() {
+			return new PushCommand(null, null, Direction.RIGHT, true);
+		}
+
+		public static PushCommand left() {
+			return new PushCommand(null, null, Direction.LEFT, true);
+		}
+
+		public PushCommand value(ByteBuffer value) {
+			return new PushCommand(null, Collections.singletonList(value), direction, upsert);
+		}
+
+		public PushCommand values(List<ByteBuffer> values) {
+			return new PushCommand(null, values, direction, upsert);
+		}
+
+		public PushCommand to(ByteBuffer key) {
+			return new PushCommand(key, values, direction, upsert);
+		}
+
+		public PushCommand ifExists() {
+			return new PushCommand(getKey(), values, direction, false);
+		}
+
+		public List<ByteBuffer> getValues() {
+			return values;
+		}
+
+		public boolean getUpsert() {
+			return upsert;
+		}
+
+		public Direction getDirection() {
+			return direction;
+		}
+	}
+
+	/**
+	 * Append {@code values} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> rPush(ByteBuffer key, List<ByteBuffer> values) {
+
+		Assert.notNull(key, "command must not be null!");
+		Assert.notNull(values, "Values must not be null!");
+
+		return push(Mono.just(PushCommand.right().values(values).to(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Append {@code values} to {@code key} only if {@code key} already exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> rPushX(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "command must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+
+		return push(Mono.just(PushCommand.right().value(value).to(key).ifExists())).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Prepend {@code values} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> lPush(ByteBuffer key, List<ByteBuffer> values) {
+
+		Assert.notNull(key, "command must not be null!");
+		Assert.notNull(values, "Values must not be null!");
+
+		return push(Mono.just(PushCommand.left().values(values).to(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Prepend {@code value} to {@code key} if {@code key} already exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> lPushX(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "command must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+
+		return push(Mono.just(PushCommand.left().value(value).to(key).ifExists())).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Prepend {@link PushCommand#getValues()} to {@link PushCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<PushCommand, Long>> push(Publisher<PushCommand> commands);
+
+	/**
+	 * Get the size of list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> lLen(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return lLen(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Get the size of list stored at {@link KeyCommand#getKey()}
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<KeyCommand, Long>> lLen(Publisher<KeyCommand> commands);
+
+	/**
+	 * Get elements between {@code begin} and {@code end} from list at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> lRange(ByteBuffer key, long start, long end) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return lRange(Mono.just(RangeCommand.key(key).fromIndex(start).toIndex(end))).next()
+				.map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get elements in {@link RangeCommand#getRange()} from list at {@link RangeCommand#getKey()}
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<RangeCommand, ByteBuffer>> lRange(Publisher<RangeCommand> commands);
+
+	/**
+	 * Trim list at {@code key} to elements between {@code begin} and {@code end}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 */
+	default Mono<Boolean> lTrim(ByteBuffer key, long start, long end) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return lTrim(Mono.just(RangeCommand.key(key).fromIndex(start).toIndex(end))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Trim list at {@link RangeCommand#getKey()} to elements within {@link RangeCommand#getRange()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<RangeCommand>> lTrim(Publisher<RangeCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class LIndexCommand extends KeyCommand {
+
+		private final Long index;
+
+		private LIndexCommand(ByteBuffer key, Long index) {
+
+			super(key);
+			this.index = index;
+		}
+
+		public static LIndexCommand elementAt(Long index) {
+			return new LIndexCommand(null, index);
+		}
+
+		public LIndexCommand from(ByteBuffer key) {
+			return new LIndexCommand(key, index);
+		}
+
+		public Long getIndex() {
+			return index;
+		}
+	}
+
+	/**
+	 * Get element at {@code index} form list at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param index
+	 * @return
+	 */
+	default Mono<ByteBuffer> lIndex(ByteBuffer key, long index) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return lIndex(Mono.just(LIndexCommand.elementAt(index).from(key))).next().map(ByteBufferResponse::getOutput);
+	}
+
+	/**
+	 * Get element at {@link LIndexCommand#getIndex()} form list at {@link LIndexCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<ByteBufferResponse<LIndexCommand>> lIndex(Publisher<LIndexCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class LInsertCommand extends KeyCommand {
+
+		private final Position position;
+		private final ByteBuffer pivot;
+		private final ByteBuffer value;
+
+		public LInsertCommand(ByteBuffer key, Position position, ByteBuffer pivot, ByteBuffer value) {
+
+			super(key);
+			this.position = position;
+			this.pivot = pivot;
+			this.value = value;
+		}
+
+		public static LInsertCommand value(ByteBuffer value) {
+			return new LInsertCommand(null, null, null, value);
+		}
+
+		public LInsertCommand before(ByteBuffer pivot) {
+			return new LInsertCommand(getKey(), Position.BEFORE, pivot, value);
+		}
+
+		public LInsertCommand after(ByteBuffer pivot) {
+			return new LInsertCommand(getKey(), Position.AFTER, pivot, value);
+		}
+
+		public LInsertCommand forKey(ByteBuffer key) {
+			return new LInsertCommand(key, position, pivot, value);
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+
+		public Position getPosition() {
+			return position;
+		}
+
+		public ByteBuffer getPivot() {
+			return pivot;
+		}
+	}
+
+	/**
+	 * Insert {@code value} {@link Position#BEFORE} or {@link Position#AFTER} existing {@code pivot} for {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> lInsert(ByteBuffer key, Position position, ByteBuffer pivot, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null!");
+		Assert.notNull(position, "position must not be null!");
+		Assert.notNull(pivot, "pivot must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+
+		LInsertCommand command = LInsertCommand.value(value);
+		command = Position.BEFORE.equals(position) ? command.before(pivot) : command.after(pivot);
+		command = command.forKey(key);
+		return lInsert(Mono.just(command)).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Insert {@link LInsertCommand#getValue()} {@link Position#BEFORE} or {@link Position#AFTER} existing
+	 * {@link LInsertCommand#getPivot()} for {@link LInsertCommand#getKey()}
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<LInsertCommand, Long>> lInsert(Publisher<LInsertCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class LSetCommand extends KeyCommand {
+
+		private final Long index;
+		private final ByteBuffer value;
+
+		private LSetCommand(ByteBuffer key, Long index, ByteBuffer value) {
+
+			super(key);
+			this.index = index;
+			this.value = value;
+		}
+
+		public static LSetCommand elementAt(Long index) {
+			return new LSetCommand(null, index, null);
+		}
+
+		public LSetCommand to(ByteBuffer value) {
+			return new LSetCommand(getKey(), index, value);
+		}
+
+		public LSetCommand forKey(ByteBuffer key) {
+			return new LSetCommand(key, index, value);
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+
+		public Long getIndex() {
+			return index;
+		}
+	}
+
+	/**
+	 * Set the {@code value} list element at {@code index}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param index
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> lSet(ByteBuffer key, long index, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return lSet(Mono.just(LSetCommand.elementAt(index).to(value).forKey(key))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set the {@link LSetCommand#getValue()} list element at {@link LSetCommand#getKey()}.
+	 *
+	 * @param commands
+	 * @return
+	 */
+	Flux<BooleanResponse<LSetCommand>> lSet(Publisher<LSetCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class LRemCommand extends KeyCommand {
+
+		private final Long count;
+		private final ByteBuffer value;
+
+		private LRemCommand(ByteBuffer key, Long count, ByteBuffer value) {
+			super(key);
+			this.count = count;
+			this.value = value;
+		}
+
+		public static LRemCommand all() {
+			return new LRemCommand(null, 0L, null);
+		}
+
+		public static LRemCommand first(Long count) {
+			return new LRemCommand(null, count, null);
+		}
+
+		public static LRemCommand last(Long count) {
+
+			Long value = count < 0L ? count : Math.negateExact(count);
+			return new LRemCommand(null, value, null);
+		}
+
+		public LRemCommand occurancesOf(ByteBuffer value) {
+			return new LRemCommand(getKey(), count, value);
+		}
+
+		public LRemCommand from(ByteBuffer key) {
+			return new LRemCommand(key, count, value);
+		}
+
+		public Long getCount() {
+			return count;
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+	}
+
+	/**
+	 * Removes all occurrences of {@code value} from the list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> lRem(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return lRem(Mono.just(LRemCommand.all().occurancesOf(value).from(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Removes the first {@code count} occurrences of {@code value} from the list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param count must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> lRem(ByteBuffer key, Long count, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(count, "count must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return lRem(Mono.just(LRemCommand.first(count).occurancesOf(value).from(key))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Removes the {@link LRemCommand#getCount()} occurrences of {@link LRemCommand#getValue()} from the list stored at
+	 * {@link LRemCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<LRemCommand, Long>> lRem(Publisher<LRemCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class PopCommand extends KeyCommand {
+
+		private final Direction direction;
+
+		private PopCommand(ByteBuffer key, Direction direction) {
+
+			super(key);
+			this.direction = direction;
+		}
+
+		public static PopCommand right() {
+			return new PopCommand(null, Direction.RIGHT);
+		}
+
+		public static PopCommand left() {
+			return new PopCommand(null, Direction.LEFT);
+		}
+
+		public PopCommand from(ByteBuffer key) {
+			return new PopCommand(key, direction);
+		}
+
+		public Direction getDirection() {
+			return direction;
+		}
+
+	}
+
+	/**
+	 * Removes and returns first element in list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<ByteBuffer> lPop(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return pop(Mono.just(PopCommand.left().from(key))).next().map(ByteBufferResponse::getOutput);
+	}
+
+	/**
+	 * Removes and returns last element in list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<ByteBuffer> rPop(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return pop(Mono.just(PopCommand.right().from(key))).next().map(ByteBufferResponse::getOutput);
+	}
+
+	/**
+	 * Removes and returns last element in list stored at {@link KeyCommand#getKey()}
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<ByteBufferResponse<PopCommand>> pop(Publisher<PopCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class BPopCommand implements Command {
+
+		private final List<ByteBuffer> keys;
+		private final Duration timeout;
+		private final Direction direction;
+
+		private BPopCommand(List<ByteBuffer> keys, Duration timeout, Direction direction) {
+			this.keys = keys;
+			this.timeout = timeout;
+			this.direction = direction;
+		}
+
+		public static BPopCommand right() {
+			return new BPopCommand(null, Duration.ZERO, Direction.RIGHT);
+		}
+
+		public static BPopCommand left() {
+			return new BPopCommand(null, Duration.ZERO, Direction.LEFT);
+		}
+
+		public BPopCommand from(List<ByteBuffer> keys) {
+			return new BPopCommand(keys, Duration.ZERO, direction);
+		}
+
+		public BPopCommand blockingFor(Duration timeout) {
+			return new BPopCommand(keys, timeout, direction);
+		}
+
+		@Override
+		public ByteBuffer getKey() {
+			return null;
+		}
+
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+
+		public Duration getTimeout() {
+			return timeout;
+		}
+
+		public Direction getDirection() {
+			return direction;
+		}
+
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class PopResult {
+
+		private final List<ByteBuffer> result;
+
+		public PopResult(List<ByteBuffer> result) {
+			this.result = result;
+		}
+
+		public ByteBuffer getKey() {
+			return ObjectUtils.isEmpty(result) ? null : result.get(0);
+		}
+
+		public ByteBuffer getValue() {
+			return ObjectUtils.isEmpty(result) ? null : result.get(1);
+		}
+
+		public List<ByteBuffer> getRaw() {
+			return Collections.unmodifiableList(result);
+		}
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class PopResponse extends CommandResponse<BPopCommand, PopResult> {
+
+		public PopResponse(BPopCommand input, PopResult output) {
+			super(input, output);
+		}
+
+	}
+
+	/**
+	 * Removes and returns first element from lists stored at {@code keys}. <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param timeout must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<PopResult> blPop(List<ByteBuffer> keys, Duration timeout) {
+
+		Assert.notNull(keys, "keys must not be null.");
+		Assert.notNull(timeout, "timeout must not be null.");
+
+		return bPop(Mono.just(BPopCommand.left().from(keys).blockingFor(timeout))).next().map(PopResponse::getOutput);
+	}
+
+	/**
+	 * Removes and returns last element from lists stored at {@code keys}. <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param timeout must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<PopResult> brPop(List<ByteBuffer> keys, Duration timeout) {
+
+		Assert.notNull(keys, "keys must not be null.");
+		Assert.notNull(timeout, "timeout must not be null.");
+
+		return bPop(Mono.just(BPopCommand.right().from(keys).blockingFor(timeout))).next().map(PopResponse::getOutput);
+	}
+
+	/**
+	 * Removes and returns the top {@link BPopCommand#getDirection()} element from lists stored at
+	 * {@link BPopCommand#getKeys()}.<br>
+	 * <b>Blocks connection</b> until element available or {@link BPopCommand#getTimeout()} reached.
+	 *
+	 * @param commands
+	 * @return
+	 */
+	Flux<PopResponse> bPop(Publisher<BPopCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class RPopLPushCommand extends KeyCommand {
+
+		private final ByteBuffer destination;
+
+		private RPopLPushCommand(ByteBuffer key, ByteBuffer destination) {
+
+			super(key);
+			this.destination = destination;
+		}
+
+		public static RPopLPushCommand from(ByteBuffer sourceKey) {
+			return new RPopLPushCommand(sourceKey, null);
+		}
+
+		public RPopLPushCommand to(ByteBuffer destinationKey) {
+			return new RPopLPushCommand(getKey(), destinationKey);
+		}
+
+		public ByteBuffer getDestination() {
+			return destination;
+		}
+
+	}
+
+	/**
+	 * Remove the last element from list at {@code source}, append it to {@code destination} and return its value.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @param destination must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<ByteBuffer> rPopLPush(ByteBuffer source, ByteBuffer destination) {
+
+		Assert.notNull(source, "source must not be null");
+		Assert.notNull(destination, "destination must not be null");
+
+		return rPopLPush(Mono.just(RPopLPushCommand.from(source).to(destination))).next()
+				.map(ByteBufferResponse::getOutput);
+	}
+
+	/**
+	 * Remove the last element from list at {@link RPopLPushCommand#getKey()}, append it to
+	 * {@link RPopLPushCommand#getDestination()} and return its value.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @param destination must not be {@literal null}.
+	 * @return
+	 */
+	Flux<ByteBufferResponse<RPopLPushCommand>> rPopLPush(Publisher<RPopLPushCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class BRPopLPushCommand extends KeyCommand {
+
+		private final ByteBuffer destination;
+		private final Duration timeout;
+
+		private BRPopLPushCommand(ByteBuffer key, ByteBuffer destination, Duration timeout) {
+
+			super(key);
+			this.destination = destination;
+			this.timeout = timeout;
+		}
+
+		public static BRPopLPushCommand from(ByteBuffer sourceKey) {
+			return new BRPopLPushCommand(sourceKey, null, null);
+		}
+
+		public BRPopLPushCommand to(ByteBuffer destinationKey) {
+			return new BRPopLPushCommand(getKey(), destinationKey, timeout);
+		}
+
+		public BRPopLPushCommand blockingFor(Duration timeout) {
+			return new BRPopLPushCommand(getKey(), destination, timeout);
+		}
+
+		public ByteBuffer getDestination() {
+			return destination;
+		}
+
+		public Duration getTimeout() {
+			return timeout;
+		}
+	}
+
+	/**
+	 * Remove the last element from list at {@code source}, append it to {@code destination} and return its value.
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached. <br />
+	 *
+	 * @param source must not be {@literal null}.
+	 * @param destination must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<ByteBuffer> bRPopLPush(ByteBuffer source, ByteBuffer destination, Duration timeout) {
+
+		Assert.notNull(source, "source must not be null");
+		Assert.notNull(destination, "destination must not be null");
+
+		return bRPopLPush(Mono.just(BRPopLPushCommand.from(source).to(destination).blockingFor(timeout))).next()
+				.map(ByteBufferResponse::getOutput);
+	}
+
+	/**
+	 * Remove the last element from list at {@link BRPopLPushCommand#getKey()}, append it to
+	 * {@link BRPopLPushCommand#getDestination()} and return its value. <br />
+	 * <b>Blocks connection</b> until element available or {@link BRPopLPushCommand#getTimeout()} reached.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @param destination must not be {@literal null}.
+	 * @return
+	 */
+	Flux<ByteBufferResponse<BRPopLPushCommand>> bRPopLPush(Publisher<BRPopLPushCommand> commands);
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveNumberCommands.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveNumberCommands {
+
+	/**
+	 * Increment value of {@code key} by 1.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> incr(ByteBuffer key) {
+
+
+			Assert.notNull(key, "key must not be null");
+
+		return incr(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Increment value of {@code key} by 1.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<KeyCommand, Long>> incr(Publisher<KeyCommand> keys);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class IncrByCommand<T extends Number> extends KeyCommand {
+
+		private T value;
+
+		private IncrByCommand(ByteBuffer key, T value) {
+			super(key);
+			this.value = value;
+		}
+
+		public static <T extends Number> IncrByCommand<T> incr(ByteBuffer key) {
+			return new IncrByCommand<T>(key, null);
+		}
+
+		public IncrByCommand<T> by(T value) {
+			return new IncrByCommand<T>(getKey(), value);
+		}
+
+		public T getValue() {
+			return value;
+		}
+
+	}
+
+	/**
+	 * Increment value of {@code key} by {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default <T extends Number> Mono<T> incrBy(ByteBuffer key, T value) {
+
+
+			Assert.notNull(key, "key must not be null");
+			Assert.notNull(value, "value must not be null");
+
+
+		return incrBy(Mono.just(IncrByCommand.<T> incr(key).by(value))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Increment value of {@code key} by {@code value}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	<T extends Number> Flux<NumericResponse<ReactiveNumberCommands.IncrByCommand<T>, T>> incrBy(
+			Publisher<ReactiveNumberCommands.IncrByCommand<T>> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class DecrByCommand<T extends Number> extends KeyCommand {
+
+		private T value;
+
+		private DecrByCommand(ByteBuffer key, T value) {
+			super(key);
+			this.value = value;
+		}
+
+		public static <T extends Number> ReactiveNumberCommands.DecrByCommand<T> decr(ByteBuffer key) {
+			return new DecrByCommand<T>(key, null);
+		}
+
+		public ReactiveNumberCommands.DecrByCommand<T> by(T value) {
+			return new DecrByCommand<T>(getKey(), value);
+		}
+
+		public T getValue() {
+			return value;
+		}
+
+	}
+
+	/**
+	 * Decrement value of {@code key} by 1.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> decr(ByteBuffer key) {
+
+
+			Assert.notNull(key, "key must not be null");
+
+
+		return decr(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Decrement value of {@code key} by 1.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<KeyCommand, Long>> decr(Publisher<KeyCommand> keys);
+
+	/**
+	 * Decrement value of {@code key} by {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default <T extends Number> Mono<T> decrBy(ByteBuffer key, T value) {
+
+
+			Assert.notNull(key, "key must not be null");
+			Assert.notNull(value, "value must not be null");
+
+
+		return decrBy(Mono.just(DecrByCommand.<T> decr(key).by(value))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Decrement value of {@code key} by {@code value}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	<T extends Number> Flux<NumericResponse<ReactiveNumberCommands.DecrByCommand<T>, T>> decrBy(
+			Publisher<ReactiveNumberCommands.DecrByCommand<T>> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class HIncrByCommand<T extends Number> extends KeyCommand {
+
+		private final ByteBuffer field;
+		private final T value;
+
+		private HIncrByCommand(ByteBuffer key, ByteBuffer field, T value) {
+
+			super(key);
+			this.field = field;
+			this.value = value;
+		}
+
+		public static <T extends Number> HIncrByCommand<T> incr(ByteBuffer field) {
+			return new HIncrByCommand<T>(null, field, null);
+		}
+
+		public HIncrByCommand<T> by(T value) {
+			return new HIncrByCommand<T>(getKey(), field, value);
+		}
+
+		public HIncrByCommand<T> forKey(ByteBuffer key) {
+			return new HIncrByCommand<T>(key, field, value);
+		}
+
+		public T getValue() {
+			return value;
+		}
+
+		public ByteBuffer getField() {
+			return field;
+		}
+	}
+
+	/**
+	 * Increment {@code value} of a hash {@code field} by the given {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default <T extends Number> Mono<T> hIncrBy(ByteBuffer key, ByteBuffer field, T value) {
+
+
+			Assert.notNull(key, "key must not be null");
+			Assert.notNull(field, "field must not be null");
+			Assert.notNull(value, "value must not be null");
+
+
+		return hIncrBy(Mono.just(HIncrByCommand.<T> incr(field).by(value).forKey(key))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Increment {@code value} of a hash {@code field} by the given {@code value}.
+	 *
+	 * @return
+	 */
+	<T extends Number> Flux<NumericResponse<HIncrByCommand<T>, T>> hIncrBy(Publisher<HIncrByCommand<T>> commands);
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveNumberCommands.java
@@ -26,27 +26,29 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
+ * Redis numeric commands executed using reactive infrastructure.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 public interface ReactiveNumberCommands {
 
 	/**
-	 * Increment value of {@code key} by 1.
+	 * Increment value of {@literal key} by 1.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
 	 */
 	default Mono<Long> incr(ByteBuffer key) {
 
-
-			Assert.notNull(key, "key must not be null");
+		Assert.notNull(key, "Key must not be null!");
 
 		return incr(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
 	}
 
 	/**
-	 * Increment value of {@code key} by 1.
+	 * Increment value of {@literal key} by 1.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
@@ -54,6 +56,8 @@ public interface ReactiveNumberCommands {
 	Flux<NumericResponse<KeyCommand, Long>> incr(Publisher<KeyCommand> keys);
 
 	/**
+	 * {@code INCRBY} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class IncrByCommand<T extends Number> extends KeyCommand {
@@ -65,22 +69,43 @@ public interface ReactiveNumberCommands {
 			this.value = value;
 		}
 
+		/**
+		 * Creates a new {@link IncrByCommand} given a {@link ByteBuffer key}.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link IncrByCommand} for {@link ByteBuffer key}.
+		 */
 		public static <T extends Number> IncrByCommand<T> incr(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new IncrByCommand<T>(key, null);
 		}
 
+		/**
+		 * Applies the numeric {@literal value}. Constructs a new command instance with all previously configured
+		 * properties.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return a new {@link IncrByCommand} with {@literal value} applied.
+		 */
 		public IncrByCommand<T> by(T value) {
+
+			Assert.notNull(value, "Value must not be null!");
+
 			return new IncrByCommand<T>(getKey(), value);
 		}
 
+		/**
+		 * @return
+		 */
 		public T getValue() {
 			return value;
 		}
-
 	}
 
 	/**
-	 * Increment value of {@code key} by {@code value}.
+	 * Increment value of {@literal key} by {@literal value}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
@@ -88,25 +113,24 @@ public interface ReactiveNumberCommands {
 	 */
 	default <T extends Number> Mono<T> incrBy(ByteBuffer key, T value) {
 
-
-			Assert.notNull(key, "key must not be null");
-			Assert.notNull(value, "value must not be null");
-
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(value, "Value must not be null!");
 
 		return incrBy(Mono.just(IncrByCommand.<T> incr(key).by(value))).next().map(NumericResponse::getOutput);
 	}
 
 	/**
-	 * Increment value of {@code key} by {@code value}.
+	 * Increment value of {@literal key} by {@literal value}.
 	 *
-	 * @param keys must not be {@literal null}.
-	 * @param value must not be {@literal null}.
+	 * @param commands must not be {@literal null}.
 	 * @return
 	 */
 	<T extends Number> Flux<NumericResponse<ReactiveNumberCommands.IncrByCommand<T>, T>> incrBy(
 			Publisher<ReactiveNumberCommands.IncrByCommand<T>> commands);
 
 	/**
+	 * {@code DECRBY} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class DecrByCommand<T extends Number> extends KeyCommand {
@@ -118,37 +142,56 @@ public interface ReactiveNumberCommands {
 			this.value = value;
 		}
 
-		public static <T extends Number> ReactiveNumberCommands.DecrByCommand<T> decr(ByteBuffer key) {
+		/**
+		 * Creates a new {@link DecrByCommand} given a {@link ByteBuffer key}.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link DecrByCommand} for {@link ByteBuffer key}.
+		 */
+		public static <T extends Number> DecrByCommand<T> decr(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new DecrByCommand<T>(key, null);
 		}
 
-		public ReactiveNumberCommands.DecrByCommand<T> by(T value) {
+		/**
+		 * Applies the numeric {@literal value}. Constructs a new command instance with all previously configured
+		 * properties.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return a new {@link DecrByCommand} with {@literal value} applied.
+		 */
+		public DecrByCommand<T> by(T value) {
+
+			Assert.notNull(value, "Value must not be null!");
+
 			return new DecrByCommand<T>(getKey(), value);
 		}
 
+		/**
+		 * @return
+		 */
 		public T getValue() {
 			return value;
 		}
-
 	}
 
 	/**
-	 * Decrement value of {@code key} by 1.
+	 * Decrement value of {@literal key} by 1.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
 	 */
 	default Mono<Long> decr(ByteBuffer key) {
 
-
-			Assert.notNull(key, "key must not be null");
-
+		Assert.notNull(key, "Key must not be null!");
 
 		return decr(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
 	}
 
 	/**
-	 * Decrement value of {@code key} by 1.
+	 * Decrement value of {@literal key} by 1.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
@@ -156,7 +199,7 @@ public interface ReactiveNumberCommands {
 	Flux<NumericResponse<KeyCommand, Long>> decr(Publisher<KeyCommand> keys);
 
 	/**
-	 * Decrement value of {@code key} by {@code value}.
+	 * Decrement value of {@literal key} by {@literal value}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
@@ -164,25 +207,23 @@ public interface ReactiveNumberCommands {
 	 */
 	default <T extends Number> Mono<T> decrBy(ByteBuffer key, T value) {
 
-
-			Assert.notNull(key, "key must not be null");
-			Assert.notNull(value, "value must not be null");
-
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(value, "Value must not be null!");
 
 		return decrBy(Mono.just(DecrByCommand.<T> decr(key).by(value))).next().map(NumericResponse::getOutput);
 	}
 
 	/**
-	 * Decrement value of {@code key} by {@code value}.
+	 * Decrement value of {@literal key} by {@literal value}.
 	 *
-	 * @param keys must not be {@literal null}.
-	 * @param value must not be {@literal null}.
+	 * @param commands must not be {@literal null}.
 	 * @return
 	 */
-	<T extends Number> Flux<NumericResponse<ReactiveNumberCommands.DecrByCommand<T>, T>> decrBy(
-			Publisher<ReactiveNumberCommands.DecrByCommand<T>> commands);
+	<T extends Number> Flux<NumericResponse<DecrByCommand<T>, T>> decrBy(Publisher<DecrByCommand<T>> commands);
 
 	/**
+	 * {@code HINCRBY} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class HIncrByCommand<T extends Number> extends KeyCommand {
@@ -193,33 +234,68 @@ public interface ReactiveNumberCommands {
 		private HIncrByCommand(ByteBuffer key, ByteBuffer field, T value) {
 
 			super(key);
+
 			this.field = field;
 			this.value = value;
 		}
 
+		/**
+		 * Creates a new {@link HIncrByCommand} given a {@link ByteBuffer key}.
+		 *
+		 * @param field must not be {@literal null}.
+		 * @return a new {@link HIncrByCommand} for {@link ByteBuffer key}.
+		 */
 		public static <T extends Number> HIncrByCommand<T> incr(ByteBuffer field) {
+
+			Assert.notNull(field, "Field must not be null!");
+
 			return new HIncrByCommand<T>(null, field, null);
 		}
 
+		/**
+		 * Applies the numeric {@literal value}. Constructs a new command instance with all previously configured
+		 * properties.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return a new {@link HIncrByCommand} with {@literal value} applied.
+		 */
 		public HIncrByCommand<T> by(T value) {
+
+			Assert.notNull(value, "Value must not be null!");
+
 			return new HIncrByCommand<T>(getKey(), field, value);
 		}
 
+		/**
+		 * Applies the {@literal key}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link HIncrByCommand} with {@literal key} applied.
+		 */
 		public HIncrByCommand<T> forKey(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new HIncrByCommand<T>(key, field, value);
 		}
 
+		/**
+		 * @return
+		 */
 		public T getValue() {
 			return value;
 		}
 
+		/**
+		 * @return
+		 */
 		public ByteBuffer getField() {
 			return field;
 		}
 	}
 
 	/**
-	 * Increment {@code value} of a hash {@code field} by the given {@code value}.
+	 * Increment {@literal value} of a hash {@literal field} by the given {@literal value}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param field must not be {@literal null}.
@@ -228,18 +304,16 @@ public interface ReactiveNumberCommands {
 	 */
 	default <T extends Number> Mono<T> hIncrBy(ByteBuffer key, ByteBuffer field, T value) {
 
-
-			Assert.notNull(key, "key must not be null");
-			Assert.notNull(field, "field must not be null");
-			Assert.notNull(value, "value must not be null");
-
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(field, "Field must not be null!");
+		Assert.notNull(value, "Value must not be null!");
 
 		return hIncrBy(Mono.just(HIncrByCommand.<T> incr(field).by(value).forKey(key))).next()
 				.map(NumericResponse::getOutput);
 	}
 
 	/**
-	 * Increment {@code value} of a hash {@code field} by the given {@code value}.
+	 * Increment {@literal value} of a hash {@literal field} by the given {@literal value}.
 	 *
 	 * @return
 	 */

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisClusterConnection.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveRedisClusterConnection extends ReactiveRedisConnection {
+
+	@Override
+	ReactiveClusterKeyCommands keyCommands();
+
+	@Override
+	ReactiveClusterStringCommands stringCommands();
+
+	@Override
+	ReactiveClusterNumberCommands numberCommands();
+
+	@Override
+	ReactiveClusterListCommands listCommands();
+
+	@Override
+	ReactiveClusterSetCommands setCommands();
+
+	@Override
+	ReactiveClusterZSetCommands zSetCommands();
+
+	@Override
+	ReactiveClusterHashCommands hashCommands();
+
+	@Override
+	ReactiveClusterGeoCommands geoCommands();
+
+	@Override
+	ReactiveClusterHyperLogLogCommands hyperLogLogCommands();
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.data.domain.Range;
+
+import lombok.Data;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveRedisConnection extends Closeable {
+
+	/**
+	 * Get {@link ReactiveKeyCommands}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	ReactiveKeyCommands keyCommands();
+
+	/**
+	 * Get {@link ReactiveStringCommands}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	ReactiveStringCommands stringCommands();
+
+	/**
+	 * Get {@link ReactiveNumberCommands}
+	 *
+	 * @return never {@literal null}.
+	 */
+	ReactiveNumberCommands numberCommands();
+
+	/**
+	 * Get {@link ReactiveListCommands}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	ReactiveListCommands listCommands();
+
+	/**
+	 * Get {@link ReactiveSetCommands}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	ReactiveSetCommands setCommands();
+
+	/**
+	 * Get {@link ReactiveZSetCommands}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	ReactiveZSetCommands zSetCommands();
+
+	/**
+	 * Get {@link ReactiveHashCommands}.
+	 *
+	 * @return
+	 */
+	ReactiveHashCommands hashCommands();
+
+	/**
+	 * Get {@link ReacktiveGeoCommands}
+	 *
+	 * @return never {@literal null}.
+	 */
+	ReactiveGeoCommands geoCommands();
+
+	/**
+	 * Get {@link ReactiveHyperLogLogCommands}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	ReactiveHyperLogLogCommands hyperLogLogCommands();
+
+	interface Command {
+
+		ByteBuffer getKey();
+
+		default String getName() {
+			return getClass().getSimpleName().replace("Command", "").toUpperCase();
+		}
+
+		static <T extends Command> Builder<T> create(Class<T> type) {
+			return new CommandBuilder<T>(type);
+		}
+
+		interface Builder<T extends Command> extends Consumer<Object> {
+
+			default Builder<T> forKey(String key) {
+				return forKey(key.getBytes(Charset.forName("UTF-8")));
+			}
+
+			default Builder<T> forKey(byte[] key) {
+				return forKey(ByteBuffer.wrap(key));
+			}
+
+			default Builder<T> forKey(ByteBuffer key) {
+				return forKey(() -> key);
+			}
+
+			Builder<T> forKey(Supplier<ByteBuffer> keySupplier);
+
+			T build();
+		}
+
+		class CommandBuilder<T extends Command> implements Builder<T> {
+
+			List<Object> argumentList = new ArrayList<>();
+
+			Class<T> type;
+			Supplier<ByteBuffer> key;
+
+			public CommandBuilder(Class<T> type) {
+				this.type = type;
+			}
+
+			public Builder<T> forKey(Supplier<ByteBuffer> key) {
+				this.key = key;
+				return this;
+			}
+
+			@Override
+			public void accept(Object t) {
+				argumentList.add(t);
+			}
+
+			@Override
+			public T build() {
+
+				try {
+					T x = BeanUtils.instantiateClass(type);
+
+					DirectFieldAccessor dfa = new DirectFieldAccessor(x);
+					dfa.setPropertyValue("key", key);
+					return x;
+
+				} catch (IllegalArgumentException | SecurityException e) {
+					throw new IllegalArgumentException(" ¯\\_(ツ)_/¯", e);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class KeyCommand implements Command {
+
+		private ByteBuffer key;
+
+		public KeyCommand(ByteBuffer key) {
+			this.key = key;
+		}
+
+		@Override
+		public ByteBuffer getKey() {
+			return key;
+		}
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class RangeCommand extends KeyCommand {
+
+		Range<Long> range;
+
+		public RangeCommand(ByteBuffer key, Range<Long> range) {
+
+			super(key);
+			this.range = range != null ? range : new Range<>(0L, Long.MAX_VALUE);
+		}
+
+		public static RangeCommand key(ByteBuffer key) {
+			return new RangeCommand(key, null);
+		}
+
+		public RangeCommand within(Range<Long> range) {
+			return new RangeCommand(getKey(), range);
+		}
+
+		public RangeCommand fromIndex(Long start) {
+			return new RangeCommand(getKey(), new Range<>(start, range.getUpperBound()));
+		}
+
+		public RangeCommand toIndex(Long end) {
+			return new RangeCommand(getKey(), new Range<>(range.getLowerBound(), end));
+		}
+
+		public Range<Long> getRange() {
+			return range;
+		}
+	}
+
+	@Data
+	class CommandResponse<I, O> {
+
+		private final I input;
+		private final O output;
+	}
+
+	class BooleanResponse<I> extends CommandResponse<I, Boolean> {
+
+		public BooleanResponse(I input, Boolean output) {
+			super(input, output);
+		}
+	}
+
+	class ByteBufferResponse<I> extends CommandResponse<I, ByteBuffer> {
+
+		public ByteBufferResponse(I input, ByteBuffer output) {
+			super(input, output);
+		}
+	}
+
+	class MultiValueResponse<I, O> extends CommandResponse<I, List<O>> {
+
+		public MultiValueResponse(I input, List<O> output) {
+			super(input, output);
+		}
+	}
+
+	class NumericResponse<I, O extends Number> extends CommandResponse<I, O> {
+
+		public NumericResponse(I input, O output) {
+			super(input, output);
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
@@ -17,21 +17,33 @@ package org.springframework.data.redis.connection;
 
 import java.io.Closeable;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
-import org.springframework.beans.BeanUtils;
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.data.domain.Range;
+import org.springframework.util.Assert;
 
 import lombok.Data;
 
 /**
+ * Redis connection using reactive infrastructure declaring entry points for reactive command execution.
+ * <p>
+ * {@link ReactiveRedisConnection} is typically implemented by a stateful object that requires to be {@link #close()
+ * closed} once it is no longer required.
+ * <p>
+ * Commands can be either executed by passing plain arguments like {@code key}, {@code value} or wrapped inside a
+ * command stream. Streaming command execution accepts {@link org.reactivestreams.Publisher} of a particular
+ * {@link Command}. Commands are executed at the time their emission.
+ * <p>
+ * Arguments are binary-safe by using {@link ByteBuffer} arguments. Expect {@link ByteBuffer} to be consumed by
+ * {@link ReactiveRedisConnection} invocation or during execution. Any {@link ByteBuffer} used as method parameter
+ * should not be altered after invocation.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
+ * @see Command
+ * @see CommandResponse
+ * @see KeyCommand
  */
 public interface ReactiveRedisConnection extends Closeable {
 
@@ -85,7 +97,7 @@ public interface ReactiveRedisConnection extends Closeable {
 	ReactiveHashCommands hashCommands();
 
 	/**
-	 * Get {@link ReacktiveGeoCommands}
+	 * Get {@link ReactiveGeoCommands}
 	 *
 	 * @return never {@literal null}.
 	 */
@@ -98,86 +110,48 @@ public interface ReactiveRedisConnection extends Closeable {
 	 */
 	ReactiveHyperLogLogCommands hyperLogLogCommands();
 
+	/**
+	 * Base interface for Redis commands executed with a reactive infrastructure.
+	 *
+	 * @author Christoph Strobl
+	 * @author Mark Paluch
+	 */
 	interface Command {
 
+		/**
+		 * @return the key related to this command.
+		 */
 		ByteBuffer getKey();
 
+		/**
+		 * @return command name as {@link String}.
+		 */
 		default String getName() {
 			return getClass().getSimpleName().replace("Command", "").toUpperCase();
-		}
-
-		static <T extends Command> Builder<T> create(Class<T> type) {
-			return new CommandBuilder<T>(type);
-		}
-
-		interface Builder<T extends Command> extends Consumer<Object> {
-
-			default Builder<T> forKey(String key) {
-				return forKey(key.getBytes(Charset.forName("UTF-8")));
-			}
-
-			default Builder<T> forKey(byte[] key) {
-				return forKey(ByteBuffer.wrap(key));
-			}
-
-			default Builder<T> forKey(ByteBuffer key) {
-				return forKey(() -> key);
-			}
-
-			Builder<T> forKey(Supplier<ByteBuffer> keySupplier);
-
-			T build();
-		}
-
-		class CommandBuilder<T extends Command> implements Builder<T> {
-
-			List<Object> argumentList = new ArrayList<>();
-
-			Class<T> type;
-			Supplier<ByteBuffer> key;
-
-			public CommandBuilder(Class<T> type) {
-				this.type = type;
-			}
-
-			public Builder<T> forKey(Supplier<ByteBuffer> key) {
-				this.key = key;
-				return this;
-			}
-
-			@Override
-			public void accept(Object t) {
-				argumentList.add(t);
-			}
-
-			@Override
-			public T build() {
-
-				try {
-					T x = BeanUtils.instantiateClass(type);
-
-					DirectFieldAccessor dfa = new DirectFieldAccessor(x);
-					dfa.setPropertyValue("key", key);
-					return x;
-
-				} catch (IllegalArgumentException | SecurityException e) {
-					throw new IllegalArgumentException(" ¯\\_(ツ)_/¯", e);
-				}
-			}
 		}
 	}
 
 	/**
+	 * {@link Command} for key-bound operations.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class KeyCommand implements Command {
 
 		private ByteBuffer key;
 
+		/**
+		 * Creates a new {@link KeyCommand} given a {@code key}.
+		 *
+		 * @param key must not be {@literal null}.
+		 */
 		public KeyCommand(ByteBuffer key) {
 			this.key = key;
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.Command#getKey()
+		 */
 		@Override
 		public ByteBuffer getKey() {
 			return key;
@@ -191,33 +165,77 @@ public interface ReactiveRedisConnection extends Closeable {
 
 		Range<Long> range;
 
-		public RangeCommand(ByteBuffer key, Range<Long> range) {
+		/**
+		 * Creates a new {@link RangeCommand} given a {@code key} and {@link Range}.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @param range may be {@literal null} if unbounded.
+		 */
+		private RangeCommand(ByteBuffer key, Range<Long> range) {
 
 			super(key);
 			this.range = range != null ? range : new Range<>(0L, Long.MAX_VALUE);
 		}
 
+		/**
+		 * Creates a new {@link RangeCommand} given a {@code key}.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link RangeCommand} for {@code key}.
+		 */
 		public static RangeCommand key(ByteBuffer key) {
 			return new RangeCommand(key, null);
 		}
 
+		/**
+		 * Applies a {@link Range}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param range must not be {@literal null}.
+		 * @return a new {@link RangeCommand} with {@link Range} applied.
+		 */
 		public RangeCommand within(Range<Long> range) {
+
+			Assert.notNull(range, "Range must not be null!");
+
 			return new RangeCommand(getKey(), range);
 		}
 
-		public RangeCommand fromIndex(Long start) {
+		/**
+		 * Applies a lower bound to the {@link Range}. Constructs a new command instance with all previously configured
+		 * properties.
+		 *
+		 * @param start
+		 * @return a new {@link RangeCommand} with the lower bound applied.
+		 */
+		public RangeCommand fromIndex(long start) {
 			return new RangeCommand(getKey(), new Range<>(start, range.getUpperBound()));
 		}
 
-		public RangeCommand toIndex(Long end) {
+		/**
+		 * Applies an upper bound to the {@link Range}. Constructs a new command instance with all previously configured
+		 * properties.
+		 *
+		 * @param end
+		 * @return a new {@link RangeCommand} with the upper bound applied.
+		 */
+		public RangeCommand toIndex(long end) {
 			return new RangeCommand(getKey(), new Range<>(range.getLowerBound(), end));
 		}
 
+		/**
+		 * @return the {@link Range}.
+		 */
 		public Range<Long> getRange() {
 			return range;
 		}
 	}
 
+	/**
+	 * Base class for command responses.
+	 *
+	 * @param <I> command input type.
+	 * @param <O> command output type.
+	 */
 	@Data
 	class CommandResponse<I, O> {
 
@@ -225,6 +243,9 @@ public interface ReactiveRedisConnection extends Closeable {
 		private final O output;
 	}
 
+	/**
+	 * {@link CommandResponse} implementation for {@link Boolean} responses.
+	 */
 	class BooleanResponse<I> extends CommandResponse<I, Boolean> {
 
 		public BooleanResponse(I input, Boolean output) {
@@ -232,6 +253,9 @@ public interface ReactiveRedisConnection extends Closeable {
 		}
 	}
 
+	/**
+	 * {@link CommandResponse} implementation for {@link ByteBuffer} responses.
+	 */
 	class ByteBufferResponse<I> extends CommandResponse<I, ByteBuffer> {
 
 		public ByteBufferResponse(I input, ByteBuffer output) {
@@ -239,6 +263,9 @@ public interface ReactiveRedisConnection extends Closeable {
 		}
 	}
 
+	/**
+	 * {@link CommandResponse} implementation for {@link List} responses.
+	 */
 	class MultiValueResponse<I, O> extends CommandResponse<I, List<O>> {
 
 		public MultiValueResponse(I input, List<O> output) {
@@ -246,11 +273,13 @@ public interface ReactiveRedisConnection extends Closeable {
 		}
 	}
 
+	/**
+	 * {@link CommandResponse} implementation for {@link Number numeric} responses.
+	 */
 	class NumericResponse<I, O extends Number> extends CommandResponse<I, O> {
 
 		public NumericResponse(I input, O output) {
 			super(input, output);
 		}
 	}
-
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
@@ -16,6 +16,8 @@
 package org.springframework.data.redis.connection;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -33,12 +35,17 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
+ * Redis Set commands executed using reactive infrastructure.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 public interface ReactiveSetCommands {
 
 	/**
+	 * {@code SADD} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SAddCommand extends KeyCommand {
@@ -48,28 +55,59 @@ public interface ReactiveSetCommands {
 		private SAddCommand(ByteBuffer key, List<ByteBuffer> values) {
 
 			super(key);
+
 			this.values = values;
 		}
 
-		public static SAddCommand value(ByteBuffer values) {
-			return values(Collections.singletonList(values));
+		/**
+		 * Creates a new {@link SAddCommand} given a {@literal value}.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return a new {@link SAddCommand} for a {@literal value}.
+		 */
+		public static SAddCommand value(ByteBuffer value) {
+
+			Assert.notNull(value, "Value must not be null!");
+
+			return values(Collections.singletonList(value));
 		}
 
-		public static SAddCommand values(List<ByteBuffer> values) {
-			return new SAddCommand(null, values);
+		/**
+		 * Creates a new {@link SAddCommand} given a {@link Collection} of values.
+		 *
+		 * @param values must not be {@literal null}.
+		 * @return a new {@link SAddCommand} for a {@link Collection} of values.
+		 */
+		public static SAddCommand values(Collection<ByteBuffer> values) {
+
+			Assert.notNull(values, "Values must not be null!");
+
+			return new SAddCommand(null, new ArrayList<>(values));
 		}
 
+		/**
+		 * Applies the {@literal key}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link SAddCommand} with {@literal key} applied.
+		 */
 		public SAddCommand to(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new SAddCommand(key, values);
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getValues() {
 			return values;
 		}
 	}
 
 	/**
-	 * Add given {@code value} to set at {@code key}.
+	 * Add given {@literal value} to set at {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
@@ -77,22 +115,22 @@ public interface ReactiveSetCommands {
 	 */
 	default Mono<Long> sAdd(ByteBuffer key, ByteBuffer value) {
 
-		Assert.notNull(value, "value must not be null");
+		Assert.notNull(value, "Value must not be null!");
 
 		return sAdd(key, Collections.singletonList(value));
 	}
 
 	/**
-	 * Add given {@code values} to set at {@code key}.
+	 * Add given {@literal values} to set at {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
 	 */
-	default Mono<Long> sAdd(ByteBuffer key, List<ByteBuffer> values) {
+	default Mono<Long> sAdd(ByteBuffer key, Collection<ByteBuffer> values) {
 
-		Assert.notNull(key, "key must not be null");
-		Assert.notNull(values, "values must not be null");
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(values, "Values must not be null!");
 
 		return sAdd(Mono.just(SAddCommand.values(values).to(key))).next().map(NumericResponse::getOutput);
 	}
@@ -106,37 +144,70 @@ public interface ReactiveSetCommands {
 	Flux<NumericResponse<SAddCommand, Long>> sAdd(Publisher<SAddCommand> commands);
 
 	/**
+	 * {@code SREM} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SRemCommand extends KeyCommand {
 
 		private final List<ByteBuffer> values;
 
-		public SRemCommand(ByteBuffer key, List<ByteBuffer> values) {
+		private SRemCommand(ByteBuffer key, List<ByteBuffer> values) {
 
 			super(key);
+
 			this.values = values;
 		}
 
-		public static SRemCommand value(ByteBuffer values) {
-			return values(Collections.singletonList(values));
+		/**
+		 * Creates a new {@link SRemCommand} given a {@literal value}.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return a new {@link SRemCommand} for a {@literal value}.
+		 */
+		public static SRemCommand value(ByteBuffer value) {
+
+			Assert.notNull(value, "Value must not be null!");
+
+			return values(Collections.singletonList(value));
 		}
 
-		public static SRemCommand values(List<ByteBuffer> values) {
-			return new SRemCommand(null, values);
+		/**
+		 * Creates a new {@link SRemCommand} given a {@link Collection} of values.
+		 *
+		 * @param values must not be {@literal null}.
+		 * @return a new {@link SRemCommand} for a {@link Collection} of values.
+		 */
+		public static SRemCommand values(Collection<ByteBuffer> values) {
+
+			Assert.notNull(values, "Values must not be null!");
+
+			return new SRemCommand(null, new ArrayList<>(values));
 		}
 
+		/**
+		 * Applies the {@literal key}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link SRemCommand} with {@literal key} applied.
+		 */
 		public SRemCommand from(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new SRemCommand(key, values);
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getValues() {
 			return values;
 		}
 	}
 
 	/**
-	 * Remove given {@code value} from set at {@code key} and return the number of removed elements.
+	 * Remove given {@literal value} from set at {@literal key} and return the number of removed elements.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
@@ -144,22 +215,22 @@ public interface ReactiveSetCommands {
 	 */
 	default Mono<Long> sRem(ByteBuffer key, ByteBuffer value) {
 
-		Assert.notNull(value, "value must not be null");
+		Assert.notNull(value, "Value must not be null!");
 
 		return sRem(key, Collections.singletonList(value));
 	}
 
 	/**
-	 * Remove given {@code values} from set at {@code key} and return the number of removed elements.
+	 * Remove given {@literal values} from set at {@literal key} and return the number of removed elements.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
 	 */
-	default Mono<Long> sRem(ByteBuffer key, List<ByteBuffer> values) {
+	default Mono<Long> sRem(ByteBuffer key, Collection<ByteBuffer> values) {
 
-		Assert.notNull(key, "key must not be null");
-		Assert.notNull(values, "values must not be null");
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(values, "Values must not be null!");
 
 		return sRem(Mono.just(SRemCommand.values(values).from(key))).next().map(NumericResponse::getOutput);
 	}
@@ -173,14 +244,14 @@ public interface ReactiveSetCommands {
 	Flux<NumericResponse<SRemCommand, Long>> sRem(Publisher<SRemCommand> commands);
 
 	/**
-	 * Remove and return a random member from set at {@code key}.
+	 * Remove and return a random member from set at {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
 	 */
 	default Mono<ByteBuffer> sPop(ByteBuffer key) {
 
-		Assert.notNull(key, "key must not be null");
+		Assert.notNull(key, "Key must not be null!");
 
 		return sPop(Mono.just(new KeyCommand(key))).next().map(ByteBufferResponse::getOutput);
 	}
@@ -194,6 +265,8 @@ public interface ReactiveSetCommands {
 	Flux<ByteBufferResponse<KeyCommand>> sPop(Publisher<KeyCommand> commands);
 
 	/**
+	 * {@code SMOVE} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SMoveCommand extends KeyCommand {
@@ -208,29 +281,63 @@ public interface ReactiveSetCommands {
 			this.value = value;
 		}
 
+		/**
+		 * Creates a new {@link SMoveCommand} given a {@literal value}.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return a new {@link SMoveCommand} for a {@literal value}.
+		 */
 		public static SMoveCommand value(ByteBuffer value) {
+
+			Assert.notNull(value, "Value must not be null!");
+
 			return new SMoveCommand(null, null, value);
 		}
 
+		/**
+		 * Applies the {@literal source} key. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param source must not be {@literal null}.
+		 * @return a new {@link SMoveCommand} with {@literal source} applied.
+		 */
 		public SMoveCommand from(ByteBuffer source) {
+
+			Assert.notNull(source, "Source key must not be null!");
+
 			return new SMoveCommand(source, destination, value);
 		}
 
+		/**
+		 * Applies the {@literal destination} key. Constructs a new command instance with all previously configured
+		 * properties.
+		 *
+		 * @param destination must not be {@literal null}.
+		 * @return a new {@link SMoveCommand} with {@literal destination} applied.
+		 */
 		public SMoveCommand to(ByteBuffer destination) {
+
+			Assert.notNull(destination, "Destination key must not be null!");
+
 			return new SMoveCommand(getKey(), destination, value);
 		}
 
+		/**
+		 * @return
+		 */
 		public ByteBuffer getDestination() {
 			return destination;
 		}
 
+		/**
+		 * @return
+		 */
 		public ByteBuffer getValue() {
 			return value;
 		}
 	}
 
 	/**
-	 * Move {@code value} from {@code sourceKey} to {@code destinationKey}
+	 * Move {@literal value} from {@literal sourceKey} to {@literal destinationKey}
 	 *
 	 * @param sourceKey must not be {@literal null}.
 	 * @param destinationKey must not be {@literal null}.
@@ -239,9 +346,9 @@ public interface ReactiveSetCommands {
 	 */
 	default Mono<Boolean> sMove(ByteBuffer sourceKey, ByteBuffer destinationKey, ByteBuffer value) {
 
-		Assert.notNull(sourceKey, "sourceKey must not be null");
-		Assert.notNull(destinationKey, "destinationKey must not be null");
-		Assert.notNull(value, "value must not be null");
+		Assert.notNull(sourceKey, "SourceKey must not be null!");
+		Assert.notNull(destinationKey, "DestinationKey must not be null!");
+		Assert.notNull(value, "Value must not be null!");
 
 		return sMove(Mono.just(SMoveCommand.value(value).from(sourceKey).to(destinationKey))).next()
 				.map(BooleanResponse::getOutput);
@@ -256,14 +363,14 @@ public interface ReactiveSetCommands {
 	Flux<BooleanResponse<SMoveCommand>> sMove(Publisher<SMoveCommand> commands);
 
 	/**
-	 * Get size of set at {@code key}.
+	 * Get size of set at {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
 	 */
 	default Mono<Long> sCard(ByteBuffer key) {
 
-		Assert.notNull(key, "key must not be null");
+		Assert.notNull(key, "Key must not be null!");
 
 		return sCard(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
 	}
@@ -277,6 +384,8 @@ public interface ReactiveSetCommands {
 	Flux<NumericResponse<KeyCommand, Long>> sCard(Publisher<KeyCommand> commands);
 
 	/**
+	 * {@code SISMEMBER} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SIsMemberCommand extends KeyCommand {
@@ -286,24 +395,46 @@ public interface ReactiveSetCommands {
 		private SIsMemberCommand(ByteBuffer key, ByteBuffer value) {
 
 			super(key);
+
 			this.value = value;
 		}
 
+		/**
+		 * Creates a new {@link SIsMemberCommand} given a {@literal value}.
+		 *
+		 * @param value must not be {@literal null}.
+		 * @return a new {@link SIsMemberCommand} for a {@literal value}.
+		 */
 		public static SIsMemberCommand value(ByteBuffer value) {
+
+			Assert.notNull(value, "Value must not be null!");
+
 			return new SIsMemberCommand(null, value);
 		}
 
+		/**
+		 * Applies the {@literal set} key. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param set must not be {@literal null}.
+		 * @return a new {@link SIsMemberCommand} with {@literal set} applied.
+		 */
 		public SIsMemberCommand of(ByteBuffer set) {
+
+			Assert.notNull(set, "Set key must not be null!");
+
 			return new SIsMemberCommand(set, value);
 		}
 
+		/**
+		 * @return
+		 */
 		public ByteBuffer getValue() {
 			return value;
 		}
 	}
 
 	/**
-	 * Check if set at {@code key} contains {@code value}.
+	 * Check if set at {@literal key} contains {@literal value}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
@@ -311,8 +442,8 @@ public interface ReactiveSetCommands {
 	 */
 	default Mono<Boolean> sIsMember(ByteBuffer key, ByteBuffer value) {
 
-		Assert.notNull(key, "key must not be null");
-		Assert.notNull(value, "value must not be null");
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(value, "Value must not be null!");
 
 		return sIsMember(Mono.just(SIsMemberCommand.value(value).of(key))).next().map(BooleanResponse::getOutput);
 	}
@@ -326,6 +457,8 @@ public interface ReactiveSetCommands {
 	Flux<BooleanResponse<SIsMemberCommand>> sIsMember(Publisher<SIsMemberCommand> commands);
 
 	/**
+	 * {@code SINTER} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SInterCommand implements Command {
@@ -336,29 +469,44 @@ public interface ReactiveSetCommands {
 			this.keys = keys;
 		}
 
-		public static SInterCommand keys(List<ByteBuffer> keys) {
-			return new SInterCommand(keys);
+		/**
+		 * Creates a new {@link SInterCommand} given a {@link Collection} of keys.
+		 *
+		 * @param keys must not be {@literal null}.
+		 * @return a new {@link SInterCommand} for a {@link Collection} of values.
+		 */
+		public static SInterCommand keys(Collection<ByteBuffer> keys) {
+
+			Assert.notNull(keys, "Keys must not be null!");
+
+			return new SInterCommand(new ArrayList<>(keys));
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.Command#getKey()
+		 */
 		@Override
 		public ByteBuffer getKey() {
 			return null;
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getKeys() {
 			return keys;
 		}
 	}
 
 	/**
-	 * Returns the members intersecting all given sets at {@code keys}.
+	 * Returns the members intersecting all given sets at {@literal keys}.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
 	 */
-	default Mono<List<ByteBuffer>> sInter(List<ByteBuffer> keys) {
+	default Mono<List<ByteBuffer>> sInter(Collection<ByteBuffer> keys) {
 
-		Assert.notNull(keys, "keys must not be null");
+		Assert.notNull(keys, "Keys must not be null!");
 
 		return sInter(Mono.just(SInterCommand.keys(keys))).next().map(MultiValueResponse::getOutput);
 	}
@@ -372,6 +520,8 @@ public interface ReactiveSetCommands {
 	Flux<MultiValueResponse<SInterCommand, ByteBuffer>> sInter(Publisher<SInterCommand> commands);
 
 	/**
+	 * {@code SINTERSTORE} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SInterStoreCommand extends KeyCommand {
@@ -381,40 +531,63 @@ public interface ReactiveSetCommands {
 		private SInterStoreCommand(ByteBuffer key, List<ByteBuffer> keys) {
 
 			super(key);
+
 			this.keys = keys;
 		}
 
-		public static SInterStoreCommand keys(List<ByteBuffer> keys) {
-			return new SInterStoreCommand(null, keys);
+		/**
+		 * Creates a new {@link SInterStoreCommand} given a {@link Collection} of keys.
+		 *
+		 * @param keys must not be {@literal null}.
+		 * @return a new {@link SInterStoreCommand} for a {@link Collection} of values.
+		 */
+		public static SInterStoreCommand keys(Collection<ByteBuffer> keys) {
+
+			Assert.notNull(keys, "Keys must not be null!");
+
+			return new SInterStoreCommand(null, new ArrayList<>(keys));
 		}
 
+		/**
+		 * Applies the {@literal key} at which the result is stored. Constructs a new command instance with all previously
+		 * configured properties.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link SInterStoreCommand} with {@literal key} applied.
+		 */
 		public SInterStoreCommand storeAt(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new SInterStoreCommand(key, keys);
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getKeys() {
 			return keys;
 		}
 	}
 
 	/**
-	 * Intersect all given sets at {@code keys} and store result in {@code destinationKey}.
+	 * Intersect all given sets at {@literal keys} and store result in {@literal destinationKey}.
 	 *
 	 * @param destinationKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
-	 * @return size of set stored a {@code destinationKey}.
+	 * @return size of set stored a {@literal destinationKey}.
 	 */
-	default Mono<Long> sInterStore(ByteBuffer destinationKey, List<ByteBuffer> keys) {
+	default Mono<Long> sInterStore(ByteBuffer destinationKey, Collection<ByteBuffer> keys) {
 
-		Assert.notNull(destinationKey, "destinationKey must not be null");
-		Assert.notNull(keys, "keys must not be null");
+		Assert.notNull(destinationKey, "DestinationKey must not be null!");
+		Assert.notNull(keys, "Keys must not be null!");
 
 		return sInterStore(Mono.just(SInterStoreCommand.keys(keys).storeAt(destinationKey))).next()
 				.map(NumericResponse::getOutput);
 	}
 
 	/**
-	 * Intersect all given sets at {@code keys} and store result in {@code destinationKey}.
+	 * Intersect all given sets at {@literal keys} and store result in {@literal destinationKey}.
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
@@ -422,6 +595,8 @@ public interface ReactiveSetCommands {
 	Flux<NumericResponse<SInterStoreCommand, Long>> sInterStore(Publisher<SInterStoreCommand> commands);
 
 	/**
+	 * {@code SUNION} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SUnionCommand implements Command {
@@ -432,29 +607,44 @@ public interface ReactiveSetCommands {
 			this.keys = keys;
 		}
 
-		public static SUnionCommand keys(List<ByteBuffer> keys) {
-			return new SUnionCommand(keys);
+		/**
+		 * Creates a new {@link SUnionCommand} given a {@link Collection} of keys.
+		 *
+		 * @param keys must not be {@literal null}.
+		 * @return a new {@link SUnionCommand} for a {@link Collection} of values.
+		 */
+		public static SUnionCommand keys(Collection<ByteBuffer> keys) {
+
+			Assert.notNull(keys, "Keys must not be null!");
+
+			return new SUnionCommand(new ArrayList<>(keys));
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.Command#getKey()
+		 */
 		@Override
 		public ByteBuffer getKey() {
 			return null;
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getKeys() {
 			return keys;
 		}
 	}
 
 	/**
-	 * Returns the members intersecting all given sets at {@code keys}.
+	 * Returns the members intersecting all given sets at {@literal keys}.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
 	 */
-	default Mono<List<ByteBuffer>> sUnion(List<ByteBuffer> keys) {
+	default Mono<List<ByteBuffer>> sUnion(Collection<ByteBuffer> keys) {
 
-		Assert.notNull(keys, "keys must not be null");
+		Assert.notNull(keys, "Keys must not be null!");
 
 		return sUnion(Mono.just(SUnionCommand.keys(keys))).next().map(MultiValueResponse::getOutput);
 	}
@@ -477,40 +667,63 @@ public interface ReactiveSetCommands {
 		private SUnionStoreCommand(ByteBuffer key, List<ByteBuffer> keys) {
 
 			super(key);
+
 			this.keys = keys;
 		}
 
-		public static SUnionStoreCommand keys(List<ByteBuffer> keys) {
-			return new SUnionStoreCommand(null, keys);
+		/**
+		 * Creates a new {@link SUnionStoreCommand} given a {@link Collection} of keys.
+		 *
+		 * @param keys must not be {@literal null}.
+		 * @return a new {@link SUnionStoreCommand} for a {@link Collection} of values.
+		 */
+		public static SUnionStoreCommand keys(Collection<ByteBuffer> keys) {
+
+			Assert.notNull(keys, "Keys must not be null!");
+
+			return new SUnionStoreCommand(null, new ArrayList<>(keys));
 		}
 
+		/**
+		 * Applies the {@literal key} at which the result is stored. Constructs a new command instance with all previously
+		 * configured properties.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link SUnionStoreCommand} with {@literal key} applied.
+		 */
 		public SUnionStoreCommand storeAt(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new SUnionStoreCommand(key, keys);
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getKeys() {
 			return keys;
 		}
 	}
 
 	/**
-	 * Union all given sets at {@code keys} and store result in {@code destinationKey}.
+	 * Union all given sets at {@literal keys} and store result in {@literal destinationKey}.
 	 *
 	 * @param destinationKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
-	 * @return size of set stored a {@code destinationKey}.
+	 * @return size of set stored a {@literal destinationKey}.
 	 */
-	default Mono<Long> sUnionStore(ByteBuffer destinationKey, List<ByteBuffer> keys) {
+	default Mono<Long> sUnionStore(ByteBuffer destinationKey, Collection<ByteBuffer> keys) {
 
-		Assert.notNull(destinationKey, "destinationKey must not be null");
-		Assert.notNull(keys, "keys must not be null");
+		Assert.notNull(destinationKey, "DestinationKey must not be null!");
+		Assert.notNull(keys, "Keys must not be null!");
 
 		return sUnionStore(Mono.just(SUnionStoreCommand.keys(keys).storeAt(destinationKey))).next()
 				.map(NumericResponse::getOutput);
 	}
 
 	/**
-	 * Union all given sets at {@code keys} and store result in {@code destinationKey}.
+	 * Union all given sets at {@literal keys} and store result in {@literal destinationKey}.
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
@@ -518,6 +731,8 @@ public interface ReactiveSetCommands {
 	Flux<NumericResponse<SUnionStoreCommand, Long>> sUnionStore(Publisher<SUnionStoreCommand> commands);
 
 	/**
+	 * {@code SDIFF} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SDiffCommand implements Command {
@@ -528,29 +743,44 @@ public interface ReactiveSetCommands {
 			this.keys = keys;
 		}
 
-		public static SDiffCommand keys(List<ByteBuffer> keys) {
-			return new SDiffCommand(keys);
+		/**
+		 * Creates a new {@link SDiffCommand} given a {@link Collection} of keys.
+		 *
+		 * @param keys must not be {@literal null}.
+		 * @return a new {@link SDiffCommand} for a {@link Collection} of values.
+		 */
+		public static SDiffCommand keys(Collection<ByteBuffer> keys) {
+
+			Assert.notNull(keys, "Keys must not be null!");
+
+			return new SDiffCommand(new ArrayList<>(keys));
 		}
 
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.Command#getKey()
+		 */
 		@Override
 		public ByteBuffer getKey() {
 			return null;
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getKeys() {
 			return keys;
 		}
 	}
 
 	/**
-	 * Returns the diff of the members of all given sets at {@code keys}.
+	 * Returns the diff of the members of all given sets at {@literal keys}.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
 	 */
-	default Mono<List<ByteBuffer>> sDiff(List<ByteBuffer> keys) {
+	default Mono<List<ByteBuffer>> sDiff(Collection<ByteBuffer> keys) {
 
-		Assert.notNull(keys, "keys must not be null");
+		Assert.notNull(keys, "Keys must not be null!");
 
 		return sDiff(Mono.just(SDiffCommand.keys(keys))).next().map(MultiValueResponse::getOutput);
 	}
@@ -564,6 +794,8 @@ public interface ReactiveSetCommands {
 	Flux<MultiValueResponse<SDiffCommand, ByteBuffer>> sDiff(Publisher<SDiffCommand> commands);
 
 	/**
+	 * {@code SDIFFSTORE} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SDiffStoreCommand extends KeyCommand {
@@ -573,40 +805,63 @@ public interface ReactiveSetCommands {
 		private SDiffStoreCommand(ByteBuffer key, List<ByteBuffer> keys) {
 
 			super(key);
+
 			this.keys = keys;
 		}
 
-		public static SDiffStoreCommand keys(List<ByteBuffer> keys) {
-			return new SDiffStoreCommand(null, keys);
+		/**
+		 * Creates a new {@link SDiffStoreCommand} given a {@link Collection} of keys.
+		 *
+		 * @param keys must not be {@literal null}.
+		 * @return a new {@link SDiffStoreCommand} for a {@link Collection} of values.
+		 */
+		public static SDiffStoreCommand keys(Collection<ByteBuffer> keys) {
+
+			Assert.notNull(keys, "Keys must not be null!");
+
+			return new SDiffStoreCommand(null, new ArrayList<>(keys));
 		}
 
+		/**
+		 * Applies the {@literal key} at which the result is stored. Constructs a new command instance with all previously
+		 * configured properties.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link SDiffStoreCommand} with {@literal key} applied.
+		 */
 		public SDiffStoreCommand storeAt(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new SDiffStoreCommand(key, keys);
 		}
 
+		/**
+		 * @return
+		 */
 		public List<ByteBuffer> getKeys() {
 			return keys;
 		}
 	}
 
 	/**
-	 * Diff all given sets at {@code keys} and store result in {@code destinationKey}.
+	 * Diff all given sets at {@literal keys} and store result in {@literal destinationKey}.
 	 *
 	 * @param destinationKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
-	 * @return size of set stored a {@code destinationKey}.
+	 * @return size of set stored a {@literal destinationKey}.
 	 */
-	default Mono<Long> sDiffStore(ByteBuffer destinationKey, List<ByteBuffer> keys) {
+	default Mono<Long> sDiffStore(ByteBuffer destinationKey, Collection<ByteBuffer> keys) {
 
-		Assert.notNull(destinationKey, "destinationKey must not be null");
-		Assert.notNull(keys, "keys must not be null");
+		Assert.notNull(destinationKey, "DestinationKey must not be null!");
+		Assert.notNull(keys, "Keys must not be null!");
 
 		return sDiffStore(Mono.just(SDiffStoreCommand.keys(keys).storeAt(destinationKey))).next()
 				.map(NumericResponse::getOutput);
 	}
 
 	/**
-	 * Diff all given sets at {@code keys} and store result in {@code destinationKey}.
+	 * Diff all given sets at {@literal keys} and store result in {@literal destinationKey}.
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
@@ -614,14 +869,14 @@ public interface ReactiveSetCommands {
 	Flux<NumericResponse<SDiffStoreCommand, Long>> sDiffStore(Publisher<SDiffStoreCommand> commands);
 
 	/**
-	 * Get all elements of set at {@code key}.
+	 * Get all elements of set at {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
 	 */
 	default Mono<List<ByteBuffer>> sMembers(ByteBuffer key) {
 
-		Assert.notNull(key, "key must not be null");
+		Assert.notNull(key, "Key must not be null!");
 
 		return sMembers(Mono.just(new KeyCommand(key))).next().map(MultiValueResponse::getOutput);
 	}
@@ -635,6 +890,8 @@ public interface ReactiveSetCommands {
 	Flux<MultiValueResponse<KeyCommand, ByteBuffer>> sMembers(Publisher<KeyCommand> commands);
 
 	/**
+	 * {@code SRANDMEMBER} command parameters.
+	 *
 	 * @author Christoph Strobl
 	 */
 	class SRandMembersCommand extends KeyCommand {
@@ -647,25 +904,48 @@ public interface ReactiveSetCommands {
 			this.count = count;
 		}
 
-		public static SRandMembersCommand valueCount(Long nrValuesToRetrieve) {
+		/**
+		 * Creates a new {@link SRandMembersCommand} given the number of values to retrieve.
+		 *
+		 * @param nrValuesToRetrieve
+		 * @return a new {@link SRandMembersCommand} for a number of values to retrieve.
+		 */
+		public static SRandMembersCommand valueCount(long nrValuesToRetrieve) {
 			return new SRandMembersCommand(null, nrValuesToRetrieve);
 		}
 
+		/**
+		 * Creates a new {@link SRandMembersCommand} to retrieve one random member.
+		 *
+		 * @return a new {@link SRandMembersCommand} to retrieve one random member.
+		 */
 		public static SRandMembersCommand singleValue() {
 			return new SRandMembersCommand(null, null);
 		}
 
+		/**
+		 * Applies the {@literal key}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link SRandMembersCommand} with {@literal key} applied.
+		 */
 		public SRandMembersCommand from(ByteBuffer key) {
+
+			Assert.notNull(key, "Key must not be null!");
+
 			return new SRandMembersCommand(key, count);
 		}
 
+		/**
+		 * @return
+		 */
 		public Optional<Long> getCount() {
 			return Optional.ofNullable(count);
 		}
 	}
 
 	/**
-	 * Get random element from set at {@code key}.
+	 * Get random element from set at {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
@@ -675,7 +955,7 @@ public interface ReactiveSetCommands {
 	}
 
 	/**
-	 * Get {@code count} random elements from set at {@code key}.
+	 * Get {@literal count} random elements from set at {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param count must not be {@literal null}.
@@ -683,8 +963,8 @@ public interface ReactiveSetCommands {
 	 */
 	default Mono<List<ByteBuffer>> sRandMember(ByteBuffer key, Long count) {
 
-		Assert.notNull(key, "key must not be null");
-		Assert.notNull(count, "count must not be null");
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(count, "Count must not be null!");
 
 		return sRandMember(Mono.just(SRandMembersCommand.valueCount(count).from(key))).next()
 				.map(MultiValueResponse::getOutput);

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
@@ -1,0 +1,700 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.Command;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveSetCommands {
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SAddCommand extends KeyCommand {
+
+		private List<ByteBuffer> values;
+
+		private SAddCommand(ByteBuffer key, List<ByteBuffer> values) {
+
+			super(key);
+			this.values = values;
+		}
+
+		public static SAddCommand value(ByteBuffer values) {
+			return values(Collections.singletonList(values));
+		}
+
+		public static SAddCommand values(List<ByteBuffer> values) {
+			return new SAddCommand(null, values);
+		}
+
+		public SAddCommand to(ByteBuffer key) {
+			return new SAddCommand(key, values);
+		}
+
+		public List<ByteBuffer> getValues() {
+			return values;
+		}
+	}
+
+	/**
+	 * Add given {@code value} to set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> sAdd(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(value, "value must not be null");
+
+		return sAdd(key, Collections.singletonList(value));
+	}
+
+	/**
+	 * Add given {@code values} to set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> sAdd(ByteBuffer key, List<ByteBuffer> values) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(values, "values must not be null");
+
+		return sAdd(Mono.just(SAddCommand.values(values).to(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Add given {@link SAddCommand#getValues()} to set at {@link SAddCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<SAddCommand, Long>> sAdd(Publisher<SAddCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SRemCommand extends KeyCommand {
+
+		private final List<ByteBuffer> values;
+
+		public SRemCommand(ByteBuffer key, List<ByteBuffer> values) {
+
+			super(key);
+			this.values = values;
+		}
+
+		public static SRemCommand value(ByteBuffer values) {
+			return values(Collections.singletonList(values));
+		}
+
+		public static SRemCommand values(List<ByteBuffer> values) {
+			return new SRemCommand(null, values);
+		}
+
+		public SRemCommand from(ByteBuffer key) {
+			return new SRemCommand(key, values);
+		}
+
+		public List<ByteBuffer> getValues() {
+			return values;
+		}
+	}
+
+	/**
+	 * Remove given {@code value} from set at {@code key} and return the number of removed elements.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> sRem(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(value, "value must not be null");
+
+		return sRem(key, Collections.singletonList(value));
+	}
+
+	/**
+	 * Remove given {@code values} from set at {@code key} and return the number of removed elements.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> sRem(ByteBuffer key, List<ByteBuffer> values) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(values, "values must not be null");
+
+		return sRem(Mono.just(SRemCommand.values(values).from(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Remove given {@link SRemCommand#getValues()} from set at {@link SRemCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<SRemCommand, Long>> sRem(Publisher<SRemCommand> commands);
+
+	/**
+	 * Remove and return a random member from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<ByteBuffer> sPop(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return sPop(Mono.just(new KeyCommand(key))).next().map(ByteBufferResponse::getOutput);
+	}
+
+	/**
+	 * Remove and return a random member from set at {@link KeyCommand#getKey()}
+	 *
+	 * @param commands
+	 * @return
+	 */
+	Flux<ByteBufferResponse<KeyCommand>> sPop(Publisher<KeyCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SMoveCommand extends KeyCommand {
+
+		private final ByteBuffer destination;
+		private final ByteBuffer value;
+
+		private SMoveCommand(ByteBuffer key, ByteBuffer destination, ByteBuffer value) {
+
+			super(key);
+			this.destination = destination;
+			this.value = value;
+		}
+
+		public static SMoveCommand value(ByteBuffer value) {
+			return new SMoveCommand(null, null, value);
+		}
+
+		public SMoveCommand from(ByteBuffer source) {
+			return new SMoveCommand(source, destination, value);
+		}
+
+		public SMoveCommand to(ByteBuffer destination) {
+			return new SMoveCommand(getKey(), destination, value);
+		}
+
+		public ByteBuffer getDestination() {
+			return destination;
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+	}
+
+	/**
+	 * Move {@code value} from {@code sourceKey} to {@code destinationKey}
+	 *
+	 * @param sourceKey must not be {@literal null}.
+	 * @param destinationKey must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> sMove(ByteBuffer sourceKey, ByteBuffer destinationKey, ByteBuffer value) {
+
+		Assert.notNull(sourceKey, "sourceKey must not be null");
+		Assert.notNull(destinationKey, "destinationKey must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return sMove(Mono.just(SMoveCommand.value(value).from(sourceKey).to(destinationKey))).next()
+				.map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Move {@link SMoveCommand#getValue()} from {@link SMoveCommand#getKey()} to {@link SMoveCommand#getDestination()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<SMoveCommand>> sMove(Publisher<SMoveCommand> commands);
+
+	/**
+	 * Get size of set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> sCard(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return sCard(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Get size of set at {@link KeyCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<KeyCommand, Long>> sCard(Publisher<KeyCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SIsMemberCommand extends KeyCommand {
+
+		private final ByteBuffer value;
+
+		private SIsMemberCommand(ByteBuffer key, ByteBuffer value) {
+
+			super(key);
+			this.value = value;
+		}
+
+		public static SIsMemberCommand value(ByteBuffer value) {
+			return new SIsMemberCommand(null, value);
+		}
+
+		public SIsMemberCommand of(ByteBuffer set) {
+			return new SIsMemberCommand(set, value);
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+	}
+
+	/**
+	 * Check if set at {@code key} contains {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> sIsMember(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return sIsMember(Mono.just(SIsMemberCommand.value(value).of(key))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Check if set at {@link SIsMemberCommand#getKey()} contains {@link SIsMemberCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<SIsMemberCommand>> sIsMember(Publisher<SIsMemberCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SInterCommand implements Command {
+
+		private final List<ByteBuffer> keys;
+
+		private SInterCommand(List<ByteBuffer> keys) {
+			this.keys = keys;
+		}
+
+		public static SInterCommand keys(List<ByteBuffer> keys) {
+			return new SInterCommand(keys);
+		}
+
+		@Override
+		public ByteBuffer getKey() {
+			return null;
+		}
+
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+	}
+
+	/**
+	 * Returns the members intersecting all given sets at {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> sInter(List<ByteBuffer> keys) {
+
+		Assert.notNull(keys, "keys must not be null");
+
+		return sInter(Mono.just(SInterCommand.keys(keys))).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Returns the members intersecting all given sets at {@link SInterCommand#getKeys()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<SInterCommand, ByteBuffer>> sInter(Publisher<SInterCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SInterStoreCommand extends KeyCommand {
+
+		private final List<ByteBuffer> keys;
+
+		private SInterStoreCommand(ByteBuffer key, List<ByteBuffer> keys) {
+
+			super(key);
+			this.keys = keys;
+		}
+
+		public static SInterStoreCommand keys(List<ByteBuffer> keys) {
+			return new SInterStoreCommand(null, keys);
+		}
+
+		public SInterStoreCommand storeAt(ByteBuffer key) {
+			return new SInterStoreCommand(key, keys);
+		}
+
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+	}
+
+	/**
+	 * Intersect all given sets at {@code keys} and store result in {@code destinationKey}.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
+	 * @return size of set stored a {@code destinationKey}.
+	 */
+	default Mono<Long> sInterStore(ByteBuffer destinationKey, List<ByteBuffer> keys) {
+
+		Assert.notNull(destinationKey, "destinationKey must not be null");
+		Assert.notNull(keys, "keys must not be null");
+
+		return sInterStore(Mono.just(SInterStoreCommand.keys(keys).storeAt(destinationKey))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Intersect all given sets at {@code keys} and store result in {@code destinationKey}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<SInterStoreCommand, Long>> sInterStore(Publisher<SInterStoreCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SUnionCommand implements Command {
+
+		private final List<ByteBuffer> keys;
+
+		private SUnionCommand(List<ByteBuffer> keys) {
+			this.keys = keys;
+		}
+
+		public static SUnionCommand keys(List<ByteBuffer> keys) {
+			return new SUnionCommand(keys);
+		}
+
+		@Override
+		public ByteBuffer getKey() {
+			return null;
+		}
+
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+	}
+
+	/**
+	 * Returns the members intersecting all given sets at {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> sUnion(List<ByteBuffer> keys) {
+
+		Assert.notNull(keys, "keys must not be null");
+
+		return sUnion(Mono.just(SUnionCommand.keys(keys))).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Returns the members intersecting all given sets at {@link SInterCommand#getKeys()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<SUnionCommand, ByteBuffer>> sUnion(Publisher<SUnionCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SUnionStoreCommand extends KeyCommand {
+
+		private final List<ByteBuffer> keys;
+
+		private SUnionStoreCommand(ByteBuffer key, List<ByteBuffer> keys) {
+
+			super(key);
+			this.keys = keys;
+		}
+
+		public static SUnionStoreCommand keys(List<ByteBuffer> keys) {
+			return new SUnionStoreCommand(null, keys);
+		}
+
+		public SUnionStoreCommand storeAt(ByteBuffer key) {
+			return new SUnionStoreCommand(key, keys);
+		}
+
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+	}
+
+	/**
+	 * Union all given sets at {@code keys} and store result in {@code destinationKey}.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
+	 * @return size of set stored a {@code destinationKey}.
+	 */
+	default Mono<Long> sUnionStore(ByteBuffer destinationKey, List<ByteBuffer> keys) {
+
+		Assert.notNull(destinationKey, "destinationKey must not be null");
+		Assert.notNull(keys, "keys must not be null");
+
+		return sUnionStore(Mono.just(SUnionStoreCommand.keys(keys).storeAt(destinationKey))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Union all given sets at {@code keys} and store result in {@code destinationKey}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<SUnionStoreCommand, Long>> sUnionStore(Publisher<SUnionStoreCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SDiffCommand implements Command {
+
+		private final List<ByteBuffer> keys;
+
+		private SDiffCommand(List<ByteBuffer> keys) {
+			this.keys = keys;
+		}
+
+		public static SDiffCommand keys(List<ByteBuffer> keys) {
+			return new SDiffCommand(keys);
+		}
+
+		@Override
+		public ByteBuffer getKey() {
+			return null;
+		}
+
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+	}
+
+	/**
+	 * Returns the diff of the members of all given sets at {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> sDiff(List<ByteBuffer> keys) {
+
+		Assert.notNull(keys, "keys must not be null");
+
+		return sDiff(Mono.just(SDiffCommand.keys(keys))).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Returns the diff of the members of all given sets at {@link SInterCommand#getKeys()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<SDiffCommand, ByteBuffer>> sDiff(Publisher<SDiffCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SDiffStoreCommand extends KeyCommand {
+
+		private final List<ByteBuffer> keys;
+
+		private SDiffStoreCommand(ByteBuffer key, List<ByteBuffer> keys) {
+
+			super(key);
+			this.keys = keys;
+		}
+
+		public static SDiffStoreCommand keys(List<ByteBuffer> keys) {
+			return new SDiffStoreCommand(null, keys);
+		}
+
+		public SDiffStoreCommand storeAt(ByteBuffer key) {
+			return new SDiffStoreCommand(key, keys);
+		}
+
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+	}
+
+	/**
+	 * Diff all given sets at {@code keys} and store result in {@code destinationKey}.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
+	 * @return size of set stored a {@code destinationKey}.
+	 */
+	default Mono<Long> sDiffStore(ByteBuffer destinationKey, List<ByteBuffer> keys) {
+
+		Assert.notNull(destinationKey, "destinationKey must not be null");
+		Assert.notNull(keys, "keys must not be null");
+
+		return sDiffStore(Mono.just(SDiffStoreCommand.keys(keys).storeAt(destinationKey))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Diff all given sets at {@code keys} and store result in {@code destinationKey}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<SDiffStoreCommand, Long>> sDiffStore(Publisher<SDiffStoreCommand> commands);
+
+	/**
+	 * Get all elements of set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> sMembers(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return sMembers(Mono.just(new KeyCommand(key))).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get all elements of set at {@link KeyCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<KeyCommand, ByteBuffer>> sMembers(Publisher<KeyCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SRandMembersCommand extends KeyCommand {
+
+		private final Long count;
+
+		private SRandMembersCommand(ByteBuffer key, Long count) {
+
+			super(key);
+			this.count = count;
+		}
+
+		public static SRandMembersCommand valueCount(Long nrValuesToRetrieve) {
+			return new SRandMembersCommand(null, nrValuesToRetrieve);
+		}
+
+		public static SRandMembersCommand singleValue() {
+			return new SRandMembersCommand(null, null);
+		}
+
+		public SRandMembersCommand from(ByteBuffer key) {
+			return new SRandMembersCommand(key, count);
+		}
+
+		public Optional<Long> getCount() {
+			return Optional.ofNullable(count);
+		}
+	}
+
+	/**
+	 * Get random element from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<ByteBuffer> sRandMember(ByteBuffer key) {
+		return sRandMember(key, 1L).map(vals -> vals.isEmpty() ? null : vals.iterator().next());
+	}
+
+	/**
+	 * Get {@code count} random elements from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param count must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> sRandMember(ByteBuffer key, Long count) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(count, "count must not be null");
+
+		return sRandMember(Mono.just(SRandMembersCommand.valueCount(count).from(key))).next()
+				.map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get {@link SRandMembersCommand#getCount()} random elements from set at {@link SRandMembersCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<SRandMembersCommand, ByteBuffer>> sRandMember(Publisher<SRandMembersCommand> commands);
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
@@ -1,0 +1,752 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.Command;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.RangeCommand;
+import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
+import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
+import org.springframework.data.redis.core.types.Expiration;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveStringCommands {
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SetCommand extends KeyCommand {
+
+		private ByteBuffer value;
+		private Expiration expiration;
+		private SetOption option;
+
+		private SetCommand(ByteBuffer key, ByteBuffer value, Expiration expiration, SetOption option) {
+
+			super(key);
+			this.value = value;
+			this.expiration = expiration;
+			this.option = option;
+		}
+
+		public static ReactiveStringCommands.SetCommand set(ByteBuffer key) {
+			return new SetCommand(key, null, null, null);
+		}
+
+		public ReactiveStringCommands.SetCommand value(ByteBuffer value) {
+			return new SetCommand(getKey(), value, expiration, option);
+		}
+
+		public ReactiveStringCommands.SetCommand expiring(Expiration expiration) {
+			return new SetCommand(getKey(), value, expiration, option);
+		}
+
+		public ReactiveStringCommands.SetCommand withSetOption(SetOption option) {
+			return new SetCommand(getKey(), value, expiration, option);
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+
+		public Optional<Expiration> getExpiration() {
+			return Optional.ofNullable(expiration);
+		}
+
+		public Optional<SetOption> getOption() {
+			return Optional.ofNullable(option);
+		}
+	}
+
+	/**
+	 * Set {@literal value} for {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> set(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+
+		return set(Mono.just(SetCommand.set(key).value(value))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set {@literal value} for {@literal key} with {@literal expiration} and {@literal options}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @param expiration must not be {@literal null}.
+	 * @param option must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> set(ByteBuffer key, ByteBuffer value, Expiration expiration, SetOption option) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+
+		return set(Mono.just(SetCommand.set(key).value(value).withSetOption(option).expiring(expiration))).next()
+				.map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set each and every {@link KeyValue} item separately.
+	 *
+	 * @param values must not be {@literal null}.
+	 * @return {@link Flux} of {@link SetResponse} holding the {@link KeyValue} pair to set along with the command result.
+	 */
+	Flux<BooleanResponse<ReactiveStringCommands.SetCommand>> set(Publisher<ReactiveStringCommands.SetCommand> commands);
+
+	/**
+	 * Get single element stored at {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return empty {@link ByteBuffer} in case {@literal key} does not exist.
+	 */
+	default Mono<ByteBuffer> get(ByteBuffer key) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return get(Mono.just(new KeyCommand(key))).next().map((result) -> result.getOutput());
+	}
+
+	/**
+	 * Get elements one by one.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@link Flux} of {@link GetResponse} holding the {@literal key} to get along with the value retrieved.
+	 */
+	Flux<ByteBufferResponse<KeyCommand>> get(Publisher<KeyCommand> keys);
+
+	/**
+	 * Set {@literal value} for {@literal key} and return the existing value.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<ByteBuffer> getSet(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+
+		return getSet(Mono.just(SetCommand.set(key).value(value))).next().map(ByteBufferResponse::getOutput);
+	}
+
+	/**
+	 * Set {@literal value} for {@literal key} and return the existing value one by one.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return {@link Flux} of {@link GetSetResponse} holding the {@link KeyValue} pair to set along with the previously
+	 *         existing value.
+	 */
+	Flux<ByteBufferResponse<ReactiveStringCommands.SetCommand>> getSet(
+			Publisher<ReactiveStringCommands.SetCommand> command);
+
+	/**
+	 * Get multiple values in one batch.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> mGet(List<ByteBuffer> keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+
+		return mGet(Mono.just(keys)).next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get multiple values at in batches.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<List<ByteBuffer>, ByteBuffer>> mGet(Publisher<List<ByteBuffer>> keysets);
+
+	/**
+	 * Set {@code value} for {@code key}, only if {@code key} does not exist.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> setNX(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "Keys must not be null!");
+		Assert.notNull(value, "Keys must not be null!");
+
+		return setNX(Mono.just(SetCommand.set(key).value(value))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set {@code key value} pairs, only if {@code key} does not exist.
+	 *
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<ReactiveStringCommands.SetCommand>> setNX(Publisher<ReactiveStringCommands.SetCommand> values);
+
+	/**
+	 * Set {@code key value} pair and {@link Expiration}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @param expireTimeout must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> setEX(ByteBuffer key, ByteBuffer value, Expiration expireTimeout) {
+
+		Assert.notNull(key, "Keys must not be null!");
+		Assert.notNull(value, "Keys must not be null!");
+		Assert.notNull(key, "ExpireTimeout must not be null!");
+
+		return setEX(Mono.just(SetCommand.set(key).value(value).expiring(expireTimeout))).next()
+				.map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set {@code key value} pairs and {@link Expiration}.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @param expireTimeout must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<ReactiveStringCommands.SetCommand>> setEX(Publisher<ReactiveStringCommands.SetCommand> command);
+
+	/**
+	 * Set {@code key value} pair and {@link Expiration}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @param expireTimeout must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> pSetEX(ByteBuffer key, ByteBuffer value, Expiration expireTimeout) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+		Assert.notNull(key, "ExpireTimeout must not be null!");
+
+		return pSetEX(Mono.just(SetCommand.set(key).value(value).expiring(expireTimeout))).next()
+				.map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set {@code key value} pairs and {@link Expiration}.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @param expireTimeout must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<ReactiveStringCommands.SetCommand>> pSetEX(Publisher<ReactiveStringCommands.SetCommand> command);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class MSetCommand implements Command {
+
+		private Map<ByteBuffer, ByteBuffer> keyValuePairs;
+
+		private MSetCommand(Map<ByteBuffer, ByteBuffer> keyValuePairs) {
+			this.keyValuePairs = keyValuePairs;
+		}
+
+		@Override
+		public ByteBuffer getKey() {
+			return null;
+		}
+
+		public static ReactiveStringCommands.MSetCommand mset(Map<ByteBuffer, ByteBuffer> keyValuePairs) {
+			return new MSetCommand(keyValuePairs);
+		}
+
+		public Map<ByteBuffer, ByteBuffer> getKeyValuePairs() {
+			return keyValuePairs;
+		}
+	}
+
+	/**
+	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple}.
+	 *
+	 * @param tuples must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> mSet(Map<ByteBuffer, ByteBuffer> tuples) {
+
+		Assert.notNull(tuples, "Tuples must not be null!");
+
+		return mSet(Mono.just(MSetCommand.mset(tuples))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set multiple keys to multiple values using key-value pairs provided in {@code source}.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<ReactiveStringCommands.MSetCommand>> mSet(Publisher<ReactiveStringCommands.MSetCommand> source);
+
+	/**
+	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuples} only if the provided key does
+	 * not exist.
+	 *
+	 * @param tuples must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Boolean> mSetNX(Map<ByteBuffer, ByteBuffer> tuples) {
+
+		Assert.notNull(tuples, "Tuples must not be null!");
+
+		return mSetNX(Mono.just(MSetCommand.mset(tuples))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuples} only if the provided key does
+	 * not exist.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<ReactiveStringCommands.MSetCommand>> mSetNX(
+			Publisher<ReactiveStringCommands.MSetCommand> source);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class AppendCommand extends KeyCommand {
+
+		private ByteBuffer value;
+
+		private AppendCommand(ByteBuffer key, ByteBuffer value) {
+
+			super(key);
+			this.value = value;
+		}
+
+		public static ReactiveStringCommands.AppendCommand key(ByteBuffer key) {
+			return new AppendCommand(key, null);
+		}
+
+		public ReactiveStringCommands.AppendCommand append(ByteBuffer value) {
+			return new AppendCommand(getKey(), value);
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+
+	}
+
+	/**
+	 * Append a {@code value} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> append(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+
+		return append(Mono.just(AppendCommand.key(key).append(value))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Append a {@link KeyValue#value} to {@link KeyValue#key}
+	 *
+	 * @param source must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ReactiveStringCommands.AppendCommand, Long>> append(
+			Publisher<ReactiveStringCommands.AppendCommand> source);
+
+	/**
+	 * Get a substring of value of {@code key} between {@code begin} and {@code end}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param begin
+	 * @param end
+	 * @return
+	 */
+	default Mono<ByteBuffer> getRange(ByteBuffer key, long begin, long end) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return getRange(Mono.just(RangeCommand.key(key).fromIndex(begin).toIndex(end))).next()
+				.map(ByteBufferResponse::getOutput);
+	}
+
+	/**
+	 * Get a substring of value of {@code key} between {@code begin} and {@code end}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param begin
+	 * @param end
+	 * @return
+	 */
+	Flux<ByteBufferResponse<RangeCommand>> getRange(Publisher<RangeCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class SetRangeCommand extends KeyCommand {
+
+		private ByteBuffer value;
+		private Long offset;
+
+		private SetRangeCommand(ByteBuffer key, ByteBuffer value, Long offset) {
+
+			super(key);
+			this.value = value;
+			this.offset = offset;
+		}
+
+		public static ReactiveStringCommands.SetRangeCommand overwrite(ByteBuffer key) {
+			return new SetRangeCommand(key, null, null);
+		}
+
+		public ReactiveStringCommands.SetRangeCommand withValue(ByteBuffer value) {
+			return new SetRangeCommand(getKey(), value, offset);
+		}
+
+		public ReactiveStringCommands.SetRangeCommand atPosition(Long index) {
+			return new SetRangeCommand(getKey(), value, index);
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+
+		public Long getOffset() {
+			return offset;
+		}
+	}
+
+	/**
+	 * Overwrite parts of {@code key} starting at the specified {@code offset} with given {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @param offset
+	 * @return
+	 */
+	default Mono<Long> setRange(ByteBuffer key, ByteBuffer value, long offset) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(value, "Value must not be null!");
+
+		return setRange(Mono.just(SetRangeCommand.overwrite(key).withValue(value).atPosition(offset))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Overwrite parts of {@link KeyValue#key} starting at the specified {@code offset} with given {@link KeyValue#value}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param offset must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ReactiveStringCommands.SetRangeCommand, Long>> setRange(
+			Publisher<ReactiveStringCommands.SetRangeCommand> commands);
+
+	class GetBitCommand extends KeyCommand {
+
+		public Long offset;
+
+		public GetBitCommand(ByteBuffer key, Long offset) {
+
+			super(key);
+			this.offset = offset;
+		}
+
+		public static ReactiveStringCommands.GetBitCommand bit(ByteBuffer key) {
+			return new GetBitCommand(key, null);
+		}
+
+		public ReactiveStringCommands.GetBitCommand atOffset(Long offset) {
+			return new GetBitCommand(getKey(), offset);
+		}
+
+		public Long getOffset() {
+			return offset;
+		}
+	}
+
+	/**
+	 * Get the bit value at {@code offset} of value at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param offset
+	 * @return
+	 */
+	default Mono<Boolean> getBit(ByteBuffer key, long offset) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return getBit(Mono.just(GetBitCommand.bit(key).atOffset(offset))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Get the bit value at {@code offset} of value at {@code key}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param offset must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<ReactiveStringCommands.GetBitCommand>> getBit(
+			Publisher<ReactiveStringCommands.GetBitCommand> commands);
+
+	class SetBitCommand extends KeyCommand {
+
+		private Long offset;
+		private Boolean value;
+
+		private SetBitCommand(ByteBuffer key, Long offset, Boolean value) {
+
+			super(key);
+			this.offset = offset;
+			this.value = value;
+		}
+
+		public static ReactiveStringCommands.SetBitCommand bit(ByteBuffer key) {
+			return new SetBitCommand(key, null, null);
+		}
+
+		public ReactiveStringCommands.SetBitCommand atOffset(Long index) {
+			return new ReactiveStringCommands.SetBitCommand(getKey(), index, value);
+		}
+
+		public ReactiveStringCommands.SetBitCommand to(Boolean bit) {
+			return new ReactiveStringCommands.SetBitCommand(getKey(), offset, bit);
+		}
+
+		public Long getOffset() {
+			return offset;
+		}
+
+		public Boolean getValue() {
+			return value;
+		}
+	}
+
+	/**
+	 * Sets the bit at {@code offset} in value stored at {@code key} and return the original value.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param offset
+	 * @param value
+	 * @return
+	 */
+	default Mono<Boolean> setBit(ByteBuffer key, long offset, boolean value) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return setBit(Mono.just(SetBitCommand.bit(key).atOffset(offset).to(value))).next().map(BooleanResponse::getOutput);
+	}
+
+	/**
+	 * Sets the bit at {@code offset} in value stored at {@code key} and return the original value.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param offset must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	Flux<BooleanResponse<ReactiveStringCommands.SetBitCommand>> setBit(
+			Publisher<ReactiveStringCommands.SetBitCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class BitCountCommand extends KeyCommand {
+
+		private Range<Long> range;
+
+		public BitCountCommand(ByteBuffer key, Range<Long> range) {
+
+			super(key);
+			this.range = range;
+		}
+
+		public static ReactiveStringCommands.BitCountCommand bitCount(ByteBuffer key) {
+			return new ReactiveStringCommands.BitCountCommand(key, null);
+		}
+
+		public ReactiveStringCommands.BitCountCommand within(Range<Long> range) {
+			return new ReactiveStringCommands.BitCountCommand(getKey(), range);
+		}
+
+		public Range<Long> getRange() {
+			return range;
+		}
+
+	}
+
+	/**
+	 * Count the number of set bits (population counting) in value stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> bitCount(ByteBuffer key) {
+
+		Assert.notNull(key, "Key must not be null");
+
+		return bitCount(Mono.just(BitCountCommand.bitCount(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Count the number of set bits (population counting) of value stored at {@code key} between {@code begin} and
+	 * {@code end}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param begin
+	 * @param end
+	 * @return
+	 */
+	default Mono<Long> bitCount(ByteBuffer key, long begin, long end) {
+
+		Assert.notNull(key, "Key must not be null");
+
+		return bitCount(Mono.just(BitCountCommand.bitCount(key).within(new Range<>(begin, end)))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Count the number of set bits (population counting) of value stored at {@code key} between {@code begin} and
+	 * {@code end}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param begin must not be {@literal null}.
+	 * @param end must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ReactiveStringCommands.BitCountCommand, Long>> bitCount(
+			Publisher<ReactiveStringCommands.BitCountCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class BitOpCommand {
+
+		private List<ByteBuffer> keys;
+		private BitOperation bitOp;
+		private ByteBuffer destinationKey;
+
+		private BitOpCommand(List<ByteBuffer> keys, BitOperation bitOp, ByteBuffer destinationKey) {
+
+			this.keys = keys;
+			this.bitOp = bitOp;
+			this.destinationKey = destinationKey;
+		}
+
+		public static ReactiveStringCommands.BitOpCommand perform(BitOperation bitOp) {
+			return new ReactiveStringCommands.BitOpCommand(null, bitOp, null);
+		}
+
+		public BitOperation getBitOp() {
+			return bitOp;
+		}
+
+		public ReactiveStringCommands.BitOpCommand onKeys(List<ByteBuffer> keys) {
+			return new ReactiveStringCommands.BitOpCommand(keys, bitOp, destinationKey);
+		}
+
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+
+		public ReactiveStringCommands.BitOpCommand andSaveAs(ByteBuffer destinationKey) {
+			return new ReactiveStringCommands.BitOpCommand(keys, bitOp, destinationKey);
+		}
+
+		public ByteBuffer getDestinationKey() {
+			return destinationKey;
+		}
+
+	}
+
+	/**
+	 * Perform bitwise operations between strings.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param bitOp must not be {@literal null}.
+	 * @param destination must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> bitOp(List<ByteBuffer> keys, BitOperation bitOp, ByteBuffer destination) {
+
+		Assert.notNull(keys, "keys must not be null");
+
+		return bitOp(Mono.just(BitOpCommand.perform(bitOp).onKeys(keys).andSaveAs(destination))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Perform bitwise operations between strings.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param bitOp must not be {@literal null}.
+	 * @param destination must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ReactiveStringCommands.BitOpCommand, Long>> bitOp(
+			Publisher<ReactiveStringCommands.BitOpCommand> commands);
+
+	/**
+	 * Get the length of the value stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> strLen(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return strLen(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Get the length of the value stored at {@code key}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<KeyCommand, Long>> strLen(Publisher<KeyCommand> keys);
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
@@ -1,0 +1,1254 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.domain.Range;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
+import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
+import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public interface ReactiveZSetCommands {
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class AgrumentConverters {
+
+		public static Object lowerBoundArgOf(Range<?> range) {
+			return rangeToLowerBoundArgumentConverter(false).convert(range);
+		}
+
+		public static Object upperBoundArgOf(Range<?> range) {
+			return rangeToLowerBoundArgumentConverter(true).convert(range);
+		}
+
+		public static Converter<Range<?>, Object> rangeToLowerBoundArgumentConverter(Boolean upper) {
+
+			return (source) -> {
+
+				// TODO: fix range exclusion pattern when DATACMNS-920 is resolved
+				DirectFieldAccessFallbackBeanWrapper bw = new DirectFieldAccessFallbackBeanWrapper(source);
+
+				Boolean inclusive = upper ? Boolean.valueOf(bw.getPropertyValue("upperInclusive").toString())
+						: Boolean.valueOf(bw.getPropertyValue("lowerInclusive").toString());
+				Object value = upper ? source.getUpperBound() : source.getLowerBound();
+
+				if (value instanceof Double) {
+
+					Object converted = doubleToRangeConverter().convert((Double) value);
+					if (!(converted instanceof String) && !inclusive) {
+						return "(" + converted.toString();
+					}
+					return converted;
+				}
+
+				if (value instanceof String) {
+					if (!StringUtils.hasText((String) value)) {
+						return upper ? "+" : "-";
+					}
+					if (ObjectUtils.nullSafeEquals(value, "+") || ObjectUtils.nullSafeEquals(value, "-")) {
+						return value;
+					}
+					return (inclusive ? "[" : "(") + value.toString();
+				}
+
+				return inclusive ? value : "(" + value;
+			};
+		}
+
+		public static Converter<Double, Object> doubleToRangeConverter() {
+
+			return (source) -> {
+				if (source.equals(Double.NEGATIVE_INFINITY)) {
+					return "-inf";
+				}
+				if (source.equals(Double.POSITIVE_INFINITY)) {
+					return "+inf";
+				}
+				return source;
+			};
+		}
+
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZAddCommand extends KeyCommand {
+
+		private final List<Tuple> tuples;
+		private final Boolean upsert;
+		private final Boolean returnTotalChanged;
+		private final Boolean incr;
+
+		private ZAddCommand(ByteBuffer key, List<Tuple> tuples, Boolean upsert, Boolean returnTotalChanged, Boolean incr) {
+
+			super(key);
+			this.tuples = tuples;
+			this.upsert = upsert;
+			this.returnTotalChanged = returnTotalChanged;
+			this.incr = incr;
+		}
+
+		public static ZAddCommand tuple(Tuple tuple) {
+			return tuples(Collections.singletonList(tuple));
+		}
+
+		public static ZAddCommand tuples(List<Tuple> tuples) {
+			return new ZAddCommand(null, tuples, null, null, null);
+		}
+
+		public ZAddCommand to(ByteBuffer key) {
+			return new ZAddCommand(key, tuples, upsert, returnTotalChanged, incr);
+		}
+
+		public ZAddCommand xx() {
+			return new ZAddCommand(getKey(), tuples, false, returnTotalChanged, incr);
+		}
+
+		public ZAddCommand nx() {
+			return new ZAddCommand(getKey(), tuples, true, returnTotalChanged, incr);
+		}
+
+		public ZAddCommand ch() {
+			return new ZAddCommand(getKey(), tuples, upsert, true, incr);
+		}
+
+		public ZAddCommand incr() {
+			return new ZAddCommand(getKey(), tuples, upsert, upsert, true);
+		}
+
+		public List<Tuple> getTuples() {
+			return tuples;
+		}
+
+		public Optional<Boolean> getUpsert() {
+			return Optional.ofNullable(upsert);
+		}
+
+		public Optional<Boolean> getIncr() {
+			return Optional.ofNullable(incr);
+		}
+
+		public Optional<Boolean> getReturnTotalChanged() {
+			return Optional.ofNullable(returnTotalChanged);
+		}
+	}
+
+	/**
+	 * Add {@code value} to a sorted set at {@code key}, or update its {@code score} if it already exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param score must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zAdd(ByteBuffer key, Double score, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(score, "score must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return zAdd(Mono.just(ZAddCommand.tuple(new DefaultTuple(value.array(), score)).to(key))).next()
+				.map(resp -> resp.getOutput().longValue());
+	}
+
+	/**
+	 * Add {@link ZAddCommand#getTuple()} to a sorted set at {@link ZAddCommand#getKey()}, or update its {@code score} if
+	 * it already exists.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ZAddCommand, Number>> zAdd(Publisher<ZAddCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZRemCommand extends KeyCommand {
+
+		private final List<ByteBuffer> values;
+
+		private ZRemCommand(ByteBuffer key, List<ByteBuffer> values) {
+
+			super(key);
+			this.values = values;
+		}
+
+		public static ZRemCommand values(List<ByteBuffer> values) {
+			return new ZRemCommand(null, values);
+		}
+
+		public ZRemCommand from(ByteBuffer key) {
+			return new ZRemCommand(key, values);
+		}
+
+		public List<ByteBuffer> getValues() {
+			return values;
+		}
+	}
+
+	/**
+	 * Remove {@code value} from sorted set. Return number of removed elements.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zRem(ByteBuffer key, ByteBuffer value) {
+		return zRem(key, Collections.singletonList(value));
+	}
+
+	/**
+	 * Remove {@code values} from sorted set. Return number of removed elements.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zRem(ByteBuffer key, List<ByteBuffer> values) {
+
+		Assert.notNull(values, "values must not be null");
+
+		return zRem(Mono.just(ZRemCommand.values(values).from(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Remove {@link ZRemCommand#getValues()} from sorted set. Return number of removed elements.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ZRemCommand, Long>> zRem(Publisher<ZRemCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZIncrByCommand extends KeyCommand {
+
+		private final ByteBuffer value;
+		private final Number increment;
+
+		public ZIncrByCommand(ByteBuffer key, ByteBuffer value, Number increment) {
+
+			super(key);
+			this.value = value;
+			this.increment = increment;
+		}
+
+		public static ZIncrByCommand scoreOf(ByteBuffer member) {
+			return new ZIncrByCommand(null, member, null);
+		}
+
+		public ZIncrByCommand by(Number increment) {
+			return new ZIncrByCommand(getKey(), value, increment);
+		}
+
+		public ZIncrByCommand storedWithin(ByteBuffer key) {
+			return new ZIncrByCommand(key, value, increment);
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+
+		public Number getIncrement() {
+			return increment;
+		}
+	}
+
+	/**
+	 * Increment the score of element with {@code value} in sorted set by {@code increment}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param increment must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Double> zIncrBy(ByteBuffer key, Number increment, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(increment, "increment must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return zIncrBy(Mono.just(ZIncrByCommand.scoreOf(value).by(increment).storedWithin(key))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Increment the score of element with {@link ZIncrByCommand#getValue()} in sorted set by
+	 * {@link ZIncrByCommand#getIncrement()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ZIncrByCommand, Double>> zIncrBy(Publisher<ZIncrByCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZRankCommand extends KeyCommand {
+
+		private final ByteBuffer value;
+		private final Direction direction;
+
+		private ZRankCommand(ByteBuffer key, ByteBuffer value, Direction direction) {
+
+			super(key);
+			this.value = value;
+			this.direction = direction;
+		}
+
+		public static ZRankCommand indexOf(ByteBuffer member) {
+			return new ZRankCommand(null, member, Direction.ASC);
+		}
+
+		public static ZRankCommand reverseIndexOf(ByteBuffer member) {
+			return new ZRankCommand(null, member, Direction.DESC);
+		}
+
+		public ZRankCommand storedWithin(ByteBuffer key) {
+			return new ZRankCommand(key, value, direction);
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+
+		public Direction getDirection() {
+			return direction;
+		}
+	}
+
+	/**
+	 * Determine the index of element with {@code value} in a sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zRank(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return zRank(Mono.just(ZRankCommand.indexOf(value).storedWithin(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Determine the index of element with {@code value} in a sorted set when scored high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zRevRank(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return zRank(Mono.just(ZRankCommand.reverseIndexOf(value).storedWithin(key))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Determine the index of element with {@code value} in a sorted set when scored by
+	 * {@link ZRankCommand#getDirection()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ZRankCommand, Long>> zRank(Publisher<ZRankCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZRangeCommand extends KeyCommand {
+
+		private final Range<Long> range;
+		private final Boolean withScores;
+		private final Direction direction;
+
+		public ZRangeCommand(ByteBuffer key, Range<Long> range, Direction direction, Boolean withScores) {
+			super(key);
+			this.range = range;
+			this.withScores = withScores;
+			this.direction = direction;
+		}
+
+		public static ZRangeCommand reverseValuesWithin(Range<Long> range) {
+			return new ZRangeCommand(null, range, Direction.DESC, null);
+		}
+
+		public static ZRangeCommand valuesWithin(Range<Long> range) {
+			return new ZRangeCommand(null, range, Direction.ASC, null);
+		}
+
+		public ZRangeCommand withScores() {
+			return new ZRangeCommand(getKey(), range, direction, Boolean.TRUE);
+		}
+
+		public ZRangeCommand from(ByteBuffer key) {
+			return new ZRangeCommand(key, range, direction, withScores);
+		}
+
+		public Range<Long> getRange() {
+			return range;
+		}
+
+		public Optional<Boolean> getWithScores() {
+			return Optional.ofNullable(withScores);
+		}
+
+		public Direction getDirection() {
+			return direction;
+		}
+	}
+
+	/**
+	 * Get elements in {@code range} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRange(ByteBuffer key, Range<Long> range) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return zRange(Mono.just(ZRangeCommand.valuesWithin(range).from(key))).next().map(
+				resp -> resp.getOutput().stream().map(tuple -> ByteBuffer.wrap(tuple.getValue())).collect(Collectors.toList()));
+	}
+
+	/**
+	 * Get set of {@link Tuple}s in {@code range} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<Tuple>> zRangeWithScores(ByteBuffer key, Range<Long> range) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return zRange(Mono.just(ZRangeCommand.valuesWithin(range).withScores().from(key))).next()
+				.map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get elements in {@code range} from sorted set in reverse {@code score} ordering.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRevRange(ByteBuffer key, Range<Long> range) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return zRange(Mono.just(ZRangeCommand.reverseValuesWithin(range).from(key))).next().map(
+				resp -> resp.getOutput().stream().map(tuple -> ByteBuffer.wrap(tuple.getValue())).collect(Collectors.toList()));
+	}
+
+	/**
+	 * Get set of {@link Tuple}s in {@code range} from sorted set in reverse {@code score} ordering.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<Tuple>> zRevRangeWithScores(ByteBuffer key, Range<Long> range) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return zRange(Mono.just(ZRangeCommand.reverseValuesWithin(range).withScores().from(key))).next()
+				.map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get set of {@link Tuple}s in {@code range} from sorted set.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<ZRangeCommand, Tuple>> zRange(Publisher<ZRangeCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZRangeByScoreCommand extends KeyCommand {
+
+		private final Range<Double> range;
+		private final Boolean withScores;
+		private final Direction direction;
+		private final Limit limit;
+
+		private ZRangeByScoreCommand(ByteBuffer key, Range<Double> range, Direction direction, Boolean withScores,
+				Limit limit) {
+
+			super(key);
+			this.range = range;
+			this.withScores = withScores;
+			this.direction = direction;
+			this.limit = limit;
+		}
+
+		public static ZRangeByScoreCommand reverseScoresWithin(Range<Double> range) {
+			return new ZRangeByScoreCommand(null, range, Direction.DESC, null, null);
+		}
+
+		public static ZRangeByScoreCommand scoresWithin(Range<Double> range) {
+			return new ZRangeByScoreCommand(null, range, Direction.ASC, null, null);
+		}
+
+		public ZRangeByScoreCommand withScores() {
+			return new ZRangeByScoreCommand(getKey(), range, direction, Boolean.TRUE, limit);
+		}
+
+		public ZRangeByScoreCommand from(ByteBuffer key) {
+			return new ZRangeByScoreCommand(key, range, direction, withScores, limit);
+		}
+
+		public ZRangeByScoreCommand limitTo(Limit limit) {
+			return new ZRangeByScoreCommand(getKey(), range, direction, withScores, limit);
+		}
+
+		public Range<Double> getRange() {
+			return range;
+		}
+
+		public Optional<Boolean> getWithScores() {
+			return Optional.ofNullable(withScores);
+		}
+
+		public Direction getDirection() {
+			return direction;
+		}
+
+		public Optional<Limit> getLimit() {
+			return Optional.ofNullable(limit);
+		}
+	}
+
+	/**
+	 * Get elements in {@code range} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRangeByScore(ByteBuffer key, Range<Double> range) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return zRangeByScore(Mono.just(ZRangeByScoreCommand.scoresWithin(range).from(key))).next().map(
+				resp -> resp.getOutput().stream().map(tuple -> ByteBuffer.wrap(tuple.getValue())).collect(Collectors.toList()));
+	}
+
+	/**
+	 * Get elements in {@code range} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @param limit can be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRangeByScore(ByteBuffer key, Range<Double> range, Limit limit) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRangeByScore(Mono.just(ZRangeByScoreCommand.scoresWithin(range).from(key).limitTo(limit))).next().map(
+				resp -> resp.getOutput().stream().map(tuple -> ByteBuffer.wrap(tuple.getValue())).collect(Collectors.toList()));
+	}
+
+	/**
+	 * Get set of {@link Tuple}s in {@code range} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<Tuple>> zRangeByScoreWithScores(ByteBuffer key, Range<Double> range) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRangeByScore(Mono.just(ZRangeByScoreCommand.scoresWithin(range).withScores().from(key))).next()
+				.map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get set of {@link Tuple}s in {@code range} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @param limit can be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<Tuple>> zRangeByScoreWithScores(ByteBuffer key, Range<Double> range, Limit limit) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRangeByScore(Mono.just(ZRangeByScoreCommand.scoresWithin(range).withScores().from(key).limitTo(limit)))
+				.next().map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get elements in {@code range} from sorted set in reverse {@code score} ordering.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRevRangeByScore(ByteBuffer key, Range<Double> range) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return zRangeByScore(Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).from(key))).next().map(
+				resp -> resp.getOutput().stream().map(tuple -> ByteBuffer.wrap(tuple.getValue())).collect(Collectors.toList()));
+	}
+
+	/**
+	 * Get elements in {@code range} from sorted set in reverse {@code score} ordering.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @param limit can be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRevRangeByScore(ByteBuffer key, Range<Double> range, Limit limit) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRangeByScore(Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).from(key).limitTo(limit))).next()
+				.map(resp -> resp.getOutput().stream().map(tuple -> ByteBuffer.wrap(tuple.getValue()))
+						.collect(Collectors.toList()));
+	}
+
+	/**
+	 * Get set of {@link Tuple}s in {@code range} from sorted set in reverse {@code score} ordering.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<Tuple>> zRevRangeByScoreWithScores(ByteBuffer key, Range<Double> range) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRangeByScore(Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).withScores().from(key))).next()
+				.map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get set of {@link Tuple}s in {@code range} from sorted set in reverse {@code score} ordering.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @param limit can be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<Tuple>> zRevRangeByScoreWithScores(ByteBuffer key, Range<Double> range, Limit limit) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRangeByScore(
+				Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).withScores().from(key).limitTo(limit))).next()
+						.map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get set of {@link Tuple}s in {@code range} from sorted set.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<ZRangeByScoreCommand, Tuple>> zRangeByScore(Publisher<ZRangeByScoreCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZCountCommand extends KeyCommand {
+
+		private final Range<Double> range;
+
+		private ZCountCommand(ByteBuffer key, Range<Double> range) {
+
+			super(key);
+			this.range = range;
+		}
+
+		public static ZCountCommand scoresWithin(Range<Double> range) {
+			return new ZCountCommand(null, range);
+		}
+
+		public ZCountCommand forKey(ByteBuffer key) {
+			return new ZCountCommand(key, range);
+		}
+
+		public Range<Double> getRange() {
+			return range;
+		}
+
+	}
+
+	/**
+	 * Count number of elements within sorted set with scores within {@link Range}. <br />
+	 * <b>NOTE</b> please use {@link Double#NEGATIVE_INFINITY} for {@code -inf} and {@link Double#POSITIVE_INFINITY} for
+	 * {@code +inf}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zCount(ByteBuffer key, Range<Double> range) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zCount(Mono.just(ZCountCommand.scoresWithin(range).forKey(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Count number of elements within sorted set with scores within {@link Range}. <br />
+	 * <b>NOTE</b> please use {@link Double#NEGATIVE_INFINITY} for {@code -inf} and {@link Double#POSITIVE_INFINITY} for
+	 * {@code +inf}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ZCountCommand, Long>> zCount(Publisher<ZCountCommand> commands);
+
+	/**
+	 * Get the size of sorted set with {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zCard(ByteBuffer key) {
+
+		Assert.notNull(key, "key must not be null");
+
+		return zCard(Mono.just(new KeyCommand(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Get the size of sorted set with {@link KeyCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<KeyCommand, Long>> zCard(Publisher<KeyCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZScoreCommand extends KeyCommand {
+
+		private final ByteBuffer value;
+
+		private ZScoreCommand(ByteBuffer key, ByteBuffer value) {
+
+			super(key);
+			this.value = value;
+		}
+
+		public static ZScoreCommand scoreOf(ByteBuffer member) {
+			return new ZScoreCommand(null, member);
+		}
+
+		public ZScoreCommand forKey(ByteBuffer key) {
+			return new ZScoreCommand(key, value);
+		}
+
+		public ByteBuffer getValue() {
+			return value;
+		}
+
+	}
+
+	/**
+	 * Get the score of element with {@code value} from sorted set with key {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Double> zScore(ByteBuffer key, ByteBuffer value) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(value, "value must not be null");
+
+		return zScore(Mono.just(ZScoreCommand.scoreOf(value).forKey(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Get the score of element with {@link ZScoreCommand#getValue()} from sorted set with key
+	 * {@link ZScoreCommand#getKey()}
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ZScoreCommand, Double>> zScore(Publisher<ZScoreCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZRemRangeByRankCommand extends KeyCommand {
+
+		private final Range<Long> range;
+
+		private ZRemRangeByRankCommand(ByteBuffer key, Range<Long> range) {
+			super(key);
+			this.range = range;
+		}
+
+		public static ZRemRangeByRankCommand valuesWithin(Range<Long> range) {
+			return new ZRemRangeByRankCommand(null, range);
+		}
+
+		public ZRemRangeByRankCommand from(ByteBuffer key) {
+			return new ZRemRangeByRankCommand(key, range);
+		}
+
+		public Range<Long> getRange() {
+			return range;
+		}
+	}
+
+	/**
+	 * Remove elements in {@link Range} from sorted set with {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zRemRangeByRank(ByteBuffer key, Range<Long> range) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRemRangeByRank(Mono.just(ZRemRangeByRankCommand.valuesWithin(range).from(key))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Remove elements in {@link Range} from sorted set with {@link ZRemRangeByRankCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ZRemRangeByRankCommand, Long>> zRemRangeByRank(Publisher<ZRemRangeByRankCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZRemRangeByScoreCommand extends KeyCommand {
+
+		private final Range<Double> range;
+
+		private ZRemRangeByScoreCommand(ByteBuffer key, Range<Double> range) {
+
+			super(key);
+			this.range = range;
+		}
+
+		public static ZRemRangeByScoreCommand scoresWithin(Range<Double> range) {
+			return new ZRemRangeByScoreCommand(null, range);
+		}
+
+		public ZRemRangeByScoreCommand from(ByteBuffer key) {
+			return new ZRemRangeByScoreCommand(key, range);
+		}
+
+		public Range<Double> getRange() {
+			return range;
+		}
+
+	}
+
+	/**
+	 * Remove elements in {@link Range} from sorted set with {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zRemRangeByScore(ByteBuffer key, Range<Double> range) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRemRangeByScore(Mono.just(ZRemRangeByScoreCommand.scoresWithin(range).from(key))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Remove elements in {@link Range} from sorted set with {@link ZRemRangeByRankCommand#getKey()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 */
+	Flux<NumericResponse<ZRemRangeByScoreCommand, Long>> zRemRangeByScore(Publisher<ZRemRangeByScoreCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZUnionStoreCommand extends KeyCommand {
+
+		private final List<ByteBuffer> sourceKeys;
+		private final List<Double> weights;
+		private final Aggregate aggregateFunction;
+
+		private ZUnionStoreCommand(ByteBuffer key, List<ByteBuffer> sourceKeys, List<Double> weights, Aggregate aggregate) {
+
+			super(key);
+			this.sourceKeys = sourceKeys;
+			this.weights = weights;
+			this.aggregateFunction = aggregate;
+		}
+
+		public static ZUnionStoreCommand sets(List<ByteBuffer> keys) {
+			return new ZUnionStoreCommand(null, keys, null, null);
+		}
+
+		public ZUnionStoreCommand applyWeights(List<Double> weights) {
+			return new ZUnionStoreCommand(getKey(), sourceKeys, weights, aggregateFunction);
+		}
+
+		public ZUnionStoreCommand aggregateUsing(Aggregate aggregateFunction) {
+			return new ZUnionStoreCommand(getKey(), sourceKeys, weights, aggregateFunction);
+		}
+
+		public ZUnionStoreCommand storeAs(ByteBuffer key) {
+			return new ZUnionStoreCommand(key, sourceKeys, weights, aggregateFunction);
+		}
+
+		public List<ByteBuffer> getSourceKeys() {
+			return sourceKeys;
+		}
+
+		public List<Double> getWeights() {
+			return weights == null ? Collections.emptyList() : weights;
+		}
+
+		public Optional<Aggregate> getAggregateFunction() {
+			return Optional.ofNullable(aggregateFunction);
+		}
+
+		public Integer getNumKeys() {
+			return sourceKeys != null ? sourceKeys.size() : null;
+		}
+	}
+
+	/**
+	 * Union sorted {@code sets} and store result in destination {@code destinationKey}.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets) {
+		return zUnionStore(destinationKey, sets, null);
+	}
+
+	/**
+	 * Union sorted {@code sets} and store result in destination {@code destinationKey} and apply weights to individual
+	 * sets.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @param weights can be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights) {
+		return zUnionStore(destinationKey, sets, weights, null);
+	}
+
+	/**
+	 * Union sorted {@code sets} by applying {@code aggregateFunction} and store result in destination
+	 * {@code destinationKey} and apply weights to individual sets.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @param weights can be {@literal null}.
+	 * @param aggregateFunction can be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights,
+			Aggregate aggregateFunction) {
+
+		Assert.notNull(destinationKey, "destinationKey must not be null");
+		Assert.notNull(sets, "sets must not be null");
+
+		return zUnionStore(Mono.just(
+				ZUnionStoreCommand.sets(sets).aggregateUsing(aggregateFunction).applyWeights(weights).storeAs(destinationKey)))
+						.next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Union sorted {@code sets} by applying {@code aggregateFunction} and store result in destination
+	 * {@code destinationKey} and apply weights to individual sets.
+	 *
+	 * @param commands
+	 * @return
+	 */
+	Flux<NumericResponse<ZUnionStoreCommand, Long>> zUnionStore(Publisher<ZUnionStoreCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZInterStoreCommand extends KeyCommand {
+
+		private final List<ByteBuffer> sourceKeys;
+		private final List<Double> weights;
+		private final Aggregate aggregateFunction;
+
+		private ZInterStoreCommand(ByteBuffer key, List<ByteBuffer> sourceKeys, List<Double> weights, Aggregate aggregate) {
+
+			super(key);
+			this.sourceKeys = sourceKeys;
+			this.weights = weights;
+			this.aggregateFunction = aggregate;
+		}
+
+		public static ZInterStoreCommand sets(List<ByteBuffer> keys) {
+			return new ZInterStoreCommand(null, keys, null, null);
+		}
+
+		public ZInterStoreCommand applyWeights(List<Double> weights) {
+			return new ZInterStoreCommand(getKey(), sourceKeys, weights, aggregateFunction);
+		}
+
+		public ZInterStoreCommand aggregateUsing(Aggregate aggregateFunction) {
+			return new ZInterStoreCommand(getKey(), sourceKeys, weights, aggregateFunction);
+		}
+
+		public ZInterStoreCommand storeAs(ByteBuffer key) {
+			return new ZInterStoreCommand(key, sourceKeys, weights, aggregateFunction);
+		}
+
+		public List<ByteBuffer> getSourceKeys() {
+			return sourceKeys;
+		}
+
+		public List<Double> getWeights() {
+			return weights == null ? Collections.emptyList() : weights;
+		}
+
+		public Optional<Aggregate> getAggregateFunction() {
+			return Optional.ofNullable(aggregateFunction);
+		}
+
+		public Integer getNumKeys() {
+			return sourceKeys != null ? sourceKeys.size() : null;
+		}
+	}
+
+	/**
+	 * Intersect sorted {@code sets} and store result in destination {@code destinationKey}.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets) {
+		return zInterStore(destinationKey, sets, null);
+	}
+
+	/**
+	 * Intersect sorted {@code sets} and store result in destination {@code destinationKey} and apply weights to
+	 * individual sets.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @param weights can be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights) {
+		return zInterStore(destinationKey, sets, weights, null);
+	}
+
+	/**
+	 * Intersect sorted {@code sets} by applying {@code aggregateFunction} and store result in destination
+	 * {@code destinationKey} and apply weights to individual sets.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @param weights can be {@literal null}.
+	 * @param aggregateFunction can be {@literal null}.
+	 * @return
+	 */
+	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights,
+			Aggregate aggregateFunction) {
+
+		Assert.notNull(destinationKey, "destinationKey must not be null");
+		Assert.notNull(sets, "sets must not be null");
+
+		return zInterStore(Mono.just(
+				ZInterStoreCommand.sets(sets).aggregateUsing(aggregateFunction).applyWeights(weights).storeAs(destinationKey)))
+						.next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Intersect sorted {@code sets} by applying {@code aggregateFunction} and store result in destination
+	 * {@code destinationKey} and apply weights to individual sets.
+	 *
+	 * @param commands
+	 * @return
+	 */
+	Flux<NumericResponse<ZInterStoreCommand, Long>> zInterStore(Publisher<ZInterStoreCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class ZRangeByLexCommand extends KeyCommand {
+
+		private final Range<String> range;
+		private final Direction direction;
+		private final Limit limit;
+
+		private ZRangeByLexCommand(ByteBuffer key, Range<String> range, Direction direction, Limit limit) {
+
+			super(key);
+			this.range = range;
+			this.direction = direction;
+			this.limit = limit;
+		}
+
+		public static ZRangeByLexCommand reverseStringsWithin(Range<String> range) {
+			return new ZRangeByLexCommand(null, range, Direction.DESC, null);
+		}
+
+		public static ZRangeByLexCommand stringsWithin(Range<String> range) {
+			return new ZRangeByLexCommand(null, range, Direction.ASC, null);
+		}
+
+		public ZRangeByLexCommand from(ByteBuffer key) {
+			return new ZRangeByLexCommand(key, range, direction, limit);
+		}
+
+		public ZRangeByLexCommand limitTo(Limit limit) {
+			return new ZRangeByLexCommand(getKey(), range, direction, limit);
+		}
+
+		public Range<String> getRange() {
+			return range;
+		}
+
+		public Limit getLimit() {
+			return limit;
+		}
+
+		public Direction getDirection() {
+			return direction;
+		}
+	}
+
+	/**
+	 * Get all the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRangeByLex(ByteBuffer key, Range<String> range) {
+		return zRangeByLex(key, range, null);
+	}
+
+	/**
+	 * Get all the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering. Result is
+	 * limited via {@link Limit}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @param limit can be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRangeByLex(ByteBuffer key, Range<String> range, Limit limit) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRangeByLex(Mono.just(ZRangeByLexCommand.stringsWithin(range).from(key).limitTo(limit))).next()
+				.map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get all the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRevRangeByLex(ByteBuffer key, Range<String> range) {
+		return zRevRangeByLex(key, range, null);
+	}
+
+	/**
+	 * Get all the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering. Result is
+	 * limited via {@link Limit}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @param limit can be {@literal null}.
+	 * @return
+	 */
+	default Mono<List<ByteBuffer>> zRevRangeByLex(ByteBuffer key, Range<String> range, Limit limit) {
+
+		Assert.notNull(key, "key must not be null");
+		Assert.notNull(range, "range must not be null");
+
+		return zRangeByLex(Mono.just(ZRangeByLexCommand.reverseStringsWithin(range).from(key).limitTo(limit))).next()
+				.map(MultiValueResponse::getOutput);
+	}
+
+	/**
+	 * Get all the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering. Result is
+	 * limited via {@link Limit} and sorted by {@link ZRangeByLexCommand#getDirection()}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @param limit can be {@literal null}.
+	 * @return
+	 */
+	Flux<MultiValueResponse<ZRangeByLexCommand, ByteBuffer>> zRangeByLex(Publisher<ZRangeByLexCommand> commands);
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterNode.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterNode.java
@@ -58,7 +58,7 @@ public class RedisClusterNode extends RedisNode {
 	public RedisClusterNode(String id) {
 
 		this(new SlotRange(Collections.<Integer> emptySet()));
-		Assert.notNull(id, "Id must not be null");
+		Assert.notNull(id, "Id must not be null!");
 		this.id = id;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,22 @@ public interface RedisConnectionFactory extends PersistenceExceptionTranslator {
 	 * Provides a suitable connection for interacting with Redis Cluster.
 	 * 
 	 * @return
-	 * @throws
 	 * @since 1.7
 	 */
 	RedisClusterConnection getClusterConnection();
+
+	/**
+	 * @return
+	 * @since 2.0.
+	 */
+	ReactiveRedisConnection getReactiveConnection();
+
+	/**
+	 *
+	 * @return
+	 * @since 2.0
+	 */
+	ReactiveRedisClusterConnection getReactiveClusterConnection();
 
 	/**
 	 * Specifies if pipelined results should be converted to the expected data type. If false, results of

--- a/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
@@ -199,7 +199,7 @@ public interface RedisGeoCommands {
 	 * @author Christoph Strobl
 	 * @since 1.8
 	 */
-	public class GeoRadiusCommandArgs {
+	public class GeoRadiusCommandArgs implements Cloneable {
 
 		Set<Flag> flags = new LinkedHashSet<Flag>(2, 1);
 		Long limit;
@@ -308,6 +308,16 @@ public interface RedisGeoCommands {
 
 		public static enum Flag {
 			WITHCOORD, WITHDIST
+		}
+
+		@Override
+		protected GeoRadiusCommandArgs clone() {
+
+			GeoRadiusCommandArgs tmp = new GeoRadiusCommandArgs();
+			tmp.flags = this.flags != null ? new LinkedHashSet<>(this.flags) : new LinkedHashSet<>(2);
+			tmp.limit = this.limit;
+			tmp.sortDirection = this.sortDirection;
+			return tmp;
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
@@ -174,6 +174,10 @@ abstract public class Converters {
 		};
 	}
 
+	public static Boolean stringToBoolean(String s) {
+		return ObjectUtils.nullSafeEquals("OK", s);
+	}
+
 	public static Converter<String, Properties> stringToProps() {
 		return STRING_TO_PROPS;
 	}
@@ -378,7 +382,7 @@ abstract public class Converters {
 	 * @author Christoph Strobl
 	 * @since 1.8
 	 */
-	static enum DistanceConverterFactory {
+	enum DistanceConverterFactory {
 
 		INSTANCE;
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -33,14 +33,7 @@ import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
 import org.springframework.data.redis.PassThroughExceptionTranslationStrategy;
 import org.springframework.data.redis.RedisConnectionFailureException;
-import org.springframework.data.redis.connection.ClusterCommandExecutor;
-import org.springframework.data.redis.connection.RedisClusterConfiguration;
-import org.springframework.data.redis.connection.RedisClusterConnection;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisNode;
-import org.springframework.data.redis.connection.RedisSentinelConfiguration;
-import org.springframework.data.redis.connection.RedisSentinelConnection;
+import org.springframework.data.redis.connection.*;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ReflectionUtils;
@@ -362,8 +355,22 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.dao.support.PersistenceExceptionTranslator#translateExceptionIfPossible(java.lang.RuntimeException)
+	 * @see org.springframework.data.redis.connection.RedisConnectionFactory#getReactiveConnection()
 	 */
+	@Override
+	public ReactiveRedisConnection getReactiveConnection() {
+		throw new UnsupportedOperationException("Jedis does not support racative connections");
+	}
+
+	@Override
+	public ReactiveRedisClusterConnection getReactiveClusterConnection() {
+		throw new UnsupportedOperationException("Jedis does not support racative connections");
+	}
+
+	/*
+		 * (non-Javadoc)
+		 * @see org.springframework.dao.support.PersistenceExceptionTranslator#translateExceptionIfPossible(java.lang.RuntimeException)
+		 */
 	public DataAccessException translateExceptionIfPossible(RuntimeException ex) {
 		return EXCEPTION_TRANSLATION.translate(ex);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClient.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClient.java
@@ -52,15 +52,6 @@ public class AuthenticatingRedisClient extends RedisClient {
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.lambdaworks.redis.RedisClient#connectAsync(com.lambdaworks.redis.codec.RedisCodec)
-	 */
-	@Override
-	public <K, V> RedisAsyncCommands<K, V> connectAsync(RedisCodec<K, V> codec) {
-		return super.connectAsync(codec);
-	}
-
-	/*
-	 * (non-Javadoc)
 	 * @see com.lambdaworks.redis.RedisClient#connectPubSub(com.lambdaworks.redis.codec.RedisCodec)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -1219,14 +1219,14 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 		try {
 			if (isPipelined()) {
-				pipeline(new LettuceStatusResult(((RedisAsyncCommands) getAsyncDedicatedConnection()).watch(keys)));
+				pipeline(new LettuceStatusResult(((RedisAsyncCommands) getAsyncDedicatedConnection()).watch((Object[]) keys)));
 				return;
 			}
 			if (isQueueing()) {
-				transaction(new LettuceTxStatusResult(((RedisAsyncCommands) getDedicatedConnection()).watch()));
+				transaction(new LettuceTxStatusResult(((RedisAsyncCommands) getDedicatedConnection()).watch((Object[]) keys)));
 				return;
 			}
-			((RedisCommands) getDedicatedConnection()).watch(keys);
+			((RedisCommands) getDedicatedConnection()).watch((Object[]) keys);
 		} catch (Exception ex) {
 			throw convertLettuceAccessException(ex);
 		}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -204,6 +204,24 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 		return new LettuceClusterConnection((RedisClusterClient) client, clusterCommandExecutor);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConnectionFactory#getReactiveConnection()
+	 */
+	@Override
+	public LettuceReactiveRedisConnection getReactiveConnection() {
+		return new LettuceReactiveRedisConnection(client);
+	}
+
+	@Override
+	public LettuceReactiveRedisClusterConnection getReactiveClusterConnection() {
+		if(!isClusterAware()) {
+			throw new InvalidDataAccessApiUsageException("Cluster is not configured!");
+		}
+
+		return new LettuceReactiveRedisClusterConnection((RedisClusterClient)client);
+	}
+
 	public void initConnection() {
 
 		synchronized (this.connectionMonitor) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -345,6 +345,10 @@ abstract public class LettuceConverters extends Converters {
 		return BYTES_LIST_TO_TUPLE_LIST_CONVERTER;
 	}
 
+	public static Point geoCoordinatesToPoint(GeoCoordinates geoCoordinates) {
+		return GEO_COORDINATE_TO_POINT_CONVERTER.convert(geoCoordinates);
+	}
+
 	public static Converter<String, List<RedisClientInfo>> stringToRedisClientListConverter() {
 		return new Converter<String, List<RedisClientInfo>>() {
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -54,6 +54,7 @@ import org.springframework.data.redis.connection.convert.LongToBooleanConverter;
 import org.springframework.data.redis.connection.convert.StringToRedisClientInfoConverter;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
+import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
@@ -739,7 +740,7 @@ abstract public class LettuceConverters extends Converters {
 		ByteBuffer buffer = ByteBuffer.allocate(prefix.length + value.length);
 		buffer.put(prefix);
 		buffer.put(value);
-		return toString(buffer.array());
+		return toString(ByteUtils.getBytes(buffer));
 	}
 
 	public static List<RedisClusterNode> partitionsToClusterNodes(Partitions partitions) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -16,18 +16,9 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
@@ -51,6 +42,7 @@ import org.springframework.data.redis.connection.RedisNode.NodeType;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisServer;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
+import org.springframework.data.redis.connection.RedisZSetCommands;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range.Boundary;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 import org.springframework.data.redis.connection.ReturnType;
@@ -67,15 +59,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
-import com.lambdaworks.redis.GeoArgs;
-import com.lambdaworks.redis.GeoCoordinates;
-import com.lambdaworks.redis.GeoWithin;
-import com.lambdaworks.redis.KeyValue;
-import com.lambdaworks.redis.RedisURI;
-import com.lambdaworks.redis.ScoredValue;
-import com.lambdaworks.redis.ScriptOutputType;
-import com.lambdaworks.redis.SetArgs;
-import com.lambdaworks.redis.SortArgs;
+import com.lambdaworks.redis.*;
 import com.lambdaworks.redis.cluster.models.partitions.Partitions;
 import com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode.NodeFlag;
 import com.lambdaworks.redis.protocol.LettuceCharsets;
@@ -111,6 +95,9 @@ abstract public class LettuceConverters extends Converters {
 	private static final Converter<List<byte[]>, Long> BYTES_LIST_TO_TIME_CONVERTER;
 	private static final Converter<GeoCoordinates, Point> GEO_COORDINATE_TO_POINT_CONVERTER;
 	private static final ListConverter<GeoCoordinates, Point> GEO_COORDINATE_LIST_TO_POINT_LIST_CONVERTER;
+	private static final Converter<KeyValue<Object, Object>, Object> KEY_VALUE_UNWRAPPER;
+	private static final ListConverter<KeyValue<Object, Object>, Object> KEY_VALUE_LIST_UNWRAPPER;
+	private static final Converter<TransactionResult, List<Object>> TRANSACTION_RESULT_UNWRAPPER;
 
 	public static final byte[] PLUS_BYTES;
 	public static final byte[] MINUS_BYTES;
@@ -167,8 +154,8 @@ abstract public class LettuceConverters extends Converters {
 					return null;
 				}
 				List<byte[]> list = new ArrayList<byte[]>(2);
-				list.add(source.key);
-				list.add(source.value);
+				list.add(source.getKey());
+				list.add(source.getValue());
 				return list;
 			}
 		};
@@ -218,7 +205,7 @@ abstract public class LettuceConverters extends Converters {
 		};
 		SCORED_VALUE_TO_TUPLE = new Converter<ScoredValue<byte[]>, Tuple>() {
 			public Tuple convert(ScoredValue<byte[]> source) {
-				return source != null ? new DefaultTuple(source.value, Double.valueOf(source.score)) : null;
+				return source != null ? new DefaultTuple(source.getValue(), Double.valueOf(source.getScore())) : null;
 			}
 		};
 		BYTES_LIST_TO_TUPLE_LIST_CONVERTER = new Converter<List<byte[]>, List<Tuple>>() {
@@ -329,12 +316,29 @@ abstract public class LettuceConverters extends Converters {
 		GEO_COORDINATE_TO_POINT_CONVERTER = new Converter<com.lambdaworks.redis.GeoCoordinates, Point>() {
 			@Override
 			public Point convert(com.lambdaworks.redis.GeoCoordinates geoCoordinate) {
-				return geoCoordinate != null ? new Point(geoCoordinate.x.doubleValue(), geoCoordinate.y.doubleValue()) : null;
+				return geoCoordinate != null ? new Point(geoCoordinate.getX().doubleValue(), geoCoordinate.getY().doubleValue()) : null;
 			}
 		};
 		GEO_COORDINATE_LIST_TO_POINT_LIST_CONVERTER = new ListConverter<GeoCoordinates, Point>(
 				GEO_COORDINATE_TO_POINT_CONVERTER);
 
+		KEY_VALUE_UNWRAPPER = new Converter<KeyValue<Object, Object>, Object>() {
+
+			@Override
+			public Object convert(KeyValue<Object, Object> source) {
+				return source.getValueOrElse(null);
+			}
+		};
+
+		KEY_VALUE_LIST_UNWRAPPER = new ListConverter<>(KEY_VALUE_UNWRAPPER);
+
+		TRANSACTION_RESULT_UNWRAPPER = new Converter<TransactionResult, List<Object>>() {
+
+			@Override
+			public List<Object> convert(TransactionResult transactionResult) {
+				return transactionResult.stream().collect(Collectors.toList());
+			}
+		};
 	}
 
 	public static List<Tuple> toTuple(List<byte[]> list) {
@@ -539,6 +543,81 @@ abstract public class LettuceConverters extends Converters {
 		}
 
 		return prefix + value;
+	}
+
+	/**
+	 * Convert a {@link org.springframework.data.redis.connection.RedisZSetCommands.Limit} to a lettuce {@link com.lambdaworks.redis.Limit}.
+	 *
+	 * @param limit
+	 * @return a lettuce {@link com.lambdaworks.redis.Limit}.
+	 * @since 2.0
+	 */
+	public static com.lambdaworks.redis.Limit toLimit(RedisZSetCommands.Limit limit){
+		return Limit.create(limit.getOffset(), limit.getCount());
+	}
+
+	/**
+	 * Convert a {@link org.springframework.data.redis.connection.RedisZSetCommands.Range} to a lettuce {@link Range}.
+	 *
+	 * @param range
+	 * @return
+	 * @since 2.0
+	 */
+	public static <T> Range<T> toRange(org.springframework.data.redis.connection.RedisZSetCommands.Range range) {
+			return Range.from(lowerBoundaryOf(range), upperBoundaryOf(range));
+	}
+
+	/**
+	 * Convert a {@link org.springframework.data.redis.connection.RedisZSetCommands.Range} to a lettuce {@link Range} and
+	 * reverse boundaries.
+	 *
+	 * @param range
+	 * @return
+	 * @since 2.0
+	 */
+	public static <T> Range<T> toRevRange(org.springframework.data.redis.connection.RedisZSetCommands.Range range) {
+		return Range.from(upperBoundaryOf(range), lowerBoundaryOf(range));
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> Range.Boundary<T> lowerBoundaryOf(org.springframework.data.redis.connection.RedisZSetCommands.Range range) {
+		return (Range.Boundary<T>) rangeToBoundaryArgumentConverter(false).convert(range);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> Range.Boundary<T> upperBoundaryOf(org.springframework.data.redis.connection.RedisZSetCommands.Range range) {
+		return (Range.Boundary<T>) rangeToBoundaryArgumentConverter(true).convert(range);
+	}
+
+	private static Converter<org.springframework.data.redis.connection.RedisZSetCommands.Range, Range.Boundary<?>> rangeToBoundaryArgumentConverter(
+			boolean upper) {
+
+		return (source) -> {
+
+			Boundary sourceBoundary = upper ? source.getMax() : source.getMin();
+			if (sourceBoundary == null || sourceBoundary.getValue() == null) {
+				return Range.Boundary.unbounded();
+			}
+
+			boolean inclusive = sourceBoundary.isIncluding();
+			Object value = sourceBoundary.getValue();
+
+			if (value instanceof Number) {
+				return inclusive ? Range.Boundary.including((Number) value) : Range.Boundary.excluding((Number) value);
+			}
+
+			if (value instanceof String) {
+
+				if (!StringUtils.hasText((String) value) || ObjectUtils.nullSafeEquals(value, "+")
+						|| ObjectUtils.nullSafeEquals(value, "-")) {
+					return Range.Boundary.unbounded();
+				}
+				return inclusive ? Range.Boundary.including(value.toString().getBytes(LettuceCharsets.UTF8))
+						: Range.Boundary.excluding(value.toString().getBytes(LettuceCharsets.UTF8));
+			}
+
+			return inclusive ? Range.Boundary.including((byte[]) value) : Range.Boundary.excluding((byte[]) value);
+		};
 	}
 
 	/**
@@ -821,6 +900,19 @@ abstract public class LettuceConverters extends Converters {
 	}
 
 	/**
+	 * @return
+	 * @since 2.0
+	 */
+	@SuppressWarnings("unchecked")
+	public static <K, V> ListConverter<KeyValue<K, V>, V> keyValueListUnwrapper() {
+		return (ListConverter) KEY_VALUE_LIST_UNWRAPPER;
+	}
+
+	public static Converter<TransactionResult, List<Object>> transactionResultUnwrapper() {
+		return TRANSACTION_RESULT_UNWRAPPER;
+	}
+
+	/**
 	 * @author Christoph Strobl
 	 * @since 1.8
 	 */
@@ -881,10 +973,10 @@ abstract public class LettuceConverters extends Converters {
 			@Override
 			public GeoResult<GeoLocation<byte[]>> convert(GeoWithin<byte[]> source) {
 
-				Point point = GEO_COORDINATE_TO_POINT_CONVERTER.convert(source.coordinates);
+				Point point = GEO_COORDINATE_TO_POINT_CONVERTER.convert(source.getCoordinates());
 
-				return new GeoResult<GeoLocation<byte[]>>(new GeoLocation<byte[]>(source.member, point),
-						new Distance(source.distance != null ? source.distance : 0D, metric));
+				return new GeoResult<GeoLocation<byte[]>>(new GeoLocation<byte[]>(source.getMember(), point),
+						new Distance(source.getDistance() != null ? source.getDistance() : 0D, metric));
 			}
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterGeoCommands.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import org.springframework.data.redis.connection.ReactiveClusterGeoCommands;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveClusterGeoCommands extends LettuceReactiveGeoCommands
+		implements ReactiveClusterGeoCommands {
+
+	/**
+	 * Create new {@link LettuceReactiveGeoCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveClusterGeoCommands(LettuceReactiveRedisConnection connection) {
+		super(connection);
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterGeoCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import org.springframework.data.redis.connection.ReactiveClusterGeoCommands;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHashCommands.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import org.springframework.data.redis.connection.ReactiveClusterHashCommands;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveClusterHashCommands extends LettuceReactiveHashCommands
+		implements ReactiveClusterHashCommands {
+
+	/**
+	 * Create new {@link LettuceReactiveHashCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveClusterHashCommands(LettuceReactiveRedisConnection connection) {
+		super(connection);
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHashCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import org.springframework.data.redis.connection.ReactiveClusterHashCommands;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommands.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ClusterSlotHashUtil;
+import org.springframework.data.redis.connection.ReactiveClusterHyperLogLogCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since @since 2.0
+ */
+public class LettuceReactiveClusterHyperLogLogCommands extends LettuceReactiveHyperLogLogCommands
+		implements ReactiveClusterHyperLogLogCommands {
+
+	/**
+	 * Create new {@link LettuceReactiveHyperLogLogCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveClusterHyperLogLogCommands(LettuceReactiveRedisConnection connection) {
+		super(connection);
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.BooleanResponse<PfMergeCommand>> pfMerge(Publisher<PfMergeCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null for PFMERGE");
+			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty for PFMERGE!");
+
+			List<ByteBuffer> keys = new ArrayList<>(command.getSourceKeys());
+			keys.add(command.getKey());
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys.toArray(new ByteBuffer[keys.size()]))) {
+				return super.pfMerge(Mono.just(command));
+			}
+
+			return Mono
+					.error(new InvalidDataAccessApiUsageException("All keys must map to same slot for PFMERGE in cluster mode."));
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.NumericResponse<PfCountCommand, Long>> pfCount(
+			Publisher<PfCountCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notEmpty(command.getKeys(), "Keys must be null or empty for PFCOUNT!");
+
+			if (ClusterSlotHashUtil
+					.isSameSlotForAllKeys(command.getKeys().toArray(new ByteBuffer[command.getKeys().size()]))) {
+				return super.pfCount(Mono.just(command));
+			}
+
+			return Mono
+					.error(new InvalidDataAccessApiUsageException("All keys must map to same slot for PFCOUNT in cluster mode."));
+		}));
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import java.nio.ByteBuffer;
@@ -24,7 +23,8 @@ import org.reactivestreams.Publisher;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.ReactiveClusterHyperLogLogCommands;
-import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.util.Assert;
 
 import reactor.core.publisher.Flux;
@@ -46,8 +46,11 @@ public class LettuceReactiveClusterHyperLogLogCommands extends LettuceReactiveHy
 		super(connection);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveHyperLogLogCommands#pfMerge(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.BooleanResponse<PfMergeCommand>> pfMerge(Publisher<PfMergeCommand> commands) {
+	public Flux<BooleanResponse<PfMergeCommand>> pfMerge(Publisher<PfMergeCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -66,9 +69,11 @@ public class LettuceReactiveClusterHyperLogLogCommands extends LettuceReactiveHy
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveHyperLogLogCommands#pfCount(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.NumericResponse<PfCountCommand, Long>> pfCount(
-			Publisher<PfCountCommand> commands) {
+	public Flux<NumericResponse<PfCountCommand, Long>> pfCount(Publisher<PfCountCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.ClusterSlotHashUtil;
+import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.RedisClusterNode;
+import org.springframework.util.Assert;
+
+import com.lambdaworks.redis.RedisException;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl.
+ * @since 2.0
+ */
+public class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommands
+		implements ReactiveClusterKeyCommands {
+
+	private LettuceReactiveRedisClusterConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveKeyCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveClusterKeyCommands(LettuceReactiveRedisClusterConnection connection) {
+
+		super(connection);
+		this.connection = connection;
+	}
+
+	@Override
+	public Mono<List<ByteBuffer>> keys(RedisClusterNode node, ByteBuffer pattern) {
+
+		return connection.execute(node, cmd -> {
+
+			Assert.notNull(pattern, "Pattern must not be null!");
+
+			Observable<List<ByteBuffer>> result = cmd.keys(pattern.array()).map(ByteBuffer::wrap).toList();
+			return Flux.from(LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter().convert(result));
+		}).next();
+	}
+
+	@Override
+	public Mono<ByteBuffer> randomKey(RedisClusterNode node) {
+
+		return connection.execute(node, cmd -> {
+
+			Observable<ByteBuffer> result = cmd.randomkey().map(ByteBuffer::wrap);
+			return Flux.from(LettuceReactiveRedisConnection.<ByteBuffer> monoConverter().convert(result));
+		}).next();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#rename(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<ReactiveRedisConnection.BooleanResponse<RenameCommand>> rename(Publisher<RenameCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "key must not be null.");
+			Assert.notNull(command.getNewName(), "NewName must not be null");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKey(), command.getNewName())) {
+				return super.rename(Mono.just(command));
+			}
+
+			Observable<Boolean> result = cmd.dump(command.getKey().array())
+					.switchIfEmpty(Observable.error(new RedisSystemException("Cannot rename key that does not exist",
+							new RedisException("ERR no such key."))))
+					.concatMap(value -> cmd.restore(command.getNewName().array(), 0, value)
+							.concatMap(res -> cmd.del(command.getKey().array())))
+					.map(LettuceConverters.longToBooleanConverter()::convert);
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter().convert(result)
+					.map(val -> new ReactiveRedisConnection.BooleanResponse<>(command, val));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#renameNX(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<ReactiveRedisConnection.BooleanResponse<RenameCommand>> renameNX(Publisher<RenameCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null.");
+			Assert.notNull(command.getNewName(), "NewName must not be null");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKey(), command.getNewName())) {
+				return super.renameNX(Mono.just(command));
+			}
+
+			Observable<Boolean> result =
+
+					cmd.exists(command.getNewName().array()).concatMap(exists -> {
+
+						if (exists == 1) {
+							return Observable.just(Boolean.FALSE);
+						}
+
+						return cmd.dump(command.getKey().array())
+								.switchIfEmpty(Observable.error(new RedisSystemException("Cannot rename key that does not exist",
+										new RedisException("ERR no such key."))))
+								.concatMap(value -> cmd.restore(command.getNewName().array(), 0, value)
+										.concatMap(res -> cmd.del(command.getKey().array())))
+								.map(LettuceConverters.longToBooleanConverter()::convert);
+
+					});
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter().convert(result)
+					.map(val -> new ReactiveRedisConnection.BooleanResponse<>(command, val));
+		}));
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
@@ -23,7 +23,7 @@ import org.reactivestreams.Publisher;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
-import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
 import org.springframework.data.redis.connection.RedisClusterNode;
 import org.springframework.util.Assert;
 
@@ -51,6 +51,7 @@ public class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommand
 	public LettuceReactiveClusterKeyCommands(LettuceReactiveRedisClusterConnection connection) {
 
 		super(connection);
+
 		this.connection = connection;
 	}
 
@@ -76,12 +77,12 @@ public class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommand
 	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#rename(org.reactivestreams.Publisher, java.util.function.Supplier)
 	 */
 	@Override
-	public Flux<ReactiveRedisConnection.BooleanResponse<RenameCommand>> rename(Publisher<RenameCommand> commands) {
+	public Flux<BooleanResponse<RenameCommand>> rename(Publisher<RenameCommand> commands) {
 
 		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
 
 			Assert.notNull(command.getKey(), "key must not be null.");
-			Assert.notNull(command.getNewName(), "NewName must not be null");
+			Assert.notNull(command.getNewName(), "NewName must not be null!");
 
 			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKey(), command.getNewName())) {
 				return super.rename(Mono.just(command));
@@ -93,7 +94,7 @@ public class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommand
 					.flatMap(value -> cmd.restore(command.getNewName(), 0, value).flatMap(res -> cmd.del(command.getKey())))
 					.map(LettuceConverters.longToBooleanConverter()::convert);
 
-			return result.map(val -> new ReactiveRedisConnection.BooleanResponse<>(command, val));
+			return result.map(val -> new BooleanResponse<>(command, val));
 		}));
 	}
 
@@ -102,12 +103,12 @@ public class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommand
 	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#renameNX(org.reactivestreams.Publisher, java.util.function.Supplier)
 	 */
 	@Override
-	public Flux<ReactiveRedisConnection.BooleanResponse<RenameCommand>> renameNX(Publisher<RenameCommand> commands) {
+	public Flux<BooleanResponse<RenameCommand>> renameNX(Publisher<RenameCommand> commands) {
 
 		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null.");
-			Assert.notNull(command.getNewName(), "NewName must not be null");
+			Assert.notNull(command.getNewName(), "NewName must not be null!");
 
 			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKey(), command.getNewName())) {
 				return super.renameNX(Mono.just(command));
@@ -126,7 +127,7 @@ public class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommand
 						.map(LettuceConverters.longToBooleanConverter()::convert);
 			});
 
-			return result.map(val -> new ReactiveRedisConnection.BooleanResponse<>(command, val));
+			return result.map(val -> new BooleanResponse<>(command, val));
 		}));
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
@@ -27,10 +27,10 @@ import org.springframework.util.Assert;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import rx.Observable;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 public class LettuceReactiveClusterListCommands extends LettuceReactiveListCommands
@@ -74,12 +74,10 @@ public class LettuceReactiveClusterListCommands extends LettuceReactiveListComma
 				return super.rPopLPush(Mono.just(command));
 			}
 
-			Observable<ByteBuffer> result = cmd.rpop(command.getKey().array())
-					.concatMap(value -> cmd.lpush(command.getDestination().array(), value).map(x -> value)).map(ByteBuffer::wrap);
+			Flux<ByteBuffer> result = cmd.rpop(command.getKey())
+					.flatMap(value -> cmd.lpush(command.getDestination(), value).map(x -> value));
 
-			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter().convert(result)
-					.map(value -> new ReactiveRedisConnection.ByteBufferResponse<>(command, value));
+			return result.map(value -> new ReactiveRedisConnection.ByteBufferResponse<>(command, value));
 		}));
 	}
-
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+
+import org.reactivestreams.Publisher;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ClusterSlotHashUtil;
+import org.springframework.data.redis.connection.ReactiveClusterListCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveClusterListCommands extends LettuceReactiveListCommands
+		implements ReactiveClusterListCommands {
+
+	/**
+	 * Create new {@link LettuceReactiveListCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveClusterListCommands(LettuceReactiveRedisConnection connection) {
+		super(connection);
+	}
+
+	@Override
+	public Flux<PopResponse> bPop(Publisher<BPopCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+			Assert.notNull(command.getDirection(), "Direction must not be null!");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKeys())) {
+				return super.bPop(Mono.just(command));
+			}
+
+			return Mono.error(new InvalidDataAccessApiUsageException("All keys must map to the same slot for BPOP command."));
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.ByteBufferResponse<RPopLPushCommand>> rPopLPush(
+			Publisher<RPopLPushCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getDestination(), "Destination key must not be null!");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKey(), command.getDestination())) {
+				return super.rPopLPush(Mono.just(command));
+			}
+
+			Observable<ByteBuffer> result = cmd.rpop(command.getKey().array())
+					.concatMap(value -> cmd.lpush(command.getDestination().array(), value).map(x -> value)).map(ByteBuffer::wrap);
+
+			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter().convert(result)
+					.map(value -> new ReactiveRedisConnection.ByteBufferResponse<>(command, value));
+		}));
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import java.nio.ByteBuffer;
@@ -22,7 +21,7 @@ import org.reactivestreams.Publisher;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.ReactiveClusterListCommands;
-import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
 import org.springframework.util.Assert;
 
 import reactor.core.publisher.Flux;
@@ -45,6 +44,9 @@ public class LettuceReactiveClusterListCommands extends LettuceReactiveListComma
 		super(connection);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveListCommands#bPop(org.reactivestreams.Publisher)
+	 */
 	@Override
 	public Flux<PopResponse> bPop(Publisher<BPopCommand> commands) {
 
@@ -61,9 +63,11 @@ public class LettuceReactiveClusterListCommands extends LettuceReactiveListComma
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveListCommands#rPopLPush(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.ByteBufferResponse<RPopLPushCommand>> rPopLPush(
-			Publisher<RPopLPushCommand> commands) {
+	public Flux<ByteBufferResponse<RPopLPushCommand>> rPopLPush(Publisher<RPopLPushCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -77,7 +81,7 @@ public class LettuceReactiveClusterListCommands extends LettuceReactiveListComma
 			Flux<ByteBuffer> result = cmd.rpop(command.getKey())
 					.flatMap(value -> cmd.lpush(command.getDestination(), value).map(x -> value));
 
-			return result.map(value -> new ReactiveRedisConnection.ByteBufferResponse<>(command, value));
+			return result.map(value -> new ByteBufferResponse<>(command, value));
 		}));
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterNumberCommands.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import org.springframework.data.redis.connection.ReactiveClusterNumberCommands;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveClusterNumberCommands extends LettuceReactiveNumberCommands
+		implements ReactiveClusterNumberCommands {
+
+	/**
+	 * Create new {@link LettuceReactiveStringCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveClusterNumberCommands(LettuceReactiveRedisConnection connection) {
+		super(connection);
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterNumberCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import org.springframework.data.redis.connection.ReactiveClusterNumberCommands;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ClusterSlotHashUtil;
+import org.springframework.data.redis.connection.ReactiveClusterSetCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands
+		implements ReactiveClusterSetCommands {
+
+	/**
+	 * Create new {@link LettuceReactiveSetCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveClusterSetCommands(LettuceReactiveRedisConnection connection) {
+		super(connection);
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.MultiValueResponse<SUnionCommand, ByteBuffer>> sUnion(
+			Publisher<SUnionCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKeys())) {
+				return super.sUnion(Mono.just(command));
+			}
+
+			Observable<List<ByteBuffer>> result = Observable
+					.merge(command.getKeys().stream().map(key -> cmd.smembers(key.array())).collect(Collectors.toList()))
+					.map(ByteBuffer::wrap).distinct().toList();
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter().convert(result)
+					.map(value -> new ReactiveRedisConnection.MultiValueResponse<>(command, value));
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.NumericResponse<SUnionStoreCommand, Long>> sUnionStore(
+			Publisher<SUnionStoreCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Source keys must not be null!");
+			Assert.notNull(command.getKey(), "Destination key must not be null!");
+
+			List<ByteBuffer> keys = new ArrayList<>(command.getKeys());
+			keys.add(command.getKey());
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
+				return super.sUnionStore(Mono.just(command));
+			}
+
+			return sUnion(Mono.just(SUnionCommand.keys(command.getKeys()))).next().flatMap(values -> {
+				Observable<Long> result = cmd.sadd(command.getKey().array(),
+						values.getOutput().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]));
+				return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+						.map(value -> new ReactiveRedisConnection.NumericResponse<>(command, value));
+			});
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.MultiValueResponse<SInterCommand, ByteBuffer>> sInter(
+			Publisher<SInterCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKeys())) {
+				return super.sInter(Mono.just(command));
+			}
+
+			Observable<List<ByteBuffer>> sourceSet = cmd.smembers(command.getKeys().get(0).array()).map(ByteBuffer::wrap)
+					.distinct().toList();
+
+			List<Observable<List<ByteBuffer>>> intersectingSets = new ArrayList<>();
+
+			for (int i = 1; i < command.getKeys().size(); i++) {
+				intersectingSets.add(cmd.smembers(command.getKeys().get(i).array()).map(ByteBuffer::wrap).distinct().toList());
+			}
+
+			Observable<List<ByteBuffer>> result = Observable.zip(sourceSet, Observable.merge(intersectingSets),
+					(source, intersecting) -> {
+
+						source.retainAll(intersecting);
+						return source;
+					});
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter().convert(result)
+					.map(value -> new ReactiveRedisConnection.MultiValueResponse<>(command, value));
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.NumericResponse<SInterStoreCommand, Long>> sInterStore(
+			Publisher<SInterStoreCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Source keys must not be null!");
+			Assert.notNull(command.getKey(), "Destination key must not be null!");
+
+			List<ByteBuffer> keys = new ArrayList<>(command.getKeys());
+			keys.add(command.getKey());
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
+				return super.sInterStore(Mono.just(command));
+			}
+
+			return sInter(Mono.just(SInterCommand.keys(command.getKeys()))).next().flatMap(values -> {
+				Observable<Long> result = cmd.sadd(command.getKey().array(),
+						values.getOutput().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]));
+				return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+						.map(value -> new ReactiveRedisConnection.NumericResponse<>(command, value));
+			});
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.MultiValueResponse<SDiffCommand, ByteBuffer>> sDiff(
+			Publisher<SDiffCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKeys())) {
+				return super.sDiff(Mono.just(command));
+			}
+
+			Observable<List<ByteBuffer>> sourceSet = cmd.smembers(command.getKeys().get(0).array()).map(ByteBuffer::wrap)
+					.distinct().toList();
+
+			List<Observable<List<ByteBuffer>>> intersectingSets = new ArrayList<>();
+
+			for (int i = 1; i < command.getKeys().size(); i++) {
+				intersectingSets.add(cmd.smembers(command.getKeys().get(i).array()).map(ByteBuffer::wrap).distinct().toList());
+			}
+
+			Observable<List<ByteBuffer>> result = Observable.zip(sourceSet, Observable.merge(intersectingSets),
+					(source, intersecting) -> {
+
+						source.removeAll(intersecting);
+						return source;
+					});
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter().convert(result)
+					.map(value -> new ReactiveRedisConnection.MultiValueResponse<>(command, value));
+
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.NumericResponse<SDiffStoreCommand, Long>> sDiffStore(
+			Publisher<SDiffStoreCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Source keys must not be null!");
+			Assert.notNull(command.getKey(), "Destination key must not be null!");
+
+			List<ByteBuffer> keys = new ArrayList<>(command.getKeys());
+			keys.add(command.getKey());
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
+				return super.sDiffStore(Mono.just(command));
+			}
+
+			return sDiff(Mono.just(SDiffCommand.keys(command.getKeys()))).next().flatMap(values -> {
+				Observable<Long> result = cmd.sadd(command.getKey().array(),
+						values.getOutput().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]));
+				return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+						.map(value -> new ReactiveRedisConnection.NumericResponse<>(command, value));
+			});
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.BooleanResponse<SMoveCommand>> sMove(Publisher<SMoveCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Source key must not be null!");
+			Assert.notNull(command.getDestination(), "Destination key must not be null!");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKey(), command.getDestination())) {
+				return super.sMove(Mono.just(command));
+			}
+
+			Observable<Boolean> result = cmd.exists(command.getKey().array()).flatMap(nrKeys -> nrKeys == 0
+					? Observable.empty() : cmd.sismember(command.getKey().array(), command.getValue().array()))
+					.flatMap(exists -> {
+
+						if (!exists) {
+							return Observable.just(Boolean.FALSE);
+						}
+						return cmd.sismember(command.getDestination().array(), command.getValue().array())
+								.flatMap(existsInTarget -> {
+
+									Observable<Boolean> tmp = cmd.srem(command.getKey().array(), command.getValue().array())
+											.map(nrRemoved -> nrRemoved > 0);
+									if (!existsInTarget) {
+										return tmp.flatMap(removed -> cmd.sadd(command.getDestination().array(), command.getValue().array())
+												.map(LettuceConverters::toBoolean));
+									}
+									return tmp;
+								});
+
+					});
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter().convert(result.defaultIfEmpty(Boolean.FALSE))
+					.map(value -> new ReactiveRedisConnection.BooleanResponse<>(command, value));
+		}));
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import java.nio.ByteBuffer;
@@ -24,7 +23,9 @@ import java.util.stream.Collectors;
 import org.reactivestreams.Publisher;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.ReactiveClusterSetCommands;
-import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.util.Assert;
 
 import reactor.core.publisher.Flux;
@@ -47,9 +48,11 @@ public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommand
 		super(connection);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveSetCommands#sUnion(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.MultiValueResponse<SUnionCommand, ByteBuffer>> sUnion(
-			Publisher<SUnionCommand> commands) {
+	public Flux<MultiValueResponse<SUnionCommand, ByteBuffer>> sUnion(Publisher<SUnionCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -62,13 +65,15 @@ public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommand
 			Mono<List<ByteBuffer>> result = Flux
 					.merge(command.getKeys().stream().map(cmd::smembers).collect(Collectors.toList())).distinct().collectList();
 
-			return result.map(value -> new ReactiveRedisConnection.MultiValueResponse<>(command, value));
+			return result.map(value -> new MultiValueResponse<>(command, value));
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveSetCommands#sUnionStore(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.NumericResponse<SUnionStoreCommand, Long>> sUnionStore(
-			Publisher<SUnionStoreCommand> commands) {
+	public Flux<NumericResponse<SUnionStoreCommand, Long>> sUnionStore(Publisher<SUnionStoreCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -84,14 +89,16 @@ public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommand
 
 			return sUnion(Mono.just(SUnionCommand.keys(command.getKeys()))).next().flatMap(values -> {
 				Mono<Long> result = cmd.sadd(command.getKey(), values.getOutput().stream().toArray(ByteBuffer[]::new));
-				return result.map(value -> new ReactiveRedisConnection.NumericResponse<>(command, value));
+				return result.map(value -> new NumericResponse<>(command, value));
 			});
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveSetCommands#sInter(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.MultiValueResponse<SInterCommand, ByteBuffer>> sInter(
-			Publisher<SInterCommand> commands) {
+	public Flux<MultiValueResponse<SInterCommand, ByteBuffer>> sInter(Publisher<SInterCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -115,13 +122,15 @@ public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommand
 				return source;
 			});
 
-			return result.map(value -> new ReactiveRedisConnection.MultiValueResponse<>(command, value));
+			return result.map(value -> new MultiValueResponse<>(command, value));
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveSetCommands#sInterStore(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.NumericResponse<SInterStoreCommand, Long>> sInterStore(
-			Publisher<SInterStoreCommand> commands) {
+	public Flux<NumericResponse<SInterStoreCommand, Long>> sInterStore(Publisher<SInterStoreCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -137,14 +146,16 @@ public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommand
 
 			return sInter(Mono.just(SInterCommand.keys(command.getKeys()))).next().flatMap(values -> {
 				Mono<Long> result = cmd.sadd(command.getKey(), values.getOutput().stream().toArray(ByteBuffer[]::new));
-				return result.map(value -> new ReactiveRedisConnection.NumericResponse<>(command, value));
+				return result.map(value -> new NumericResponse<>(command, value));
 			});
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveSetCommands#sDiff(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.MultiValueResponse<SDiffCommand, ByteBuffer>> sDiff(
-			Publisher<SDiffCommand> commands) {
+	public Flux<MultiValueResponse<SDiffCommand, ByteBuffer>> sDiff(Publisher<SDiffCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -168,14 +179,16 @@ public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommand
 				return source;
 			});
 
-			return result.map(value -> new ReactiveRedisConnection.MultiValueResponse<>(command, value));
+			return result.map(value -> new MultiValueResponse<>(command, value));
 
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveSetCommands#sDiffStore(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.NumericResponse<SDiffStoreCommand, Long>> sDiffStore(
-			Publisher<SDiffStoreCommand> commands) {
+	public Flux<NumericResponse<SDiffStoreCommand, Long>> sDiffStore(Publisher<SDiffStoreCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -191,13 +204,16 @@ public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommand
 
 			return sDiff(Mono.just(SDiffCommand.keys(command.getKeys()))).next().flatMap(values -> {
 				Mono<Long> result = cmd.sadd(command.getKey(), values.getOutput().stream().toArray(ByteBuffer[]::new));
-				return result.map(value -> new ReactiveRedisConnection.NumericResponse<>(command, value));
+				return result.map(value -> new NumericResponse<>(command, value));
 			});
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveSetCommands#sMove(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.BooleanResponse<SMoveCommand>> sMove(Publisher<SMoveCommand> commands) {
+	public Flux<BooleanResponse<SMoveCommand>> sMove(Publisher<SMoveCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -227,8 +243,7 @@ public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommand
 
 					});
 
-			return result.defaultIfEmpty(Boolean.FALSE)
-					.map(value -> new ReactiveRedisConnection.BooleanResponse<>(command, value));
+			return result.defaultIfEmpty(Boolean.FALSE).map(value -> new BooleanResponse<>(command, value));
 		}));
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommands.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ClusterSlotHashUtil;
+import org.springframework.data.redis.connection.ReactiveClusterStringCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveClusterStringCommands extends LettuceReactiveStringCommands
+		implements ReactiveClusterStringCommands {
+
+	/**
+	 * Create new {@link LettuceReactiveStringCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveClusterStringCommands(LettuceReactiveRedisConnection connection) {
+		super(connection);
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.NumericResponse<BitOpCommand, Long>> bitOp(Publisher<BitOpCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			List<ByteBuffer> keys = new ArrayList<>(command.getKeys());
+			keys.add(command.getDestinationKey());
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
+				return super.bitOp(Mono.just(command));
+			}
+
+			return Mono
+					.error(new InvalidDataAccessApiUsageException("All keys must map to the same slot for BITOP command."));
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.BooleanResponse<MSetCommand>> mSetNX(Publisher<MSetCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKeyValuePairs().keySet())) {
+				return super.mSetNX(Mono.just(command));
+			}
+
+			return Mono
+					.error(new InvalidDataAccessApiUsageException("All keys must map to the same slot for MSETNX command."));
+		}));
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommands.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import java.nio.ByteBuffer;
@@ -45,6 +44,9 @@ public class LettuceReactiveClusterStringCommands extends LettuceReactiveStringC
 		super(connection);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveStringCommands#bitOp(org.reactivestreams.Publisher)
+	 */
 	@Override
 	public Flux<ReactiveRedisConnection.NumericResponse<BitOpCommand, Long>> bitOp(Publisher<BitOpCommand> commands) {
 
@@ -62,6 +64,9 @@ public class LettuceReactiveClusterStringCommands extends LettuceReactiveStringC
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveStringCommands#mSetNX(org.reactivestreams.Publisher)
+	 */
 	@Override
 	public Flux<ReactiveRedisConnection.BooleanResponse<MSetCommand>> mSetNX(Publisher<MSetCommand> commands) {
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommands.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import org.reactivestreams.Publisher;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ClusterSlotHashUtil;
+import org.springframework.data.redis.connection.ReactiveClusterZSetCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since @since 2.0
+ */
+public class LettuceReactiveClusterZSetCommands extends LettuceReactiveZSetCommands
+		implements ReactiveClusterZSetCommands {
+
+	/**
+	 * Create new {@link LettuceReactiveSetCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveClusterZSetCommands(LettuceReactiveRedisConnection connection) {
+		super(connection);
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.NumericResponse<ZUnionStoreCommand, Long>> zUnionStore(
+			Publisher<ZUnionStoreCommand> commands) {
+
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty.");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getSourceKeys())) {
+				return super.zUnionStore(Mono.just(command));
+			}
+
+			return Mono
+					.error(new InvalidDataAccessApiUsageException("All keys must map to the same slot for ZUNIONSTORE command."));
+		}));
+	}
+
+	@Override
+	public Flux<ReactiveRedisConnection.NumericResponse<ZInterStoreCommand, Long>> zInterStore(
+			Publisher<ZInterStoreCommand> commands) {
+		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty.");
+
+			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getSourceKeys())) {
+				return super.zInterStore(Mono.just(command));
+			}
+
+			return Mono
+					.error(new InvalidDataAccessApiUsageException("All keys must map to the same slot for ZINTERSTORE command."));
+		}));
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommands.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import org.reactivestreams.Publisher;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.ReactiveClusterZSetCommands;
-import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.util.Assert;
 
 import reactor.core.publisher.Flux;
@@ -42,9 +41,11 @@ public class LettuceReactiveClusterZSetCommands extends LettuceReactiveZSetComma
 		super(connection);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveZSetCommands#zUnionStore(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.NumericResponse<ZUnionStoreCommand, Long>> zUnionStore(
-			Publisher<ZUnionStoreCommand> commands) {
+	public Flux<NumericResponse<ZUnionStoreCommand, Long>> zUnionStore(Publisher<ZUnionStoreCommand> commands) {
 
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
@@ -59,9 +60,11 @@ public class LettuceReactiveClusterZSetCommands extends LettuceReactiveZSetComma
 		}));
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveZSetCommands#zInterStore(org.reactivestreams.Publisher)
+	 */
 	@Override
-	public Flux<ReactiveRedisConnection.NumericResponse<ZInterStoreCommand, Long>> zInterStore(
-			Publisher<ZInterStoreCommand> commands) {
+	public Flux<NumericResponse<ZInterStoreCommand, Long>> zInterStore(Publisher<ZInterStoreCommand> commands) {
 		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
 
 			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty.");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommands.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.GeoResult;
+import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.Metric;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.ReactiveGeoCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.connection.RedisGeoCommands;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
+import org.springframework.util.Assert;
+
+import com.lambdaworks.redis.GeoArgs;
+import com.lambdaworks.redis.GeoWithin;
+
+import reactor.core.publisher.Flux;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveGeoCommands implements ReactiveGeoCommands {
+
+	private final LettuceReactiveRedisConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveGeoCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveGeoCommands(LettuceReactiveRedisConnection connection) {
+
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveGeoCommands#geoAdd(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<GeoAddCommand, Long>> geoAdd(Publisher<GeoAddCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getGeoLocations(), "Locations must not be null!");
+
+			List<Object> values = new ArrayList<>();
+			for (GeoLocation<ByteBuffer> location : command.getGeoLocations()) {
+
+				Assert.notNull(location.getName(), "Location.Name must not be null!");
+				Assert.notNull(location.getPoint(), "Location.Point must not be null!");
+
+				values.add(location.getPoint().getX());
+				values.add(location.getPoint().getY());
+				values.add(location.getName().array());
+			}
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.geoadd(command.getKey().array(), values.toArray()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveGeoCommands#geoDist(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<CommandResponse<GeoDistCommand, Distance>> geoDist(Publisher<GeoDistCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getFrom(), "From member must not be null!");
+			Assert.notNull(command.getTo(), "To member must not be null!");
+
+			Metric metric = command.getMetric().isPresent() ? command.getMetric().get() : RedisGeoCommands.DistanceUnit.METERS;
+
+			GeoArgs.Unit geoUnit = LettuceConverters.toGeoArgsUnit(metric);
+			Converter<Double, Distance> distanceConverter = LettuceConverters.distanceConverterForMetric(metric);
+
+			Observable<Distance> result = cmd
+					.geodist(command.getKey().array(), command.getFrom().array(), command.getTo().array(), geoUnit)
+					.map(distanceConverter::convert);
+
+			return LettuceReactiveRedisConnection.<Distance> monoConverter().convert(result)
+					.map(value -> new CommandResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveGeoCommands#geoHash(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<GeoHashCommand, String>> geoHash(Publisher<GeoHashCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getMembers(), "Members must not be null!");
+
+			return LettuceReactiveRedisConnection.<List<String>> monoConverter()
+					.convert(cmd.geohash(command.getKey().array(),
+							command.getMembers().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])).toList())
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveGeoCommands#geoPos(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<GeoPosCommand, Point>> geoPos(Publisher<GeoPosCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getMembers(), "Members must not be null!");
+
+			Observable<List<Point>> result = cmd
+					.geopos(command.getKey().array(),
+							command.getMembers().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
+					.map(LettuceConverters::geoCoordinatesToPoint).toList();
+
+			return LettuceReactiveRedisConnection.<List<Point>> monoConverter().convert(result)
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveGeoCommands#geoRadius(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<CommandResponse<GeoRadiusCommand, GeoResults<GeoLocation<ByteBuffer>>>> geoRadius(
+			Publisher<GeoRadiusCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getPoint(), "Point must not be null!");
+			Assert.notNull(command.getDistance(), "Distance must not be null!");
+
+			GeoArgs geoArgs = command.getArgs().isPresent() ? LettuceConverters.toGeoArgs(command.getArgs().get()) : new GeoArgs();
+
+			Observable<GeoResults<GeoLocation<ByteBuffer>>> result = cmd
+					.georadius(command.getKey().array(), command.getPoint().getX(), command.getPoint().getY(),
+							command.getDistance().getValue(), LettuceConverters.toGeoArgsUnit(command.getDistance().getMetric()),
+							geoArgs)
+					.map(converter(command.getDistance().getMetric())::convert).toList().map(vals -> new GeoResults<>(vals));
+
+			return LettuceReactiveRedisConnection.<GeoResults<GeoLocation<ByteBuffer>>> monoConverter().convert(result)
+					.map(value -> new CommandResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveGeoCommands#geoRadiusByMember(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<CommandResponse<GeoRadiusByMemberCommand, GeoResults<GeoLocation<ByteBuffer>>>> geoRadiusByMember(
+			Publisher<GeoRadiusByMemberCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getMember(), "Member must not be null!");
+			Assert.notNull(command.getDistance(), "Distance must not be null!");
+
+			GeoArgs geoArgs = command.getArgs().isPresent() ? LettuceConverters.toGeoArgs(command.getArgs().get()) : new GeoArgs();
+
+			Observable<GeoResults<GeoLocation<ByteBuffer>>> result = cmd
+					.georadiusbymember(command.getKey().array(), command.getMember().array(), command.getDistance().getValue(),
+							LettuceConverters.toGeoArgsUnit(command.getDistance().getMetric()), geoArgs)
+					.map(converter(command.getDistance().getMetric())::convert).toList().map(vals -> new GeoResults<>(vals));
+
+			return LettuceReactiveRedisConnection.<GeoResults<GeoLocation<ByteBuffer>>> monoConverter().convert(result)
+					.map(value -> new CommandResponse<>(command, value));
+		}));
+	}
+
+	private Converter<GeoWithin<byte[]>, GeoResult<GeoLocation<ByteBuffer>>> converter(Metric metric) {
+
+		return (source) -> {
+
+			Point point = LettuceConverters.geoCoordinatesToPoint(source.coordinates);
+
+			return new GeoResult<>(new GeoLocation<>(ByteBuffer.wrap(source.member), point),
+					new Distance(source.distance != null ? source.distance : 0D, metric));
+		};
+
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveHashCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import reactor.core.publisher.Flux;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveHashCommands implements ReactiveHashCommands {
+
+	private final LettuceReactiveRedisConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveHashCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveHashCommands(LettuceReactiveRedisConnection connection) {
+
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hSet(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<HSetCommand>> hSet(Publisher<HSetCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getFieldValueMap(), "FieldValueMap must not be null!");
+
+			Observable<Boolean> result = Observable.empty();
+
+			if (command.getFieldValueMap().size() == 1) {
+
+				Entry<ByteBuffer, ByteBuffer> entry = command.getFieldValueMap().entrySet().iterator().next();
+
+				result = ObjectUtils.nullSafeEquals(command.isUpsert(), Boolean.TRUE)
+						? cmd.hset(command.getKey().array(), entry.getKey().array(), entry.getValue().array())
+						: cmd.hsetnx(command.getKey().array(), entry.getKey().array(), entry.getValue().array());
+			} else {
+
+				Map<byte[], byte[]> entries = command.getFieldValueMap().entrySet().stream()
+						.collect(Collectors.toMap(e -> e.getKey().array(), e -> e.getValue().array()));
+
+				result = cmd.hmset(command.getKey().array(), entries).map(LettuceConverters::stringToBoolean);
+			}
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter().convert(result)
+					.map(value -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hMGet(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<HGetCommand, ByteBuffer>> hMGet(Publisher<HGetCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getFields(), "Fields must not be null!");
+
+			Observable<List<ByteBuffer>> result = null;
+
+			if (command.getFields().size() == 1) {
+				result = cmd.hget(command.getKey().array(), command.getFields().iterator().next().array()).map(ByteBuffer::wrap)
+						.map(val -> val != null ? Collections.singletonList(val) : Collections.emptyList());
+			} else {
+				result = cmd
+						.hmget(command.getKey().array(),
+								command.getFields().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
+						.map(val -> val != null ? ByteBuffer.wrap(val) : null).toList();
+			}
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter().convert(result)
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hExists(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<HExistsCommand>> hExists(Publisher<HExistsCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getName(), "Name must not be null!");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+					.convert(cmd.hexists(command.getKey().array(), command.getField().array()))
+					.map(value -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hDel(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<HDelCommand, Long>> hDel(Publisher<HDelCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getFields(), "Fields must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.hdel(command.getKey().array(),
+							command.getFields().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hLen(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<KeyCommand, Long>> hLen(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Command.getKey() must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.hlen(command.getKey().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hKeys(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<KeyCommand, ByteBuffer>> hKeys(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			Observable<List<ByteBuffer>> result = cmd.hkeys(command.getKey().array()).map(ByteBuffer::wrap).toList();
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter().convert(result)
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hKeys(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<KeyCommand, ByteBuffer>> hVals(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			Observable<List<ByteBuffer>> result = cmd.hvals(command.getKey().array()).map(ByteBuffer::wrap).toList();
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter().convert(result)
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hGetAll(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<CommandResponse<KeyCommand, Map<ByteBuffer, ByteBuffer>>> hGetAll(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			Observable<Map<ByteBuffer, ByteBuffer>> result = cmd.hgetall(command.getKey().array()).map(val -> val.entrySet()
+					.stream().collect(Collectors.toMap(e -> ByteBuffer.wrap(e.getKey()), e -> ByteBuffer.wrap(e.getValue()))));
+
+			return LettuceReactiveRedisConnection.<Map<ByteBuffer, ByteBuffer>> monoConverter().convert(result)
+					.map(value -> new CommandResponse<>(command, value));
+		}));
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommands.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveHyperLogLogCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveHyperLogLogCommands implements ReactiveHyperLogLogCommands {
+
+	private final LettuceReactiveRedisConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveHyperLogLogCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveHyperLogLogCommands(LettuceReactiveRedisConnection connection) {
+
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHyperLogLogCommands#pfAdd(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<PfAddCommand, Long>> pfAdd(Publisher<PfAddCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "key must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.pfadd(command.getKey().array(),
+							command.getValues().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+					.map(value -> new NumericResponse<>(command, value));
+
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHyperLogLogCommands#pfCount(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<PfCountCommand, Long>> pfCount(Publisher<PfCountCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notEmpty(command.getKeys(), "Keys must not be empty for PFCOUNT.");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.pfcount(command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHyperLogLogCommands#pfMerge(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<PfMergeCommand>> pfMerge(Publisher<PfMergeCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Destination key must not be null for PFMERGE.");
+			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null for PFMERGE.");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+					.convert(cmd
+							.pfmerge(command.getKey().array(),
+									command.getSourceKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
+							.map(LettuceConverters::stringToBoolean))
+					.map(value -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	protected LettuceReactiveRedisConnection getConnection() {
+		return connection;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommands.java
@@ -55,9 +55,7 @@ public class LettuceReactiveHyperLogLogCommands implements ReactiveHyperLogLogCo
 
 			Assert.notNull(command.getKey(), "key must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter()
-					.convert(cmd.pfadd(command.getKey().array(),
-							command.getValues().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+			return cmd.pfadd(command.getKey(), command.getValues().stream().toArray(ByteBuffer[]::new))
 					.map(value -> new NumericResponse<>(command, value));
 
 		}));
@@ -74,8 +72,7 @@ public class LettuceReactiveHyperLogLogCommands implements ReactiveHyperLogLogCo
 
 			Assert.notEmpty(command.getKeys(), "Keys must not be empty for PFCOUNT.");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter()
-					.convert(cmd.pfcount(command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+			return cmd.pfcount(command.getKeys().stream().toArray(ByteBuffer[]::new))
 					.map(value -> new NumericResponse<>(command, value));
 		}));
 	}
@@ -92,12 +89,8 @@ public class LettuceReactiveHyperLogLogCommands implements ReactiveHyperLogLogCo
 			Assert.notNull(command.getKey(), "Destination key must not be null for PFMERGE.");
 			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null for PFMERGE.");
 
-			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
-					.convert(cmd
-							.pfmerge(command.getKey().array(),
-									command.getSourceKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
-							.map(LettuceConverters::stringToBoolean))
-					.map(value -> new BooleanResponse<>(command, value));
+			return cmd.pfmerge(command.getKey(), command.getSourceKeys().stream().toArray(ByteBuffer[]::new))
+					.map(LettuceConverters::stringToBoolean).map(value -> new BooleanResponse<>(command, value));
 		}));
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.DataType;
+import org.springframework.data.redis.connection.ReactiveKeyCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.util.Assert;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
+
+	private final LettuceReactiveRedisConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveKeyCommands}.
+	 * 
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveKeyCommands(LettuceReactiveRedisConnection connection) {
+
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#exists(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<KeyCommand>> exists(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<BooleanResponse<KeyCommand>> monoConverter()
+					.convert(cmd.exists(command.getKey().array()).map(LettuceConverters.longToBooleanConverter()::convert)
+							.map((value) -> new BooleanResponse<>(command, value)));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#type(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<CommandResponse<KeyCommand, DataType>> type(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<DataType> monoConverter()
+					.convert(cmd.type(command.getKey().array()).map(LettuceConverters::toDataType))
+					.map(respValue -> new CommandResponse<>(command, respValue));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#del(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<KeyCommand, Long>> del(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<NumericResponse<KeyCommand, Long>> monoConverter()
+					.convert(cmd.del(command.getKey().array()).map((value) -> new NumericResponse<>(command, value)));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#mDel(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<List<ByteBuffer>, Long>> mDel(Publisher<List<ByteBuffer>> keysCollection) {
+
+		return connection.execute(cmd -> Flux.from(keysCollection).flatMap((keys) -> {
+
+			Assert.notEmpty(keys, "Keys must not be null!");
+
+			return LettuceReactiveRedisConnection.<NumericResponse<List<ByteBuffer>, Long>> monoConverter()
+					.convert(cmd
+							.del(keys.stream().map(ByteBuffer::array).collect(Collectors.toList()).toArray(new byte[keys.size()][]))
+							.map((value) -> new NumericResponse<>(keys, value)));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#keys(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<ByteBuffer, ByteBuffer>> keys(Publisher<ByteBuffer> patterns) {
+		return connection.execute(cmd -> Flux.from(patterns).flatMap(pattern -> {
+
+			Assert.notNull(pattern, "Pattern must not be null!");
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
+					.convert(cmd.keys(pattern.array()).map(ByteBuffer::wrap).toList())
+					.map(value -> new MultiValueResponse<>(pattern, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#randomKey()
+	 */
+	@Override
+	public Mono<ByteBuffer> randomKey() {
+		return connection.execute(cmd -> LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
+				.convert(cmd.randomkey().map(ByteBuffer::wrap))).next();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#rename(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<BooleanResponse<RenameCommand>> rename(Publisher<RenameCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getNewName(), "New name must not be null!");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter().convert(
+					cmd.rename(command.getKey().array(), command.getNewName().array()).map(LettuceConverters::stringToBoolean))
+					.map(value -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#rename(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<BooleanResponse<RenameCommand>> renameNX(Publisher<RenameCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getNewName(), "New name must not be null!");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+					.convert(cmd.renamenx(command.getKey().array(), command.getNewName().array()))
+					.map(value -> new BooleanResponse<>(command, value));
+		}));
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
@@ -19,7 +19,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.lambdaworks.redis.api.reactive.RedisKeyReactiveCommands;
 import org.reactivestreams.Publisher;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.ReactiveKeyCommands;
@@ -32,6 +31,8 @@ import org.springframework.util.Assert;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import com.lambdaworks.redis.api.reactive.RedisKeyReactiveCommands;
 
 /**
  * @author Christoph Strobl
@@ -49,6 +50,7 @@ public class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	public LettuceReactiveKeyCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
+
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
@@ -18,7 +18,6 @@ package org.springframework.data.redis.connection.lettuce;
 import java.nio.ByteBuffer;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.List;
 
 import org.reactivestreams.Publisher;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -34,10 +33,11 @@ import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
 import reactor.core.publisher.Flux;
-import rx.Observable;
+import reactor.core.publisher.Mono;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 public class LettuceReactiveListCommands implements ReactiveListCommands {
@@ -72,20 +72,19 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 						String.format("%s PUSHX only allows one value!", command.getDirection()));
 			}
 
-			byte[][] values = command.getValues().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]);
-
-			Observable<Long> pushResult = null;
+			Mono<Long> pushResult = null;
 
 			if (ObjectUtils.nullSafeEquals(Direction.RIGHT, command.getDirection())) {
-				pushResult = command.getUpsert() ? cmd.rpush(command.getKey().array(), values)
-						: cmd.rpushx(command.getKey().array(), values[0]);
+				pushResult = command.getUpsert()
+						? cmd.rpush(command.getKey(), command.getValues().stream().toArray(ByteBuffer[]::new))
+						: cmd.rpushx(command.getKey(), command.getValues().get(0));
 			} else {
-				pushResult = command.getUpsert() ? cmd.lpush(command.getKey().array(), values)
-						: cmd.lpushx(command.getKey().array(), values[0]);
+				pushResult = command.getUpsert()
+						? cmd.lpush(command.getKey(), command.getValues().stream().toArray(ByteBuffer[]::new))
+						: cmd.lpushx(command.getKey(), command.getValues().get(0));
 			}
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(pushResult)
-					.map(value -> new NumericResponse<>(command, value));
+			return pushResult.map(value -> new NumericResponse<>(command, value));
 		}));
 	}
 
@@ -100,8 +99,7 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.llen(command.getKey().array()))
-					.map(value -> new NumericResponse<>(command, value));
+			return cmd.llen(command.getKey()).map(value -> new NumericResponse<>(command, value));
 		}));
 	}
 
@@ -117,11 +115,8 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
 
-			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
-					.convert(cmd
-							.lrange(command.getKey().array(), command.getRange().getLowerBound(), command.getRange().getUpperBound())
-							.map(ByteBuffer::wrap).toList())
-					.map(value -> new MultiValueResponse<>(command, value));
+			return cmd.lrange(command.getKey(), command.getRange().getLowerBound(), command.getRange().getUpperBound())
+					.collectList().map(value -> new MultiValueResponse<>(command, value));
 		}));
 	}
 
@@ -137,11 +132,8 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
 
-			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
-					.convert(cmd
-							.ltrim(command.getKey().array(), command.getRange().getLowerBound(), command.getRange().getUpperBound())
-							.map(LettuceConverters::stringToBoolean))
-					.map(value -> new BooleanResponse<>(command, value));
+			return cmd.ltrim(command.getKey(), command.getRange().getLowerBound(), command.getRange().getUpperBound())
+					.map(LettuceConverters::stringToBoolean).map(value -> new BooleanResponse<>(command, value));
 		}));
 	}
 
@@ -157,9 +149,7 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getIndex(), "Index value must not be null!");
 
-			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
-					.convert(cmd.lindex(command.getKey().array(), command.getIndex()).map(ByteBuffer::wrap))
-					.map(value -> new ByteBufferResponse<>(command, value));
+			return cmd.lindex(command.getKey(), command.getIndex()).map(value -> new ByteBufferResponse<>(command, value));
 		}));
 	}
 
@@ -177,10 +167,8 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 			Assert.notNull(command.getPivot(), "Pivot must not be null!");
 			Assert.notNull(command.getPosition(), "Position must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter()
-					.convert(cmd.linsert(command.getKey().array(), Position.BEFORE.equals(command.getPosition()),
-							command.getPivot().array(), command.getValue().array()))
-					.map(value -> new NumericResponse<>(command, value));
+			return cmd.linsert(command.getKey(), Position.BEFORE.equals(command.getPosition()), command.getPivot(),
+					command.getValue()).map(value -> new NumericResponse<>(command, value));
 		}));
 	}
 
@@ -199,10 +187,8 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 				Assert.notNull(command.getValue(), "value must not be null!");
 				Assert.notNull(command.getIndex(), "Index must not be null!");
 
-				return LettuceReactiveRedisConnection.<Boolean> monoConverter()
-						.convert(cmd.lset(command.getKey().array(), command.getIndex(), command.getValue().array())
-								.map(LettuceConverters::stringToBoolean))
-						.map(value -> new BooleanResponse<>(command, value));
+				return cmd.lset(command.getKey(), command.getIndex(), command.getValue())
+						.map(LettuceConverters::stringToBoolean).map(value -> new BooleanResponse<>(command, value));
 			});
 		});
 	}
@@ -220,8 +206,7 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 			Assert.notNull(command.getValue(), "Value must not be null!");
 			Assert.notNull(command.getCount(), "Count must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter()
-					.convert(cmd.lrem(command.getKey().array(), command.getCount(), command.getValue().array()))
+			return cmd.lrem(command.getKey(), command.getCount(), command.getValue())
 					.map(value -> new NumericResponse<>(command, value));
 		}));
 	}
@@ -238,11 +223,10 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getDirection(), "Direction must not be null!");
 
-			Observable<byte[]> popResult = ObjectUtils.nullSafeEquals(Direction.RIGHT, command.getDirection())
-					? cmd.rpop(command.getKey().array()) : cmd.lpop(command.getKey().array());
+			Mono<ByteBuffer> popResult = ObjectUtils.nullSafeEquals(Direction.RIGHT, command.getDirection())
+					? cmd.rpop(command.getKey()) : cmd.lpop(command.getKey());
 
-			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter().convert(popResult.map(ByteBuffer::wrap))
-					.map(value -> new ByteBufferResponse<>(command, value));
+			return popResult.map(value -> new ByteBufferResponse<>(command, value));
 		}));
 	}
 
@@ -258,16 +242,14 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getDirection(), "Direction must not be null!");
 
-			byte[][] keys = command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]);
 			long timeout = command.getTimeout().get(ChronoUnit.SECONDS);
 
-			Observable<PopResult> mappedObservable = (ObjectUtils.nullSafeEquals(Direction.RIGHT, command.getDirection())
-					? cmd.brpop(timeout, keys) : cmd.blpop(timeout, keys))
-							.map(kv -> Arrays.asList(ByteBuffer.wrap(kv.key), ByteBuffer.wrap(kv.value)))
-							.map(val -> new PopResult(val));
+			Mono<PopResult> mappedMono = (ObjectUtils.nullSafeEquals(Direction.RIGHT, command.getDirection())
+					? cmd.brpop(timeout, command.getKeys().stream().toArray(ByteBuffer[]::new))
+					: cmd.blpop(timeout, command.getKeys().stream().toArray(ByteBuffer[]::new)))
+							.map(kv -> Arrays.asList(kv.getKey(), kv.getValue())).map(PopResult::new);
 
-			return LettuceReactiveRedisConnection.<PopResult> monoConverter().convert(mappedObservable)
-					.map(value -> new PopResponse(command, value));
+			return mappedMono.map(value -> new PopResponse(command, value));
 		}));
 	}
 
@@ -283,8 +265,7 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getDestination(), "Destination key must not be null!");
 
-			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
-					.convert(cmd.rpoplpush(command.getKey().array(), command.getDestination().array()).map(ByteBuffer::wrap))
+			return cmd.rpoplpush(command.getKey(), command.getDestination())
 					.map(value -> new ByteBufferResponse<>(command, value));
 		}));
 	}
@@ -302,9 +283,8 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 			Assert.notNull(command.getDestination(), "Destination key must not be null!");
 			Assert.notNull(command.getTimeout(), "Timeout must not be null!");
 
-			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
-					.convert(cmd.brpoplpush(command.getTimeout().get(ChronoUnit.SECONDS), command.getKey().array(),
-							command.getDestination().array()).map(ByteBuffer::wrap))
+			return cmd.brpoplpush(command.getTimeout().get(ChronoUnit.SECONDS), command.getKey(), command.getDestination())
+
 					.map(value -> new ByteBufferResponse<>(command, value));
 		}));
 	}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ReactiveListCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.RangeCommand;
+import org.springframework.data.redis.connection.RedisListCommands.Position;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import reactor.core.publisher.Flux;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveListCommands implements ReactiveListCommands {
+
+	private final LettuceReactiveRedisConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveListCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveListCommands(LettuceReactiveRedisConnection connection) {
+
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#lPush(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<PushCommand, Long>> push(Publisher<PushCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notEmpty(command.getValues(), "Values must not be null or empty!");
+
+			if (!command.getUpsert() && command.getValues().size() > 1) {
+				throw new InvalidDataAccessApiUsageException(
+						String.format("%s PUSHX only allows one value!", command.getDirection()));
+			}
+
+			byte[][] values = command.getValues().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]);
+
+			Observable<Long> pushResult = null;
+
+			if (ObjectUtils.nullSafeEquals(Direction.RIGHT, command.getDirection())) {
+				pushResult = command.getUpsert() ? cmd.rpush(command.getKey().array(), values)
+						: cmd.rpushx(command.getKey().array(), values[0]);
+			} else {
+				pushResult = command.getUpsert() ? cmd.lpush(command.getKey().array(), values)
+						: cmd.lpushx(command.getKey().array(), values[0]);
+			}
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(pushResult)
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#lLen(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<KeyCommand, Long>> lLen(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.llen(command.getKey().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#lRange(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<RangeCommand, ByteBuffer>> lRange(Publisher<RangeCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getRange(), "Range must not be null!");
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
+					.convert(cmd
+							.lrange(command.getKey().array(), command.getRange().getLowerBound(), command.getRange().getUpperBound())
+							.map(ByteBuffer::wrap).toList())
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#lTrim(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<RangeCommand>> lTrim(Publisher<RangeCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getRange(), "Range must not be null!");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+					.convert(cmd
+							.ltrim(command.getKey().array(), command.getRange().getLowerBound(), command.getRange().getUpperBound())
+							.map(LettuceConverters::stringToBoolean))
+					.map(value -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#lIndex(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<ByteBufferResponse<LIndexCommand>> lIndex(Publisher<LIndexCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getIndex(), "Index value must not be null!");
+
+			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
+					.convert(cmd.lindex(command.getKey().array(), command.getIndex()).map(ByteBuffer::wrap))
+					.map(value -> new ByteBufferResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#lInsert(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<LInsertCommand, Long>> lInsert(Publisher<LInsertCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+			Assert.notNull(command.getPivot(), "Pivot must not be null!");
+			Assert.notNull(command.getPosition(), "Position must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.linsert(command.getKey().array(), Position.BEFORE.equals(command.getPosition()),
+							command.getPivot().array(), command.getValue().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#lSet(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<LSetCommand>> lSet(Publisher<LSetCommand> commands) {
+
+		return connection.execute(cmd -> {
+
+			return Flux.from(commands).flatMap(command -> {
+
+				Assert.notNull(command.getKey(), "Key must not be null!");
+				Assert.notNull(command.getValue(), "value must not be null!");
+				Assert.notNull(command.getIndex(), "Index must not be null!");
+
+				return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+						.convert(cmd.lset(command.getKey().array(), command.getIndex(), command.getValue().array())
+								.map(LettuceConverters::stringToBoolean))
+						.map(value -> new BooleanResponse<>(command, value));
+			});
+		});
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#lRem(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<LRemCommand, Long>> lRem(Publisher<LRemCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+			Assert.notNull(command.getCount(), "Count must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.lrem(command.getKey().array(), command.getCount(), command.getValue().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#rPop(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<ByteBufferResponse<PopCommand>> pop(Publisher<PopCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getDirection(), "Direction must not be null!");
+
+			Observable<byte[]> popResult = ObjectUtils.nullSafeEquals(Direction.RIGHT, command.getDirection())
+					? cmd.rpop(command.getKey().array()) : cmd.lpop(command.getKey().array());
+
+			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter().convert(popResult.map(ByteBuffer::wrap))
+					.map(value -> new ByteBufferResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#bPop(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<PopResponse> bPop(Publisher<BPopCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+			Assert.notNull(command.getDirection(), "Direction must not be null!");
+
+			byte[][] keys = command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]);
+			long timeout = command.getTimeout().get(ChronoUnit.SECONDS);
+
+			Observable<PopResult> mappedObservable = (ObjectUtils.nullSafeEquals(Direction.RIGHT, command.getDirection())
+					? cmd.brpop(timeout, keys) : cmd.blpop(timeout, keys))
+							.map(kv -> Arrays.asList(ByteBuffer.wrap(kv.key), ByteBuffer.wrap(kv.value)))
+							.map(val -> new PopResult(val));
+
+			return LettuceReactiveRedisConnection.<PopResult> monoConverter().convert(mappedObservable)
+					.map(value -> new PopResponse(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#rPopLPush(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<ByteBufferResponse<RPopLPushCommand>> rPopLPush(Publisher<RPopLPushCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getDestination(), "Destination key must not be null!");
+
+			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
+					.convert(cmd.rpoplpush(command.getKey().array(), command.getDestination().array()).map(ByteBuffer::wrap))
+					.map(value -> new ByteBufferResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveListCommands#bRPopLPush(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<ByteBufferResponse<BRPopLPushCommand>> bRPopLPush(Publisher<BRPopLPushCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getDestination(), "Destination key must not be null!");
+			Assert.notNull(command.getTimeout(), "Timeout must not be null!");
+
+			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
+					.convert(cmd.brpoplpush(command.getTimeout().get(ChronoUnit.SECONDS), command.getKey().array(),
+							command.getDestination().array()).map(ByteBuffer::wrap))
+					.map(value -> new ByteBufferResponse<>(command, value));
+		}));
+	}
+
+	protected LettuceReactiveRedisConnection getConnection() {
+		return connection;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
@@ -52,6 +52,7 @@ public class LettuceReactiveListCommands implements ReactiveListCommands {
 	public LettuceReactiveListCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
+
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
@@ -23,10 +23,11 @@ import org.springframework.util.Assert;
 import org.springframework.util.NumberUtils;
 
 import reactor.core.publisher.Flux;
-import rx.Observable;
+import reactor.core.publisher.Mono;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 public class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
@@ -55,8 +56,7 @@ public class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.incr(command.getKey().array()))
-					.map(value -> new NumericResponse<>(command, value));
+			return cmd.incr(command.getKey()).map(value -> new NumericResponse<>(command, value));
 		}));
 	}
 
@@ -74,16 +74,15 @@ public class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 
 			T incrBy = command.getValue();
 
-			Observable<? extends Number> result = null;
+			Mono<? extends Number> result = null;
 			if (incrBy instanceof Double || incrBy instanceof Float) {
-				result = cmd.incrbyfloat(command.getKey().array(), incrBy.doubleValue());
+				result = cmd.incrbyfloat(command.getKey(), incrBy.doubleValue());
 			} else {
-				result = cmd.incrby(command.getKey().array(), incrBy.longValue());
+				result = cmd.incrby(command.getKey(), incrBy.longValue());
 			}
 
-			return LettuceReactiveRedisConnection.<T> monoConverter()
-					.convert(result.map(val -> NumberUtils.convertNumberToTargetClass(val, incrBy.getClass())))
-					.map(res -> new NumericResponse<>(command, res));
+			return result.map(val -> NumberUtils.convertNumberToTargetClass(val, incrBy.getClass()))
+					.map(res -> new NumericResponse<>(command, (T) res));
 		}));
 	}
 
@@ -98,8 +97,7 @@ public class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.decr(command.getKey().array()))
-					.map(value -> new NumericResponse<>(command, value));
+			return cmd.decr(command.getKey()).map(value -> new NumericResponse<>(command, value));
 		}));
 	}
 
@@ -117,16 +115,15 @@ public class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 
 			T decrBy = command.getValue();
 
-			Observable<? extends Number> result = null;
+			Mono<? extends Number> result = null;
 			if (decrBy instanceof Double || decrBy instanceof Float) {
-				result = cmd.incrbyfloat(command.getKey().array(), decrBy.doubleValue() * (-1.0D));
+				result = cmd.incrbyfloat(command.getKey(), decrBy.doubleValue() * (-1.0D));
 			} else {
-				result = cmd.decrby(command.getKey().array(), decrBy.longValue());
+				result = cmd.decrby(command.getKey(), decrBy.longValue());
 			}
 
-			return LettuceReactiveRedisConnection.<T> monoConverter()
-					.convert(result.map(val -> NumberUtils.convertNumberToTargetClass(val, decrBy.getClass())))
-					.map(res -> new NumericResponse<>(command, res));
+			return result.map(val -> NumberUtils.convertNumberToTargetClass(val, decrBy.getClass()))
+					.map(res -> new NumericResponse<>(command, (T) res));
 		}));
 	}
 
@@ -144,17 +141,16 @@ public class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 
 			T incrBy = command.getValue();
 
-			Observable<? extends Number> result = null;
+			Mono<? extends Number> result = null;
 
 			if (incrBy instanceof Double || incrBy instanceof Float) {
-				result = cmd.hincrbyfloat(command.getKey().array(), command.getField().array(), incrBy.doubleValue());
+				result = cmd.hincrbyfloat(command.getKey(), command.getField(), incrBy.doubleValue());
 			} else {
-				result = cmd.hincrby(command.getKey().array(), command.getField().array(), incrBy.longValue());
+				result = cmd.hincrby(command.getKey(), command.getField(), incrBy.longValue());
 			}
 
-			return LettuceReactiveRedisConnection.<T> monoConverter()
-					.convert(result.map(val -> NumberUtils.convertNumberToTargetClass(val, incrBy.getClass())))
-					.map(value -> new NumericResponse<>(command, value));
+			return result.map(val -> NumberUtils.convertNumberToTargetClass(val, incrBy.getClass()))
+					.map(value -> new NumericResponse<>(command, (T) value));
 		}));
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveNumberCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.util.Assert;
+import org.springframework.util.NumberUtils;
+
+import reactor.core.publisher.Flux;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
+
+	private final LettuceReactiveRedisConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveStringCommands}.
+	 * 
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveNumberCommands(LettuceReactiveRedisConnection connection) {
+
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveNumberCommands#incr(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<KeyCommand, Long>> incr(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.incr(command.getKey().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveNumberCommands#incrBy(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public <T extends Number> Flux<NumericResponse<IncrByCommand<T>, T>> incrBy(Publisher<IncrByCommand<T>> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value for INCRBY must not be null.");
+
+			T incrBy = command.getValue();
+
+			Observable<? extends Number> result = null;
+			if (incrBy instanceof Double || incrBy instanceof Float) {
+				result = cmd.incrbyfloat(command.getKey().array(), incrBy.doubleValue());
+			} else {
+				result = cmd.incrby(command.getKey().array(), incrBy.longValue());
+			}
+
+			return LettuceReactiveRedisConnection.<T> monoConverter()
+					.convert(result.map(val -> NumberUtils.convertNumberToTargetClass(val, incrBy.getClass())))
+					.map(res -> new NumericResponse<>(command, res));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveNumberCommands#decr(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<KeyCommand, Long>> decr(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.decr(command.getKey().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveNumberCommands#decrBy(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public <T extends Number> Flux<NumericResponse<DecrByCommand<T>, T>> decrBy(Publisher<DecrByCommand<T>> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value for DECRBY must not be null.");
+
+			T decrBy = command.getValue();
+
+			Observable<? extends Number> result = null;
+			if (decrBy instanceof Double || decrBy instanceof Float) {
+				result = cmd.incrbyfloat(command.getKey().array(), decrBy.doubleValue() * (-1.0D));
+			} else {
+				result = cmd.decrby(command.getKey().array(), decrBy.longValue());
+			}
+
+			return LettuceReactiveRedisConnection.<T> monoConverter()
+					.convert(result.map(val -> NumberUtils.convertNumberToTargetClass(val, decrBy.getClass())))
+					.map(res -> new NumericResponse<>(command, res));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveNumberCommands#hIncrBy(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public <T extends Number> Flux<NumericResponse<HIncrByCommand<T>, T>> hIncrBy(Publisher<HIncrByCommand<T>> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+
+			T incrBy = command.getValue();
+
+			Observable<? extends Number> result = null;
+
+			if (incrBy instanceof Double || incrBy instanceof Float) {
+				result = cmd.hincrbyfloat(command.getKey().array(), command.getField().array(), incrBy.doubleValue());
+			} else {
+				result = cmd.hincrby(command.getKey().array(), command.getField().array(), incrBy.longValue());
+			}
+
+			return LettuceReactiveRedisConnection.<T> monoConverter()
+					.convert(result.map(val -> NumberUtils.convertNumberToTargetClass(val, incrBy.getClass())))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
@@ -36,12 +36,13 @@ public class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 
 	/**
 	 * Create new {@link LettuceReactiveStringCommands}.
-	 * 
+	 *
 	 * @param connection must not be {@literal null}.
 	 */
 	public LettuceReactiveNumberCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
+
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import org.springframework.data.redis.connection.ReactiveRedisClusterConnection;
+import org.springframework.data.redis.connection.RedisNode;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import com.lambdaworks.redis.api.rx.RedisReactiveCommands;
+import com.lambdaworks.redis.cluster.RedisClusterClient;
+import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
+import com.lambdaworks.redis.cluster.api.rx.RedisClusterReactiveCommands;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisConnection
+		implements ReactiveRedisClusterConnection {
+
+	public LettuceReactiveRedisClusterConnection(RedisClusterClient client) {
+		super(client);
+	}
+
+	@Override
+	public LettuceReactiveClusterKeyCommands keyCommands() {
+		return new LettuceReactiveClusterKeyCommands(this);
+	}
+
+	@Override
+	public LettuceReactiveClusterListCommands listCommands() {
+		return new LettuceReactiveClusterListCommands(this);
+	}
+
+	@Override
+	public LettuceReactiveClusterSetCommands setCommands() {
+		return new LettuceReactiveClusterSetCommands(this);
+	}
+
+	@Override
+	public LettuceReactiveClusterZSetCommands zSetCommands() {
+		return new LettuceReactiveClusterZSetCommands(this);
+	}
+
+	@Override
+	public LettuceReactiveClusterHyperLogLogCommands hyperLogLogCommands() {
+		return new LettuceReactiveClusterHyperLogLogCommands(this);
+	}
+
+	@Override
+	public LettuceReactiveClusterStringCommands stringCommands() {
+		return new LettuceReactiveClusterStringCommands(this);
+	}
+
+	@Override
+	public LettuceReactiveClusterGeoCommands geoCommands() {
+		return new LettuceReactiveClusterGeoCommands(this);
+	}
+
+	@Override
+	public LettuceReactiveClusterHashCommands hashCommands() {
+		return new LettuceReactiveClusterHashCommands(this);
+	}
+
+	@Override
+	public LettuceReactiveClusterNumberCommands numberCommands() {
+		return new LettuceReactiveClusterNumberCommands(this);
+	}
+
+	/**
+	 * @param callback
+	 * @return
+	 */
+	public <T> Flux<T> execute(RedisNode node, LettuceReactiveCallback<T> callback) {
+
+		try {
+			Assert.notNull(callback, "ReactiveCallback must not be null!");
+			Assert.notNull(node, "Node must not be null!");
+		} catch (IllegalArgumentException e) {
+			return Flux.error(e);
+		}
+
+		return Flux.defer(() -> callback.doWithCommands(getCommands(node))).onErrorResumeWith(translateExeception());
+	}
+
+	@Override
+	protected StatefulRedisClusterConnection<byte[], byte[]> getConnection() {
+
+		Assert.isInstanceOf(StatefulRedisClusterConnection.class, super.getConnection(),
+				"Connection needs to be instance of StatefulRedisClusterConnection");
+
+		return (StatefulRedisClusterConnection) super.getConnection();
+	}
+
+	protected RedisClusterReactiveCommands<byte[], byte[]> getCommands() {
+		return getConnection().reactive();
+	}
+
+	protected RedisReactiveCommands<byte[], byte[]> getCommands(RedisNode node) {
+
+		if (!(getConnection() instanceof StatefulRedisClusterConnection)) {
+			throw new IllegalArgumentException("o.O connection needs to be cluster compatible " + getConnection());
+		}
+
+		if (StringUtils.hasText(node.getId())) {
+			return ((StatefulRedisClusterConnection) getConnection()).getConnection(node.getId()).reactive();
+		}
+
+		return ((StatefulRedisClusterConnection) getConnection()).getConnection(node.getHost(), node.getPort()).reactive();
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
@@ -16,20 +16,23 @@
 
 package org.springframework.data.redis.connection.lettuce;
 
+import java.nio.ByteBuffer;
+
 import org.springframework.data.redis.connection.ReactiveRedisClusterConnection;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import com.lambdaworks.redis.api.rx.RedisReactiveCommands;
+import com.lambdaworks.redis.api.reactive.RedisReactiveCommands;
 import com.lambdaworks.redis.cluster.RedisClusterClient;
 import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
-import com.lambdaworks.redis.cluster.api.rx.RedisClusterReactiveCommands;
+import com.lambdaworks.redis.cluster.api.reactive.RedisClusterReactiveCommands;
 
 import reactor.core.publisher.Flux;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 public class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisConnection
@@ -101,7 +104,7 @@ public class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisC
 	}
 
 	@Override
-	protected StatefulRedisClusterConnection<byte[], byte[]> getConnection() {
+	protected StatefulRedisClusterConnection<ByteBuffer, ByteBuffer> getConnection() {
 
 		Assert.isInstanceOf(StatefulRedisClusterConnection.class, super.getConnection(),
 				"Connection needs to be instance of StatefulRedisClusterConnection");
@@ -109,11 +112,11 @@ public class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisC
 		return (StatefulRedisClusterConnection) super.getConnection();
 	}
 
-	protected RedisClusterReactiveCommands<byte[], byte[]> getCommands() {
+	protected RedisClusterReactiveCommands<ByteBuffer, ByteBuffer> getCommands() {
 		return getConnection().reactive();
 	}
 
-	protected RedisReactiveCommands<byte[], byte[]> getCommands(RedisNode node) {
+	protected RedisReactiveCommands<ByteBuffer, ByteBuffer> getCommands(RedisNode node) {
 
 		if (!(getConnection() instanceof StatefulRedisClusterConnection)) {
 			throw new IllegalArgumentException("o.O connection needs to be cluster compatible " + getConnection());

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import java.nio.ByteBuffer;
@@ -42,46 +41,73 @@ public class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisC
 		super(client);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#keyCommands()
+	 */
 	@Override
 	public LettuceReactiveClusterKeyCommands keyCommands() {
 		return new LettuceReactiveClusterKeyCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#listCommands()
+	 */
 	@Override
 	public LettuceReactiveClusterListCommands listCommands() {
 		return new LettuceReactiveClusterListCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#setCommands()
+	 */
 	@Override
 	public LettuceReactiveClusterSetCommands setCommands() {
 		return new LettuceReactiveClusterSetCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#zSetCommands()
+	 */
 	@Override
 	public LettuceReactiveClusterZSetCommands zSetCommands() {
 		return new LettuceReactiveClusterZSetCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#hyperLogLogCommands()
+	 */
 	@Override
 	public LettuceReactiveClusterHyperLogLogCommands hyperLogLogCommands() {
 		return new LettuceReactiveClusterHyperLogLogCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#stringCommands()
+	 */
 	@Override
 	public LettuceReactiveClusterStringCommands stringCommands() {
 		return new LettuceReactiveClusterStringCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#geoCommands()
+	 */
 	@Override
 	public LettuceReactiveClusterGeoCommands geoCommands() {
 		return new LettuceReactiveClusterGeoCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#hashCommands()
+	 */
 	@Override
 	public LettuceReactiveClusterHashCommands hashCommands() {
 		return new LettuceReactiveClusterHashCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#numberCommands()
+	 */
 	@Override
 	public LettuceReactiveClusterNumberCommands numberCommands() {
 		return new LettuceReactiveClusterNumberCommands(this);
@@ -103,6 +129,10 @@ public class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisC
 		return Flux.defer(() -> callback.doWithCommands(getCommands(node))).onErrorResumeWith(translateExeception());
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#getConnection()
+	 */
+	@SuppressWarnings("unchecked")
 	@Override
 	protected StatefulRedisClusterConnection<ByteBuffer, ByteBuffer> getConnection() {
 
@@ -112,10 +142,14 @@ public class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisC
 		return (StatefulRedisClusterConnection) super.getConnection();
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection#getCommands()
+	 */
 	protected RedisClusterReactiveCommands<ByteBuffer, ByteBuffer> getCommands() {
 		return getConnection().reactive();
 	}
 
+	@SuppressWarnings("unchecked")
 	protected RedisReactiveCommands<ByteBuffer, ByteBuffer> getCommands(RedisNode node) {
 
 		if (!(getConnection() instanceof StatefulRedisClusterConnection)) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
+import org.springframework.data.redis.connection.*;
+import org.springframework.util.Assert;
+
+import com.lambdaworks.redis.AbstractRedisClient;
+import com.lambdaworks.redis.RedisClient;
+import com.lambdaworks.redis.api.StatefulConnection;
+import com.lambdaworks.redis.api.StatefulRedisConnection;
+import com.lambdaworks.redis.cluster.RedisClusterClient;
+import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
+import com.lambdaworks.redis.cluster.api.rx.RedisClusterReactiveCommands;
+import com.lambdaworks.redis.codec.ByteArrayCodec;
+import com.lambdaworks.redis.codec.RedisCodec;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveRedisConnection implements ReactiveRedisConnection {
+
+	private StatefulConnection<ByteBuffer, ByteBuffer> connection;
+
+	private static final RedisCodec<byte[], byte[]> CODEC = new ByteArrayCodec();
+
+	public LettuceReactiveRedisConnection(AbstractRedisClient client) {
+
+		Assert.notNull(client, "RedisClient must not be null!");
+
+		if (client instanceof RedisClient) {
+			connection = ((RedisClient) client).connect(CODEC);
+		} else if (client instanceof RedisClusterClient) {
+			connection = ((RedisClusterClient) client).connect(CODEC);
+		} else {
+			throw new InvalidDataAccessResourceUsageException(
+					String.format("Cannot use client of type %s", client.getClass()));
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#keyCommands()
+	 */
+	@Override
+	public ReactiveKeyCommands keyCommands() {
+		return new LettuceReactiveKeyCommands(this);
+	}
+
+	@Override
+	public ReactiveStringCommands stringCommands() {
+		return new LettuceReactiveStringCommands(this);
+	}
+
+	@Override
+	public ReactiveNumberCommands numberCommands() {
+		return new LettuceReactiveNumberCommands(this);
+	}
+
+	@Override
+	public ReactiveListCommands listCommands() {
+		return new LettuceReactiveListCommands(this);
+	}
+
+	@Override
+	public ReactiveSetCommands setCommands() {
+		return new LettuceReactiveSetCommands(this);
+	}
+
+	@Override
+	public ReactiveZSetCommands zSetCommands() {
+		return new LettuceReactiveZSetCommands(this);
+	}
+
+	@Override
+	public ReactiveHashCommands hashCommands() {
+		return new LettuceReactiveHashCommands(this);
+	}
+
+	@Override
+	public ReactiveGeoCommands geoCommands() {
+		return new LettuceReactiveGeoCommands(this);
+	}
+
+	@Override
+	public ReactiveHyperLogLogCommands hyperLogLogCommands() {
+		return new LettuceReactiveHyperLogLogCommands(this);
+	}
+
+	/**
+	 * @param callback
+	 * @return
+	 */
+	public <T> Flux<T> execute(LettuceReactiveCallback<T> callback) {
+		return Flux.defer(() -> callback.doWithCommands(getCommands())).onErrorResumeWith(translateExeception());
+	}
+
+	@Override
+	public void close() {
+		connection.close();
+	}
+
+	protected StatefulConnection<byte[], byte[]> getConnection() {
+		return connection;
+	}
+
+	protected RedisClusterReactiveCommands<byte[], byte[]> getCommands() {
+
+		if (connection instanceof StatefulRedisConnection) {
+			return ((StatefulRedisConnection<byte[], byte[]>) connection).reactive();
+		} else if (connection instanceof StatefulRedisClusterConnection) {
+			return ((StatefulRedisClusterConnection<byte[], byte[]>) connection).reactive();
+		}
+
+		throw new RuntimeException("o.O unknown connection type " + connection);
+	}
+
+	<T> Function<Throwable, Publisher<? extends T>> translateExeception() {
+
+		return throwable -> {
+
+			if (throwable instanceof RuntimeException) {
+
+				DataAccessException convertedException = null;
+				if (throwable instanceof RuntimeException) {
+					convertedException = LettuceConverters.exceptionConverter().convert((RuntimeException) throwable);
+				}
+				return Flux.error(convertedException != null ? convertedException : throwable);
+			}
+
+			return Flux.error(throwable);
+		};
+	}
+
+	interface LettuceReactiveCallback<T> {
+		Publisher<T> doWithCommands(RedisClusterReactiveCommands<byte[], byte[]> cmd);
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
@@ -19,7 +19,6 @@ import java.nio.ByteBuffer;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
-import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.redis.connection.*;
@@ -35,8 +34,6 @@ import com.lambdaworks.redis.cluster.api.reactive.RedisClusterReactiveCommands;
 import com.lambdaworks.redis.codec.RedisCodec;
 
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import rx.Observable;
 
 /**
  * @author Christoph Strobl
@@ -71,41 +68,65 @@ public class LettuceReactiveRedisConnection implements ReactiveRedisConnection {
 		return new LettuceReactiveKeyCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#stringCommands()
+	 */
 	@Override
 	public ReactiveStringCommands stringCommands() {
 		return new LettuceReactiveStringCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#numberCommands()
+	 */
 	@Override
 	public ReactiveNumberCommands numberCommands() {
 		return new LettuceReactiveNumberCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#listCommands()
+	 */
 	@Override
 	public ReactiveListCommands listCommands() {
 		return new LettuceReactiveListCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#setCommands()
+	 */
 	@Override
 	public ReactiveSetCommands setCommands() {
 		return new LettuceReactiveSetCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#zSetCommands()
+	 */
 	@Override
 	public ReactiveZSetCommands zSetCommands() {
 		return new LettuceReactiveZSetCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#hashCommands()
+	 */
 	@Override
 	public ReactiveHashCommands hashCommands() {
 		return new LettuceReactiveHashCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#geoCommands()
+	 */
 	@Override
 	public ReactiveGeoCommands geoCommands() {
 		return new LettuceReactiveGeoCommands(this);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#hyperLogLogCommands()
+	 */
 	@Override
 	public ReactiveHyperLogLogCommands hyperLogLogCommands() {
 		return new LettuceReactiveHyperLogLogCommands(this);
@@ -119,6 +140,9 @@ public class LettuceReactiveRedisConnection implements ReactiveRedisConnection {
 		return Flux.defer(() -> callback.doWithCommands(getCommands())).onErrorResumeWith(translateExeception());
 	}
 
+	/* (non-Javadoc)
+	 * @see java.io.Closeable#close()
+	 */
 	@Override
 	public void close() {
 		connection.close();

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
@@ -27,13 +27,13 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiVa
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.data.redis.connection.ReactiveSetCommands;
 import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
 
 import reactor.core.publisher.Flux;
-import rx.Observable;
+import reactor.core.publisher.Mono;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 public class LettuceReactiveSetCommands implements ReactiveSetCommands {
@@ -63,9 +63,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValues(), "Values must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter()
-					.convert(cmd.sadd(command.getKey().array(),
-							command.getValues().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+			return cmd.sadd(command.getKey(), command.getValues().stream().toArray(ByteBuffer[]::new))
 					.map(value -> new NumericResponse<>(command, value));
 		}));
 	}
@@ -82,9 +80,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValues(), "Values must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter()
-					.convert(cmd.srem(command.getKey().array(),
-							command.getValues().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+			return cmd.srem(command.getKey(), command.getValues().stream().toArray(ByteBuffer[]::new))
 					.map(value -> new NumericResponse<>(command, value));
 		}));
 	}
@@ -100,9 +96,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
-			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
-					.convert(cmd.spop(command.getKey().array()).map(ByteBuffer::wrap))
-					.map(value -> new ByteBufferResponse<>(command, value));
+			return cmd.spop(command.getKey()).map(value -> new ByteBufferResponse<>(command, value));
 		}));
 	}
 
@@ -119,8 +113,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 			Assert.notNull(command.getDestination(), "Destination key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
 
-			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
-					.convert(cmd.smove(command.getKey().array(), command.getDestination().array(), command.getValue().array()))
+			return cmd.smove(command.getKey(), command.getDestination(), command.getValue())
 					.map(value -> new BooleanResponse<>(command, value));
 		}));
 	}
@@ -136,8 +129,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.scard(command.getKey().array()))
-					.map(value -> new NumericResponse<>(command, value));
+			return cmd.scard(command.getKey()).map(value -> new NumericResponse<>(command, value));
 		}));
 	}
 
@@ -153,9 +145,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
 
-			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
-					.convert(cmd.sismember(command.getKey().array(), command.getValue().array()))
-					.map(value -> new BooleanResponse<>(command, value));
+			return cmd.sismember(command.getKey(), command.getValue()).map(value -> new BooleanResponse<>(command, value));
 		}));
 	}
 
@@ -170,9 +160,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 
-			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
-					.convert(cmd.sinter(command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
-							.map(ByteBuffer::wrap).toList())
+			return cmd.sinter(command.getKeys().stream().toArray(ByteBuffer[]::new)).collectList()
 					.map(value -> new MultiValueResponse<>(command, value));
 		}));
 	}
@@ -189,9 +177,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter()
-					.convert(cmd.sinterstore(command.getKey().array(),
-							command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+			return cmd.sinterstore(command.getKey(), command.getKeys().stream().toArray(ByteBuffer[]::new))
 					.map(value -> new NumericResponse<>(command, value));
 		}));
 	}
@@ -207,9 +193,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 
-			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
-					.convert(cmd.sunion(command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
-							.map(ByteBuffer::wrap).toList())
+			return cmd.sunion(command.getKeys().stream().toArray(ByteBuffer[]::new)).collectList()
 					.map(value -> new MultiValueResponse<>(command, value));
 		}));
 	}
@@ -226,9 +210,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter()
-					.convert(cmd.sunionstore(command.getKey().array(),
-							command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+			return cmd.sunionstore(command.getKey(), command.getKeys().stream().toArray(ByteBuffer[]::new))
 					.map(value -> new NumericResponse<>(command, value));
 		}));
 	}
@@ -244,9 +226,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 
-			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
-					.convert(cmd.sdiff(command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
-							.map(ByteBuffer::wrap).toList())
+			return cmd.sdiff(command.getKeys().stream().toArray(ByteBuffer[]::new)).collectList()
 					.map(value -> new MultiValueResponse<>(command, value));
 		}));
 	}
@@ -263,9 +243,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
 
-			return LettuceReactiveRedisConnection.<Long> monoConverter()
-					.convert(cmd.sdiffstore(command.getKey().array(),
-							command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+			return cmd.sdiffstore(command.getKey(), command.getKeys().stream().toArray(ByteBuffer[]::new))
 					.map(value -> new NumericResponse<>(command, value));
 		}));
 	}
@@ -281,9 +259,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
-			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
-					.convert(cmd.smembers(command.getKey().array()).map(ByteBuffer::wrap).toList())
-					.map(value -> new MultiValueResponse<>(command, value));
+			return cmd.smembers(command.getKey()).collectList().map(value -> new MultiValueResponse<>(command, value));
 		}));
 	}
 
@@ -301,12 +277,10 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 
 			boolean singleElement = !command.getCount().isPresent() || command.getCount().get().equals(1L);
 
-			Observable<List<ByteBuffer>> result = singleElement
-					? cmd.srandmember(command.getKey().array()).map(ByteBuffer::wrap).map(Collections::singletonList)
-					: cmd.srandmember(command.getKey().array(), command.getCount().get()).map(ByteBuffer::wrap).toList();
+			Mono<List<ByteBuffer>> result = singleElement ? cmd.srandmember(command.getKey()).map(Collections::singletonList)
+					: cmd.srandmember(command.getKey(), command.getCount().get()).collectList();
 
-			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter().convert(result)
-					.map(value -> new MultiValueResponse<>(command, value));
+			return result.map(value -> new MultiValueResponse<>(command, value));
 		}));
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.connection.ReactiveSetCommands;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import reactor.core.publisher.Flux;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveSetCommands implements ReactiveSetCommands {
+
+	private final LettuceReactiveRedisConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveSetCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveSetCommands(LettuceReactiveRedisConnection connection) {
+
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sAdd(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<SAddCommand, Long>> sAdd(Publisher<SAddCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValues(), "Values must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.sadd(command.getKey().array(),
+							command.getValues().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sRem(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<SRemCommand, Long>> sRem(Publisher<SRemCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValues(), "Values must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.srem(command.getKey().array(),
+							command.getValues().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sPop(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<ByteBufferResponse<KeyCommand>> sPop(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
+					.convert(cmd.spop(command.getKey().array()).map(ByteBuffer::wrap))
+					.map(value -> new ByteBufferResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sMove(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<SMoveCommand>> sMove(Publisher<SMoveCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getDestination(), "Destination key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+					.convert(cmd.smove(command.getKey().array(), command.getDestination().array(), command.getValue().array()))
+					.map(value -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sCard(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<KeyCommand, Long>> sCard(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.scard(command.getKey().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sIsMember(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<SIsMemberCommand>> sIsMember(Publisher<SIsMemberCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+					.convert(cmd.sismember(command.getKey().array(), command.getValue().array()))
+					.map(value -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sInter(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<SInterCommand, ByteBuffer>> sInter(Publisher<SInterCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
+					.convert(cmd.sinter(command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
+							.map(ByteBuffer::wrap).toList())
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sInterStore(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<SInterStoreCommand, Long>> sInterStore(Publisher<SInterStoreCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+			Assert.notNull(command.getKey(), "Destination key must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.sinterstore(command.getKey().array(),
+							command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sInter(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<SUnionCommand, ByteBuffer>> sUnion(Publisher<SUnionCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
+					.convert(cmd.sunion(command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
+							.map(ByteBuffer::wrap).toList())
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sInterStore(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<SUnionStoreCommand, Long>> sUnionStore(Publisher<SUnionStoreCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+			Assert.notNull(command.getKey(), "Destination key must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.sunionstore(command.getKey().array(),
+							command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sInter(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<SDiffCommand, ByteBuffer>> sDiff(Publisher<SDiffCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
+					.convert(cmd.sdiff(command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]))
+							.map(ByteBuffer::wrap).toList())
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sInterStore(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<SDiffStoreCommand, Long>> sDiffStore(Publisher<SDiffStoreCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null!");
+			Assert.notNull(command.getKey(), "Destination key must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.sdiffstore(command.getKey().array(),
+							command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sMembers(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<KeyCommand, ByteBuffer>> sMembers(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
+					.convert(cmd.smembers(command.getKey().array()).map(ByteBuffer::wrap).toList())
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSetCommands#sRandMembers(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<SRandMembersCommand, ByteBuffer>> sRandMember(
+			Publisher<SRandMembersCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			boolean singleElement = !command.getCount().isPresent() || command.getCount().get().equals(1L);
+
+			Observable<List<ByteBuffer>> result = singleElement
+					? cmd.srandmember(command.getKey().array()).map(ByteBuffer::wrap).map(Collections::singletonList)
+					: cmd.srandmember(command.getKey().array(), command.getCount().get()).map(ByteBuffer::wrap).toList();
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter().convert(result)
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	protected LettuceReactiveRedisConnection getConnection() {
+		return connection;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
@@ -48,6 +48,7 @@ public class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	public LettuceReactiveSetCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
+
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
@@ -52,6 +52,7 @@ public class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	public LettuceReactiveStringCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
+
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.RangeCommand;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.util.Assert;
+
+import com.lambdaworks.redis.SetArgs;
+
+import reactor.core.publisher.Flux;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveStringCommands implements ReactiveStringCommands {
+
+	private final LettuceReactiveRedisConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveStringCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveStringCommands(LettuceReactiveRedisConnection connection) {
+
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#mGet(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<List<ByteBuffer>, ByteBuffer>> mGet(Publisher<List<ByteBuffer>> keyCollections) {
+
+		return connection.execute(cmd -> Flux.from(keyCollections).flatMap((keys) -> {
+
+			Assert.notNull(keys, "Keys must not be null!");
+
+			return LettuceReactiveRedisConnection.<MultiValueResponse<List<ByteBuffer>, ByteBuffer>> monoConverter()
+					.convert(cmd
+							.mget(keys.stream().map(ByteBuffer::array).collect(Collectors.toList()).toArray(new byte[keys.size()][]))
+							.map((value) -> value != null ? ByteBuffer.wrap(value) : ByteBuffer.allocate(0)).toList()
+							.map((values) -> new MultiValueResponse<>(keys, values)));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#set(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<SetCommand>> set(Publisher<SetCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+
+			SetArgs args = null;
+
+			if (command.getExpiration().isPresent() || command.getOption().isPresent()) {
+				args = LettuceConverters.toSetArgs(command.getExpiration().isPresent() ? command.getExpiration().get() : null,
+						command.getOption().isPresent() ? command.getOption().get() : null);
+			}
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter().convert(
+
+					args != null ? cmd.set(command.getKey().array(), command.getValue().array(), args)
+							: cmd.set(command.getKey().array(), command.getValue().array()).map(LettuceConverters::stringToBoolean))
+					.map((value) -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#getSet(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<ByteBufferResponse<SetCommand>> getSet(Publisher<SetCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+
+			if (command.getExpiration().isPresent() || command.getOption().isPresent()) {
+				throw new IllegalArgumentException("Command must not define exipiration nor option for GETSET.");
+			}
+
+			return LettuceReactiveRedisConnection.<ByteBufferResponse<SetCommand>> monoConverter()
+					.convert(cmd.getset(command.getKey().array(), command.getValue().array())
+							.map((value) -> new ByteBufferResponse<>(command, ByteBuffer.wrap(value)))
+							.defaultIfEmpty(new ByteBufferResponse<>(command, ByteBuffer.allocate(0))));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#get(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<ByteBufferResponse<KeyCommand>> get(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<ByteBuffer> monoConverter()
+					.convert(cmd.get(command.getKey().array()).map(ByteBuffer::wrap))
+					.map((value) -> new ByteBufferResponse<>(command, value))
+					.defaultIfEmpty(new ByteBufferResponse<>(command, ByteBuffer.allocate(0)));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#setNX(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<SetCommand>> setNX(Publisher<SetCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+					.convert(cmd.setnx(command.getKey().array(), command.getValue().array()))
+					.map((value) -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#setEX(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<BooleanResponse<SetCommand>> setEX(Publisher<SetCommand> commands) {
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+			Assert.isTrue(command.getExpiration().isPresent(), "Expiration time must not be null!");
+
+			return LettuceReactiveRedisConnection.<String> monoConverter()
+					.convert(cmd.setex(command.getKey().array(), command.getExpiration().get().getExpirationTimeInSeconds(),
+							command.getValue().array()))
+					.map(LettuceConverters::stringToBoolean).map((value) -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#pSetEX(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<BooleanResponse<SetCommand>> pSetEX(Publisher<SetCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+			Assert.isTrue(command.getExpiration().isPresent(), "Expiration time must not be null!");
+
+			return LettuceReactiveRedisConnection.<String> monoConverter()
+					.convert(cmd.psetex(command.getKey().array(), command.getExpiration().get().getExpirationTimeInMilliseconds(),
+							command.getValue().array()))
+					.map(LettuceConverters::stringToBoolean).map((value) -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#mSet(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<MSetCommand>> mSet(Publisher<MSetCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notEmpty(command.getKeyValuePairs(), "Pairs must not be null or empty!");
+
+			Map<byte[], byte[]> map = new LinkedHashMap<>();
+			command.getKeyValuePairs().entrySet().forEach(entry -> map.put(entry.getKey().array(), entry.getValue().array()));
+
+			return LettuceReactiveRedisConnection.<String> monoConverter().convert(cmd.mset(map))
+					.map(LettuceConverters::stringToBoolean).map((value) -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#mSet(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<BooleanResponse<MSetCommand>> mSetNX(Publisher<MSetCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notEmpty(command.getKeyValuePairs(), "Pairs must not be null or empty!");
+
+			Map<byte[], byte[]> map = new LinkedHashMap<>();
+			command.getKeyValuePairs().entrySet().forEach(entry -> map.put(entry.getKey().array(), entry.getValue().array()));
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter().convert(cmd.msetnx(map))
+					.map((value) -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#append(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<AppendCommand, Long>> append(Publisher<AppendCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.append(command.getKey().array(), command.getValue().array()))
+					.map((value) -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#getRange(org.reactivestreams.Publisher, java.util.function.Supplier, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<ByteBufferResponse<RangeCommand>> getRange(Publisher<RangeCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getRange(), "Range must not be null!");
+
+			Range<Long> range = command.getRange();
+
+			return LettuceReactiveRedisConnection
+					.<ByteBuffer> monoConverter().convert(cmd
+							.getrange(command.getKey().array(), range.getLowerBound(), range.getUpperBound()).map(ByteBuffer::wrap))
+					.map((value) -> new ByteBufferResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#setRange(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<NumericResponse<SetRangeCommand, Long>> setRange(Publisher<SetRangeCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+			Assert.notNull(command.getOffset(), "Offset must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.setrange(command.getKey().array(), command.getOffset(), command.getValue().array()))
+					.map((value) -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#getBit(org.reactivestreams.Publisher, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<BooleanResponse<GetBitCommand>> getBit(Publisher<GetBitCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getOffset(), "Offset must not be null!");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+					.convert(cmd.getbit(command.getKey().array(), command.getOffset()).map(LettuceConverters::toBoolean))
+					.map(value -> new BooleanResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#setBit(org.reactivestreams.Publisher, java.util.function.Supplier, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<BooleanResponse<SetBitCommand>> setBit(Publisher<SetBitCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+			Assert.notNull(command.getOffset(), "Offset must not be null!");
+
+			return LettuceReactiveRedisConnection.<Boolean> monoConverter()
+					.convert(cmd.setbit(command.getKey().array(), command.getOffset(), command.getValue() ? 1 : 0)
+							.map(LettuceConverters::toBoolean))
+					.map(respValue -> new BooleanResponse<>(command, respValue));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#bitCount(org.reactivestreams.Publisher, java.util.function.Supplier, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<NumericResponse<BitCountCommand, Long>> bitCount(Publisher<BitCountCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			Range<Long> range = command.getRange();
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(range != null ? cmd.bitcount(command.getKey().array(), range.getLowerBound(), range.getUpperBound())
+							: cmd.bitcount(command.getKey().array()))
+					.map(responseValue -> new NumericResponse<>(command, responseValue));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#bitOp(org.reactivestreams.Publisher, java.util.function.Supplier, java.util.function.Supplier)
+	 */
+	@Override
+	public Flux<NumericResponse<BitOpCommand, Long>> bitOp(Publisher<BitOpCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getDestinationKey(), "DestinationKey must not be null!");
+			Assert.notEmpty(command.getKeys(), "Keys must not be null or empty");
+
+			Observable<Long> result = null;
+			byte[] destinationKey = command.getDestinationKey().array();
+			byte[][] sourceKeys = command.getKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]);
+
+			switch (command.getBitOp()) {
+				case AND:
+					result = cmd.bitopAnd(destinationKey, sourceKeys);
+					break;
+				case OR:
+					result = cmd.bitopOr(destinationKey, sourceKeys);
+					break;
+				case XOR:
+					result = cmd.bitopXor(destinationKey, sourceKeys);
+					break;
+				case NOT:
+
+					Assert.isTrue(sourceKeys.length == 1, "BITOP NOT does not allow more than 1 source key.");
+
+					result = cmd.bitopNot(destinationKey, sourceKeys[0]);
+					break;
+				default:
+					throw new IllegalArgumentException(String.format("Unknown BITOP '%s'.", command.getBitOp()));
+			}
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveStringCommands#strLen(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<KeyCommand, Long>> strLen(Publisher<KeyCommand> commands) {
+		return connection.execute(cmd -> {
+
+			return Flux.from(commands).flatMap(command -> {
+				return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.strlen(command.getKey().array()))
+						.map(respValue -> new NumericResponse<>(command, respValue));
+			});
+		});
+	}
+
+	protected LettuceReactiveRedisConnection getConnection() {
+		return connection;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.redis.connection.DefaultTuple;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.connection.ReactiveZSetCommands;
+import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
+import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import com.lambdaworks.redis.ScoredValue;
+import com.lambdaworks.redis.ZAddArgs;
+import com.lambdaworks.redis.ZStoreArgs;
+
+import reactor.core.publisher.Flux;
+import rx.Observable;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
+
+	private final LettuceReactiveRedisConnection connection;
+
+	/**
+	 * Create new {@link LettuceReactiveSetCommands}.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	public LettuceReactiveZSetCommands(LettuceReactiveRedisConnection connection) {
+
+		Assert.notNull(connection, "Connection must not be null!");
+		this.connection = connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zAdd(org.reactivestreams.Publisher)
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public Flux<NumericResponse<ZAddCommand, Number>> zAdd(Publisher<ZAddCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notEmpty(command.getTuples(), "Tuples must not be empty or null.");
+
+			ZAddArgs args = null;
+
+			if (command.getIncr().isPresent() || command.getUpsert().isPresent() || command.getReturnTotalChanged().isPresent()) {
+
+				if (command.getIncr().isPresent() && ObjectUtils.nullSafeEquals(command.getIncr().get(), Boolean.TRUE)) {
+
+					if (command.getTuples().size() > 1) {
+						throw new IllegalArgumentException("ZADD INCR must not contain more than one tuple.");
+					}
+
+					Tuple tuple = command.getTuples().iterator().next();
+
+					return LettuceReactiveRedisConnection.<Double> monoConverter()
+							.convert(cmd.zaddincr(command.getKey().array(), tuple.getScore(), tuple.getValue()))
+							.map(value -> new NumericResponse<>(command, value));
+				}
+
+				if (command.getReturnTotalChanged().isPresent() && ObjectUtils.nullSafeEquals(command.getReturnTotalChanged().get(), Boolean.TRUE)) {
+					args = ZAddArgs.Builder.ch();
+				}
+
+				if (command.getUpsert().isPresent()) {
+
+					if (command.getUpsert().get().equals(Boolean.TRUE)) {
+						args = ZAddArgs.Builder.nx();
+					} else {
+						args = ZAddArgs.Builder.xx();
+					}
+				}
+			}
+
+			ScoredValue<byte[]>[] values = (ScoredValue<byte[]>[]) command.getTuples().stream()
+					.map(tuple -> new ScoredValue<byte[]>(tuple.getScore(), tuple.getValue()))
+					.toArray(size -> new ScoredValue[size]);
+
+			Observable<Long> result = args == null ? cmd.zadd(command.getKey().array(), values)
+					: cmd.zadd(command.getKey().array(), args, values);
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zRem(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<ZRemCommand, Long>> zRem(Publisher<ZRemCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notEmpty(command.getValues(), "Values must not be null or empty!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter()
+					.convert(cmd.zrem(command.getKey().array(),
+							command.getValues().stream().map(ByteBuffer::array).toArray(size -> new byte[size][])))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zIncrBy(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<ZIncrByCommand, Double>> zIncrBy(Publisher<ZIncrByCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Member must not be null!");
+			Assert.notNull(command.getIncrement(), "Increment value must not be null!");
+
+			return LettuceReactiveRedisConnection.<Double> monoConverter()
+					.convert(
+							cmd.zincrby(command.getKey().array(), command.getIncrement().doubleValue(), command.getValue().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zRank(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<ZRankCommand, Long>> zRank(Publisher<ZRankCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+
+			Observable<Long> result = ObjectUtils.nullSafeEquals(command.getDirection(), Direction.ASC)
+					? cmd.zrank(command.getKey().array(), command.getValue().array())
+					: cmd.zrevrank(command.getKey().array(), command.getValue().array());
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zRange(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<ZRangeCommand, Tuple>> zRange(Publisher<ZRangeCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getRange(), "Range must not be null!");
+
+			Observable<List<Tuple>> result = Observable.empty();
+
+			if (ObjectUtils.nullSafeEquals(command.getDirection(), Direction.ASC)) {
+				if (command.getWithScores().isPresent() && ObjectUtils.nullSafeEquals(command.getWithScores().get(), Boolean.TRUE)) {
+
+					result = cmd.zrangeWithScores(command.getKey().array(), command.getRange().getLowerBound(),
+							command.getRange().getUpperBound()).map(sc -> (Tuple) new DefaultTuple(sc.value, sc.score)).toList();
+				} else {
+
+					result = cmd
+							.zrange(command.getKey().array(), command.getRange().getLowerBound(), command.getRange().getUpperBound())
+							.map(value -> (Tuple) new DefaultTuple(value, Double.NaN)).toList();
+				}
+			} else {
+				if (command.getWithScores().isPresent() && ObjectUtils.nullSafeEquals(command.getWithScores().get(), Boolean.TRUE)) {
+					result = cmd.zrevrangeWithScores(command.getKey().array(), command.getRange().getLowerBound(),
+							command.getRange().getUpperBound()).map(sc -> (Tuple) new DefaultTuple(sc.value, sc.score)).toList();
+				} else {
+
+					result = cmd
+							.zrevrange(command.getKey().array(), command.getRange().getLowerBound(),
+									command.getRange().getUpperBound())
+							.map(value -> (Tuple) new DefaultTuple(value, Double.NaN)).toList();
+				}
+			}
+
+			return LettuceReactiveRedisConnection.<List<Tuple>> monoConverter().convert(result)
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zRange(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<ZRangeByScoreCommand, Tuple>> zRangeByScore(Publisher<ZRangeByScoreCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getRange(), "Range must not be null!");
+
+			Object lowerBound = AgrumentConverters.lowerBoundArgOf(command.getRange());
+			Object upperBound = AgrumentConverters.upperBoundArgOf(command.getRange());
+
+			boolean requiresStringConversion = lowerBound instanceof String || upperBound instanceof String;
+
+			boolean isLimited = command.getLimit().isPresent();
+
+			Observable<List<Tuple>> result = Observable.empty();
+
+			if (ObjectUtils.nullSafeEquals(command.getDirection(), Direction.ASC)) {
+				if (command.getWithScores().isPresent() && ObjectUtils.nullSafeEquals(command.getWithScores().get(), Boolean.TRUE)) {
+
+					if (!isLimited) {
+						result = (requiresStringConversion
+								? cmd.zrangebyscoreWithScores(command.getKey().array(), lowerBound.toString(), upperBound.toString())
+								: cmd.zrangebyscoreWithScores(command.getKey().array(), (Double) lowerBound, (Double) upperBound))
+										.map(sc -> (Tuple) new DefaultTuple(sc.value, sc.score)).toList();
+					} else {
+						result = (requiresStringConversion
+								? cmd.zrangebyscoreWithScores(command.getKey().array(), lowerBound.toString(), upperBound.toString(),
+										command.getLimit().get().getOffset(), command.getLimit().get().getCount())
+								: cmd.zrangebyscoreWithScores(command.getKey().array(), (Double) lowerBound, (Double) upperBound,
+										command.getLimit().get().getOffset(), command.getLimit().get().getCount()))
+												.map(sc -> (Tuple) new DefaultTuple(sc.value, sc.score)).toList();
+					}
+				} else {
+
+					if (!isLimited) {
+						result = (requiresStringConversion
+								? cmd.zrangebyscore(command.getKey().array(), lowerBound.toString(), upperBound.toString())
+								: cmd.zrangebyscore(command.getKey().array(), (Double) lowerBound, (Double) upperBound))
+										.map(value -> (Tuple) new DefaultTuple(value, Double.NaN)).toList();
+					} else {
+
+						result = (requiresStringConversion
+								? cmd.zrangebyscore(command.getKey().array(), lowerBound.toString(), upperBound.toString(),
+										command.getLimit().get().getOffset(), command.getLimit().get().getCount())
+								: cmd.zrangebyscore(command.getKey().array(), (Double) lowerBound, (Double) upperBound,
+										command.getLimit().get().getOffset(), command.getLimit().get().getCount()))
+												.map(value -> (Tuple) new DefaultTuple(value, Double.NaN)).toList();
+					}
+				}
+			} else {
+				if (command.getWithScores().isPresent() && ObjectUtils.nullSafeEquals(command.getWithScores().get(), Boolean.TRUE)) {
+
+					if (!isLimited) {
+						result = (requiresStringConversion
+								? cmd.zrevrangebyscoreWithScores(command.getKey().array(), lowerBound.toString(), upperBound.toString())
+								: cmd.zrevrangebyscoreWithScores(command.getKey().array(), (Double) lowerBound, (Double) upperBound))
+										.map(sc -> (Tuple) new DefaultTuple(sc.value, sc.score)).toList();
+					} else {
+
+						result = (requiresStringConversion
+								? cmd.zrevrangebyscoreWithScores(command.getKey().array(), lowerBound.toString(), upperBound.toString(),
+										command.getLimit().get().getOffset(), command.getLimit().get().getCount())
+								: cmd.zrevrangebyscoreWithScores(command.getKey().array(), (Double) lowerBound, (Double) upperBound,
+										command.getLimit().get().getOffset(), command.getLimit().get().getCount()))
+												.map(sc -> (Tuple) new DefaultTuple(sc.value, sc.score)).toList();
+					}
+				} else {
+
+					if (!isLimited) {
+						result = (requiresStringConversion
+								? cmd.zrevrangebyscore(command.getKey().array(), lowerBound.toString(), upperBound.toString())
+								: cmd.zrevrangebyscore(command.getKey().array(), (Double) lowerBound, (Double) upperBound))
+										.map(value -> (Tuple) new DefaultTuple(value, Double.NaN)).toList();
+					} else {
+
+						result = (requiresStringConversion
+								? cmd.zrevrangebyscore(command.getKey().array(), lowerBound.toString(), upperBound.toString(),
+										command.getLimit().get().getOffset(), command.getLimit().get().getCount())
+								: cmd.zrevrangebyscore(command.getKey().array(), (Double) lowerBound, (Double) upperBound,
+										command.getLimit().get().getOffset(), command.getLimit().get().getCount()))
+												.map(value -> (Tuple) new DefaultTuple(value, Double.NaN)).toList();
+					}
+				}
+			}
+
+			return LettuceReactiveRedisConnection.<List<Tuple>> monoConverter().convert(result)
+					.map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zCount(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<ZCountCommand, Long>> zCount(Publisher<ZCountCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getRange(), "Range must not be null!");
+
+			Object lowerBound = AgrumentConverters.lowerBoundArgOf(command.getRange());
+			Object upperBound = AgrumentConverters.upperBoundArgOf(command.getRange());
+
+			Observable<Long> result = Observable.empty();
+
+			if (lowerBound instanceof String || upperBound instanceof String) {
+				result = cmd.zcount(command.getKey().array(), lowerBound.toString(), upperBound.toString());
+			} else {
+				result = cmd.zcount(command.getKey().array(), (Double) lowerBound, (Double) upperBound);
+			}
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zCard(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<KeyCommand, Long>> zCard(Publisher<KeyCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(cmd.zcard(command.getKey().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zScore(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<ZScoreCommand, Double>> zScore(Publisher<ZScoreCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getValue(), "Value must not be null!");
+
+			return LettuceReactiveRedisConnection.<Double> monoConverter()
+					.convert(cmd.zscore(command.getKey().array(), command.getValue().array()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zRemRangeByRank(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<ZRemRangeByRankCommand, Long>> zRemRangeByRank(
+			Publisher<ZRemRangeByRankCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getRange(), "Range must not be null!");
+
+			return LettuceReactiveRedisConnection
+					.<Long> monoConverter().convert(cmd.zremrangebyrank(command.getKey().array(),
+							command.getRange().getLowerBound(), command.getRange().getUpperBound()))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zRemRangeByRank(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<ZRemRangeByScoreCommand, Long>> zRemRangeByScore(
+			Publisher<ZRemRangeByScoreCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getRange(), "Range must not be null!");
+
+			Object lowerBound = AgrumentConverters.lowerBoundArgOf(command.getRange());
+			Object upperBound = AgrumentConverters.upperBoundArgOf(command.getRange());
+
+			Observable<Long> result = (lowerBound instanceof String || upperBound instanceof String)
+					? cmd.zremrangebyscore(command.getKey().array(), lowerBound.toString(), upperBound.toString())
+					: cmd.zremrangebyscore(command.getKey().array(), (Double) lowerBound, (Double) upperBound);
+
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zUnionStore(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<ZUnionStoreCommand, Long>> zUnionStore(Publisher<ZUnionStoreCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Destination key must not be null!");
+			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty!");
+
+			ZStoreArgs args = null;
+			if (command.getAggregateFunction().isPresent() || !command.getWeights().isEmpty()) {
+				args = zStoreArgs(command.getAggregateFunction().isPresent() ? command.getAggregateFunction().get() : null, command.getWeights());
+			}
+
+			byte[][] sourceKeys = command.getSourceKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]);
+			Observable<Long> result = args != null ? cmd.zunionstore(command.getKey().array(), args, sourceKeys)
+					: cmd.zunionstore(command.getKey().array(), sourceKeys);
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zInterStore(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<ZInterStoreCommand, Long>> zInterStore(Publisher<ZInterStoreCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Destination key must not be null!");
+			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty!");
+
+			ZStoreArgs args = null;
+			if (command.getAggregateFunction().isPresent() || !command.getWeights().isEmpty()) {
+				args = zStoreArgs(command.getAggregateFunction().isPresent() ? command.getAggregateFunction().get() : null, command.getWeights());
+			}
+
+			byte[][] sourceKeys = command.getSourceKeys().stream().map(ByteBuffer::array).toArray(size -> new byte[size][]);
+			Observable<Long> result = args != null ? cmd.zinterstore(command.getKey().array(), args, sourceKeys)
+					: cmd.zinterstore(command.getKey().array(), sourceKeys);
+			return LettuceReactiveRedisConnection.<Long> monoConverter().convert(result)
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveZSetCommands#zRangeByLex(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<MultiValueResponse<ZRangeByLexCommand, ByteBuffer>> zRangeByLex(Publisher<ZRangeByLexCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Destination key must not be null!");
+
+			Observable<byte[]> result = Observable.empty();
+
+			String lowerBound = AgrumentConverters.lowerBoundArgOf(command.getRange()).toString();
+			String upperBound = AgrumentConverters.upperBoundArgOf(command.getRange()).toString();
+
+			if (command.getLimit() != null) {
+
+				if (ObjectUtils.nullSafeEquals(command.getDirection(), Direction.ASC)) {
+					result = cmd.zrangebylex(command.getKey().array(), lowerBound, upperBound, command.getLimit().getOffset(),
+							command.getLimit().getCount());
+				} else {
+
+					// TODO: fix when https://github.com/mp911de/lettuce/issues/369 resolved
+					throw new UnsupportedOperationException("Lettuce does not support ZREVRANGEBYLEX.");
+				}
+			} else {
+				if (ObjectUtils.nullSafeEquals(command.getDirection(), Direction.ASC)) {
+					result = cmd.zrangebylex(command.getKey().array(), lowerBound, upperBound);
+				} else {
+
+					// TODO: fix when https://github.com/mp911de/lettuce/issues/369 resolved
+					throw new UnsupportedOperationException("Lettuce does not support ZREVRANGEBYLEX.");
+				}
+			}
+
+			return LettuceReactiveRedisConnection.<List<ByteBuffer>> monoConverter()
+					.convert(result.map(ByteBuffer::wrap).toList()).map(value -> new MultiValueResponse<>(command, value));
+		}));
+	}
+
+	private ZStoreArgs zStoreArgs(Aggregate aggregate, List<Double> weights) {
+
+		ZStoreArgs args = new ZStoreArgs();
+		if (aggregate != null) {
+			switch (aggregate) {
+				case MIN:
+					args.min();
+					break;
+				case MAX:
+					args.max();
+					break;
+				default:
+					args.sum();
+					break;
+			}
+		}
+
+		// TODO: fix when https://github.com/mp911de/lettuce/issues/368 resolved
+		if (weights != null) {
+			long[] lg = new long[weights.size()];
+			for (int i = 0; i < lg.length; i++) {
+				lg[i] = weights.get(i).longValue();
+			}
+			args.weights(lg);
+		}
+		return args;
+	}
+
+	protected LettuceReactiveRedisConnection getConnection() {
+		return connection;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/util/ByteUtils.java
+++ b/src/main/java/org/springframework/data/redis/util/ByteUtils.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.util;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -97,5 +98,22 @@ public final class ByteUtils {
 		System.arraycopy(additionalArrays, 0, result, 1, additionalArrays.length);
 
 		return result;
+	}
+
+	/**
+	 * Extract a byte array from {@link ByteBuffer} without consuming it.
+	 *
+	 * @param byteBuffer must not be {@literal null}.
+	 * @return
+	 * @since 2.0
+	 */
+	public static byte[] getBytes(ByteBuffer byteBuffer) {
+
+		Assert.notNull(byteBuffer, "ByteBuffer must not be null!");
+
+		ByteBuffer duplicate = byteBuffer.duplicate();
+		byte[] bytes = new byte[duplicate.remaining()];
+		duplicate.get(bytes);
+		return bytes;
 	}
 }

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheTest.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.AfterClass;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
@@ -254,7 +255,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		cache.put(key, value);
 
 		RedisCache redisCache = (RedisCache) cache;
-		assertThat(redisCache.get(key, value.getClass()), instanceOf(value.getClass()));
+		assertThat(redisCache.get(key, value.getClass()), IsInstanceOf.<Object>instanceOf(value.getClass()));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/cache/TransactionalRedisCacheManagerWithCommitUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/TransactionalRedisCacheManagerWithCommitUnitTests.java
@@ -55,7 +55,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(transactionManager = "transactionManager")
 public class TransactionalRedisCacheManagerWithCommitUnitTests {
 
-	@SuppressWarnings("rawtypes")//
+	@SuppressWarnings("rawtypes") //
 	protected @Autowired RedisTemplate redisTemplate;
 	protected @Autowired FooService transactionalService;
 

--- a/src/test/java/org/springframework/data/redis/cache/TransactionalRedisCacheManagerWithRollbackUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/TransactionalRedisCacheManagerWithRollbackUnitTests.java
@@ -51,7 +51,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(transactionManager = "transactionManager")
 public class TransactionalRedisCacheManagerWithRollbackUnitTests {
 
-	@SuppressWarnings("rawtypes")//
+	@SuppressWarnings("rawtypes") //
 	protected @Autowired RedisTemplate redisTemplate;
 	protected @Autowired FooService transactionalService;
 

--- a/src/test/java/org/springframework/data/redis/connection/AbstractTransactionalTestBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractTransactionalTestBase.java
@@ -105,8 +105,9 @@ public abstract class AbstractTransactionalTestBase {
 
 		RedisConnection connection = factory.getConnection();
 		for (String key : KEYS) {
-			Assert.assertThat("Values for " + key + " should " + (valuesShouldHaveBeenPersisted ? "" : "NOT ")
-					+ "have been found.", connection.exists(key.getBytes()), Is.is(valuesShouldHaveBeenPersisted));
+			Assert.assertThat(
+					"Values for " + key + " should " + (valuesShouldHaveBeenPersisted ? "" : "NOT ") + "have been found.",
+					connection.exists(key.getBytes()), Is.is(valuesShouldHaveBeenPersisted));
 		}
 		connection.close();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClientTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClientTests.java
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.lambdaworks.redis.RedisAsyncConnection;
 import com.lambdaworks.redis.RedisClient;
 import com.lambdaworks.redis.RedisException;
 import com.lambdaworks.redis.api.StatefulRedisConnection;
@@ -77,15 +76,15 @@ public class AuthenticatingRedisClientTests {
 
 	@Test
 	public void connectAsync() {
-		RedisAsyncConnection<String, String> conn = client.connectAsync();
-		conn.ping();
+		StatefulRedisConnection<String, String> conn = client.connect();
+		conn.sync().ping();
 		conn.close();
 	}
 
 	@Test
 	public void codecConnectAsync() {
-		RedisAsyncConnection<byte[], byte[]> conn = client.connectAsync(LettuceConnection.CODEC);
-		conn.ping();
+		StatefulRedisConnection<byte[], byte[]> conn = client.connect(LettuceConnection.CODEC);
+		conn.sync().ping();
 		conn.close();
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -260,7 +260,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.rename(KEY_1_BYTES, KEY_2_BYTES);
 
-		assertThat(nativeConnection.exists(KEY_1), is(false));
+		assertThat(nativeConnection.exists(KEY_1), is(0L));
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_1));
 	}
 
@@ -274,7 +274,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.rename(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
-		assertThat(nativeConnection.exists(SAME_SLOT_KEY_1), is(false));
+		assertThat(nativeConnection.exists(SAME_SLOT_KEY_1), is(0L));
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), is(VALUE_1));
 	}
 
@@ -288,7 +288,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		assertThat(clusterConnection.renameNX(KEY_1_BYTES, KEY_2_BYTES), is(Boolean.TRUE));
 
-		assertThat(nativeConnection.exists(KEY_1), is(false));
+		assertThat(nativeConnection.exists(KEY_1), is(0L));
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_1));
 	}
 
@@ -317,7 +317,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		assertThat(clusterConnection.renameNX(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES), is(Boolean.TRUE));
 
-		assertThat(nativeConnection.exists(SAME_SLOT_KEY_1), is(false));
+		assertThat(nativeConnection.exists(SAME_SLOT_KEY_1), is(0L));
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), is(VALUE_1));
 	}
 
@@ -529,7 +529,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		nativeConnection.lpush(KEY_1, VALUE_2, VALUE_1);
 
 		assertThat(clusterConnection.sort(KEY_1_BYTES, new DefaultSortParameters().alpha(), KEY_2_BYTES), is(1L));
-		assertThat(nativeConnection.exists(KEY_2), is(true));
+		assertThat(nativeConnection.exists(KEY_2), is(1L));
 	}
 
 	/**
@@ -951,7 +951,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.rPushX(KEY_1_BYTES, VALUE_1_BYTES);
 
-		assertThat(nativeConnection.exists(KEY_1), is(false));
+		assertThat(nativeConnection.exists(KEY_1), is(0L));
 	}
 
 	/**
@@ -962,7 +962,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.lPushX(KEY_1_BYTES, VALUE_1_BYTES);
 
-		assertThat(nativeConnection.exists(KEY_1), is(false));
+		assertThat(nativeConnection.exists(KEY_1), is(0L));
 	}
 
 	/**
@@ -1141,7 +1141,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2);
 
 		assertThat(clusterConnection.bRPopLPush(0, KEY_1_BYTES, KEY_2_BYTES), is(VALUE_1_BYTES));
-		assertThat(nativeConnection.exists(KEY_2), is(true));
+		assertThat(nativeConnection.exists(KEY_2), is(1L));
 	}
 
 	/**
@@ -1153,7 +1153,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		nativeConnection.lpush(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
 
 		assertThat(clusterConnection.bRPopLPush(0, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES), is(VALUE_1_BYTES));
-		assertThat(nativeConnection.exists(SAME_SLOT_KEY_2), is(true));
+		assertThat(nativeConnection.exists(SAME_SLOT_KEY_2), is(1L));
 	}
 
 	/**
@@ -1165,7 +1165,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		nativeConnection.lpush(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
 
 		assertThat(clusterConnection.rPopLPush(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES), is(VALUE_1_BYTES));
-		assertThat(nativeConnection.exists(SAME_SLOT_KEY_2), is(true));
+		assertThat(nativeConnection.exists(SAME_SLOT_KEY_2), is(1L));
 	}
 
 	/**
@@ -1911,7 +1911,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.hMSet(KEY_1_BYTES, hashes);
 
-		assertThat(nativeConnection.hmget(KEY_1, KEY_2, KEY_3), hasItems(VALUE_1, VALUE_2));
+		assertThat(clusterConnection.hMGet(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
 	/**
@@ -2407,7 +2407,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.upsert());
 
-		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.exists(KEY_1), is(1L));
 		assertThat(nativeConnection.ttl(KEY_1), is(1L));
 	}
 
@@ -2419,7 +2419,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.milliseconds(500), SetOption.upsert());
 
-		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.exists(KEY_1), is(1L));
 		assertThat(nativeConnection.pttl(KEY_1).doubleValue(), is(closeTo(500d, 499d)));
 	}
 
@@ -2441,7 +2441,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.persistent(), SetOption.ifAbsent());
 
-		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.exists(KEY_1), is(1L));
 		assertThat(nativeConnection.ttl(KEY_1), is(-1L));
 	}
 
@@ -2453,7 +2453,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifAbsent());
 
-		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.exists(KEY_1), is(1L));
 		assertThat(nativeConnection.ttl(KEY_1), is(1L));
 	}
 
@@ -2467,7 +2467,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.seconds(1), SetOption.ifAbsent());
 
-		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.exists(KEY_1), is(1L));
 		assertThat(nativeConnection.ttl(KEY_1), is(-1L));
 		assertThat(nativeConnection.get(KEY_1), is(equalTo(VALUE_1)));
 
@@ -2483,7 +2483,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.seconds(1), SetOption.ifPresent());
 
-		assertThat(nativeConnection.exists(KEY_1), is(true));
+		assertThat(nativeConnection.exists(KEY_1), is(1L));
 		assertThat(nativeConnection.ttl(KEY_1), is(1L));
 		assertThat(nativeConnection.get(KEY_1), is(equalTo(VALUE_2)));
 
@@ -2497,7 +2497,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifPresent());
 
-		assertThat(nativeConnection.exists(KEY_1), is(false));
+		assertThat(nativeConnection.exists(KEY_1), is(0L));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -32,6 +32,7 @@ import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.connection.DefaultStringRedisConnection;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.repository.util.QueryExecutionConverters;
 
 import com.lambdaworks.redis.RedisException;
 import com.lambdaworks.redis.api.async.RedisAsyncCommands;
@@ -324,5 +325,21 @@ public class LettuceConnectionFactoryTests {
 		} finally {
 			connection.close();
 		}
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void factoryShouldReturnReactiveConnectionWhenCorrectly() {
+
+		LettuceConnectionFactory factory = new LettuceConnectionFactory();
+		factory.afterPropertiesSet();
+
+		ConnectionFactoryTracker.add(factory);
+
+		assertThat(factory.getReactiveConnection()
+				.execute(cmd -> QueryExecutionConverters.RxJava1ObservableToMonoConverter.INSTANCE.convert(cmd.ping()))
+				.blockFirst(), is("PONG"));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -20,6 +20,7 @@ import static org.hamcrest.core.IsEqual.*;
 import static org.hamcrest.core.IsNull.*;
 import static org.junit.Assert.*;
 
+import com.lambdaworks.redis.api.reactive.BaseRedisReactiveCommands;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -339,7 +340,7 @@ public class LettuceConnectionFactoryTests {
 		ConnectionFactoryTracker.add(factory);
 
 		assertThat(factory.getReactiveConnection()
-				.execute(cmd -> QueryExecutionConverters.RxJava1ObservableToMonoConverter.INSTANCE.convert(cmd.ping()))
+				.execute(BaseRedisReactiveCommands::ping)
 				.blockFirst(), is("PONG"));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeThat;
+
+import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.springframework.data.redis.test.util.LettuceRedisClusterClientProvider;
+
+/**
+ * @author Christoph Strobl
+ */
+public abstract class LettuceReactiveClusterCommandsTestsBase {
+
+	public static @ClassRule LettuceRedisClusterClientProvider clientProvider = LettuceRedisClusterClientProvider.local();
+
+	RedisClusterCommands<String, String> nativeCommands;
+	LettuceReactiveRedisClusterConnection connection;
+
+	@Before
+	public void before() {
+		assumeThat(clientProvider.test(), is(true));
+		nativeCommands = clientProvider.getClient().connect().sync();
+		connection = new LettuceReactiveRedisClusterConnection(clientProvider.getClient());
+	}
+
+	@After
+	public void tearDown() {
+
+		if(nativeCommands != null) {
+			nativeCommands.flushall();
+			nativeCommands.close();
+		}
+
+		if(connection != null) {
+			connection.close();
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
@@ -16,14 +16,17 @@
 
 package org.springframework.data.redis.connection.lettuce;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assume.assumeThat;
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assume.*;
 
-import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.springframework.data.redis.test.util.LettuceRedisClusterClientProvider;
+
+import com.lambdaworks.redis.api.sync.RedisCommands;
+import com.lambdaworks.redis.cluster.api.sync.RedisAdvancedClusterCommands;
+import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
 
 /**
  * @author Christoph Strobl
@@ -45,12 +48,19 @@ public abstract class LettuceReactiveClusterCommandsTestsBase {
 	@After
 	public void tearDown() {
 
-		if(nativeCommands != null) {
+		if (nativeCommands != null) {
 			nativeCommands.flushall();
-			nativeCommands.close();
+
+			if (nativeCommands instanceof RedisCommands) {
+				((RedisCommands) nativeCommands).getStatefulConnection().close();
+			}
+
+			if (nativeCommands instanceof RedisAdvancedClusterCommands) {
+				((RedisAdvancedClusterCommands) nativeCommands).getStatefulConnection().close();
+			}
 		}
 
-		if(connection != null) {
+		if (connection != null) {
 			connection.close();
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommandsTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.redis.connection.lettuce.LettuceReactiveCommandsTestsBase.*;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveClusterHyperLogLogCommandsTests extends LettuceReactiveClusterCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void pfCountWithMultipleKeysShouldReturnCorrectlyWhenKeysMapToSameSlot() {
+
+		nativeCommands.pfadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 });
+		nativeCommands.pfadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 });
+
+		assertThat(connection.hyperLogLogCommands().pfCount(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER))
+				.block(), is(3L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void pfMergeShouldWorkCorrectlyWhenKeysMapToSameSlot() {
+
+		nativeCommands.pfadd(SAME_SLOT_KEY_1, new String[] { VALUE_1, VALUE_2 });
+		nativeCommands.pfadd(SAME_SLOT_KEY_2, new String[] { VALUE_2, VALUE_3 });
+
+		assertThat(
+				connection.hyperLogLogCommands()
+						.pfMerge(SAME_SLOT_KEY_3_BBUFFER, Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER)).block(),
+				is(true));
+
+		assertThat(nativeCommands.pfcount(new String[] { SAME_SLOT_KEY_3 }), is(3L));
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommandsTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.hamcrest.collection.IsIterableContainingInOrder.*;
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsEqual.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.redis.connection.RedisClusterNode.*;
+import static org.springframework.data.redis.connection.lettuce.LettuceReactiveCommandsTestsBase.*;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.data.redis.connection.RedisClusterNode;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveClusterKeyCommandsTests extends LettuceReactiveClusterCommandsTestsBase {
+
+	static final RedisClusterNode NODE_1 = newRedisClusterNode().listeningAt("127.0.0.1", 7379).build();
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void keysShouldReturnOnlyKeysFromSelectedNode() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		List<ByteBuffer> result = connection.keyCommands().keys(NODE_1, ByteBuffer.wrap("*".getBytes())).block();
+		assertThat(result, hasSize(1));
+		assertThat(result, contains(KEY_1_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void randomkeyShouldReturnOnlyKeysFromSelectedNode() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		Mono<ByteBuffer> randomkey = connection.keyCommands().randomKey(NODE_1);
+
+		for (int i = 0; i < 10; i++) {
+			assertThat(randomkey.block(), is(equalTo(KEY_1_BBUFFER)));
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommandsTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsEqual.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.redis.connection.lettuce.LettuceReactiveCommandsTestsBase.*;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.springframework.data.redis.connection.ReactiveListCommands;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveClusterListCommandsTests extends LettuceReactiveClusterCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void bRPopLPushShouldWorkCorrectlyWhenAllKeysMapToSameSlot() {
+
+		nativeCommands.rpush(SAME_SLOT_KEY_1, VALUE_1, VALUE_2, VALUE_3);
+		nativeCommands.rpush(SAME_SLOT_KEY_2, VALUE_1);
+
+		ByteBuffer result = connection.listCommands()
+				.bRPopLPush(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER, Duration.ofSeconds(1)).block();
+
+		assertThat(result, is(equalTo(VALUE_3_BBUFFER)));
+		assertThat(nativeCommands.llen(SAME_SLOT_KEY_2), is(2L));
+		assertThat(nativeCommands.lindex(SAME_SLOT_KEY_2, 0), is(equalTo(VALUE_3)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void blPopShouldReturnFirstAvailableWhenAllKeysMapToTheSameSlot() {
+
+		nativeCommands.rpush(SAME_SLOT_KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		ReactiveListCommands.PopResult result = connection.listCommands()
+				.blPop(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER), Duration.ofSeconds(1L)).block();
+		assertThat(result.getKey(), is(equalTo(SAME_SLOT_KEY_1_BBUFFER)));
+		assertThat(result.getValue(), is(equalTo(VALUE_1_BBUFFER)));
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommandsTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsEqual.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.redis.connection.lettuce.LettuceReactiveCommandsTestsBase.*;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.data.redis.connection.RedisStringCommands;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.0
+ */
+public class LettuceReactiveClusterStringCommandsTests extends LettuceReactiveClusterCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void mSetNXShouldAddMultipleKeyValueParisWhenMappedToSameSlot() {
+
+		Map<ByteBuffer, ByteBuffer> map = new LinkedHashMap<>();
+		map.put(SAME_SLOT_KEY_1_BBUFFER, VALUE_1_BBUFFER);
+		map.put(SAME_SLOT_KEY_2_BBUFFER, VALUE_2_BBUFFER);
+
+		connection.stringCommands().mSetNX(map).block();
+
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_1), is(equalTo(VALUE_1)));
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_2), is(equalTo(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void mSetNXShouldNotAddMultipleKeyValueParisWhenAlreadyExitAndMapToSameSlot() {
+
+		nativeCommands.set(SAME_SLOT_KEY_2, VALUE_2);
+
+		Map<ByteBuffer, ByteBuffer> map = new LinkedHashMap<>();
+		map.put(SAME_SLOT_KEY_1_BBUFFER, VALUE_1_BBUFFER);
+		map.put(SAME_SLOT_KEY_2_BBUFFER, VALUE_2_BBUFFER);
+
+		assertThat(connection.stringCommands().mSetNX(map).block(), is(false));
+
+		assertThat(nativeCommands.exists(SAME_SLOT_KEY_1), is(false));
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_2), is(equalTo(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void bitOpAndShouldWorkAsExpectedWhenKeysMapToSameSlot() {
+
+		nativeCommands.set(SAME_SLOT_KEY_1, VALUE_1);
+		nativeCommands.set(SAME_SLOT_KEY_2, VALUE_2);
+
+		assertThat(connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER),
+				RedisStringCommands.BitOperation.AND, SAME_SLOT_KEY_3_BBUFFER).block(), is(7L));
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_3), is(equalTo("value-0")));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void bitOpOrShouldWorkAsExpectedWhenKeysMapToSameSlot() {
+
+		nativeCommands.set(SAME_SLOT_KEY_1, VALUE_1);
+		nativeCommands.set(SAME_SLOT_KEY_2, VALUE_2);
+
+		assertThat(connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER),
+				RedisStringCommands.BitOperation.OR, SAME_SLOT_KEY_3_BBUFFER).block(), is(7L));
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_3), is(equalTo(VALUE_3)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void bitNotShouldThrowExceptionWhenMoreThanOnSourceKeyAndKeysMapToSameSlot() {
+
+		connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER),
+				RedisStringCommands.BitOperation.NOT, SAME_SLOT_KEY_3_BBUFFER).block();
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommandsTests.java
@@ -65,7 +65,7 @@ public class LettuceReactiveClusterStringCommandsTests extends LettuceReactiveCl
 
 		assertThat(connection.stringCommands().mSetNX(map).block(), is(false));
 
-		assertThat(nativeCommands.exists(SAME_SLOT_KEY_1), is(false));
+		assertThat(nativeCommands.exists(SAME_SLOT_KEY_1), is(0L));
 		assertThat(nativeCommands.get(SAME_SLOT_KEY_2), is(equalTo(VALUE_2)));
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommandsTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.redis.connection.lettuce.LettuceReactiveCommandsTestsBase.*;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveClusterZSetCommandsTests extends LettuceReactiveClusterCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zUnionStoreShouldWorkWhenAllKeysMapToSameSlot() {
+
+		nativeCommands.zadd(SAME_SLOT_KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(SAME_SLOT_KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(SAME_SLOT_KEY_2, 1D, VALUE_1);
+		nativeCommands.zadd(SAME_SLOT_KEY_2, 2D, VALUE_2);
+		nativeCommands.zadd(SAME_SLOT_KEY_2, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zUnionStore(SAME_SLOT_KEY_3_BBUFFER,
+				Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER), Arrays.asList(2D, 3D)).block(), is(3L));
+
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zInterStoreShouldWorkCorrectlyWhenKeysMapToSameSlot() {
+
+		nativeCommands.zadd(SAME_SLOT_KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(SAME_SLOT_KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(SAME_SLOT_KEY_2, 1D, VALUE_1);
+		nativeCommands.zadd(SAME_SLOT_KEY_2, 2D, VALUE_2);
+		nativeCommands.zadd(SAME_SLOT_KEY_2, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zInterStore(SAME_SLOT_KEY_3_BBUFFER,
+				Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER), Arrays.asList(2D, 3D)).block(), is(2L));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeThat;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+
+import com.lambdaworks.redis.AbstractRedisClient;
+import com.lambdaworks.redis.cluster.RedisClusterClient;
+import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
+import org.hamcrest.core.Is;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
+
+import com.lambdaworks.redis.RedisClient;
+import com.lambdaworks.redis.api.sync.RedisCommands;
+import org.springframework.data.redis.test.util.LettuceRedisClusterClientProvider;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(Parameterized.class)
+public class LettuceReactiveCommandsTestsBase {
+
+	static final String KEY_1 = "key-1";
+	static final String KEY_2 = "key-2";
+	static final String KEY_3 = "key-3";
+	static final String SAME_SLOT_KEY_1 = "{key}-1";
+	static final String SAME_SLOT_KEY_2 = "{key}-2";
+	static final String SAME_SLOT_KEY_3 = "{key}-3";
+	static final String VALUE_1 = "value-1";
+	static final String VALUE_2 = "value-2";
+	static final String VALUE_3 = "value-3";
+
+	static final byte[] SAME_SLOT_KEY_1_BYTES = SAME_SLOT_KEY_1.getBytes(Charset.forName("UTF-8"));
+	static final byte[] SAME_SLOT_KEY_2_BYTES = SAME_SLOT_KEY_2.getBytes(Charset.forName("UTF-8"));
+	static final byte[] SAME_SLOT_KEY_3_BYTES = SAME_SLOT_KEY_3.getBytes(Charset.forName("UTF-8"));
+	static final byte[] KEY_1_BYTES = KEY_1.getBytes(Charset.forName("UTF-8"));
+	static final byte[] KEY_2_BYTES = KEY_2.getBytes(Charset.forName("UTF-8"));
+	static final byte[] KEY_3_BYTES = KEY_3.getBytes(Charset.forName("UTF-8"));
+	static final byte[] VALUE_1_BYTES = VALUE_1.getBytes(Charset.forName("UTF-8"));
+	static final byte[] VALUE_2_BYTES = VALUE_2.getBytes(Charset.forName("UTF-8"));
+	static final byte[] VALUE_3_BYTES = VALUE_3.getBytes(Charset.forName("UTF-8"));
+
+	static final ByteBuffer KEY_1_BBUFFER = ByteBuffer.wrap(KEY_1_BYTES);
+	static final ByteBuffer SAME_SLOT_KEY_1_BBUFFER = ByteBuffer.wrap(SAME_SLOT_KEY_1_BYTES);
+	static final ByteBuffer VALUE_1_BBUFFER = ByteBuffer.wrap(VALUE_1_BYTES);
+
+	static final ByteBuffer KEY_2_BBUFFER = ByteBuffer.wrap(KEY_2_BYTES);
+	static final ByteBuffer SAME_SLOT_KEY_2_BBUFFER = ByteBuffer.wrap(SAME_SLOT_KEY_2_BYTES);
+	static final ByteBuffer VALUE_2_BBUFFER = ByteBuffer.wrap(VALUE_2_BYTES);
+
+	static final ByteBuffer KEY_3_BBUFFER = ByteBuffer.wrap(KEY_3_BYTES);
+	static final ByteBuffer SAME_SLOT_KEY_3_BBUFFER = ByteBuffer.wrap(SAME_SLOT_KEY_3_BYTES);
+	static final ByteBuffer VALUE_3_BBUFFER = ByteBuffer.wrap(VALUE_3_BYTES);
+
+	@Parameterized.Parameter(value = 0) public Object clientProvider;
+
+	LettuceReactiveRedisConnection connection;
+	RedisClusterCommands<String, String> nativeCommands;
+
+	@Parameterized.Parameters
+	public static List<Object> parameters() {
+		return Arrays.asList(LettuceRedisClientProvider.local(), LettuceRedisClusterClientProvider.local());
+	}
+
+	@Before
+	public void setUp() {
+
+		AbstractRedisClient abstractRedisClient = null;
+		if (clientProvider instanceof LettuceRedisClientProvider) {
+			abstractRedisClient = ((LettuceRedisClientProvider) clientProvider).getClient();
+		} else if (clientProvider instanceof LettuceRedisClusterClientProvider) {
+			abstractRedisClient = ((LettuceRedisClusterClientProvider) clientProvider).getClient();
+			assumeThat(((LettuceRedisClusterClientProvider) clientProvider).test(), is(true));
+		}
+
+		if (abstractRedisClient instanceof RedisClient) {
+			nativeCommands = ((RedisClient) abstractRedisClient).connect().sync();
+			connection = new LettuceReactiveRedisConnection(abstractRedisClient);
+
+		} else if (abstractRedisClient instanceof RedisClusterClient) {
+			nativeCommands = ((RedisClusterClient) abstractRedisClient).connect().sync();
+			connection = new LettuceReactiveRedisClusterConnection((RedisClusterClient) abstractRedisClient);
+		}
+
+	}
+
+	@After
+	public void tearDown() {
+
+		if (nativeCommands != null) {
+			flushAll();
+			nativeCommands.close();
+		}
+
+		if (connection != null) {
+			connection.close();
+		}
+	}
+
+	private void flushAll() {
+		nativeCommands.flushall();
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommandsTests.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.hamcrest.collection.IsIterableContainingInOrder.*;
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.hamcrest.number.IsCloseTo.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.redis.connection.RedisGeoCommands.DistanceUnit.*;
+import static org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs.*;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveGeoCommandsTests extends LettuceReactiveCommandsTestsBase {
+
+	private static final String ARIGENTO_MEMBER_NAME = "arigento";
+	private static final String CATANIA_MEMBER_NAME = "catania";
+	private static final String PALERMO_MEMBER_NAME = "palermo";
+
+	private static final Point POINT_ARIGENTO = new Point(13.583333, 37.316667);
+	private static final Point POINT_CATANIA = new Point(15.087269, 37.502669);
+	private static final Point POINT_PALERMO = new Point(13.361389, 38.115556);
+
+	private static final GeoLocation<ByteBuffer> ARIGENTO = new GeoLocation<>(
+			ByteBuffer.wrap(ARIGENTO_MEMBER_NAME.getBytes(Charset.forName("UTF-8"))), POINT_ARIGENTO);
+	private static final GeoLocation<ByteBuffer> CATANIA = new GeoLocation<>(
+			ByteBuffer.wrap(CATANIA_MEMBER_NAME.getBytes(Charset.forName("UTF-8"))), POINT_CATANIA);
+	private static final GeoLocation<ByteBuffer> PALERMO = new GeoLocation<>(
+			ByteBuffer.wrap(PALERMO_MEMBER_NAME.getBytes(Charset.forName("UTF-8"))), POINT_PALERMO);
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoAddShouldAddSingleGeoLocationCorrectly() {
+		assertThat(connection.geoCommands().geoAdd(KEY_1_BBUFFER, ARIGENTO).block(), is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoAddShouldAddMultipleGeoLocationsCorrectly() {
+		assertThat(connection.geoCommands().geoAdd(KEY_1_BBUFFER, Arrays.asList(ARIGENTO, CATANIA, PALERMO)).block(),
+				is(3L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoDistShouldReturnDistanceInMetersByDefault() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+
+		assertThat(connection.geoCommands().geoDist(KEY_1_BBUFFER, PALERMO.getName(), CATANIA.getName()).block().getValue(),
+				is(closeTo(166274.15156960033D, 0.005)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoDistShouldReturnDistanceInDesiredMetric() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+
+		assertThat(connection.geoCommands().geoDist(KEY_1_BBUFFER, PALERMO.getName(), CATANIA.getName(), Metrics.KILOMETERS)
+				.block().getValue(), is(closeTo(166.27415156960033D, 0.005)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoHash() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+
+		assertThat(
+				connection.geoCommands().geoHash(KEY_1_BBUFFER, Arrays.asList(PALERMO.getName(), CATANIA.getName())).block(),
+				contains("sqc8b49rny0", "sqdtr74hyu0"));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoHashNotExisting() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+
+		assertThat(
+				connection.geoCommands()
+						.geoHash(KEY_1_BBUFFER, Arrays.asList(PALERMO.getName(), ARIGENTO.getName(), CATANIA.getName())).block(),
+				contains("sqc8b49rny0", null, "sqdtr74hyu0"));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoPos() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+
+		List<Point> result = connection.geoCommands()
+				.geoPos(KEY_1_BBUFFER, Arrays.asList(PALERMO.getName(), CATANIA.getName())).block();
+		assertThat(result.get(0).getX(), is(closeTo(POINT_PALERMO.getX(), 0.005)));
+		assertThat(result.get(0).getY(), is(closeTo(POINT_PALERMO.getY(), 0.005)));
+
+		assertThat(result.get(1).getX(), is(closeTo(POINT_CATANIA.getX(), 0.005)));
+		assertThat(result.get(1).getY(), is(closeTo(POINT_CATANIA.getY(), 0.005)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoPosNonExisting() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+
+		List<Point> result = connection.geoCommands()
+				.geoPos(KEY_1_BBUFFER, Arrays.asList(PALERMO.getName(), ARIGENTO.getName(), CATANIA.getName())).block();
+		assertThat(result.get(0).getX(), is(closeTo(POINT_PALERMO.getX(), 0.005)));
+		assertThat(result.get(0).getY(), is(closeTo(POINT_PALERMO.getY(), 0.005)));
+
+		assertThat(result.get(1), is(nullValue()));
+
+		assertThat(result.get(2).getX(), is(closeTo(POINT_CATANIA.getX(), 0.005)));
+		assertThat(result.get(2).getY(), is(closeTo(POINT_CATANIA.getY(), 0.005)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoRadiusShouldReturnMembersCorrectly() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, ARIGENTO.getPoint().getX(), ARIGENTO.getPoint().getY(), ARIGENTO_MEMBER_NAME);
+
+		assertThat(
+				connection.geoCommands()
+						.geoRadius(KEY_1_BBUFFER, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS))).block(),
+				hasSize(3));
+		assertThat(
+				connection.geoCommands()
+						.geoRadius(KEY_1_BBUFFER, new Circle(new Point(15D, 37D), new Distance(150D, KILOMETERS))).block(),
+				hasSize(2));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoRadiusShouldReturnDistanceCorrectly() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, ARIGENTO.getPoint().getX(), ARIGENTO.getPoint().getY(), ARIGENTO_MEMBER_NAME);
+
+		GeoResults<GeoLocation<ByteBuffer>> result = connection.geoCommands().geoRadius(KEY_1_BBUFFER,
+				new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)), newGeoRadiusArgs().includeDistance()).block();
+
+		assertThat(result.getContent().get(0).getDistance().getValue(), is(closeTo(130.423D, 0.005)));
+		assertThat(result.getContent().get(0).getDistance().getUnit(), is("km"));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoRadiusShouldApplyLimit() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, ARIGENTO.getPoint().getX(), ARIGENTO.getPoint().getY(), ARIGENTO_MEMBER_NAME);
+
+		GeoResults<GeoLocation<ByteBuffer>> result = connection.geoCommands().geoRadius(KEY_1_BBUFFER,
+				new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)), newGeoRadiusArgs().limit(2)).block();
+
+		assertThat(result.getContent(), hasSize(2));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoRadiusByMemberShouldReturnMembersCorrectly() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, ARIGENTO.getPoint().getX(), ARIGENTO.getPoint().getY(), ARIGENTO_MEMBER_NAME);
+
+		List<GeoLocation<ByteBuffer>> result = connection.geoCommands()
+				.geoRadiusByMember(KEY_1_BBUFFER, ARIGENTO.getName(), new Distance(100, KILOMETERS)).block();
+
+		assertThat(result.get(0).getName(), is(ARIGENTO.getName()));
+		assertThat(result.get(1).getName(), is(PALERMO.getName()));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoRadiusByMemberShouldReturnDistanceCorrectly() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, ARIGENTO.getPoint().getX(), ARIGENTO.getPoint().getY(), ARIGENTO_MEMBER_NAME);
+
+		GeoResults<GeoLocation<ByteBuffer>> result = connection.geoCommands().geoRadiusByMember(KEY_1_BBUFFER,
+				PALERMO.getName(), new Distance(100, KILOMETERS), newGeoRadiusArgs().includeDistance()).block();
+
+		assertThat(result.getContent(), hasSize(2));
+		assertThat(result.getContent().get(0).getDistance().getValue(), is(closeTo(90.978D, 0.005)));
+		assertThat(result.getContent().get(0).getDistance().getUnit(), is("km"));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void geoRadiusByMemberShouldApplyLimit() {
+
+		nativeCommands.geoadd(KEY_1, PALERMO.getPoint().getX(), PALERMO.getPoint().getY(), PALERMO_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, CATANIA.getPoint().getX(), CATANIA.getPoint().getY(), CATANIA_MEMBER_NAME);
+		nativeCommands.geoadd(KEY_1, ARIGENTO.getPoint().getX(), ARIGENTO.getPoint().getY(), ARIGENTO_MEMBER_NAME);
+
+		GeoResults<GeoLocation<ByteBuffer>> result = connection.geoCommands()
+				.geoRadiusByMember(KEY_1_BBUFFER, PALERMO.getName(), new Distance(200, KILOMETERS), newGeoRadiusArgs().limit(2))
+				.block();
+
+		assertThat(result.getContent(), hasSize(2));
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.*;
+import static org.hamcrest.collection.IsIterableContainingInOrder.*;
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsEqual.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveHashCommandsTests extends LettuceReactiveCommandsTestsBase {
+
+	static final String FIELD_1 = "field-1";
+	static final String FIELD_2 = "field-2";
+	static final String FIELD_3 = "field-3";
+
+	static final byte[] FIELD_1_BYTES = FIELD_1.getBytes(Charset.forName("UTF-8"));
+	static final byte[] FIELD_2_BYTES = FIELD_2.getBytes(Charset.forName("UTF-8"));
+	static final byte[] FIELD_3_BYTES = FIELD_3.getBytes(Charset.forName("UTF-8"));
+
+	static final ByteBuffer FIELD_1_BBUFFER = ByteBuffer.wrap(FIELD_1_BYTES);
+	static final ByteBuffer FIELD_2_BBUFFER = ByteBuffer.wrap(FIELD_2_BYTES);
+	static final ByteBuffer FIELD_3_BBUFFER = ByteBuffer.wrap(FIELD_3_BYTES);
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hSetShouldOperateCorrectly() {
+		assertThat(connection.hashCommands().hSet(KEY_1_BBUFFER, FIELD_1_BBUFFER, VALUE_1_BBUFFER).block(), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hSetNxShouldOperateCorrectly() {
+		assertThat(connection.hashCommands().hSetNX(KEY_1_BBUFFER, FIELD_1_BBUFFER, VALUE_1_BBUFFER).block(), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hSetNxShouldReturnFalseIfFieldAlreadyExists() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+
+		assertThat(connection.hashCommands().hSetNX(KEY_1_BBUFFER, FIELD_1_BBUFFER, VALUE_1_BBUFFER).block(), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hGetShouldReturnValueForExistingField() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		assertThat(connection.hashCommands().hGet(KEY_1_BBUFFER, FIELD_1_BBUFFER).block(), is(equalTo(VALUE_1_BBUFFER)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hGetShouldReturnNullForNotExistingField() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+
+		assertThat(connection.hashCommands().hGet(KEY_1_BBUFFER, FIELD_2_BBUFFER).block(), is(nullValue()));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hMGetShouldReturnValueForFields() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		assertThat(connection.hashCommands().hMGet(KEY_1_BBUFFER, Arrays.asList(FIELD_1_BBUFFER, FIELD_3_BBUFFER)).block(),
+				contains(VALUE_1_BBUFFER, VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hMGetShouldReturnNullValueForFieldsThatHaveNoValue() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		assertThat(connection.hashCommands()
+				.hMGet(KEY_1_BBUFFER, Arrays.asList(FIELD_1_BBUFFER, FIELD_2_BBUFFER, FIELD_3_BBUFFER)).block(),
+				contains(VALUE_1_BBUFFER, null, VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hMSetSouldSetValuesCorrectly() {
+
+		Map<ByteBuffer, ByteBuffer> fieldValues = new LinkedHashMap<>();
+		fieldValues.put(FIELD_1_BBUFFER, VALUE_1_BBUFFER);
+		fieldValues.put(FIELD_2_BBUFFER, VALUE_2_BBUFFER);
+
+		assertThat(connection.hashCommands().hMSet(KEY_1_BBUFFER, fieldValues).block(), is(true));
+		assertThat(nativeCommands.hget(KEY_1, FIELD_1), is(equalTo(VALUE_1)));
+		assertThat(nativeCommands.hget(KEY_1, FIELD_2), is(equalTo(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hExistsShouldReturnTrueForExistingField() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+
+		assertThat(connection.hashCommands().hExists(KEY_1_BBUFFER, FIELD_1_BBUFFER).block(), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hExistsShouldReturnFalseForNonExistingField() {
+		assertThat(connection.hashCommands().hExists(KEY_1_BBUFFER, FIELD_1_BBUFFER).block(), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hDelShouldRemoveSingleFieldsCorrectly() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		assertThat(connection.hashCommands().hDel(KEY_1_BBUFFER, FIELD_2_BBUFFER).block(), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hDelShouldRemoveMultipleFieldsCorrectly() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		assertThat(connection.hashCommands().hDel(KEY_1_BBUFFER, Arrays.asList(FIELD_1_BBUFFER, FIELD_3_BBUFFER)).block(),
+				is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hLenShouldReturnSizeCorrectly() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		assertThat(connection.hashCommands().hLen(KEY_1_BBUFFER).block(), is(3L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hKeysShouldReturnFieldsCorrectly() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		assertThat(connection.hashCommands().hKeys(KEY_1_BBUFFER).block(),
+				containsInAnyOrder(FIELD_1_BBUFFER, FIELD_2_BBUFFER, FIELD_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hValsShouldReturnValuesCorrectly() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		assertThat(connection.hashCommands().hVals(KEY_1_BBUFFER).block(),
+				containsInAnyOrder(VALUE_1_BBUFFER, VALUE_2_BBUFFER, VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hGetAlllShouldReturnEntriesCorrectly() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		System.out.println(connection.hashCommands().hGetAll(KEY_1_BBUFFER).block());
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.*;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -32,6 +33,7 @@ import org.junit.Test;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class LettuceReactiveHashCommandsTests extends LettuceReactiveCommandsTestsBase {
 
@@ -232,13 +234,17 @@ public class LettuceReactiveHashCommandsTests extends LettuceReactiveCommandsTes
 	 * @see DATAREDIS-525
 	 */
 	@Test
-	public void hGetAlllShouldReturnEntriesCorrectly() {
+	public void hGetAllShouldReturnEntriesCorrectly() {
 
 		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
 		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
 		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
 
-		System.out.println(connection.hashCommands().hGetAll(KEY_1_BBUFFER).block());
-	}
+		Map<ByteBuffer, ByteBuffer> expected = new HashMap<>();
+		expected.put(FIELD_1_BBUFFER, VALUE_1_BBUFFER);
+		expected.put(FIELD_2_BBUFFER, VALUE_2_BBUFFER);
+		expected.put(FIELD_3_BBUFFER, VALUE_3_BBUFFER);
 
+		assertThat(connection.hashCommands().hGetAll(KEY_1_BBUFFER).block(), is(equalTo(expected)));
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommandsTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveHyperLogLogCommandsTests extends LettuceReactiveCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void pfAddShouldAddToNonExistingKeyCorrectly() {
+
+		assertThat(connection.hyperLogLogCommands()
+				.pfAdd(KEY_1_BBUFFER, Arrays.asList(VALUE_1_BBUFFER, VALUE_2_BBUFFER, VALUE_3_BBUFFER)).block(), is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void pfAddShouldReturnZeroWhenValueAlreadyExists() {
+
+		nativeCommands.pfadd(KEY_1, new String[] { VALUE_1, VALUE_2 });
+		nativeCommands.pfadd(KEY_1, new String[] { VALUE_3 });
+
+		assertThat(connection.hyperLogLogCommands().pfAdd(KEY_1_BBUFFER, Arrays.asList(VALUE_1_BBUFFER)).block(), is(0L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void pfCountShouldReturnCorrectly() {
+
+		nativeCommands.pfadd(KEY_1, new String[] { VALUE_1, VALUE_2 });
+
+		assertThat(connection.hyperLogLogCommands().pfCount(KEY_1_BBUFFER).block(), is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void pfCountWithMultipleKeysShouldReturnCorrectly() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.pfadd(KEY_1, new String[] { VALUE_1, VALUE_2 });
+		nativeCommands.pfadd(KEY_2, new String[] { VALUE_2, VALUE_3 });
+
+		assertThat(connection.hyperLogLogCommands().pfCount(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER)).block(), is(3L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void pfMergeShouldWorkCorrectly() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.pfadd(KEY_1, new String[] { VALUE_1, VALUE_2 });
+		nativeCommands.pfadd(KEY_2, new String[] { VALUE_2, VALUE_3 });
+
+		assertThat(
+				connection.hyperLogLogCommands().pfMerge(KEY_3_BBUFFER, Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER)).block(),
+				is(true));
+
+		assertThat(nativeCommands.pfcount(new String[] { KEY_3 }), is(3L));
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
@@ -119,8 +119,8 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 		nativeCommands.set(KEY_1, VALUE_2);
 
 		assertThat(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(true));
-		assertThat(nativeCommands.exists(KEY_2), is(true));
-		assertThat(nativeCommands.exists(KEY_1), is(false));
+		assertThat(nativeCommands.exists(KEY_2), is(1L));
+		assertThat(nativeCommands.exists(KEY_1), is(0L));
 	}
 
 	/**
@@ -141,8 +141,8 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 
 		assertThat(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(true));
 
-		assertThat(nativeCommands.exists(KEY_2), is(true));
-		assertThat(nativeCommands.exists(KEY_1), is(false));
+		assertThat(nativeCommands.exists(KEY_2), is(1L));
+		assertThat(nativeCommands.exists(KEY_1), is(0L));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.junit.Assert.*;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.DataType;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.TestSubscriber;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void existsShouldReturnTrueForExistingKeys() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		assertThat(connection.keyCommands().exists(KEY_1_BBUFFER).block(), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void existsShouldReturnFalseForNonExistingKeys() {
+		assertThat(connection.keyCommands().exists(KEY_1_BBUFFER).block(), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void typeShouldReturnTypeCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_2);
+		nativeCommands.sadd(KEY_2, VALUE_2);
+		nativeCommands.hset(KEY_3, KEY_1, VALUE_1);
+
+		assertThat(connection.keyCommands().type(KEY_1_BBUFFER).block(), is(DataType.STRING));
+		assertThat(connection.keyCommands().type(KEY_2_BBUFFER).block(), is(DataType.SET));
+		assertThat(connection.keyCommands().type(KEY_3_BBUFFER).block(), is(DataType.HASH));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void keysShouldReturnCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_2);
+		nativeCommands.set(KEY_2, VALUE_2);
+		nativeCommands.set(KEY_3, VALUE_3);
+
+		nativeCommands.set(VALUE_1, KEY_1);
+		nativeCommands.set(VALUE_2, KEY_2);
+		nativeCommands.set(VALUE_3, KEY_3);
+
+		assertThat(connection.keyCommands().keys(ByteBuffer.wrap("*".getBytes())).block(), hasSize(6));
+		assertThat(connection.keyCommands().keys(ByteBuffer.wrap("key*".getBytes())).block(), hasSize(3));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void randomKeyShouldReturnAnyKey() {
+
+		nativeCommands.set(KEY_1, VALUE_2);
+		nativeCommands.set(KEY_2, VALUE_2);
+		nativeCommands.set(KEY_3, VALUE_3);
+
+		assertThat(connection.keyCommands().randomKey().block(), is(notNullValue()));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void randomKeyShouldReturnNullWhenNoKeyExists() {
+		assertThat(connection.keyCommands().randomKey().block(), is(nullValue()));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void renameShouldAlterKeyNameCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_2);
+
+		assertThat(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(true));
+		assertThat(nativeCommands.exists(KEY_2), is(true));
+		assertThat(nativeCommands.exists(KEY_1), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test(expected = RedisSystemException.class)
+	public void renameShouldThrowErrorWhenKeyDoesNotExit() {
+		assertThat(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void renameNXShouldAlterKeyNameCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_2);
+
+		assertThat(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(true));
+
+		assertThat(nativeCommands.exists(KEY_2), is(true));
+		assertThat(nativeCommands.exists(KEY_1), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void renameNXShouldNotAlterExistingKeyName() {
+
+		nativeCommands.set(KEY_1, VALUE_2);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		assertThat(connection.keyCommands().renameNX(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void shouldDeleteKeyCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		Mono<Long> result = connection.keyCommands().del(KEY_1_BBUFFER);
+		assertThat(result.block(), is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void shouldDeleteKeysCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		Flux<NumericResponse<KeyCommand, Long>> result = connection.keyCommands()
+				.del(Flux.fromIterable(Arrays.asList(new KeyCommand(KEY_1_BBUFFER), new KeyCommand(KEY_2_BBUFFER))));
+
+		TestSubscriber<NumericResponse<KeyCommand, Long>> subscriber = TestSubscriber.create();
+		result.subscribe(subscriber);
+		subscriber.await();
+
+		subscriber.assertValueCount(2);
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void shouldDeleteKeysInBatchCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		Mono<Long> result = connection.keyCommands().mDel(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER));
+
+		assertThat(result.block(), is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void shouldDeleteKeysInMultipleBatchesCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		Flux<Long> result = connection.keyCommands()
+				.mDel(
+						Flux.fromIterable(Arrays.asList(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), Arrays.asList(KEY_1_BBUFFER))))
+				.map(NumericResponse::getOutput);
+
+		TestSubscriber<Long> subscriber = TestSubscriber.create();
+		result.subscribe(subscriber);
+		subscriber.await();
+
+		subscriber.assertValueCount(2);
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommandTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommandTests.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.collection.IsIterableContainingInOrder.*;
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsEqual.*;
+import static org.hamcrest.core.IsNot.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeThat;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Arrays;
+
+import org.junit.Assume;
+import org.junit.Test;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ReactiveListCommands.PopResult;
+import org.springframework.data.redis.connection.ReactiveListCommands.PushCommand;
+import org.springframework.data.redis.connection.RedisListCommands.Position;
+
+import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveListCommandTests extends LettuceReactiveCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void rPushShouldAppendValuesCorrectly() {
+
+		nativeCommands.lpush(KEY_1, VALUE_1);
+
+		assertThat(connection.listCommands().rPush(KEY_1_BBUFFER, Arrays.asList(VALUE_2_BBUFFER, VALUE_3_BBUFFER)).block(),
+				is(3L));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_1, VALUE_2, VALUE_3));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lPushShouldPrependValuesCorrectly() {
+
+		nativeCommands.lpush(KEY_1, VALUE_1);
+
+		assertThat(connection.listCommands().lPush(KEY_1_BBUFFER, Arrays.asList(VALUE_2_BBUFFER, VALUE_3_BBUFFER)).block(),
+				is(3L));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_3, VALUE_2, VALUE_1));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void rPushXShouldAppendValuesCorrectly() {
+
+		nativeCommands.lpush(KEY_1, VALUE_1);
+
+		assertThat(connection.listCommands().rPushX(KEY_1_BBUFFER, VALUE_2_BBUFFER).block(), is(2L));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_1, VALUE_2));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lPushXShouldPrependValuesCorrectly() {
+
+		nativeCommands.lpush(KEY_1, VALUE_1);
+
+		assertThat(connection.listCommands().lPushX(KEY_1_BBUFFER, VALUE_2_BBUFFER).block(), is(2L));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_2, VALUE_1));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test(expected = InvalidDataAccessApiUsageException.class)
+	public void pushShouldThrowErrorForMoreThanOneValueWhenUsingExistsOption() {
+
+		connection.listCommands()
+				.push(Mono.just(
+						PushCommand.right().values(Arrays.asList(VALUE_1_BBUFFER, VALUE_2_BBUFFER)).to(KEY_1_BBUFFER).ifExists()))
+				.blockFirst();
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lLenShouldReturnSizeCorrectly() {
+
+		nativeCommands.lpush(KEY_1, VALUE_1, VALUE_2);
+
+		assertThat(connection.listCommands().lLen(KEY_1_BBUFFER).block(), is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lRangeShouldReturnValuesCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.listCommands().lRange(KEY_1_BBUFFER, 1, 2).block(),
+				contains(VALUE_2_BBUFFER, VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lTrimShouldReturnValuesCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.listCommands().lTrim(KEY_1_BBUFFER, 1, 2).block(), is(true));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), not(contains(VALUE_1_BBUFFER)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lIndexShouldReturnValueCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.listCommands().lIndex(KEY_1_BBUFFER, 1).block(), is(equalTo(VALUE_2_BBUFFER)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lInsertShouldAddValueCorrectlyBeforeExisting() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2);
+
+		assertThat(
+				connection.listCommands().lInsert(KEY_1_BBUFFER, Position.BEFORE, VALUE_2_BBUFFER, VALUE_3_BBUFFER).block(),
+				is(3L));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_1, VALUE_3, VALUE_2));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lInsertShouldAddValueCorrectlyAfterExisting() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2);
+
+		assertThat(
+				connection.listCommands().lInsert(KEY_1_BBUFFER, Position.AFTER, VALUE_2_BBUFFER, VALUE_3_BBUFFER).block(),
+				is(3L));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_1, VALUE_2, VALUE_3));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lSetSouldSetValueCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2);
+
+		assertThat(connection.listCommands().lSet(KEY_1_BBUFFER, 1L, VALUE_3_BBUFFER).block(), is(true));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_1, VALUE_3));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), not(contains(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lRemSouldRemoveAllValuesCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_1, VALUE_3);
+
+		assertThat(connection.listCommands().lRem(KEY_1_BBUFFER, VALUE_1_BBUFFER).block(), is(2L));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_2, VALUE_3));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), not(contains(VALUE_1)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lRemSouldRemoveFirstValuesCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_1, VALUE_3);
+
+		assertThat(connection.listCommands().lRem(KEY_1_BBUFFER, 1L, VALUE_1_BBUFFER).block(), is(1L));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_2, VALUE_1, VALUE_3));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lRemSouldRemoveLastValuesCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_1, VALUE_3);
+
+		assertThat(connection.listCommands().lRem(KEY_1_BBUFFER, -1L, VALUE_1_BBUFFER).block(), is(1L));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_1, VALUE_2, VALUE_3));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void lPopSouldRemoveFirstValueCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.listCommands().lPop(KEY_1_BBUFFER).block(), is(equalTo(VALUE_1_BBUFFER)));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_2, VALUE_3));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void rPopSouldRemoveFirstValueCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.listCommands().rPop(KEY_1_BBUFFER).block(), is(equalTo(VALUE_3_BBUFFER)));
+		assertThat(nativeCommands.lrange(KEY_1, 0, -1), contains(VALUE_1, VALUE_2));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void blPopShouldReturnFirstAvailable() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		PopResult result = connection.listCommands()
+				.blPop(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), Duration.ofSeconds(1L)).block();
+		assertThat(result.getKey(), is(equalTo(KEY_1_BBUFFER)));
+		assertThat(result.getValue(), is(equalTo(VALUE_1_BBUFFER)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void brPopShouldReturnLastAvailable() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		PopResult result = connection.listCommands()
+				.brPop(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), Duration.ofSeconds(1L)).block();
+		assertThat(result.getKey(), is(equalTo(KEY_1_BBUFFER)));
+		assertThat(result.getValue(), is(equalTo(VALUE_3_BBUFFER)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void rPopLPushShouldWorkCorrectly() {
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+		nativeCommands.rpush(KEY_2, VALUE_1);
+
+		ByteBuffer result = connection.listCommands().rPopLPush(KEY_1_BBUFFER, KEY_2_BBUFFER).block();
+
+		assertThat(result, is(equalTo(VALUE_3_BBUFFER)));
+		assertThat(nativeCommands.llen(KEY_2), is(2L));
+		assertThat(nativeCommands.lindex(KEY_2, 0), is(equalTo(VALUE_3)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void brPopLPushShouldWorkCorrectly() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+		nativeCommands.rpush(KEY_2, VALUE_1);
+
+		ByteBuffer result = connection.listCommands().bRPopLPush(KEY_1_BBUFFER, KEY_2_BBUFFER, Duration.ofSeconds(1))
+				.block();
+
+		assertThat(result, is(equalTo(VALUE_3_BBUFFER)));
+		assertThat(nativeCommands.llen(KEY_2), is(2L));
+		assertThat(nativeCommands.lindex(KEY_2, 0), is(equalTo(VALUE_3)));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommandsTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.number.IsCloseTo.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveNumberCommandsTests extends LettuceReactiveCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void incrByDoubleShouldIncreaseValueCorrectly() {
+		assertThat(connection.numberCommands().incrBy(KEY_1_BBUFFER, 1.5D).block(), is(closeTo(1.5D, 0D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void incrByIntegerShouldIncreaseValueCorrectly() {
+		assertThat(connection.numberCommands().incrBy(KEY_1_BBUFFER, 3).block(), is(3));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void decrByDoubleShouldDecreaseValueCorrectly() {
+		assertThat(connection.numberCommands().decrBy(KEY_1_BBUFFER, 1.5D).block(), is(closeTo(-1.5D, 0D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void decrByIntegerShouldDecreaseValueCorrectly() {
+		assertThat(connection.numberCommands().decrBy(KEY_1_BBUFFER, 3).block(), is(-3));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hIncrByDoubleShouldIncreaseValueCorrectly() {
+
+		nativeCommands.hset(KEY_1, KEY_1, "2");
+
+		assertThat(connection.numberCommands().hIncrBy(KEY_1_BBUFFER, KEY_1_BBUFFER, 1.5D).block(), is(closeTo(3.5D, 0D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void hIncrByIntegerShouldIncreaseValueCorrectly() {
+
+		nativeCommands.hset(KEY_1, KEY_1, "2");
+
+		assertThat(connection.numberCommands().hIncrBy(KEY_1_BBUFFER, KEY_1_BBUFFER, 3).block(), is(5));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommandsTests.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.*;
+import static org.hamcrest.collection.IsIterableContainingInOrder.*;
+import static org.hamcrest.core.AnyOf.*;
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsEqual.*;
+import static org.hamcrest.core.IsNot.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class LettuceReactiveSetCommandsTests extends LettuceReactiveCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sAddShouldAddSingleValue() {
+		assertThat(connection.setCommands().sAdd(KEY_1_BBUFFER, VALUE_1_BBUFFER).block(), is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sAddShouldAddValues() {
+		assertThat(connection.setCommands().sAdd(KEY_1_BBUFFER, Arrays.asList(VALUE_1_BBUFFER, VALUE_2_BBUFFER)).block(),
+				is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sRemShouldRemoveSingleValue() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sRem(KEY_1_BBUFFER, VALUE_1_BBUFFER).block(), is(1L));
+		assertThat(nativeCommands.sismember(KEY_1, VALUE_1), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sRemShouldRemoveValues() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sRem(KEY_1_BBUFFER, Arrays.asList(VALUE_1_BBUFFER, VALUE_2_BBUFFER)).block(),
+				is(2L));
+		assertThat(nativeCommands.sismember(KEY_1, VALUE_1), is(false));
+		assertThat(nativeCommands.sismember(KEY_1, VALUE_2), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sPopShouldRetrieveRandomValue() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sPop(KEY_1_BBUFFER).block(), is(notNullValue()));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sPopShouldReturnNullWhenNotPresent() {
+		assertThat(connection.setCommands().sPop(KEY_1_BBUFFER).block(), is(nullValue()));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sMoveShouldMoveValueCorrectly() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+		nativeCommands.sadd(KEY_2, VALUE_1);
+
+		assertThat(connection.setCommands().sMove(KEY_1_BBUFFER, KEY_2_BBUFFER, VALUE_3_BBUFFER).block(), is(true));
+		assertThat(nativeCommands.sismember(KEY_2, VALUE_3), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sMoveShouldReturnFalseIfValueIsNotAMember() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
+		nativeCommands.sadd(KEY_2, VALUE_1);
+
+ 		assertThat(connection.setCommands().sMove(KEY_1_BBUFFER, KEY_2_BBUFFER, VALUE_3_BBUFFER).block(), is(false));
+		assertThat(nativeCommands.sismember(KEY_2, VALUE_3), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sMoveShouldReturnOperateCorrectlyWhenValueAlreadyPresentInTarget() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+		nativeCommands.sadd(KEY_2, VALUE_1, VALUE_3);
+
+		assertThat(connection.setCommands().sMove(KEY_1_BBUFFER, KEY_2_BBUFFER, VALUE_3_BBUFFER).block(), is(true));
+		assertThat(nativeCommands.sismember(KEY_1, VALUE_3), is(false));
+		assertThat(nativeCommands.sismember(KEY_2, VALUE_3), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sCardShouldCountValuesCorrectly() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sCard(KEY_1_BBUFFER).block(), is(3L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sIsMemberShouldReturnTrueWhenValueContainedInKey() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
+
+		assertThat(connection.setCommands().sIsMember(KEY_1_BBUFFER, VALUE_1_BBUFFER).block(), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sIsMemberShouldReturnFalseWhenValueNotContainedInKey() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
+
+		assertThat(connection.setCommands().sIsMember(KEY_1_BBUFFER, VALUE_3_BBUFFER).block(), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sInterShouldIntersectSetsCorrectly() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
+		nativeCommands.sadd(KEY_2, VALUE_2, VALUE_3);
+
+		List<ByteBuffer> result = connection.setCommands().sInter(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER)).block();
+		assertThat(result, contains(VALUE_2_BBUFFER));
+		assertThat(result, not(containsInAnyOrder(VALUE_1_BBUFFER, VALUE_3_BBUFFER)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sInterStoreShouldReturnSizeCorrectly() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
+		nativeCommands.sadd(KEY_2, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sInterStore(KEY_3_BBUFFER, Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER)).block(),
+				is(1L));
+		assertThat(nativeCommands.sismember(KEY_3, VALUE_2), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sUnionShouldCombineSetsCorrectly() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
+		nativeCommands.sadd(KEY_2, VALUE_2, VALUE_3);
+
+		List<ByteBuffer> result = connection.setCommands().sUnion(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER)).block();
+		assertThat(result, containsInAnyOrder(VALUE_1_BBUFFER, VALUE_3_BBUFFER, VALUE_2_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sUnionStoreShouldReturnSizeCorrectly() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
+		nativeCommands.sadd(KEY_2, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sUnionStore(KEY_3_BBUFFER, Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER)).block(),
+				is(3L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sDiffShouldBeExcecutedCorrectly() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
+		nativeCommands.sadd(KEY_2, VALUE_2, VALUE_3);
+
+		List<ByteBuffer> result = connection.setCommands().sDiff(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER)).block();
+		assertThat(result, containsInAnyOrder(VALUE_1_BBUFFER));
+		assertThat(result, not(containsInAnyOrder(VALUE_2_BBUFFER, VALUE_3_BBUFFER)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sDiffStoreShouldBeExcecutedCorrectly() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
+		nativeCommands.sadd(KEY_2, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sDiffStore(KEY_3_BBUFFER, Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER)).block(),
+				is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sMembersReadsValuesFromSetCorrectly() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sMembers(KEY_1_BBUFFER).block(),
+				containsInAnyOrder(VALUE_1_BBUFFER, VALUE_2_BBUFFER, VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sRandMemberReturnsRandomMember() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sRandMember(KEY_1_BBUFFER).block(),
+				anyOf(equalTo(VALUE_1_BBUFFER), equalTo(VALUE_2_BBUFFER), equalTo(VALUE_3_BBUFFER)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void sRandMemberReturnsRandomMembers() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		assertThat(connection.setCommands().sRandMember(KEY_1_BBUFFER, 2L).block().size(), is(2));
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommandsTests.java
@@ -116,7 +116,7 @@ public class LettuceReactiveSetCommandsTests extends LettuceReactiveCommandsTest
 		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2);
 		nativeCommands.sadd(KEY_2, VALUE_1);
 
- 		assertThat(connection.setCommands().sMove(KEY_1_BBUFFER, KEY_2_BBUFFER, VALUE_3_BBUFFER).block(), is(false));
+		assertThat(connection.setCommands().sMove(KEY_1_BBUFFER, KEY_2_BBUFFER, VALUE_3_BBUFFER).block(), is(false));
 		assertThat(nativeCommands.sismember(KEY_2, VALUE_3), is(false));
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.collection.IsIterableContainingInOrder.*;
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.IsEqual.*;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeThat;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
+import org.springframework.data.redis.connection.ReactiveStringCommands.SetCommand;
+import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
+import org.springframework.data.redis.core.types.Expiration;
+
+import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.TestSubscriber;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void getSetShouldReturnPreviousValueCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		Mono<ByteBuffer> result = connection.stringCommands().getSet(KEY_1_BBUFFER, VALUE_2_BBUFFER);
+
+		assertThat(result.block(), is(equalTo(VALUE_1_BBUFFER)));
+		assertThat(nativeCommands.get(KEY_1), is(equalTo(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void getSetShouldReturnPreviousValueCorrectlyWhenNoExists() {
+
+		Mono<ByteBuffer> result = connection.stringCommands().getSet(KEY_1_BBUFFER, VALUE_2_BBUFFER);
+
+		ByteBuffer value = result.block();
+		assertThat(value, is(notNullValue()));
+		assertThat(value, is(equalTo(ByteBuffer.allocate(0))));
+		assertThat(nativeCommands.get(KEY_1), is(equalTo(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void setShouldAddValueCorrectly() {
+
+		Mono<Boolean> result = connection.stringCommands().set(KEY_1_BBUFFER, VALUE_1_BBUFFER);
+
+		assertThat(result.block(), is(true));
+		assertThat(nativeCommands.get(KEY_1), is(equalTo(VALUE_1)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void setShouldAddValuesCorrectly() {
+
+		Flux<BooleanResponse<SetCommand>> result = connection.stringCommands()
+				.set(Flux.fromIterable(Arrays.asList(SetCommand.set(KEY_1_BBUFFER).value(VALUE_1_BBUFFER),
+						SetCommand.set(KEY_2_BBUFFER).value(VALUE_2_BBUFFER))));
+
+		TestSubscriber<BooleanResponse<SetCommand>> subscriber = TestSubscriber.create();
+		result.subscribe(subscriber);
+		subscriber.await();
+
+		subscriber.assertValueCount(2);
+		assertThat(nativeCommands.get(KEY_1), is(equalTo(VALUE_1)));
+		assertThat(nativeCommands.get(KEY_2), is(equalTo(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void getShouldRetriveValueCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		Mono<ByteBuffer> result = connection.stringCommands().get(KEY_1_BBUFFER);
+		assertThat(result.block(), is(equalTo(VALUE_1_BBUFFER)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void getShouldRetriveNullValueCorrectly() {
+
+		Mono<ByteBuffer> result = connection.stringCommands().get(KEY_1_BBUFFER);
+		assertThat(result.block(), is(equalTo(ByteBuffer.allocate(0))));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void getShouldRetriveValuesCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		Flux<ByteBufferResponse<KeyCommand>> result = connection.stringCommands()
+				.get(Flux.fromStream(Arrays.asList(new KeyCommand(KEY_1_BBUFFER), new KeyCommand(KEY_2_BBUFFER)).stream()));
+
+		TestSubscriber<ByteBufferResponse<KeyCommand>> subscriber = TestSubscriber.create();
+		result.subscribe(subscriber);
+		subscriber.await();
+
+		subscriber.assertValueCount(2);
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void getShouldRetriveValuesWithNullCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_3, VALUE_3);
+
+		Flux<ByteBufferResponse<KeyCommand>> result = connection.stringCommands().get(Flux.fromStream(Arrays
+				.asList(new KeyCommand(KEY_1_BBUFFER), new KeyCommand(KEY_2_BBUFFER), new KeyCommand(KEY_3_BBUFFER)).stream()));
+
+		TestSubscriber<ByteBufferResponse<KeyCommand>> subscriber = TestSubscriber.create();
+		result.subscribe(subscriber);
+		subscriber.await();
+
+		subscriber.assertValueCount(3);
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void mGetShouldRetriveValueCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		Mono<List<ByteBuffer>> result = connection.stringCommands().mGet(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER));
+		assertThat(result.block(), contains(VALUE_1_BBUFFER, VALUE_2_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void mGetShouldRetriveNullValueCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_3, VALUE_3);
+
+		Mono<List<ByteBuffer>> result = connection.stringCommands()
+				.mGet(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER, KEY_3_BBUFFER));
+
+		assertThat(result.block(), contains(VALUE_1_BBUFFER, ByteBuffer.allocate(0), VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void mGetShouldRetriveValuesCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		Flux<List<ByteBuffer>> result = connection.stringCommands()
+				.mGet(
+						Flux.fromIterable(Arrays.asList(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), Arrays.asList(KEY_2_BBUFFER))))
+				.map(MultiValueResponse::getOutput);
+
+		TestSubscriber<List<ByteBuffer>> subscriber = TestSubscriber.create();
+		result.subscribe(subscriber);
+		subscriber.await();
+
+		subscriber.assertValueCount(2);
+		subscriber.assertContainValues(
+				new HashSet<>(Arrays.asList(Arrays.asList(VALUE_1_BBUFFER, VALUE_2_BBUFFER), Arrays.asList(VALUE_2_BBUFFER))));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void setNXshouldOnlySetValueWhenNotPresent() {
+		assertThat(connection.stringCommands().setNX(KEY_1_BBUFFER, VALUE_1_BBUFFER).block(), is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void setNXshouldNotSetValueWhenAlreadyPresent() {
+
+		nativeCommands.setnx(KEY_1, VALUE_1);
+
+		assertThat(connection.stringCommands().setNX(KEY_1_BBUFFER, VALUE_2_BBUFFER).block(), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void setEXshouldSetKeyAndExpirationTime() {
+
+		connection.stringCommands().setEX(KEY_1_BBUFFER, VALUE_1_BBUFFER, Expiration.seconds(3)).block();
+
+		assertThat(nativeCommands.ttl(KEY_1) > 1, is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void pSetEXshouldSetKeyAndExpirationTime() {
+
+		connection.stringCommands().pSetEX(KEY_1_BBUFFER, VALUE_1_BBUFFER, Expiration.milliseconds(600)).block();
+
+		assertThat(nativeCommands.pttl(KEY_1) > 1, is(true));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void mSetShouldAddMultipleKeyValueParis() {
+
+		Map<ByteBuffer, ByteBuffer> map = new LinkedHashMap<>();
+		map.put(KEY_1_BBUFFER, VALUE_1_BBUFFER);
+		map.put(KEY_2_BBUFFER, VALUE_2_BBUFFER);
+
+		connection.stringCommands().mSet(map).block();
+
+		assertThat(nativeCommands.get(KEY_1), is(equalTo(VALUE_1)));
+		assertThat(nativeCommands.get(KEY_2), is(equalTo(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void mSetNXShouldAddMultipleKeyValueParis() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		Map<ByteBuffer, ByteBuffer> map = new LinkedHashMap<>();
+		map.put(KEY_1_BBUFFER, VALUE_1_BBUFFER);
+		map.put(KEY_2_BBUFFER, VALUE_2_BBUFFER);
+
+		connection.stringCommands().mSetNX(map).block();
+
+		assertThat(nativeCommands.get(KEY_1), is(equalTo(VALUE_1)));
+		assertThat(nativeCommands.get(KEY_2), is(equalTo(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void mSetNXShouldNotAddMultipleKeyValueParisWhenAlreadyExit() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		Map<ByteBuffer, ByteBuffer> map = new LinkedHashMap<>();
+		map.put(KEY_1_BBUFFER, VALUE_1_BBUFFER);
+		map.put(KEY_2_BBUFFER, VALUE_2_BBUFFER);
+
+		assertThat(connection.stringCommands().mSetNX(map).block(), is(false));
+
+		assertThat(nativeCommands.exists(KEY_1), is(false));
+		assertThat(nativeCommands.get(KEY_2), is(equalTo(VALUE_2)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void appendShouldDoItsThing() {
+
+		assertThat(connection.stringCommands().append(KEY_1_BBUFFER, VALUE_1_BBUFFER).block(), is(7L));
+		assertThat(connection.stringCommands().append(KEY_1_BBUFFER, VALUE_2_BBUFFER).block(), is(14L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void getRangeShouldReturnSubstringCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		assertThat(connection.stringCommands().getRange(KEY_1_BBUFFER, 2, 3).block(),
+				is(equalTo(ByteBuffer.wrap("lu".getBytes()))));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void setRangeShouldReturnNewStringLengthCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		assertThat(connection.stringCommands().setRange(KEY_1_BBUFFER, VALUE_2_BBUFFER, 3).block(), is(10L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void getBitShouldReturnValueCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		assertThat(connection.stringCommands().getBit(KEY_1_BBUFFER, 1).block(), is(true));
+		assertThat(connection.stringCommands().getBit(KEY_1_BBUFFER, 7).block(), is(false));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void setBitShouldReturnValueCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		assertThat(connection.stringCommands().setBit(KEY_1_BBUFFER, 1, false).block(), is(true));
+		assertThat(nativeCommands.getbit(KEY_1, 1), is(0L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void bitCountShouldReturnValueCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		assertThat(connection.stringCommands().bitCount(KEY_1_BBUFFER).block(), is(28L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void bitCountShouldCountInRangeCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		assertThat(connection.stringCommands().bitCount(KEY_1_BBUFFER, 2, 4).block(), is(13L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void bitOpAndShouldWorkAsExpected() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		assertThat(connection.stringCommands()
+				.bitOp(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), BitOperation.AND, KEY_3_BBUFFER).block(), is(7L));
+		assertThat(nativeCommands.get(KEY_3), is(equalTo("value-0")));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void bitOpOrShouldWorkAsExpected() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		assertThat(connection.stringCommands()
+				.bitOp(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), BitOperation.OR, KEY_3_BBUFFER).block(), is(7L));
+		assertThat(nativeCommands.get(KEY_3), is(equalTo(VALUE_3)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void bitNotShouldThrowExceptionWhenMoreThanOnSourceKey() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		connection.stringCommands().bitOp(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), BitOperation.NOT, KEY_3_BBUFFER)
+				.block();
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void strLenShouldReturnValueCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		assertThat(connection.stringCommands().strLen(KEY_1_BBUFFER).block(), is(7L));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
@@ -309,7 +309,7 @@ public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsT
 
 		assertThat(connection.stringCommands().mSetNX(map).block(), is(false));
 
-		assertThat(nativeCommands.exists(KEY_1), is(false));
+		assertThat(nativeCommands.exists(KEY_1), is(0L));
 		assertThat(nativeCommands.get(KEY_2), is(equalTo(VALUE_2)));
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
@@ -1,0 +1,594 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeThat;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.junit.Test;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.DefaultTuple;
+import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTestsBase {
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zAddShouldAddValuesWithScores() {
+		assertThat(connection.zSetCommands().zAdd(KEY_1_BBUFFER, 3.5D, VALUE_1_BBUFFER).block(), is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRemShouldRemoveValuesFromSet() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRem(KEY_1_BBUFFER, Arrays.asList(VALUE_1_BBUFFER, VALUE_3_BBUFFER)).block(),
+				is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zIncrByShouldInreaseAndReturnScore() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+
+		assertThat(connection.zSetCommands().zIncrBy(KEY_1_BBUFFER, 3.5D, VALUE_1_BBUFFER).block(), is(4.5D));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRankShouldReturnIndexCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRank(KEY_1_BBUFFER, VALUE_3_BBUFFER).block(), is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRevRankShouldReturnIndexCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRevRank(KEY_1_BBUFFER, VALUE_3_BBUFFER).block(), is(0L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRangeShouldReturnValuesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRange(KEY_1_BBUFFER, new Range<Long>(1L, 2L)).block(),
+				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER, VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRangeWithScoreShouldReturnTuplesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRangeWithScores(KEY_1_BBUFFER, new Range<Long>(1L, 2L)).block(),
+				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D),
+						new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRevRangeShouldReturnValuesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRevRange(KEY_1_BBUFFER, new Range<Long>(1L, 2L)).block(),
+				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER, VALUE_1_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRevRangeWithScoreShouldReturnTuplesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRevRangeWithScores(KEY_1_BBUFFER, new Range<Long>(1L, 2L)).block(),
+				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D),
+						new DefaultTuple(VALUE_1_BBUFFER.array(), 1D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRangeByScoreShouldReturnValuesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D)).block(),
+				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER, VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRangeByScoreShouldReturnValuesCorrectlyWithMinExclusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true)).block(),
+				IsIterableContainingInOrder.contains(VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRangeByScoreShouldReturnValuesCorrectlyWithMaxExclusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false)).block(),
+				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRangeByScoreWithScoreShouldReturnTuplesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D)).block(),
+				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D),
+						new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRangeByScoreWithScoreShouldReturnTuplesCorrectlyWithMinExclusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(
+				connection.zSetCommands().zRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true)).block(),
+				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRangeByScoreWithScoreShouldReturnTuplesCorrectlyWithMaxExclusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(
+				connection.zSetCommands().zRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false)).block(),
+				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRevRangeByScoreShouldReturnValuesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRevRangeByScore(KEY_1_BBUFFER, new Range<>(3D, 2D)).block(),
+				IsIterableContainingInOrder.contains(VALUE_3_BBUFFER, VALUE_2_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRevRangeByScoreShouldReturnValuesCorrectlyWithMinExclusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRevRangeByScore(KEY_1_BBUFFER, new Range<>(3D, 2D, true, false)).block(),
+				IsIterableContainingInOrder.contains(VALUE_3_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRevRangeByScoreShouldReturnValuesCorrectlyWithMaxExclusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRevRangeByScore(KEY_1_BBUFFER, new Range<>(3D, 2D, false, true)).block(),
+				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRevRangeByScoreWithScoreShouldReturnTuplesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(3D, 2D)).block(),
+				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_3_BBUFFER.array(), 3D),
+						new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRevRangeByScoreWithScoreShouldReturnTuplesCorrectlyWithMinExclusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(
+				connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(3D, 2D, true, false)).block(),
+				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRevRangeByScoreWithScoreShouldReturnTuplesCorrectlyWithMaxExclusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(
+				connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(3D, 2D, false, true)).block(),
+				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zCountShouldCountValuesInRange() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zCount(KEY_1_BBUFFER, new Range<>(2D, 3D)).block(), is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zCountShouldCountValuesInRangeWithMinExlusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zCount(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true)).block(), is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zCountShouldCountValuesInRangeWithMaxExlusion() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zCount(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false)).block(), is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zCountShouldCountValuesInRangeWithNegativeInfinity() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zCount(KEY_1_BBUFFER, new Range<>(Double.NEGATIVE_INFINITY, 2D)).block(),
+				is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zCountShouldCountValuesInRangeWithPositiveInfinity() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zCount(KEY_1_BBUFFER, new Range<>(2D, Double.POSITIVE_INFINITY)).block(),
+				is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zCardShouldReturnSizeCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zCard(KEY_1_BBUFFER).block(), is(3L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zScoreShouldReturnScoreCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+
+		assertThat(connection.zSetCommands().zScore(KEY_1_BBUFFER, VALUE_2_BBUFFER).block(), is(2D));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRemRangeByRankShouldRemoveValuesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRemRangeByRank(KEY_1_BBUFFER, new Range<>(1L, 2L)).block(), is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRemRangeByScoreShouldRemoveValuesCorrectly() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRemRangeByScore(KEY_1_BBUFFER, new Range<>(1D, 2D)).block(), is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRemRangeByScoreShouldRemoveValuesCorrectlyWithNegativeInfinity() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(
+				connection.zSetCommands().zRemRangeByScore(KEY_1_BBUFFER, new Range<>(Double.NEGATIVE_INFINITY, 2D)).block(),
+				is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRemRangeByScoreShouldRemoveValuesCorrectlyWithPositiveInfinity() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(
+				connection.zSetCommands().zRemRangeByScore(KEY_1_BBUFFER, new Range<>(2D, Double.POSITIVE_INFINITY)).block(),
+				is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRemRangeByScoreShouldRemoveValuesCorrectlyWithExcludingMinRange() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRemRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true)).block(),
+				is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRemRangeByScoreShouldRemoveValuesCorrectlyWithExcludingMaxRange() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		assertThat(connection.zSetCommands().zRemRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false)).block(),
+				is(1L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zUnionStoreShouldWorkCorrectly() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_2, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_2, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_2, 3D, VALUE_3);
+
+		assertThat(
+				connection.zSetCommands()
+						.zUnionStore(KEY_3_BBUFFER, Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), Arrays.asList(2D, 3D)).block(),
+				is(3L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zInterStoreShouldWorkCorrectly() {
+
+		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_2, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_2, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_2, 3D, VALUE_3);
+
+		assertThat(
+				connection.zSetCommands()
+						.zInterStore(KEY_3_BBUFFER, Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), Arrays.asList(2D, 3D)).block(),
+				is(2L));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test
+	public void zRangeByLex() {
+
+		nativeCommands.zadd(KEY_1, 0D, "a");
+		nativeCommands.zadd(KEY_1, 0D, "b");
+		nativeCommands.zadd(KEY_1, 0D, "c");
+		nativeCommands.zadd(KEY_1, 0D, "d");
+		nativeCommands.zadd(KEY_1, 0D, "e");
+		nativeCommands.zadd(KEY_1, 0D, "f");
+		nativeCommands.zadd(KEY_1, 0D, "g");
+
+		assertThat(connection.zSetCommands().zRangeByLex(KEY_1_BBUFFER, new Range<>("", "c")).block(),
+				IsIterableContainingInOrder.contains(ByteBuffer.wrap("a".getBytes()), ByteBuffer.wrap("b".getBytes()),
+						ByteBuffer.wrap("c".getBytes())));
+
+		assertThat(connection.zSetCommands().zRangeByLex(KEY_1_BBUFFER, new Range<>("", "c", true, false)).block(),
+				IsIterableContainingInOrder.contains(ByteBuffer.wrap("a".getBytes()), ByteBuffer.wrap("b".getBytes())));
+
+		assertThat(connection.zSetCommands().zRangeByLex(KEY_1_BBUFFER, new Range<>("aaa", "g", true, false)).block(),
+				IsIterableContainingInOrder.contains(ByteBuffer.wrap("b".getBytes()), ByteBuffer.wrap("c".getBytes()),
+						ByteBuffer.wrap("d".getBytes()), ByteBuffer.wrap("e".getBytes()), ByteBuffer.wrap("f".getBytes())));
+	}
+
+	/**
+	 * @see DATAREDIS-525
+	 */
+	@Test(expected = UnsupportedOperationException.class)
+	public void zRevRangeByLex() {
+
+		nativeCommands.zadd(KEY_1, 0D, "a");
+		nativeCommands.zadd(KEY_1, 0D, "b");
+		nativeCommands.zadd(KEY_1, 0D, "c");
+		nativeCommands.zadd(KEY_1, 0D, "d");
+		nativeCommands.zadd(KEY_1, 0D, "e");
+		nativeCommands.zadd(KEY_1, 0D, "f");
+		nativeCommands.zadd(KEY_1, 0D, "g");
+
+		assertThat(connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("c", "")).block(),
+				IsIterableContainingInOrder.contains(ByteBuffer.wrap("c".getBytes()), ByteBuffer.wrap("b".getBytes()),
+						ByteBuffer.wrap("a".getBytes())));
+
+		assertThat(connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("c", "", false, true)).block(),
+				IsIterableContainingInOrder.contains(ByteBuffer.wrap("a".getBytes()), ByteBuffer.wrap("b".getBytes())));
+
+		assertThat(connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("g", "aaa", false, true)).block(),
+				IsIterableContainingInOrder.contains(ByteBuffer.wrap("f".getBytes()), ByteBuffer.wrap("e".getBytes()),
+						ByteBuffer.wrap("d".getBytes()), ByteBuffer.wrap("c".getBytes()), ByteBuffer.wrap("b".getBytes())));
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
@@ -30,6 +30,7 @@ import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTestsBase {
 
@@ -568,7 +569,7 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 	/**
 	 * @see DATAREDIS-525
 	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void zRevRangeByLex() {
 
 		nativeCommands.zadd(KEY_1, 0D, "a");
@@ -584,7 +585,7 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 						ByteBuffer.wrap("a".getBytes())));
 
 		assertThat(connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("c", "", false, true)).block(),
-				IsIterableContainingInOrder.contains(ByteBuffer.wrap("a".getBytes()), ByteBuffer.wrap("b".getBytes())));
+				IsIterableContainingInOrder.contains(ByteBuffer.wrap("b".getBytes()), ByteBuffer.wrap("a".getBytes())));
 
 		assertThat(connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("g", "aaa", false, true)).block(),
 				IsIterableContainingInOrder.contains(ByteBuffer.wrap("f".getBytes()), ByteBuffer.wrap("e".getBytes()),

--- a/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClientProvider.java
+++ b/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClientProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.test.util;
+
+import org.junit.rules.ExternalResource;
+
+import com.lambdaworks.redis.RedisClient;
+import com.lambdaworks.redis.RedisURI;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceRedisClientProvider extends ExternalResource {
+
+	String host = "127.0.0.1";
+	int port = 6379;
+
+	RedisClient client;
+
+	@Override
+	protected void before()  {
+
+		try {
+			super.before();
+		} catch (Throwable throwable) {
+			throwable.printStackTrace();
+		}
+
+		client = RedisClient.create(RedisURI.builder().withHost(host).withPort(port).build());
+	}
+
+	@Override
+	protected void after() {
+		super.after();
+		client.shutdown();
+	}
+
+	public RedisClient getClient() {
+		if(client == null) {
+			before();
+		}
+		return client;
+	}
+
+	public void destroy() {
+
+		if(client != null) {
+			after();
+		}
+	}
+
+	public static LettuceRedisClientProvider local() {
+		return new LettuceRedisClientProvider();
+	}
+}

--- a/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClientProvider.java
+++ b/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClientProvider.java
@@ -19,6 +19,7 @@ import org.junit.rules.ExternalResource;
 
 import com.lambdaworks.redis.RedisClient;
 import com.lambdaworks.redis.RedisURI;
+import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
 
 /**
  * @author Christoph Strobl
@@ -39,7 +40,7 @@ public class LettuceRedisClientProvider extends ExternalResource {
 			throwable.printStackTrace();
 		}
 
-		client = RedisClient.create(RedisURI.builder().withHost(host).withPort(port).build());
+		client = RedisClient.create(LettuceTestClientResources.getSharedClientResources(), RedisURI.builder().withHost(host).withPort(port).build());
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClusterClientProvider.java
+++ b/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClusterClientProvider.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016. the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.test.util;
+
+import com.lambdaworks.redis.cluster.RedisClusterClient;
+import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
+import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
+import org.junit.rules.ExternalResource;
+
+import com.lambdaworks.redis.RedisClient;
+import com.lambdaworks.redis.RedisURI;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceRedisClusterClientProvider extends ExternalResource {
+
+	String host = "127.0.0.1";
+	int port = 7379;
+
+	RedisClusterClient client;
+
+	@Override
+	protected void before()  {
+
+		try {
+			super.before();
+		} catch (Throwable throwable) {
+			throwable.printStackTrace();
+		}
+
+		client = RedisClusterClient.create(RedisURI.builder().withHost(host).withPort(port).build());
+	}
+
+	@Override
+	protected void after() {
+
+		super.after();
+		client.shutdown();
+	}
+
+	public RedisClusterClient getClient() {
+
+		if(client == null) {
+			before();
+		}
+		return client;
+	}
+
+	public void destroy() {
+
+		if(client != null) {
+			after();
+		}
+	}
+
+	public boolean test() {
+
+		try {
+			StatefulRedisClusterConnection<String, String> conn = getClient().connect();
+			conn.close();
+		} catch (Exception e) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public static LettuceRedisClusterClientProvider local() {
+		return new LettuceRedisClusterClientProvider();
+	}
+}

--- a/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClusterClientProvider.java
+++ b/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClusterClientProvider.java
@@ -31,16 +31,16 @@
  */
 package org.springframework.data.redis.test.util;
 
+import org.junit.rules.ExternalResource;
+import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
+
+import com.lambdaworks.redis.RedisURI;
 import com.lambdaworks.redis.cluster.RedisClusterClient;
 import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
-import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
-import org.junit.rules.ExternalResource;
-
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.RedisURI;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class LettuceRedisClusterClientProvider extends ExternalResource {
 
@@ -50,7 +50,7 @@ public class LettuceRedisClusterClientProvider extends ExternalResource {
 	RedisClusterClient client;
 
 	@Override
-	protected void before()  {
+	protected void before() {
 
 		try {
 			super.before();
@@ -58,7 +58,8 @@ public class LettuceRedisClusterClientProvider extends ExternalResource {
 			throwable.printStackTrace();
 		}
 
-		client = RedisClusterClient.create(RedisURI.builder().withHost(host).withPort(port).build());
+		client = RedisClusterClient.create(LettuceTestClientResources.getSharedClientResources(),
+				RedisURI.builder().withHost(host).withPort(port).build());
 	}
 
 	@Override
@@ -70,7 +71,7 @@ public class LettuceRedisClusterClientProvider extends ExternalResource {
 
 	public RedisClusterClient getClient() {
 
-		if(client == null) {
+		if (client == null) {
 			before();
 		}
 		return client;
@@ -78,7 +79,7 @@ public class LettuceRedisClusterClientProvider extends ExternalResource {
 
 	public void destroy() {
 
-		if(client != null) {
+		if (client != null) {
 			after();
 		}
 	}

--- a/src/test/java/reactor/test/TestSubscriber.java
+++ b/src/test/java/reactor/test/TestSubscriber.java
@@ -1,0 +1,1129 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.Fuseable;
+import reactor.core.Receiver;
+import reactor.core.Trackable;
+import reactor.core.publisher.Operators;
+
+/**
+ * <pre>
+ *  ###############################################################
+ *  ###############################################################
+ *  ###############################################################
+ *
+ *  	THIS CODE IS IMPORTED FROM REACTOR-CORE BECAUSE OF
+ *  	https://github.com/reactor/reactor-core/issues/135
+ *
+ *  ###############################################################
+ *  ###############################################################
+ *  ###############################################################
+ * </pre>
+ *
+ * A Subscriber implementation that hosts assertion tests for its state and allows asynchronous cancellation and
+ * requesting.
+ * <p>
+ * To create a new instance of {@link TestSubscriber}, you have the choice between these static methods:
+ * <ul>
+ * <li>{@link TestSubscriber#subscribe(Publisher)}: create a new {@link TestSubscriber}, subscribe to it with the
+ * specified {@link Publisher} and requests an unbounded number of elements.</li>
+ * <li>{@link TestSubscriber#subscribe(Publisher, long)}: create a new {@link TestSubscriber}, subscribe to it with the
+ * specified {@link Publisher} and requests {@code n} elements (can be 0 if you want no initial demand).
+ * <li>{@link TestSubscriber#create()}: create a new {@link TestSubscriber} and requests an unbounded number of
+ * elements.</li>
+ * <li>{@link TestSubscriber#create(long)}: create a new {@link TestSubscriber} and requests {@code n} elements (can be
+ * 0 if you want no initial demand).
+ * </ul>
+ * <p>
+ * If you are testing asynchronous publishers, don't forget to use one of the {@code await*()} methods to wait for the
+ * data to assert.
+ * <p>
+ * You can extend this class but only the onNext, onError and onComplete can be overridden. You can call
+ * {@link #request(long)} and {@link #cancel()} from any thread or from within the overridable methods but you should
+ * avoid calling the assertXXX methods asynchronously.
+ * <p>
+ * Usage:
+ *
+ * <pre>
+ * {@code
+ * TestSubscriber
+ *   .subscribe(publisher)
+ *   .await()
+ *   .assertValues("ABC", "DEF");
+ * }
+ * </pre>
+ *
+ * @param <T> the value type.
+ * @author Sebastien Deleuze
+ * @author David Karnok
+ * @author Anatoly Kadyshev
+ * @author Stephane Maldini
+ * @author Brian Clozel
+ */
+public class TestSubscriber<T> implements Subscriber<T>, Subscription, Trackable, Receiver {
+
+	/**
+	 * Default timeout for waiting next values to be received
+	 */
+	public static final Duration DEFAULT_VALUES_TIMEOUT = Duration.ofSeconds(3);
+
+	@SuppressWarnings("rawtypes") private static final AtomicLongFieldUpdater<TestSubscriber> REQUESTED = AtomicLongFieldUpdater
+			.newUpdater(TestSubscriber.class, "requested");
+
+	@SuppressWarnings("rawtypes") private static final AtomicReferenceFieldUpdater<TestSubscriber, List> NEXT_VALUES = AtomicReferenceFieldUpdater
+			.newUpdater(TestSubscriber.class, List.class, "values");
+
+	@SuppressWarnings("rawtypes") private static final AtomicReferenceFieldUpdater<TestSubscriber, Subscription> S = AtomicReferenceFieldUpdater
+			.newUpdater(TestSubscriber.class, Subscription.class, "s");
+
+	private final List<Throwable> errors = new LinkedList<>();
+
+	private final CountDownLatch cdl = new CountDownLatch(1);
+
+	volatile Subscription s;
+
+	volatile long requested;
+
+	volatile List<T> values = new LinkedList<>();
+
+	/**
+	 * The fusion mode to request.
+	 */
+	private int requestedFusionMode = -1;
+
+	/**
+	 * The established fusion mode.
+	 */
+	private volatile int establishedFusionMode = -1;
+
+	/**
+	 * The fuseable QueueSubscription in case a fusion mode was specified.
+	 */
+	private Fuseable.QueueSubscription<T> qs;
+
+	private int subscriptionCount = 0;
+
+	private int completionCount = 0;
+
+	private volatile long valueCount = 0L;
+
+	private volatile long nextValueAssertedCount = 0L;
+
+	private Duration valuesTimeout = DEFAULT_VALUES_TIMEOUT;
+
+	private boolean valuesStorage = true;
+
+	// ==============================================================================================================
+	// Static methods
+	// ==============================================================================================================
+
+	/**
+	 * Blocking method that waits until {@code conditionSupplier} returns true, or if it does not before the specified
+	 * timeout, throws an {@link AssertionError} with the specified error message supplier.
+	 *
+	 * @param timeout the timeout duration
+	 * @param errorMessageSupplier the error message supplier
+	 * @param conditionSupplier condition to break out of the wait loop
+	 * @throws AssertionError
+	 */
+	public static void await(Duration timeout, Supplier<String> errorMessageSupplier, BooleanSupplier conditionSupplier) {
+
+		Objects.requireNonNull(errorMessageSupplier);
+		Objects.requireNonNull(conditionSupplier);
+		Objects.requireNonNull(timeout);
+
+		long timeoutNs = timeout.toNanos();
+		long startTime = System.nanoTime();
+		do {
+			if (conditionSupplier.getAsBoolean()) {
+				return;
+			}
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new RuntimeException(e);
+			}
+		} while (System.nanoTime() - startTime < timeoutNs);
+		throw new AssertionError(errorMessageSupplier.get());
+	}
+
+	/**
+	 * Blocking method that waits until {@code conditionSupplier} returns true, or if it does not before the specified
+	 * timeout, throw an {@link AssertionError} with the specified error message.
+	 *
+	 * @param timeout the timeout duration
+	 * @param errorMessage the error message
+	 * @param conditionSupplier condition to break out of the wait loop
+	 * @throws AssertionError
+	 */
+	public static void await(Duration timeout, final String errorMessage, BooleanSupplier conditionSupplier) {
+		await(timeout, new Supplier<String>() {
+			@Override
+			public String get() {
+				return errorMessage;
+			}
+		}, conditionSupplier);
+	}
+
+	/**
+	 * Create a new {@link TestSubscriber} that requests an unbounded number of elements.
+	 * <p>
+	 * Be sure at least a publisher has subscribed to it via {@link Publisher#subscribe(Subscriber)} before use assert
+	 * methods.
+	 *
+	 * @see #subscribe(Publisher)
+	 * @param <T> the observed value type
+	 * @return a fresh TestSubscriber instance
+	 */
+	public static <T> TestSubscriber<T> create() {
+		return new TestSubscriber<>();
+	}
+
+	/**
+	 * Create a new {@link TestSubscriber} that requests initially {@code n} elements. You can then manage the demand with
+	 * {@link Subscription#request(long)}.
+	 * <p>
+	 * Be sure at least a publisher has subscribed to it via {@link Publisher#subscribe(Subscriber)} before use assert
+	 * methods.
+	 *
+	 * @param n Number of elements to request (can be 0 if you want no initial demand).
+	 * @see #subscribe(Publisher, long)
+	 * @param <T> the observed value type
+	 * @return a fresh TestSubscriber instance
+	 */
+	public static <T> TestSubscriber<T> create(long n) {
+		return new TestSubscriber<>(n);
+	}
+
+	/**
+	 * Create a new {@link TestSubscriber} that requests an unbounded number of elements, and make the specified
+	 * {@code publisher} subscribe to it.
+	 *
+	 * @param publisher The publisher to subscribe with
+	 * @param <T> the observed value type
+	 * @return a fresh TestSubscriber instance
+	 */
+	public static <T> TestSubscriber<T> subscribe(Publisher<T> publisher) {
+		TestSubscriber<T> subscriber = new TestSubscriber<>();
+		publisher.subscribe(subscriber);
+		return subscriber;
+	}
+
+	/**
+	 * Create a new {@link TestSubscriber} that requests initially {@code n} elements, and make the specified
+	 * {@code publisher} subscribe to it. You can then manage the demand with {@link Subscription#request(long)}.
+	 *
+	 * @param publisher The publisher to subscribe with
+	 * @param n Number of elements to request (can be 0 if you want no initial demand).
+	 * @param <T> the observed value type
+	 * @return a fresh TestSubscriber instance
+	 */
+	public static <T> TestSubscriber<T> subscribe(Publisher<T> publisher, long n) {
+		TestSubscriber<T> subscriber = new TestSubscriber<>(n);
+		publisher.subscribe(subscriber);
+		return subscriber;
+	}
+
+	// ==============================================================================================================
+	// Private constructors
+	// ==============================================================================================================
+
+	private TestSubscriber() {
+		this(Long.MAX_VALUE);
+	}
+
+	private TestSubscriber(long n) {
+		if (n < 0) {
+			throw new IllegalArgumentException("initialRequest >= required but it was " + n);
+		}
+		REQUESTED.lazySet(this, n);
+	}
+
+	// ==============================================================================================================
+	// Configuration
+	// ==============================================================================================================
+
+	/**
+	 * Enable or disabled the values storage. It is enabled by default, and can be disable in order to be able to perform
+	 * performance benchmarks or tests with a huge amount values.
+	 *
+	 * @param enabled enable value storage?
+	 * @return this
+	 */
+	public final TestSubscriber<T> configureValuesStorage(boolean enabled) {
+		this.valuesStorage = enabled;
+		return this;
+	}
+
+	/**
+	 * Configure the timeout in seconds for waiting next values to be received (3 seconds by default).
+	 *
+	 * @param timeout the new default value timeout duration
+	 * @return this
+	 */
+	public final TestSubscriber<T> configureValuesTimeout(Duration timeout) {
+		this.valuesTimeout = timeout;
+		return this;
+	}
+
+	/**
+	 * Returns the established fusion mode or -1 if it was not enabled
+	 *
+	 * @return the fusion mode, see Fuseable constants
+	 */
+	public final int establishedFusionMode() {
+		return establishedFusionMode;
+	}
+
+	// ==============================================================================================================
+	// Assertions
+	// ==============================================================================================================
+
+	/**
+	 * Assert a complete successfully signal has been received.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertComplete() {
+		assertNoError();
+		int c = completionCount;
+		if (c == 0) {
+			throw new AssertionError("Not completed", null);
+		}
+		if (c > 1) {
+			throw new AssertionError("Multiple completions: " + c, null);
+		}
+		return this;
+	}
+
+	/**
+	 * Assert the specified values have been received. Values storage should be enabled to use this method.
+	 *
+	 * @param expectedValues the values to assert
+	 * @see #configureValuesStorage(boolean)
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertContainValues(Set<? extends T> expectedValues) {
+		if (!valuesStorage) {
+			throw new IllegalStateException("Using assertNoValues() requires enabling values storage");
+		}
+		if (expectedValues.size() > values.size()) {
+			throw new AssertionError("Actual contains fewer elements" + values, null);
+		}
+
+		Iterator<? extends T> expected = expectedValues.iterator();
+
+		for (;;) {
+			boolean n2 = expected.hasNext();
+			if (n2) {
+				T t2 = expected.next();
+				if (!values.contains(t2)) {
+					throw new AssertionError(
+							"The element is not contained in the " + "received resuls" + " = " + valueAndClass(t2), null);
+				}
+			} else {
+				break;
+			}
+		}
+		return this;
+	}
+
+	/**
+	 * Assert an error signal has been received.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertError() {
+		assertNotComplete();
+		int s = errors.size();
+		if (s == 0) {
+			throw new AssertionError("No error", null);
+		}
+		if (s > 1) {
+			throw new AssertionError("Multiple errors: " + s, null);
+		}
+		return this;
+	}
+
+	/**
+	 * Assert an error signal has been received.
+	 *
+	 * @param clazz The class of the exception contained in the error signal
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertError(Class<? extends Throwable> clazz) {
+		assertNotComplete();
+		int s = errors.size();
+		if (s == 0) {
+			throw new AssertionError("No error", null);
+		}
+		if (s == 1) {
+			Throwable e = errors.get(0);
+			if (!clazz.isInstance(e)) {
+				throw new AssertionError("Error class incompatible: expected = " + clazz + ", actual = " + e, null);
+			}
+		}
+		if (s > 1) {
+			throw new AssertionError("Multiple errors: " + s, null);
+		}
+		return this;
+	}
+
+	public final TestSubscriber<T> assertErrorMessage(String message) {
+		assertNotComplete();
+		int s = errors.size();
+		if (s == 0) {
+			assertionError("No error", null);
+		}
+		if (s == 1) {
+			if (!Objects.equals(message, errors.get(0).getMessage())) {
+				assertionError(
+						"Error class incompatible: expected = \"" + message + "\", actual = \"" + errors.get(0).getMessage() + "\"",
+						null);
+			}
+		}
+		if (s > 1) {
+			assertionError("Multiple errors: " + s, null);
+		}
+
+		return this;
+	}
+
+	/**
+	 * Assert an error signal has been received.
+	 *
+	 * @param expectation A method that can verify the exception contained in the error signal and throw an exception
+	 *          (like an {@link AssertionError}) if the exception is not valid.
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertErrorWith(Consumer<? super Throwable> expectation) {
+		assertNotComplete();
+		int s = errors.size();
+		if (s == 0) {
+			throw new AssertionError("No error", null);
+		}
+		if (s == 1) {
+			expectation.accept(errors.get(0));
+		}
+		if (s > 1) {
+			throw new AssertionError("Multiple errors: " + s, null);
+		}
+		return this;
+	}
+
+	/**
+	 * Assert that the upstream was a Fuseable source.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertFuseableSource() {
+		if (qs == null) {
+			throw new AssertionError("Upstream was not Fuseable");
+		}
+		return this;
+	}
+
+	/**
+	 * Assert that the fusion mode was granted.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertFusionEnabled() {
+		if (establishedFusionMode != Fuseable.SYNC && establishedFusionMode != Fuseable.ASYNC) {
+			throw new AssertionError("Fusion was not enabled");
+		}
+		return this;
+	}
+
+	public final TestSubscriber<T> assertFusionMode(int expectedMode) {
+		if (establishedFusionMode != expectedMode) {
+			throw new AssertionError("Wrong fusion mode: expected: " + fusionModeName(expectedMode) + ", actual: "
+					+ fusionModeName(establishedFusionMode));
+		}
+		return this;
+	}
+
+	/**
+	 * Assert that the fusion mode was granted.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertFusionRejected() {
+		if (establishedFusionMode != Fuseable.NONE) {
+			throw new AssertionError("Fusion was granted");
+		}
+		return this;
+	}
+
+	/**
+	 * Assert no error signal has been received.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertNoError() {
+		int s = errors.size();
+		if (s == 1) {
+			Throwable e = errors.get(0);
+			String valueAndClass = e == null ? null : e + " (" + e.getClass().getSimpleName() + ")";
+			throw new AssertionError("Error present: " + valueAndClass, null);
+		}
+		if (s > 1) {
+			throw new AssertionError("Multiple errors: " + s, null);
+		}
+		return this;
+	}
+
+	/**
+	 * Assert no values have been received.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertNoValues() {
+		if (valueCount != 0) {
+			throw new AssertionError("No values expected but received: [length = " + values.size() + "] " + values, null);
+		}
+		return this;
+	}
+
+	/**
+	 * Assert that the upstream was not a Fuseable source.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertNonFuseableSource() {
+		if (qs != null) {
+			throw new AssertionError("Upstream was Fuseable");
+		}
+		return this;
+	}
+
+	/**
+	 * Assert no complete successfully signal has been received.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertNotComplete() {
+		int c = completionCount;
+		if (c == 1) {
+			throw new AssertionError("Completed", null);
+		}
+		if (c > 1) {
+			throw new AssertionError("Multiple completions: " + c, null);
+		}
+		return this;
+	}
+
+	/**
+	 * Assert no subscription occurred.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertNotSubscribed() {
+		int s = subscriptionCount;
+
+		if (s == 1) {
+			throw new AssertionError("OnSubscribe called once", null);
+		}
+		if (s > 1) {
+			throw new AssertionError("OnSubscribe called multiple times: " + s, null);
+		}
+
+		return this;
+	}
+
+	/**
+	 * Assert no complete successfully or error signal has been received.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertNotTerminated() {
+		if (cdl.getCount() == 0) {
+			throw new AssertionError("Terminated", null);
+		}
+		return this;
+	}
+
+	/**
+	 * Assert subscription occurred (once).
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertSubscribed() {
+		int s = subscriptionCount;
+
+		if (s == 0) {
+			throw new AssertionError("OnSubscribe not called", null);
+		}
+		if (s > 1) {
+			throw new AssertionError("OnSubscribe called multiple times: " + s, null);
+		}
+
+		return this;
+	}
+
+	/**
+	 * Assert either complete successfully or error signal has been received.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertTerminated() {
+		if (cdl.getCount() != 0) {
+			throw new AssertionError("Not terminated", null);
+		}
+		return this;
+	}
+
+	/**
+	 * Assert {@code n} values has been received.
+	 *
+	 * @param n the expected value count
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertValueCount(long n) {
+		if (valueCount != n) {
+			throw new AssertionError("Different value count: expected = " + n + ", actual = " + valueCount, null);
+		}
+		return this;
+	}
+
+	/**
+	 * Assert the specified values have been received in the same order read by the passed {@link Iterable}. Values
+	 * storage should be enabled to use this method.
+	 *
+	 * @param expectedSequence the values to assert
+	 * @see #configureValuesStorage(boolean)
+	 * @return this
+	 */
+	public final TestSubscriber<T> assertValueSequence(Iterable<? extends T> expectedSequence) {
+		if (!valuesStorage) {
+			throw new IllegalStateException("Using assertNoValues() requires enabling values storage");
+		}
+		Iterator<T> actual = values.iterator();
+		Iterator<? extends T> expected = expectedSequence.iterator();
+		int i = 0;
+		for (;;) {
+			boolean n1 = actual.hasNext();
+			boolean n2 = expected.hasNext();
+			if (n1 && n2) {
+				T t1 = actual.next();
+				T t2 = expected.next();
+				if (!Objects.equals(t1, t2)) {
+					throw new AssertionError("The element with index " + i + " does not match: expected = " + valueAndClass(t2)
+							+ ", actual = " + valueAndClass(t1), null);
+				}
+				i++;
+			} else if (n1 && !n2) {
+				throw new AssertionError("Actual contains more elements" + values, null);
+			} else if (!n1 && n2) {
+				throw new AssertionError("Actual contains fewer elements: " + values, null);
+			} else {
+				break;
+			}
+		}
+		return this;
+	}
+
+	/**
+	 * Assert the specified values have been received in the declared order. Values storage should be enabled to use this
+	 * method.
+	 *
+	 * @param expectedValues the values to assert
+	 * @return this
+	 * @see #configureValuesStorage(boolean)
+	 */
+	@SafeVarargs
+	public final TestSubscriber<T> assertValues(T... expectedValues) {
+		return assertValueSequence(Arrays.asList(expectedValues));
+	}
+
+	/**
+	 * Assert the specified values have been received in the declared order. Values storage should be enabled to use this
+	 * method.
+	 *
+	 * @param expectations One or more methods that can verify the values and throw a exception (like an
+	 *          {@link AssertionError}) if the value is not valid.
+	 * @return this
+	 * @see #configureValuesStorage(boolean)
+	 */
+	@SafeVarargs
+	public final TestSubscriber<T> assertValuesWith(Consumer<T>... expectations) {
+		if (!valuesStorage) {
+			throw new IllegalStateException("Using assertNoValues() requires enabling values storage");
+		}
+		final int expectedValueCount = expectations.length;
+		if (expectedValueCount != values.size()) {
+			throw new AssertionError("Different value count: expected = " + expectedValueCount + ", actual = " + valueCount,
+					null);
+		}
+		for (int i = 0; i < expectedValueCount; i++) {
+			Consumer<T> consumer = expectations[i];
+			T actualValue = values.get(i);
+			consumer.accept(actualValue);
+		}
+		return this;
+	}
+
+	// ==============================================================================================================
+	// Await methods
+	// ==============================================================================================================
+
+	/**
+	 * Blocking method that waits until a complete successfully or error signal is received.
+	 *
+	 * @return this
+	 */
+	public final TestSubscriber<T> await() {
+		if (cdl.getCount() == 0) {
+			return this;
+		}
+		try {
+			cdl.await();
+		} catch (InterruptedException ex) {
+			throw new AssertionError("Wait interrupted", ex);
+		}
+		return this;
+	}
+
+	/**
+	 * Blocking method that waits until a complete successfully or error signal is received or until a timeout occurs.
+	 *
+	 * @param timeout The timeout value
+	 * @return this
+	 */
+	public final TestSubscriber<T> await(Duration timeout) {
+		if (cdl.getCount() == 0) {
+			return this;
+		}
+		try {
+			if (!cdl.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+				throw new AssertionError("No complete or error signal before timeout");
+			}
+			return this;
+		} catch (InterruptedException ex) {
+			throw new AssertionError("Wait interrupted", ex);
+		}
+	}
+
+	/**
+	 * Blocking method that waits until {@code n} next values have been received.
+	 *
+	 * @param n the value count to assert
+	 * @return this
+	 */
+	public final TestSubscriber<T> awaitAndAssertNextValueCount(final long n) {
+		await(valuesTimeout, () -> {
+			if (valuesStorage) {
+				return String.format("%d out of %d next values received within %d, " + "values : %s",
+						valueCount - nextValueAssertedCount, n, valuesTimeout.toMillis(), values.toString());
+			}
+			return String.format("%d out of %d next values received within %d", valueCount - nextValueAssertedCount, n,
+					valuesTimeout.toMillis());
+		}, () -> valueCount >= (nextValueAssertedCount + n));
+		nextValueAssertedCount += n;
+		return this;
+	}
+
+	/**
+	 * Blocking method that waits until {@code n} next values have been received (n is the number of values provided) to
+	 * assert them.
+	 *
+	 * @param values the values to assert
+	 * @return this
+	 */
+	@SafeVarargs
+	@SuppressWarnings("unchecked")
+	public final TestSubscriber<T> awaitAndAssertNextValues(T... values) {
+		final int expectedNum = values.length;
+		final List<Consumer<T>> expectations = new ArrayList<>();
+		for (int i = 0; i < expectedNum; i++) {
+			final T expectedValue = values[i];
+			expectations.add(actualValue -> {
+				if (!actualValue.equals(expectedValue)) {
+					throw new AssertionError(String.format("Expected Next signal: %s, but got: %s", expectedValue, actualValue));
+				}
+			});
+		}
+		awaitAndAssertNextValuesWith(expectations.toArray((Consumer<T>[]) new Consumer[0]));
+		return this;
+	}
+
+	/**
+	 * Blocking method that waits until {@code n} next values have been received (n is the number of expectations
+	 * provided) to assert them.
+	 *
+	 * @param expectations One or more methods that can verify the values and throw a exception (like an
+	 *          {@link AssertionError}) if the value is not valid.
+	 * @return this
+	 */
+	@SafeVarargs
+	public final TestSubscriber<T> awaitAndAssertNextValuesWith(Consumer<T>... expectations) {
+		valuesStorage = true;
+		final int expectedValueCount = expectations.length;
+		await(valuesTimeout, () -> {
+			if (valuesStorage) {
+				return String.format("%d out of %d next values received within %d, " + "values : %s",
+						valueCount - nextValueAssertedCount, expectedValueCount, valuesTimeout.toMillis(), values.toString());
+			}
+			return String.format("%d out of %d next values received within %d ms", valueCount - nextValueAssertedCount,
+					expectedValueCount, valuesTimeout.toMillis());
+		}, () -> valueCount >= (nextValueAssertedCount + expectedValueCount));
+		List<T> nextValuesSnapshot;
+		List<T> empty = new ArrayList<>();
+		for (;;) {
+			nextValuesSnapshot = values;
+			if (NEXT_VALUES.compareAndSet(this, values, empty)) {
+				break;
+			}
+		}
+		if (nextValuesSnapshot.size() < expectedValueCount) {
+			throw new AssertionError(String.format("Expected %d number of signals but received %d", expectedValueCount,
+					nextValuesSnapshot.size()));
+		}
+		for (int i = 0; i < expectedValueCount; i++) {
+			Consumer<T> consumer = expectations[i];
+			T actualValue = nextValuesSnapshot.get(i);
+			consumer.accept(actualValue);
+		}
+		nextValueAssertedCount += expectedValueCount;
+		return this;
+	}
+
+	// ==============================================================================================================
+	// Overrides
+	// ==============================================================================================================
+
+	@Override
+	public void cancel() {
+		Subscription a = s;
+		if (a != Operators.cancelledSubscription()) {
+			a = S.getAndSet(this, Operators.cancelledSubscription());
+			if (a != null && a != Operators.cancelledSubscription()) {
+				a.cancel();
+			}
+		}
+	}
+
+	@Override
+	public final boolean isCancelled() {
+		return s == Operators.cancelledSubscription();
+	}
+
+	@Override
+	public final boolean isStarted() {
+		return s != null;
+	}
+
+	@Override
+	public final boolean isTerminated() {
+		return isCancelled();
+	}
+
+	@Override
+	public void onComplete() {
+		completionCount++;
+		cdl.countDown();
+	}
+
+	@Override
+	public void onError(Throwable t) {
+		errors.add(t);
+		cdl.countDown();
+	}
+
+	@Override
+	public void onNext(T t) {
+		if (establishedFusionMode == Fuseable.ASYNC) {
+			for (;;) {
+				t = qs.poll();
+				if (t == null) {
+					break;
+				}
+				valueCount++;
+				if (valuesStorage) {
+					List<T> nextValuesSnapshot;
+					for (;;) {
+						nextValuesSnapshot = values;
+						nextValuesSnapshot.add(t);
+						if (NEXT_VALUES.compareAndSet(this, nextValuesSnapshot, nextValuesSnapshot)) {
+							break;
+						}
+					}
+				}
+			}
+		} else {
+			valueCount++;
+			if (valuesStorage) {
+				List<T> nextValuesSnapshot;
+				for (;;) {
+					nextValuesSnapshot = values;
+					nextValuesSnapshot.add(t);
+					if (NEXT_VALUES.compareAndSet(this, nextValuesSnapshot, nextValuesSnapshot)) {
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void onSubscribe(Subscription s) {
+		subscriptionCount++;
+		int requestMode = requestedFusionMode;
+		if (requestMode >= 0) {
+			if (!setWithoutRequesting(s)) {
+				if (!isCancelled()) {
+					errors.add(new IllegalStateException("Subscription already set: " + subscriptionCount));
+				}
+			} else {
+				if (s instanceof Fuseable.QueueSubscription) {
+					this.qs = (Fuseable.QueueSubscription<T>) s;
+
+					int m = qs.requestFusion(requestMode);
+					establishedFusionMode = m;
+
+					if (m == Fuseable.SYNC) {
+						for (;;) {
+							T v = qs.poll();
+							if (v == null) {
+								onComplete();
+								break;
+							}
+
+							onNext(v);
+						}
+					} else {
+						requestDeferred();
+					}
+				} else {
+					requestDeferred();
+				}
+			}
+		} else {
+			if (!set(s)) {
+				if (!isCancelled()) {
+					errors.add(new IllegalStateException("Subscription already set: " + subscriptionCount));
+				}
+			}
+		}
+	}
+
+	@Override
+	public void request(long n) {
+		if (Operators.validate(n)) {
+			if (establishedFusionMode != Fuseable.SYNC) {
+				normalRequest(n);
+			}
+		}
+	}
+
+	@Override
+	public final long requestedFromDownstream() {
+		return requested;
+	}
+
+	/**
+	 * Setup what fusion mode should be requested from the incomining Subscription if it happens to be QueueSubscription
+	 *
+	 * @param requestMode the mode to request, see Fuseable constants
+	 * @return this
+	 */
+	public final TestSubscriber<T> requestedFusionMode(int requestMode) {
+		this.requestedFusionMode = requestMode;
+		return this;
+	}
+
+	@Override
+	public Subscription upstream() {
+		return s;
+	}
+
+	// ==============================================================================================================
+	// Non public methods
+	// ==============================================================================================================
+
+	protected final void normalRequest(long n) {
+		Subscription a = s;
+		if (a != null) {
+			a.request(n);
+		} else {
+			Operators.addAndGet(REQUESTED, this, n);
+
+			a = s;
+
+			if (a != null) {
+				long r = REQUESTED.getAndSet(this, 0L);
+
+				if (r != 0L) {
+					a.request(r);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Requests the deferred amount if not zero.
+	 */
+	protected final void requestDeferred() {
+		long r = REQUESTED.getAndSet(this, 0L);
+
+		if (r != 0L) {
+			s.request(r);
+		}
+	}
+
+	/**
+	 * Atomically sets the single subscription and requests the missed amount from it.
+	 *
+	 * @param s
+	 * @return false if this arbiter is cancelled or there was a subscription already set
+	 */
+	protected final boolean set(Subscription s) {
+		Objects.requireNonNull(s, "s");
+		Subscription a = this.s;
+		if (a == Operators.cancelledSubscription()) {
+			s.cancel();
+			return false;
+		}
+		if (a != null) {
+			s.cancel();
+			Operators.reportSubscriptionSet();
+			return false;
+		}
+
+		if (S.compareAndSet(this, null, s)) {
+
+			long r = REQUESTED.getAndSet(this, 0L);
+
+			if (r != 0L) {
+				s.request(r);
+			}
+
+			return true;
+		}
+
+		a = this.s;
+
+		if (a != Operators.cancelledSubscription()) {
+			s.cancel();
+			return false;
+		}
+
+		Operators.reportSubscriptionSet();
+		return false;
+	}
+
+	/**
+	 * Sets the Subscription once but does not request anything.
+	 *
+	 * @param s the Subscription to set
+	 * @return true if successful, false if the current subscription is not null
+	 */
+	protected final boolean setWithoutRequesting(Subscription s) {
+		Objects.requireNonNull(s, "s");
+		for (;;) {
+			Subscription a = this.s;
+			if (a == Operators.cancelledSubscription()) {
+				s.cancel();
+				return false;
+			}
+			if (a != null) {
+				s.cancel();
+				Operators.reportSubscriptionSet();
+				return false;
+			}
+
+			if (S.compareAndSet(this, null, s)) {
+				return true;
+			}
+		}
+	}
+
+	/**
+	 * Prepares and throws an AssertionError exception based on the message, cause, the active state and the potential
+	 * errors so far.
+	 *
+	 * @param message the message
+	 * @param cause the optional Throwable cause
+	 * @throws AssertionError as expected
+	 */
+	protected final void assertionError(String message, Throwable cause) {
+		StringBuilder b = new StringBuilder();
+
+		if (cdl.getCount() != 0) {
+			b.append("(active) ");
+		}
+		b.append(message);
+
+		List<Throwable> err = errors;
+		if (!err.isEmpty()) {
+			b.append(" (+ ").append(err.size()).append(" errors)");
+		}
+		AssertionError e = new AssertionError(b.toString(), cause);
+
+		for (Throwable t : err) {
+			e.addSuppressed(t);
+		}
+
+		throw e;
+	}
+
+	protected final String fusionModeName(int mode) {
+		switch (mode) {
+			case -1:
+				return "Disabled";
+			case Fuseable.NONE:
+				return "None";
+			case Fuseable.SYNC:
+				return "Sync";
+			case Fuseable.ASYNC:
+				return "Async";
+			default:
+				return "Unknown(" + mode + ")";
+		}
+	}
+
+	protected final String valueAndClass(Object o) {
+		if (o == null) {
+			return null;
+		}
+		return o + " (" + o.getClass().getSimpleName() + ")";
+	}
+
+}


### PR DESCRIPTION
We introduced reactor based reactive connection support via ReactiveRedisConnection and ReactiveRedisClusterConnection.

A reactive connection can be obtained via the ConnectionFactory. This is currently only possible when using the Lettuce Redis driver.

----

Related ticket: [DATAREDIS-525](https://jira.spring.io/browse/DATAREDIS-525).