### PR TITLE
DATAREDIS-592 - Consider expiry timeout in synchronized RedisCache mode.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-592-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 package org.springframework.data.redis.cache;
-
-import static org.springframework.util.Assert.*;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -41,7 +39,6 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.ObjectUtils;
 
 /**
  * Cache implementation on top of Redis.
@@ -142,8 +139,9 @@ public class RedisCache extends AbstractValueAdaptingCache {
 	 */
 	public <T> T get(final Object key, final Callable<T> valueLoader) {
 
-		BinaryRedisCacheElement rce = new BinaryRedisCacheElement(
-				new RedisCacheElement(getRedisCacheKey(key), new StoreTranslatingCallable(valueLoader)), cacheValueAccessor);
+		RedisCacheElement cacheElement = new RedisCacheElement(getRedisCacheKey(key),
+				new StoreTranslatingCallable(valueLoader)).expireAfter(cacheMetadata.getDefaultExpiration());
+		BinaryRedisCacheElement rce = new BinaryRedisCacheElement(cacheElement, cacheValueAccessor);
 
 		ValueWrapper val = get(key);
 		if (val != null) {

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
@@ -101,8 +101,8 @@ public class RedisCacheUnitTests {
 		cache = new RedisCache(CACHE_NAME, PREFIX_BYTES, templateSpy, EXPIRATION);
 		cache.put(KEY, VALUE);
 
-		verify(connectionMock, times(1)).set(eq(KEY_WITH_PREFIX_BYTES), eq(VALUE_BYTES));
-		verify(connectionMock, times(1)).expire(eq(KEY_WITH_PREFIX_BYTES), eq(EXPIRATION));
+		verify(connectionMock).set(eq(KEY_WITH_PREFIX_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).expire(eq(KEY_WITH_PREFIX_BYTES), eq(EXPIRATION));
 		verify(connectionMock, never()).zAdd(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0D), any(byte[].class));
 	}
 
@@ -112,9 +112,9 @@ public class RedisCacheUnitTests {
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, EXPIRATION);
 		cache.put(KEY, VALUE);
 
-		verify(connectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
-		verify(connectionMock, times(1)).expire(eq(KEY_BYTES), eq(EXPIRATION));
-		verify(connectionMock, times(1)).zAdd(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0D), eq(KEY_BYTES));
+		verify(connectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).expire(eq(KEY_BYTES), eq(EXPIRATION));
+		verify(connectionMock).zAdd(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0D), eq(KEY_BYTES));
 	}
 
 	@Test // DATAREDIS-369
@@ -123,7 +123,7 @@ public class RedisCacheUnitTests {
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, EXPIRATION);
 		cache.clear();
 
-		verify(connectionMock, times(1)).zRange(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0L), eq(127L));
+		verify(connectionMock).zRange(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0L), eq(127L));
 	}
 
 	@Test // DATAREDIS-369
@@ -132,7 +132,7 @@ public class RedisCacheUnitTests {
 		cache = new RedisCache(CACHE_NAME, PREFIX_BYTES, templateSpy, EXPIRATION);
 		cache.clear();
 
-		verify(connectionMock, times(1)).eval(any(byte[].class), eq(ReturnType.INTEGER), eq(0),
+		verify(connectionMock).eval(any(byte[].class), eq(ReturnType.INTEGER), eq(0),
 				eq((PREFIX + "*").getBytes()));
 	}
 
@@ -222,10 +222,10 @@ public class RedisCacheUnitTests {
 			}
 		});
 
-		verify(connectionMock, times(1)).get(eq(KEY_BYTES));
-		verify(connectionMock, times(1)).multi();
-		verify(connectionMock, times(1)).del(eq(KEY_BYTES));
-		verify(connectionMock, times(1)).exec();
+		verify(connectionMock).get(eq(KEY_BYTES));
+		verify(connectionMock).multi();
+		verify(connectionMock).del(eq(KEY_BYTES));
+		verify(connectionMock).exec();
 	}
 
 	@Test // DATAREDIS-553
@@ -242,10 +242,10 @@ public class RedisCacheUnitTests {
 		});
 
 		verify(valueSerializerMock).serialize(isA(NullValue.class));
-		verify(connectionMock, times(1)).get(eq(KEY_BYTES));
-		verify(connectionMock, times(1)).multi();
-		verify(connectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
-		verify(connectionMock, times(1)).exec();
+		verify(connectionMock).get(eq(KEY_BYTES));
+		verify(connectionMock).multi();
+		verify(connectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).exec();
 	}
 
 	@Test // DATAREDIS-443, DATAREDIS-592
@@ -260,11 +260,11 @@ public class RedisCacheUnitTests {
 			}
 		});
 
-		verify(connectionMock, times(1)).get(eq(KEY_BYTES));
-		verify(connectionMock, times(1)).multi();
-		verify(connectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).get(eq(KEY_BYTES));
+		verify(connectionMock).multi();
+		verify(connectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
 		verify(connectionMock, never()).expire(any(byte[].class), anyLong());
-		verify(connectionMock, times(1)).exec();
+		verify(connectionMock).exec();
 	}
 
 	@Test // DATAREDIS-592
@@ -313,7 +313,7 @@ public class RedisCacheUnitTests {
 
 		cache.put(KEY, VALUE);
 
-		verify(clusterConnectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(clusterConnectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
 		verify(clusterConnectionMock, never()).multi();
 		verify(clusterConnectionMock, never()).exec();
 		verifyZeroInteractions(connectionMock);
@@ -334,8 +334,8 @@ public class RedisCacheUnitTests {
 			}
 		});
 
-		verify(clusterConnectionMock, times(1)).get(eq(KEY_BYTES));
-		verify(clusterConnectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(clusterConnectionMock).get(eq(KEY_BYTES));
+		verify(clusterConnectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
 
 		verify(clusterConnectionMock, never()).multi();
 		verify(clusterConnectionMock, never()).exec();

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
@@ -248,7 +248,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, times(1)).exec();
 	}
 
-	@Test // DATAREDIS-443
+	@Test // DATAREDIS-443, DATAREDIS-592
 	public void getWithCallableShouldReadValueFromCallableAddToCache() {
 
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, 0L);
@@ -263,7 +263,27 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, times(1)).get(eq(KEY_BYTES));
 		verify(connectionMock, times(1)).multi();
 		verify(connectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock, never()).expire(any(byte[].class), anyLong());
 		verify(connectionMock, times(1)).exec();
+	}
+
+	@Test // DATAREDIS-592
+	public void getWithCallableShouldReadValueFromCallableAddToCacheWithTtl() {
+
+		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, 100L);
+
+		cache.get(KEY, new Callable<Object>() {
+			@Override
+			public Object call() throws Exception {
+				return VALUE;
+			}
+		});
+
+		verify(connectionMock).get(eq(KEY_BYTES));
+		verify(connectionMock).multi();
+		verify(connectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).expire(eq(KEY_BYTES), eq(100L));
+		verify(connectionMock).exec();
 	}
 
 	@Test // DATAREDIS-443


### PR DESCRIPTION
We now consider the element expiry when retrieving cache elements with a value loader. Previously, all cache elements that were cached using `@Cacheable(sync=true)` or used `RedisCache.get(Object, Callable)` directly were considered eternal without setting a TTL.

---

Related ticket: [DATAREDIS-592](https://jira.spring.io/browse/DATAREDIS-592)