### PR TITLE
DATAREDIS-593 - Use Enum.name() to represent enum values.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.DATAREDIS-593-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/convert/BinaryConverters.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/BinaryConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,9 @@ import org.springframework.util.NumberUtils;
 
 /**
  * Set of {@link ReadingConverter} and {@link WritingConverter} used to convert Objects into binary format.
- * 
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.7
  */
 final class BinaryConverters {
@@ -108,6 +109,7 @@ final class BinaryConverters {
 
 	/**
 	 * @author Christoph Strobl
+	 * @author Mark Paluch
 	 * @since 1.7
 	 */
 	@WritingConverter
@@ -120,9 +122,8 @@ final class BinaryConverters {
 				return new byte[] {};
 			}
 
-			return fromString(source.toString());
+			return fromString(source.name());
 		}
-
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.springframework.data.redis.core.convert;
+
+import lombok.EqualsAndHashCode;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -36,10 +38,9 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
-import lombok.EqualsAndHashCode;
-
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class ConversionTestEntities {
 
@@ -97,7 +98,13 @@ public class ConversionTestEntities {
 	}
 
 	public static enum Gender {
-		MALE, FEMALE
+		MALE, FEMALE {
+
+			@Override
+			public String toString() {
+				return "Superwoman";
+			}
+		}
 	}
 
 	public static class AddressWithPostcode extends Address {

--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -32,16 +32,7 @@ import java.time.LocalTime;
 import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import org.hamcrest.core.IsEqual;
 import org.junit.Before;
@@ -56,20 +47,8 @@ import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.mapping.model.MappingException;
 import org.springframework.data.redis.core.PartialUpdate;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Address;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.AddressWithId;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.AddressWithPostcode;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.ExipringPersonWithExplicitProperty;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.ExpiringPerson;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Gender;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Location;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Person;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Species;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.TaVeren;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.TheWheelOfTime;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.TypeWithObjectValueTypes;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.WithArrays;
 import org.springframework.data.redis.core.convert.KeyspaceConfiguration.KeyspaceSettings;
+import org.springframework.data.redis.core.convert.ConversionTestEntities.*;
 import org.springframework.data.redis.core.mapping.RedisMappingContext;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.util.StringUtils;
@@ -78,8 +57,10 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
+ * Unit tests for {@link MappingRedisConverter}.
  * @author Christoph Strobl
  * @author Greg Turnquist
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class MappingRedisConverterUnitTests {
@@ -621,21 +602,21 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.period, is(Period.parse("P1Y2M25D")));
 	}
 
-	@Test // DATAREDIS-425
+	@Test // DATAREDIS-425, DATAREDIS-593
 	public void writesEnumValuesCorrectly() {
 
-		rand.gender = Gender.MALE;
+		rand.gender = Gender.FEMALE;
 
-		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("gender", "MALE"));
+		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("gender", "FEMALE"));
 	}
 
-	@Test // DATAREDIS-425
+	@Test // DATAREDIS-425, DATAREDIS-593
 	public void readsEnumValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
-				new RedisData(Bucket.newBucketFromStringMap(Collections.singletonMap("gender", "MALE"))));
+				new RedisData(Bucket.newBucketFromStringMap(Collections.singletonMap("gender", "FEMALE"))));
 
-		assertThat(target.gender, is(Gender.MALE));
+		assertThat(target.gender, is(Gender.FEMALE));
 	}
 
 	@Test // DATAREDIS-425


### PR DESCRIPTION
We now serialize Enum values using their name (`Enum.name()`) instead of using their string representation (`Enum.toString()`). `toString` can be customized in Enums to no longer report their name but a different value. A customized value cannot be used to re-instantiate the Enum value, only its name.

This change affects serialization and will only affect new/updated values. Stored values with a customized toString representation still can't be deserialized until they were updated in Redis.

---

Related ticket: [DATAREDIS-593](https://jira.spring.io/browse/DATAREDIS-593)