### PR TITLE
DATAREDIS-589 - Fix NPE for non repository related keyspace events.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REDIS_VERSION:=3.2.0
+REDIS_VERSION:=3.2.6
 SPRING_PROFILE?=ci
 
 #######
@@ -25,6 +25,8 @@ work/redis-%.conf:
 
 	echo port $* >> $@
 	echo daemonize yes >> $@
+	echo protected-mode no >> $@
+	echo notify-keyspace-events Ex >> $@
 	echo pidfile $(shell pwd)/work/redis-$*.pid >> $@
 	echo logfile $(shell pwd)/work/redis-$*.log >> $@
 	echo save \"\" >> $@
@@ -36,6 +38,8 @@ work/redis-6379.conf:
 
 	echo port 6379 >> $@
 	echo daemonize yes >> $@
+	echo protected-mode no >> $@
+	echo notify-keyspace-events Ex >> $@
 	echo pidfile $(shell pwd)/work/redis-6379.pid >> $@
 	echo logfile $(shell pwd)/work/redis-6379.log >> $@
 	echo save \"\" >> $@
@@ -57,6 +61,7 @@ work/sentinel-%.conf:
 
 	echo port $* >> $@
 	echo daemonize yes >> $@
+	echo protected-mode no >> $@
 	echo bind 0.0.0.0 >> $@
 	echo pidfile $(shell pwd)/work/sentinel-$*.pid >> $@
 	echo logfile $(shell pwd)/work/sentinel-$*.log >> $@
@@ -80,6 +85,7 @@ work/cluster-%.conf:
 	@mkdir -p $(@D)
 
 	echo port $* >> $@
+	echo protected-mode no >> $@
 	echo cluster-enabled yes  >> $@
 	echo cluster-config-file $(shell pwd)/work/nodes-$*.conf  >> $@
 	echo cluster-node-timeout 5  >> $@

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-589-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
@@ -48,12 +48,24 @@ public class RedisKeyExpiredEvent<T> extends RedisKeyspaceEvent {
 
 	/**
 	 * Creates new {@link RedisKeyExpiredEvent}
-	 * 
+	 *
 	 * @param key
 	 * @param value
 	 */
 	public RedisKeyExpiredEvent(byte[] key, Object value) {
-		super(key);
+		this(null, key, value);
+	}
+
+	/**
+	 * Creates new {@link RedisKeyExpiredEvent}
+	 *
+	 * @pamam channel
+	 * @param key
+	 * @param value
+	 * @since 1.8
+	 */
+	public RedisKeyExpiredEvent(String channel, byte[] key, Object value) {
+		super(channel, key);
 
 		args = ByteUtils.split(key, ':');
 		this.value = value;

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyspaceEvent.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyspaceEvent.java
@@ -25,13 +25,28 @@ import org.springframework.context.ApplicationEvent;
  */
 public class RedisKeyspaceEvent extends ApplicationEvent {
 
+	private final String channel;
+
 	/**
 	 * Creates new {@link RedisKeyspaceEvent}.
-	 * 
+	 *
 	 * @param key The key that expired. Must not be {@literal null}.
 	 */
 	public RedisKeyspaceEvent(byte[] key) {
+		this(null, key);
+	}
+
+	/**
+	 * Creates new {@link RedisKeyspaceEvent}.
+	 *
+	 * @param channel The source channel aka subscription topic. Can be {@literal null}.
+	 * @param key The key that expired. Must not be {@literal null}.
+	 * @since 1.8
+	 */
+	public RedisKeyspaceEvent(String channel, byte[] key) {
+
 		super(key);
+		this.channel = channel;
 	}
 
 	/*
@@ -40,6 +55,15 @@ public class RedisKeyspaceEvent extends ApplicationEvent {
 	 */
 	public byte[] getSource() {
 		return (byte[]) super.getSource();
+	}
+
+	/**
+	 *
+	 * @return can be {@literal null}.
+	 * @since 1.8
+	 */
+	public String getChannel() {
+		return this.channel;
 	}
 
 }

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -289,6 +289,28 @@ public class RedisKeyValueAdapterTests {
 	}
 
 	/**
+	 * @see DATAREDIS-589
+	 */
+	@Test
+	public void keyExpiredEventWithoutKeyspaceShouldBeIgnored() {
+
+		Map<String, String> map = new LinkedHashMap<String, String>();
+		map.put("_class", Person.class.getName());
+		map.put("firstname", "rand");
+		map.put("address.country", "Andor");
+
+		template.opsForSet().add("persons", "1");
+		template.opsForSet().add("persons:firstname:rand", "1");
+		template.opsForSet().add("persons:1:idx", "persons:firstname:rand");
+
+		adapter.onApplicationEvent(new RedisKeyExpiredEvent("1".getBytes(Bucket.CHARSET)));
+
+		assertThat(template.hasKey("persons:firstname:rand"), is(true));
+		assertThat(template.hasKey("persons:1:idx"), is(true));
+		assertThat(template.opsForSet().members("persons"), hasItem("1"));
+	}
+
+	/**
 	 * @see DATAREDIS-512
 	 */
 	@Test


### PR DESCRIPTION
We now no longer rely on `ApplicationEvents` captured in the `RedisKeyValueAdapter` for performing cleanup operations for expired keys, but do this along with the phantom key removal. This removes a flaw when initializing a non repository related `KeyspaceEventListener` publishing events that actually are unrelated to the `Adapter`.

Additionally upgraded test infrastructure to utilize Redis 3.2.6 with disabled protected-mode and enabled keyspace-events.