### PR TITLE
DATAREDIS-574 - Introduce dedicated RedisClientConfig

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,10 +208,6 @@
 						<include>**/*Tests.java</include>
 						<include>**/*Test.java</include>
 					</includes>
-					<systemProperties>
-						<gemfire.disableShutdownHook>true</gemfire.disableShutdownHook>
-						<javax.net.ssl.keyStore>${basedir}/src/test/resources/trusted.keystore</javax.net.ssl.keyStore>
-					</systemProperties>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-574-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -678,9 +678,7 @@ class RedisOperationsProducer {
   @Produces
   RedisConnectionFactory redisConnectionFactory() {
 
-    JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory();
-    jedisConnectionFactory.setHostName("localhost");
-    jedisConnectionFactory.setPort(6379);
+    JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory(new RedisStandaloneConfiguration());
     jedisConnectionFactory.afterPropertiesSet();
 
     return jedisConnectionFactory;

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.util.StringUtils;
  * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} using connecting
  * to <a href="http://redis.io/topics/cluster-spec">Redis Cluster</a>. Useful when setting up a high availability Redis
  * environment.
- * 
+ *
  * @author Christoph Strobl
  * @author Mark Paluch
  * @since 1.7
@@ -47,6 +47,7 @@ public class RedisClusterConfiguration {
 
 	private Set<RedisNode> clusterNodes;
 	private Integer maxRedirects;
+	private String password;
 
 	/**
 	 * Creates new {@link RedisClusterConfiguration}.
@@ -57,16 +58,15 @@ public class RedisClusterConfiguration {
 
 	/**
 	 * Creates {@link RedisClusterConfiguration} for given hostPort combinations.
-	 * 
+	 *
 	 * <pre>
+	 * <code>
 	 * clusterHostAndPorts[0] = 127.0.0.1:23679
-	 * clusterHostAndPorts[1] = 127.0.0.1:23680
-	 * ...
-	 * 
+	 * clusterHostAndPorts[1] = 127.0.0.1:23680 ...
+	 * </code>
 	 * <pre>
-	 * 
-	 * @param cluster must not be
-	 * {@literal null}.
+	 *
+	 * @param clusterNodes must not be {@literal null}.
 	 */
 	public RedisClusterConfiguration(Collection<String> clusterNodes) {
 		this(new MapPropertySource("RedisClusterConfiguration", asMap(clusterNodes, -1, -1, null)));
@@ -74,7 +74,7 @@ public class RedisClusterConfiguration {
 
 	/**
 	 * Creates {@link RedisClusterConfiguration} looking up values in given {@link PropertySource}.
-	 * 
+	 *
 	 * <pre>
 	 * <code>
 	 * spring.redis.cluster.nodes=127.0.0.1:23679,127.0.0.1:23680,127.0.0.1:23681
@@ -83,7 +83,7 @@ public class RedisClusterConfiguration {
 	 * spring.redis.cluster.password=foobar
 	 * </code>
 	 * </pre>
-	 * 
+	 *
 	 * @param propertySource must not be {@literal null}.
 	 */
 	public RedisClusterConfiguration(PropertySource<?> propertySource) {
@@ -104,7 +104,7 @@ public class RedisClusterConfiguration {
 
 	/**
 	 * Set {@literal cluster nodes} to connect to.
-	 * 
+	 *
 	 * @param nodes must not be {@literal null}.
 	 */
 	public void setClusterNodes(Iterable<RedisNode> nodes) {
@@ -120,7 +120,7 @@ public class RedisClusterConfiguration {
 
 	/**
 	 * Returns an {@link Collections#unmodifiableSet(Set)} of {@literal cluster nodes}.
-	 * 
+	 *
 	 * @return {@link Set} of nodes. Never {@literal null}.
 	 */
 	public Set<RedisNode> getClusterNodes() {
@@ -129,7 +129,7 @@ public class RedisClusterConfiguration {
 
 	/**
 	 * Add a cluster node to configuration.
-	 * 
+	 *
 	 * @param node must not be {@literal null}.
 	 */
 	public void addClusterNode(RedisNode node) {
@@ -177,6 +177,22 @@ public class RedisClusterConfiguration {
 		for (String hostAndPort : hostAndPorts) {
 			addClusterNode(readHostAndPortFromString(hostAndPort));
 		}
+	}
+
+	/**
+	 * @return
+	 * @since 2.0
+	 */
+	public String getPassword() {
+		return password;
+	}
+
+	/**
+	 * @param password
+	 * @since 2.0
+	 */
+	public void setPassword(String password) {
+		this.password = password;
 	}
 
 	private RedisNode readHostAndPortFromString(String hostAndPort) {

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
@@ -47,7 +47,7 @@ public class RedisClusterConfiguration {
 
 	private Set<RedisNode> clusterNodes;
 	private Integer maxRedirects;
-	private String password;
+	private RedisPassword password = RedisPassword.none();
 
 	/**
 	 * Creates new {@link RedisClusterConfiguration}.
@@ -183,15 +183,18 @@ public class RedisClusterConfiguration {
 	 * @return
 	 * @since 2.0
 	 */
-	public String getPassword() {
+	public RedisPassword getPassword() {
 		return password;
 	}
 
 	/**
-	 * @param password
+	 * @param password must not be {@literal null}.
 	 * @since 2.0
 	 */
-	public void setPassword(String password) {
+	public void setPassword(RedisPassword password) {
+
+		Assert.notNull(password, "RedisPassword must not be null!");
+
 		this.password = password;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ public class RedisClusterConfiguration {
 	 * clusterHostAndPorts[0] = 127.0.0.1:23679
 	 * clusterHostAndPorts[1] = 127.0.0.1:23680 ...
 	 * </code>
+	 *
 	 * <pre>
 	 *
 	 * @param clusterNodes must not be {@literal null}.
@@ -93,8 +94,8 @@ public class RedisClusterConfiguration {
 		this.clusterNodes = new LinkedHashSet<RedisNode>();
 
 		if (propertySource.containsProperty(REDIS_CLUSTER_NODES_CONFIG_PROPERTY)) {
-			appendClusterNodes(commaDelimitedListToSet(propertySource.getProperty(REDIS_CLUSTER_NODES_CONFIG_PROPERTY)
-					.toString()));
+			appendClusterNodes(
+					commaDelimitedListToSet(propertySource.getProperty(REDIS_CLUSTER_NODES_CONFIG_PROPERTY).toString()));
 		}
 		if (propertySource.containsProperty(REDIS_CLUSTER_MAX_REDIRECTS_CONFIG_PROPERTY)) {
 			this.maxRedirects = NumberUtils.parseNumber(
@@ -180,7 +181,9 @@ public class RedisClusterConfiguration {
 	}
 
 	/**
-	 * @return
+	 * Get the {@link RedisPassword} defined.
+	 *
+	 * @return never {@literal null}.
 	 * @since 2.0
 	 */
 	public RedisPassword getPassword() {

--- a/src/main/java/org/springframework/data/redis/connection/RedisPassword.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisPassword.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Value object which may or may not contain a Redis password.
@@ -34,13 +36,14 @@ import org.springframework.util.Assert;
  * The password is stored as character array.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class RedisPassword {
 
-	private static final RedisPassword NONE = new RedisPassword(new char[0]);
+	private static final RedisPassword NONE = new RedisPassword(new char[] {});
 
 	private final char[] thePassword;
 
@@ -53,7 +56,7 @@ public class RedisPassword {
 	public static RedisPassword of(String passwordAsString) {
 
 		return Optional.ofNullable(passwordAsString) //
-				.filter(it -> it.length() != 0) //
+				.filter(StringUtils::hasText) //
 				.map(it -> new RedisPassword(it.toCharArray())) //
 				.orElseGet(RedisPassword::none);
 	}
@@ -61,13 +64,13 @@ public class RedisPassword {
 	/**
 	 * Create a {@link RedisPassword} from a {@code char} array.
 	 *
-	 * @param passwordAsChars the password as string.
+	 * @param passwordAsChars the password as char array.
 	 * @return the {@link RedisPassword} for {@code passwordAsChars}.
 	 */
 	public static RedisPassword of(char[] passwordAsChars) {
 
 		return Optional.ofNullable(passwordAsChars) //
-				.filter(it -> it.length != 0) //
+				.filter(it -> !ObjectUtils.isEmpty(passwordAsChars)) //
 				.map(it -> new RedisPassword(Arrays.copyOf(it, it.length))) //
 				.orElseGet(RedisPassword::none);
 	}
@@ -87,7 +90,7 @@ public class RedisPassword {
 	 * @return {@code true} if there is a password present, otherwise {@code false}
 	 */
 	public boolean isPresent() {
-		return thePassword.length != 0;
+		return !ObjectUtils.isEmpty(thePassword);
 	}
 
 	/**
@@ -117,11 +120,7 @@ public class RedisPassword {
 
 		Assert.notNull(mapper, "Mapper function must not be null!");
 
-		if (isPresent()) {
-			return Optional.ofNullable(mapper.apply(thePassword));
-		}
-
-		return Optional.empty();
+		return toOptional().map(mapper);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/RedisPassword.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisPassword.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.util.Assert;
+
+/**
+ * Value object which may or may not contain a Redis password.
+ * <p/>
+ * If a password is present, {@code isPresent()} will return {@code true} and {@code get()} will return the value.
+ * <p/>
+ * The password is stored as character array.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class RedisPassword {
+
+	private static final RedisPassword NONE = new RedisPassword(new char[0]);
+
+	private final char[] thePassword;
+
+	/**
+	 * Create a {@link RedisPassword} from a {@link String}.
+	 *
+	 * @param passwordAsString the password as string.
+	 * @return the {@link RedisPassword} for {@code passwordAsString}.
+	 */
+	public static RedisPassword of(String passwordAsString) {
+
+		return Optional.ofNullable(passwordAsString) //
+				.filter(it -> it.length() != 0) //
+				.map(it -> new RedisPassword(it.toCharArray())) //
+				.orElseGet(RedisPassword::none);
+	}
+
+	/**
+	 * Create a {@link RedisPassword} from a {@code char} array.
+	 *
+	 * @param passwordAsChars the password as string.
+	 * @return the {@link RedisPassword} for {@code passwordAsChars}.
+	 */
+	public static RedisPassword of(char[] passwordAsChars) {
+
+		return Optional.ofNullable(passwordAsChars) //
+				.filter(it -> it.length != 0) //
+				.map(it -> new RedisPassword(Arrays.copyOf(it, it.length))) //
+				.orElseGet(RedisPassword::none);
+	}
+
+	/**
+	 * Create an absent {@link RedisPassword}.
+	 *
+	 * @return the absent {@link RedisPassword}.
+	 */
+	public static RedisPassword none() {
+		return NONE;
+	}
+
+	/**
+	 * Return {@code true} if there is a password present, otherwise {@code false}.
+	 *
+	 * @return {@code true} if there is a password present, otherwise {@code false}
+	 */
+	public boolean isPresent() {
+		return thePassword.length != 0;
+	}
+
+	/**
+	 * Return the password value if present. Throws {@link NoSuchElementException} if the password is absent.
+	 *
+	 * @return the password.
+	 * @throws NoSuchElementException if the password is absent.
+	 */
+	public char[] get() throws NoSuchElementException {
+
+		if (isPresent()) {
+			return Arrays.copyOf(thePassword, thePassword.length);
+		}
+
+		throw new NoSuchElementException("No password present.");
+	}
+
+	/**
+	 * Map the password using a {@link Function} and return a {@link Optional} containing the mapped value.
+	 * <p/>
+	 * Absent passwords return a {@link Optional#empty()}.
+	 *
+	 * @param mapper must not be {@literal null}.
+	 * @return the mapped result.
+	 */
+	public <R> Optional<R> map(Function<char[], R> mapper) {
+
+		Assert.notNull(mapper, "Mapper function must not be null!");
+
+		if (isPresent()) {
+			return Optional.ofNullable(mapper.apply(thePassword));
+		}
+
+		return Optional.empty();
+	}
+
+	/**
+	 * Adopt the password to {@link Optional} containing the password value.
+	 * <p/>
+	 * Absent passwords return a {@link Optional#empty()}.
+	 *
+	 * @return the {@link Optional} containing the password value.
+	 */
+	public Optional<char[]> toOptional() {
+
+		if (isPresent()) {
+			return Optional.ofNullable(get());
+		}
+
+		return Optional.empty();
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return String.format("%s[%s]", getClass().getSimpleName(), isPresent() ? "*****" : "<none>");
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -54,7 +54,7 @@ public class RedisSentinelConfiguration {
 	 * Creates new {@link RedisSentinelConfiguration}.
 	 */
 	public RedisSentinelConfiguration() {
-		this(new MapPropertySource("RedisSentinelConfiguration", Collections.<String, Object> emptyMap()));
+		this(new MapPropertySource("RedisSentinelConfiguration", Collections.emptyMap()));
 	}
 
 	/**
@@ -89,7 +89,7 @@ public class RedisSentinelConfiguration {
 
 		notNull(propertySource, "PropertySource must not be null!");
 
-		this.sentinels = new LinkedHashSet<RedisNode>();
+		this.sentinels = new LinkedHashSet<>();
 
 		if (propertySource.containsProperty(REDIS_SENTINEL_MASTER_CONFIG_PROPERTY)) {
 			this.setMaster(propertySource.getProperty(REDIS_SENTINEL_MASTER_CONFIG_PROPERTY).toString());
@@ -145,13 +145,7 @@ public class RedisSentinelConfiguration {
 	public void setMaster(final String name) {
 
 		notNull(name, "Name of sentinel master must not be null.");
-		setMaster(new NamedNode() {
-
-			@Override
-			public String getName() {
-				return name;
-			}
-		});
+		setMaster(() -> name);
 	}
 
 	/**
@@ -237,13 +231,13 @@ public class RedisSentinelConfiguration {
 	 */
 	public void setDatabase(int index) {
 
-		Assert.isTrue(index >= 0, "invalid DB index (a positive index required)");
+		Assert.isTrue(index >= 0, () -> String.format("Invalid DB index '%s' (a positive index required)", index));
 
 		this.database = index;
 	}
 
 	/**
-	 * @return
+	 * @return never {@literal null}.
 	 * @since 2.0
 	 */
 	public RedisPassword getPassword() {
@@ -280,7 +274,7 @@ public class RedisSentinelConfiguration {
 		hasText(master, "Master address must not be null or empty!");
 		notNull(sentinelHostAndPorts, "SentinelHostAndPorts must not be null!");
 
-		Map<String, Object> map = new HashMap<String, Object>();
+		Map<String, Object> map = new HashMap<>();
 		map.put(REDIS_SENTINEL_MASTER_CONFIG_PROPERTY, master);
 		map.put(REDIS_SENTINEL_NODES_CONFIG_PROPERTY, StringUtils.collectionToCommaDelimitedString(sentinelHostAndPorts));
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.connection;
 
 import static org.springframework.util.Assert.*;
+import static org.springframework.util.Assert.hasText;
 import static org.springframework.util.StringUtils.*;
 
 import java.util.Collections;
@@ -26,6 +27,7 @@ import java.util.Set;
 
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -44,6 +46,8 @@ public class RedisSentinelConfiguration {
 
 	private NamedNode master;
 	private Set<RedisNode> sentinels;
+	private int database;
+	private String password;
 
 	/**
 	 * Creates new {@link RedisSentinelConfiguration}.
@@ -56,9 +60,7 @@ public class RedisSentinelConfiguration {
 	 * Creates {@link RedisSentinelConfiguration} for given hostPort combinations.
 	 * 
 	 * <pre>
-	 * sentinelHostAndPorts[0] = 127.0.0.1:23679
-	 * sentinelHostAndPorts[1] = 127.0.0.1:23680
-	 * ...
+	 * sentinelHostAndPorts[0] = 127.0.0.1:23679 sentinelHostAndPorts[1] = 127.0.0.1:23680 ...
 	 * 
 	 * <pre>
 	 * 
@@ -93,8 +95,8 @@ public class RedisSentinelConfiguration {
 		}
 
 		if (propertySource.containsProperty(REDIS_SENTINEL_NODES_CONFIG_PROPERTY)) {
-			appendSentinels(commaDelimitedListToSet(propertySource.getProperty(REDIS_SENTINEL_NODES_CONFIG_PROPERTY)
-					.toString()));
+			appendSentinels(
+					commaDelimitedListToSet(propertySource.getProperty(REDIS_SENTINEL_NODES_CONFIG_PROPERTY).toString()));
 		}
 	}
 
@@ -216,6 +218,43 @@ public class RedisSentinelConfiguration {
 		for (String hostAndPort : hostAndPorts) {
 			addSentinel(readHostAndPortFromString(hostAndPort));
 		}
+	}
+
+	/**
+	 * @return
+	 * @since 2.0
+	 */
+	public int getDatabase() {
+		return database;
+	}
+
+	/**
+	 * Sets the index of the database used by this connection factory. Default is 0.
+	 *
+	 * @param index database index.
+	 * @since 2.0
+	 */
+	public void setDatabase(int index) {
+
+		Assert.isTrue(index >= 0, "invalid DB index (a positive index required)");
+
+		this.database = index;
+	}
+
+	/**
+	 * @return
+	 * @since 2.0
+	 */
+	public String getPassword() {
+		return password;
+	}
+
+	/**
+	 * @param password
+	 * @since 2.0
+	 */
+	public void setPassword(String password) {
+		this.password = password;
 	}
 
 	private RedisNode readHostAndPortFromString(String hostAndPort) {

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Mark Paluch
  * @since 1.4
  */
 public class RedisSentinelConfiguration {

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.util.StringUtils;
  * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} using connecting
  * to <a href="http://redis.io/topics/sentinel">Redis Sentinel(s)</a>. Useful when setting up a high availability Redis
  * environment.
- * 
+ *
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Mark Paluch
@@ -48,7 +48,7 @@ public class RedisSentinelConfiguration {
 	private NamedNode master;
 	private Set<RedisNode> sentinels;
 	private int database;
-	private String password;
+	private RedisPassword password = RedisPassword.none();
 
 	/**
 	 * Creates new {@link RedisSentinelConfiguration}.
@@ -59,12 +59,12 @@ public class RedisSentinelConfiguration {
 
 	/**
 	 * Creates {@link RedisSentinelConfiguration} for given hostPort combinations.
-	 * 
+	 *
 	 * <pre>
 	 * sentinelHostAndPorts[0] = 127.0.0.1:23679 sentinelHostAndPorts[1] = 127.0.0.1:23680 ...
-	 * 
+	 *
 	 * <pre>
-	 * 
+	 *
 	 * @param sentinelHostAndPorts must not be {@literal null}.
 	 * @since 1.5
 	 */
@@ -74,14 +74,14 @@ public class RedisSentinelConfiguration {
 
 	/**
 	 * Creates {@link RedisSentinelConfiguration} looking up values in given {@link PropertySource}.
-	 * 
+	 *
 	 * <pre>
 	 * <code>
 	 * spring.redis.sentinel.master=myMaster
 	 * spring.redis.sentinel.nodes=127.0.0.1:23679,127.0.0.1:23680,127.0.0.1:23681
 	 * </code>
 	 * </pre>
-	 * 
+	 *
 	 * @param propertySource must not be {@literal null}.
 	 * @since 1.5
 	 */
@@ -103,7 +103,7 @@ public class RedisSentinelConfiguration {
 
 	/**
 	 * Set {@literal Sentinels} to connect to.
-	 * 
+	 *
 	 * @param sentinels must not be {@literal null}.
 	 */
 	public void setSentinels(Iterable<RedisNode> sentinels) {
@@ -119,7 +119,7 @@ public class RedisSentinelConfiguration {
 
 	/**
 	 * Returns an {@link Collections#unmodifiableSet(Set)} of {@literal Sentinels}.
-	 * 
+	 *
 	 * @return {@link Set} of sentinels. Never {@literal null}.
 	 */
 	public Set<RedisNode> getSentinels() {
@@ -128,7 +128,7 @@ public class RedisSentinelConfiguration {
 
 	/**
 	 * Add sentinel.
-	 * 
+	 *
 	 * @param sentinel must not be {@literal null}.
 	 */
 	public void addSentinel(RedisNode sentinel) {
@@ -139,7 +139,7 @@ public class RedisSentinelConfiguration {
 
 	/**
 	 * Set the master node via its name.
-	 * 
+	 *
 	 * @param name must not be {@literal null}.
 	 */
 	public void setMaster(final String name) {
@@ -156,7 +156,7 @@ public class RedisSentinelConfiguration {
 
 	/**
 	 * Set the master.
-	 * 
+	 *
 	 * @param master must not be {@literal null}.
 	 */
 	public void setMaster(NamedNode master) {
@@ -167,7 +167,7 @@ public class RedisSentinelConfiguration {
 
 	/**
 	 * Get the {@literal Sentinel} master node.
-	 * 
+	 *
 	 * @return
 	 */
 	public NamedNode getMaster() {
@@ -246,15 +246,18 @@ public class RedisSentinelConfiguration {
 	 * @return
 	 * @since 2.0
 	 */
-	public String getPassword() {
+	public RedisPassword getPassword() {
 		return password;
 	}
 
 	/**
-	 * @param password
+	 * @param password must not be {@literal null}.
 	 * @since 2.0
 	 */
-	public void setPassword(String password) {
+	public void setPassword(RedisPassword password) {
+
+		Assert.notNull(password, "RedisPassword must not be null!");
+
 		this.password = password;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
@@ -32,7 +32,7 @@ public class RedisStandaloneConfiguration {
 	private String hostName = DEFAULT_HOST;
 	private int port = DEFAULT_PORT;
 	private int database;
-	private String password;
+	private RedisPassword password = RedisPassword.none();
 
 	/**
 	 * Create a new default {@link RedisStandaloneConfiguration}.
@@ -114,14 +114,17 @@ public class RedisStandaloneConfiguration {
 	/**
 	 * @return
 	 */
-	public String getPassword() {
+	public RedisPassword getPassword() {
 		return password;
 	}
 
 	/**
-	 * @param password
+	 * @param password must not be {@literal null}.
 	 */
-	public void setPassword(String password) {
+	public void setPassword(RedisPassword password) {
+
+		Assert.notNull(password, "RedisPassword must not be null!");
+
 		this.password = password;
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
@@ -19,9 +19,10 @@ import org.springframework.util.Assert;
 
 /**
  * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} using connecting
- * to <a href="http://redis.io/">Redis</a>.
+ * to a single node <a href="http://redis.io/">Redis</a> installation.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  */
 public class RedisStandaloneConfiguration {
@@ -106,13 +107,13 @@ public class RedisStandaloneConfiguration {
 	 */
 	public void setDatabase(int index) {
 
-		Assert.isTrue(index >= 0, "invalid DB index (a positive index required)");
+		Assert.isTrue(index >= 0, () -> String.format("Invalid DB index '%s' (a positive index required)", index));
 
 		this.database = index;
 	}
 
 	/**
-	 * @return
+	 * @return never {@literal null}.
 	 */
 	public RedisPassword getPassword() {
 		return password;

--- a/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import org.springframework.util.Assert;
+
+/**
+ * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} using connecting
+ * to <a href="http://redis.io/">Redis</a>.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+public class RedisStandaloneConfiguration {
+
+	public static final String DEFAULT_HOST = "localhost";
+	public static final int DEFAULT_PORT = 6379;
+
+	private String hostName = DEFAULT_HOST;
+	private int port = DEFAULT_PORT;
+	private int database;
+	private String password;
+
+	/**
+	 * Create a new default {@link RedisStandaloneConfiguration}.
+	 */
+	public RedisStandaloneConfiguration() {}
+
+	/**
+	 * Create a new {@link RedisStandaloneConfiguration} given {@code hostName}.
+	 *
+	 * @param hostName must not be {@literal null} or empty.
+	 */
+	public RedisStandaloneConfiguration(String hostName) {
+		this(hostName, DEFAULT_PORT);
+	}
+
+	/**
+	 * Create a new {@link RedisStandaloneConfiguration} given {@code hostName} and {@code port}.
+	 *
+	 * @param hostName must not be {@literal null} or empty.
+	 * @param port a valid TCP port (1-65535).
+	 */
+	public RedisStandaloneConfiguration(String hostName, int port) {
+
+		Assert.hasText(hostName, "Host name must not be null or empty!");
+		Assert.isTrue(port >= 1 && port <= 65535,
+				() -> String.format("Port %d must be a valid TCP port in the range between 1-65535!", port));
+
+		this.hostName = hostName;
+		this.port = port;
+	}
+
+	/**
+	 * @return
+	 */
+	public String getHostName() {
+		return hostName;
+	}
+
+	/**
+	 * @return
+	 */
+	public int getPort() {
+		return port;
+	}
+
+	/**
+	 * @param hostName
+	 */
+	public void setHostName(String hostName) {
+		this.hostName = hostName;
+	}
+
+	/**
+	 * @param port
+	 */
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	/**
+	 * @return
+	 */
+	public int getDatabase() {
+		return database;
+	}
+
+	/**
+	 * Sets the index of the database used by this connection factory. Default is 0.
+	 *
+	 * @param index database index.
+	 */
+	public void setDatabase(int index) {
+
+		Assert.isTrue(index >= 0, "invalid DB index (a positive index required)");
+
+		this.database = index;
+	}
+
+	/**
+	 * @return
+	 */
+	public String getPassword() {
+		return password;
+	}
+
+	/**
+	 * @param password
+	 */
+	public void setPassword(String password) {
+		this.password = password;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
@@ -61,7 +61,7 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#useSsl()
 	 */
 	@Override
-	public boolean useSsl() {
+	public boolean isUseSsl() {
 		return useSsl;
 	}
 
@@ -93,7 +93,7 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#usePooling()
 	 */
 	@Override
-	public boolean usePooling() {
+	public boolean isUsePooling() {
 		return usePooling;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.jedis;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+/**
+ * Default implementation of {@literal JedisClientConfiguration}.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+class DefaultJedisClientConfiguration implements JedisClientConfiguration {
+
+	private final boolean useSsl;
+	private final Optional<SSLSocketFactory> sslSocketFactory;
+	private final Optional<SSLParameters> sslParameters;
+	private final Optional<HostnameVerifier> hostnameVerifier;
+	private final boolean usePooling;
+	private final Optional<GenericObjectPoolConfig> poolConfig;
+	private final Optional<String> clientName;
+	private final Duration readTimeout;
+	private final Duration connectTimeout;
+
+	DefaultJedisClientConfiguration(boolean useSsl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
+			HostnameVerifier hostnameVerifier, boolean usePooling, GenericObjectPoolConfig poolConfig, String clientName,
+			Duration readTimeout, Duration connectTimeout) {
+
+		this.useSsl = useSsl;
+		this.sslSocketFactory = Optional.ofNullable(sslSocketFactory);
+		this.sslParameters = Optional.ofNullable(sslParameters);
+		this.hostnameVerifier = Optional.ofNullable(hostnameVerifier);
+		this.usePooling = usePooling;
+		this.poolConfig = Optional.ofNullable(poolConfig);
+		this.clientName = Optional.ofNullable(clientName);
+		this.readTimeout = readTimeout;
+		this.connectTimeout = connectTimeout;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#useSsl()
+	 */
+	@Override
+	public boolean useSsl() {
+		return useSsl;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getSslSocketFactory()
+	 */
+	@Override
+	public Optional<SSLSocketFactory> getSslSocketFactory() {
+		return sslSocketFactory;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getSslParameters()
+	 */
+	@Override
+	public Optional<SSLParameters> getSslParameters() {
+		return sslParameters;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getHostnameVerifier()
+	 */
+	@Override
+	public Optional<HostnameVerifier> getHostnameVerifier() {
+		return hostnameVerifier;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#usePooling()
+	 */
+	@Override
+	public boolean usePooling() {
+		return usePooling;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getPoolConfig()
+	 */
+	@Override
+	public Optional<GenericObjectPoolConfig> getPoolConfig() {
+		return poolConfig;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getClientName()
+	 */
+	@Override
+	public Optional<String> getClientName() {
+		return clientName;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getReadTimeout()
+	 */
+	@Override
+	public Duration getReadTimeout() {
+		return readTimeout;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getConnectTimeout()
+	 */
+	@Override
+	public Duration getConnectTimeout() {
+		return connectTimeout;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
@@ -133,11 +133,25 @@ public interface JedisClientConfiguration {
 		JedisSslClientConfigurationBuilder useSsl();
 
 		/**
+		 * Use plaintext connections instead of SSL.
+		 *
+		 * @return {@link JedisSslClientConfigurationBuilder}.
+		 */
+		JedisClientConfigurationBuilder usePlaintext();
+
+		/**
 		 * Enable connection-pooling.
 		 *
 		 * @return {@link JedisPoolingClientConfigurationBuilder}.
 		 */
 		JedisPoolingClientConfigurationBuilder usePooling();
+
+		/**
+		 * Disable connection-pooling.
+		 *
+		 * @return {@link JedisClientConfigurationBuilder}.
+		 */
+		JedisClientConfigurationBuilder useUnpooledConnections();
 
 		/**
 		 * Configure a {@code clientName} to be set with {@code CLIENT SETNAME}.
@@ -265,6 +279,16 @@ public interface JedisClientConfiguration {
 		}
 
 		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder#usePlaintext()
+		 */
+		@Override
+		public JedisClientConfigurationBuilder usePlaintext() {
+
+			this.useSsl = false;
+			return this;
+		}
+
+		/* (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisSslClientConfigurationBuilder#sslSocketFactory(javax.net.ssl.SSLSocketFactory)
 		 */
 		@Override
@@ -307,6 +331,16 @@ public interface JedisClientConfiguration {
 		public DefaultJedisClientConfigurationBuilder usePooling() {
 
 			this.usePooling = true;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder#useUnpooledConnections()
+		 */
+		@Override
+		public JedisClientConfigurationBuilder useUnpooledConnections() {
+
+			this.usePooling = false;
 			return this;
 		}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.jedis;
+
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.Optional;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.springframework.util.Assert;
+
+/**
+ * Redis client configuration for jedis. This configuration provides optional configuration elements such as
+ * {@link SSLSocketFactory} and {@link JedisPoolConfig} specific to jedis client features.
+ * <p>
+ * Providing optional elements allows a more specific configuration of the client:
+ * <ul>
+ * <li>Whether to use SSL</li>
+ * <li>Optional {@link SSLSocketFactory}</li>
+ * <li>Optional {@link SSLParameters}</li>
+ * <li>Optional {@link HostnameVerifier}</li>
+ * <li>Whether to use connection-pooling</li>
+ * <li>Optional {@link GenericObjectPoolConfig}</li>
+ * <li>Connect {@link Duration timeout}</li>
+ * <li>Read {@link Duration timeout}</li>
+ * </ul>
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ * @see redis.clients.jedis.Jedis
+ * @see org.springframework.data.redis.connection.RedisStandaloneConfiguration
+ * @see org.springframework.data.redis.connection.RedisSentinelConfiguration
+ * @see org.springframework.data.redis.connection.RedisClusterConfiguration
+ */
+public interface JedisClientConfiguration {
+
+	/**
+	 * @return {@literal true} to use SSL, {@literal false} to use unencrypted connections.
+	 */
+	boolean useSsl();
+
+	/**
+	 * @return the optional {@link SSLSocketFactory}.
+	 */
+	Optional<SSLSocketFactory> getSslSocketFactory();
+
+	/**
+	 * @return the optional {@link SSLParameters}.
+	 */
+	Optional<SSLParameters> getSslParameters();
+
+	/**
+	 * @return the optional {@link HostnameVerifier}.
+	 */
+	Optional<HostnameVerifier> getHostnameVerifier();
+
+	/**
+	 * @return {@literal true} to use connection-pooling.
+	 */
+	boolean usePooling();
+
+	/**
+	 * @return the optional {@link GenericObjectPoolConfig}.
+	 */
+	Optional<GenericObjectPoolConfig> getPoolConfig();
+
+	/**
+	 * @return the optional client name to be set with {@code CLIENT SETNAME}.
+	 */
+	Optional<String> getClientName();
+
+	/**
+	 * @return the connection timeout.
+	 * @see java.net.Socket#connect(SocketAddress, int)
+	 */
+	Duration getConnectTimeout();
+
+	/**
+	 * @return the read timeout.
+	 * @see java.net.Socket#setSoTimeout(int)
+	 */
+	Duration getReadTimeout();
+
+	/**
+	 * Creates a new {@link JedisClientConfigurationBuilder} to build {@link JedisClientConfiguration} to be used with the
+	 * jedis client.
+	 *
+	 * @return a new {@link JedisClientConfigurationBuilder} to build {@link JedisClientConfiguration}.
+	 */
+	static JedisClientConfigurationBuilder builder() {
+		return new DefaultJedisClientConfigurationBuilder();
+	}
+
+	/**
+	 * Creates an empty {@link JedisClientConfiguration}.
+	 *
+	 * @return an empty {@link JedisClientConfiguration}.
+	 */
+	static JedisClientConfiguration create() {
+		return builder().build();
+	}
+
+	/**
+	 * Builder for {@link JedisClientConfiguration}.
+	 */
+	interface JedisClientConfigurationBuilder {
+
+		/**
+		 * Enable SSL connections.
+		 *
+		 * @return {@link JedisSslClientConfigurationBuilder}.
+		 */
+		JedisSslClientConfigurationBuilder useSsl();
+
+		/**
+		 * Enable connection-pooling.
+		 *
+		 * @return {@link JedisPoolingClientConfigurationBuilder}.
+		 */
+		JedisPoolingClientConfigurationBuilder usePooling();
+
+		/**
+		 * Configure a {@code clientName} to be set with {@code CLIENT SETNAME}.
+		 *
+		 * @param clientName must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		JedisClientConfigurationBuilder clientName(String clientName);
+
+		/**
+		 * Configure a read timeout.
+		 *
+		 * @param readTimeout must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		JedisClientConfigurationBuilder readTimeout(Duration readTimeout);
+
+		/**
+		 * Configure a connection timeout.
+		 *
+		 * @param connectTimeout must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		JedisClientConfigurationBuilder connectTimeout(Duration connectTimeout);
+
+		/**
+		 * Build the {@link JedisClientConfiguration} with the configuration applied from this builder.
+		 *
+		 * @return a new {@link JedisClientConfiguration} object.
+		 */
+		JedisClientConfiguration build();
+	}
+
+	/**
+	 * Builder for Pooling-related {@link JedisClientConfiguration}.
+	 */
+	interface JedisPoolingClientConfigurationBuilder {
+
+		/**
+		 * @param poolConfig must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		JedisPoolingClientConfigurationBuilder poolConfig(GenericObjectPoolConfig poolConfig);
+
+		/**
+		 * Return to {@link JedisClientConfigurationBuilder}.
+		 *
+		 * @return {@link JedisClientConfigurationBuilder}.
+		 */
+		JedisClientConfigurationBuilder and();
+
+		/**
+		 * Build the {@link JedisClientConfiguration} with the configuration applied from this builder.
+		 *
+		 * @return a new {@link JedisClientConfiguration} object.
+		 */
+		JedisClientConfiguration build();
+	}
+
+	/**
+	 * Builder for SSL-related {@link JedisClientConfiguration}.
+	 */
+	interface JedisSslClientConfigurationBuilder {
+
+		/**
+		 * @param sslSocketFactory must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		JedisSslClientConfigurationBuilder sslSocketFactory(SSLSocketFactory sslSocketFactory);
+
+		/**
+		 * @param sslParameters must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		JedisSslClientConfigurationBuilder sslParameters(SSLParameters sslParameters);
+
+		/**
+		 * @param hostnameVerifier must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		JedisSslClientConfigurationBuilder hostnameVerifier(HostnameVerifier hostnameVerifier);
+
+		/**
+		 * Return to {@link JedisClientConfigurationBuilder}.
+		 *
+		 * @return {@link JedisClientConfigurationBuilder}.
+		 */
+		JedisClientConfigurationBuilder and();
+
+		/**
+		 * Build the {@link JedisClientConfiguration} with the configuration applied from this builder.
+		 *
+		 * @return a new {@link JedisClientConfiguration} object.
+		 */
+		JedisClientConfiguration build();
+	}
+
+	/**
+	 * Default {@link JedisClientConfigurationBuilder} implementation to build an immutable
+	 * {@link JedisClientConfiguration}.
+	 */
+	class DefaultJedisClientConfigurationBuilder implements JedisClientConfigurationBuilder,
+			JedisPoolingClientConfigurationBuilder, JedisSslClientConfigurationBuilder {
+
+		private boolean useSsl;
+		private SSLSocketFactory sslSocketFactory;
+		private SSLParameters sslParameters;
+		private HostnameVerifier hostnameVerifier;
+		private boolean usePooling;
+		private GenericObjectPoolConfig poolConfig = new JedisPoolConfig();
+		private String clientName;
+		private Duration readTimeout = Duration.ofMillis(Protocol.DEFAULT_TIMEOUT);
+		private Duration connectTimeout = Duration.ofMillis(Protocol.DEFAULT_TIMEOUT);
+
+		private DefaultJedisClientConfigurationBuilder() {}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder#useSsl()
+		 */
+		@Override
+		public DefaultJedisClientConfigurationBuilder useSsl() {
+
+			this.useSsl = true;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisSslClientConfigurationBuilder#sslSocketFactory(javax.net.ssl.SSLSocketFactory)
+		 */
+		@Override
+		public DefaultJedisClientConfigurationBuilder sslSocketFactory(SSLSocketFactory sslSocketFactory) {
+
+			Assert.notNull(sslSocketFactory, "SSLSocketFactory must not be null!");
+
+			this.sslSocketFactory = sslSocketFactory;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisSslClientConfigurationBuilder#sslParameters(javax.net.ssl.SSLParameters)
+		 */
+		@Override
+		public DefaultJedisClientConfigurationBuilder sslParameters(SSLParameters sslParameters) {
+
+			Assert.notNull(sslParameters, "SSLParameters must not be null!");
+
+			this.sslParameters = sslParameters;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisSslClientConfigurationBuilder#hostnameVerifier(javax.net.ssl.HostnameVerifier)
+		 */
+		@Override
+		public DefaultJedisClientConfigurationBuilder hostnameVerifier(HostnameVerifier hostnameVerifier) {
+
+			Assert.notNull(hostnameVerifier, "HostnameVerifier must not be null!");
+
+			this.hostnameVerifier = hostnameVerifier;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder#usePooling()
+		 */
+		@Override
+		public DefaultJedisClientConfigurationBuilder usePooling() {
+
+			this.usePooling = true;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisPoolingClientConfigurationBuilder#poolConfig(org.apache.commons.pool2.impl.GenericObjectPoolConfig)
+		 */
+		@Override
+		public DefaultJedisClientConfigurationBuilder poolConfig(GenericObjectPoolConfig poolConfig) {
+
+			Assert.notNull(poolConfig, "GenericObjectPoolConfig must not be null!");
+
+			this.poolConfig = poolConfig;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisPoolingClientConfigurationBuilder#and()
+		 */
+		@Override
+		public JedisClientConfigurationBuilder and() {
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder#clientName(java.lang.String)
+		 */
+		@Override
+		public JedisClientConfigurationBuilder clientName(String clientName) {
+
+			Assert.hasText(clientName, "Client name must not be null or empty!");
+
+			this.clientName = clientName;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder#readTimeout(java.time.Duration)
+		 */
+		@Override
+		public JedisClientConfigurationBuilder readTimeout(Duration readTimeout) {
+
+			Assert.notNull(readTimeout, "Duration must not be null!");
+
+			this.readTimeout = readTimeout;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder#connectTimeout(java.time.Duration)
+		 */
+		@Override
+		public JedisClientConfigurationBuilder connectTimeout(Duration connectTimeout) {
+
+			Assert.notNull(connectTimeout, "Duration must not be null!");
+
+			this.connectTimeout = connectTimeout;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder#build()
+		 */
+		@Override
+		public JedisClientConfiguration build() {
+
+			return new DefaultJedisClientConfiguration(useSsl, sslSocketFactory, sslParameters, hostnameVerifier, usePooling,
+					poolConfig, clientName, readTimeout, connectTimeout);
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.Client;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
@@ -26,11 +27,17 @@ import redis.clients.jedis.Protocol;
 import redis.clients.util.Pool;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -51,19 +58,31 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisSentinelConnection;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
  * Connection factory creating <a href="http://github.com/xetorthio/jedis">Jedis</a> based connections.
+ * <p>
+ * {@link JedisConnectionFactory} should be configured using an environmental configuration and the
+ * {@link JedisClientConfiguration client configuration}. Jedis supports the following environmental configurations:
+ * <ul>
+ * <li>{@link RedisStandaloneConfiguration}</li>
+ * <li>{@link RedisSentinelConfiguration}</li>
+ * <li>{@link RedisClusterConfiguration}</li>
+ * </ul>
  *
  * @author Costin Leau
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Fu Jian
+ * @see JedisClientConfiguration
+ * @see Jedis
  */
 public class JedisConnectionFactory implements InitializingBean, DisposableBean, RedisConnectionFactory {
 
@@ -72,7 +91,6 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			JedisConverters.exceptionConverter());
 
 	private static final Method SET_TIMEOUT_METHOD;
-	private static final Method GET_TIMEOUT_METHOD;
 
 	static {
 
@@ -83,27 +101,15 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			setTimeoutMethodCandidate = ReflectionUtils.findMethod(JedisShardInfo.class, "setSoTimeout", int.class);
 		}
 		SET_TIMEOUT_METHOD = setTimeoutMethodCandidate;
-
-		Method getTimeoutMethodCandidate = ReflectionUtils.findMethod(JedisShardInfo.class, "getTimeout");
-		if (getTimeoutMethodCandidate == null) {
-			getTimeoutMethodCandidate = ReflectionUtils.findMethod(JedisShardInfo.class, "getSoTimeout");
-		}
-
-		GET_TIMEOUT_METHOD = getTimeoutMethodCandidate;
 	}
 
+	private final JedisClientConfiguration clientConfiguration;
 	private JedisShardInfo shardInfo;
-	private String hostName = "localhost";
-	private int port = Protocol.DEFAULT_PORT;
-	private int timeout = Protocol.DEFAULT_TIMEOUT;
-	private String password;
-	private boolean usePool = true;
-	private boolean useSsl = false;
+	private boolean providedShardInfo = false;
 	private Pool<Jedis> pool;
-	private JedisPoolConfig poolConfig = new JedisPoolConfig();
-	private int dbIndex = 0;
-	private String clientName;
 	private boolean convertPipelineAndTxResults = true;
+	private RedisStandaloneConfiguration standaloneConfig = new RedisStandaloneConfiguration("localhost",
+			Protocol.DEFAULT_PORT);
 	private RedisSentinelConfiguration sentinelConfig;
 	private RedisClusterConfiguration clusterConfig;
 	private JedisCluster cluster;
@@ -113,16 +119,38 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * Constructs a new <code>JedisConnectionFactory</code> instance with default settings (default connection pooling, no
 	 * shard information).
 	 */
-	public JedisConnectionFactory() {}
+	public JedisConnectionFactory() {
+		this(new MutableJedisClientConfiguration());
+	}
+
+	/**
+	 * Constructs a new {@link JedisConnectionFactory} instance given {@link JedisClientConfiguration}.
+	 *
+	 * @param clientConfig must not be {@literal null}
+	 * @since 2.0
+	 */
+	private JedisConnectionFactory(JedisClientConfiguration clientConfig) {
+
+		Assert.notNull(clientConfig, "JedisClientConfiguration must not be null!");
+
+		this.clientConfiguration = clientConfig;
+	}
 
 	/**
 	 * Constructs a new <code>JedisConnectionFactory</code> instance. Will override the other connection parameters passed
 	 * to the factory.
 	 *
 	 * @param shardInfo shard information
+	 * @deprecated since 2.0, configure Jedis with {@link JedisClientConfiguration} and
+	 *             {@link RedisStandaloneConfiguration}.
 	 */
+	@Deprecated
 	public JedisConnectionFactory(JedisShardInfo shardInfo) {
+
+		this(MutableJedisClientConfiguration.create(shardInfo));
+
 		this.shardInfo = shardInfo;
+		this.providedShardInfo = true;
 	}
 
 	/**
@@ -138,11 +166,11 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * Constructs a new {@link JedisConnectionFactory} instance using the given {@link JedisPoolConfig} applied to
 	 * {@link JedisSentinelPool}.
 	 *
-	 * @param sentinelConfig
+	 * @param sentinelConfig must not be {@literal null}.
 	 * @since 1.4
 	 */
 	public JedisConnectionFactory(RedisSentinelConfiguration sentinelConfig) {
-		this(sentinelConfig, null);
+		this(sentinelConfig, new MutableJedisClientConfiguration());
 	}
 
 	/**
@@ -154,31 +182,97 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @since 1.4
 	 */
 	public JedisConnectionFactory(RedisSentinelConfiguration sentinelConfig, JedisPoolConfig poolConfig) {
+
 		this.sentinelConfig = sentinelConfig;
-		this.poolConfig = poolConfig != null ? poolConfig : new JedisPoolConfig();
+		this.clientConfiguration = MutableJedisClientConfiguration
+				.create(poolConfig != null ? poolConfig : new JedisPoolConfig());
 	}
 
 	/**
 	 * Constructs a new {@link JedisConnectionFactory} instance using the given {@link RedisClusterConfiguration} applied
 	 * to create a {@link JedisCluster}.
 	 *
-	 * @param clusterConfig
+	 * @param clusterConfig must not be {@literal null}.
 	 * @since 1.7
 	 */
 	public JedisConnectionFactory(RedisClusterConfiguration clusterConfig) {
-		this.clusterConfig = clusterConfig;
+		this(clusterConfig, new MutableJedisClientConfiguration());
 	}
 
 	/**
 	 * Constructs a new {@link JedisConnectionFactory} instance using the given {@link RedisClusterConfiguration} applied
 	 * to create a {@link JedisCluster}.
 	 *
-	 * @param clusterConfig
+	 * @param clusterConfig must not be {@literal null}.
 	 * @since 1.7
 	 */
 	public JedisConnectionFactory(RedisClusterConfiguration clusterConfig, JedisPoolConfig poolConfig) {
+
+		Assert.notNull(clusterConfig, "RedisClusterConfiguration must not be null!");
+
 		this.clusterConfig = clusterConfig;
-		this.poolConfig = poolConfig;
+		this.clientConfiguration = MutableJedisClientConfiguration.create(poolConfig);
+	}
+
+	/**
+	 * Constructs a new {@link JedisConnectionFactory} instance using the given {@link RedisStandaloneConfiguration}.
+	 *
+	 * @param standaloneConfig must not be {@literal null}.
+	 * @since 2.0
+	 */
+	public JedisConnectionFactory(RedisStandaloneConfiguration standaloneConfig) {
+		this(standaloneConfig, new MutableJedisClientConfiguration());
+	}
+
+	/**
+	 * Constructs a new {@link JedisConnectionFactory} instance using the given {@link RedisStandaloneConfiguration} and
+	 * {@link JedisClientConfiguration}.
+	 *
+	 * @param standaloneConfig must not be {@literal null}.
+	 * @param clientConfig must not be {@literal null}.
+	 * @since 2.0
+	 */
+	public JedisConnectionFactory(RedisStandaloneConfiguration standaloneConfig, JedisClientConfiguration clientConfig) {
+
+		this(clientConfig);
+
+		Assert.notNull(standaloneConfig, "RedisStandaloneConfiguration must not be null!");
+
+		this.standaloneConfig = standaloneConfig;
+	}
+
+	/**
+	 * Constructs a new {@link JedisConnectionFactory} instance using the given {@link RedisSentinelConfiguration} and
+	 * {@link JedisClientConfiguration}.
+	 *
+	 * @param sentinelConfig must not be {@literal null}.
+	 * @param clientConfig must not be {@literal null}.
+	 * @since 2.0
+	 */
+	public JedisConnectionFactory(RedisSentinelConfiguration sentinelConfig, JedisClientConfiguration clientConfig) {
+
+		this(clientConfig);
+
+		Assert.notNull(sentinelConfig, "RedisSentinelConfiguration must not be null!");
+
+		this.sentinelConfig = sentinelConfig;
+	}
+
+	/**
+	 * Constructs a new {@link JedisConnectionFactory} instance using the given {@link RedisClusterConfiguration} and
+	 * {@link JedisClientConfiguration}.
+	 *
+	 * @param clusterConfig must not be {@literal null}.
+	 * @param clientConfig must not be {@literal null}.
+	 * @since 2.0
+	 */
+	public JedisConnectionFactory(RedisClusterConfiguration clusterConfig, JedisClientConfiguration clientConfig) {
+
+		this(clientConfig);
+
+		Assert.notNull(clusterConfig, "RedisClusterConfiguration must not be null!");
+
+		this.clusterConfig = clusterConfig;
 	}
 
 	/**
@@ -190,11 +284,11 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	protected Jedis fetchJedisConnector() {
 		try {
 
-			if (usePool && pool != null) {
+			if (getUsePool() && pool != null) {
 				return pool.getResource();
 			}
 
-			Jedis jedis = new Jedis(getShardInfo());
+			Jedis jedis = createJedis();
 			// force initialization (see Jedis issue #82)
 			jedis.connect();
 
@@ -203,6 +297,25 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 		} catch (Exception ex) {
 			throw new RedisConnectionFailureException("Cannot get Jedis connection", ex);
 		}
+	}
+
+	private Jedis createJedis() {
+
+		if (providedShardInfo) {
+			return new Jedis(getShardInfo());
+		}
+
+		Jedis jedis = new Jedis(getHostName(), getPort(), getConnectTimeout(), getReadTimeout(), isUseSsl(),
+				clientConfiguration.getSslSocketFactory().orElse(null), //
+				clientConfiguration.getSslParameters().orElse(null), //
+				clientConfiguration.getHostnameVerifier().orElse(null));
+
+		Client client = jedis.getClient();
+
+		client.setPassword(getPassword());
+		client.setDb(getDatabase());
+
+		return jedis;
 	}
 
 	/**
@@ -221,23 +334,33 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
 	 */
 	public void afterPropertiesSet() {
-		if (shardInfo == null) {
-			shardInfo = new JedisShardInfo(hostName, port);
 
-			if (StringUtils.hasLength(password)) {
-				shardInfo.setPassword(password);
+		if (shardInfo == null && clientConfiguration instanceof MutableJedisClientConfiguration) {
+
+			providedShardInfo = false;
+			shardInfo = new JedisShardInfo(getHostName(), getPort(), isUseSsl(), //
+					clientConfiguration.getSslSocketFactory().orElse(null), //
+					clientConfiguration.getSslParameters().orElse(null), //
+					clientConfiguration.getHostnameVerifier().orElse(null));
+
+			if (StringUtils.hasLength(getPassword())) {
+				shardInfo.setPassword(getPassword());
 			}
 
-			if (timeout > 0) {
-				setTimeoutOn(shardInfo, timeout);
+			int readTimeout = getReadTimeout();
+
+			if (readTimeout > 0) {
+				setTimeoutOn(shardInfo, readTimeout);
 			}
+
+			getMutableConfiguration().setShardInfo(shardInfo);
 		}
 
-		if (usePool && clusterConfig == null) {
+		if (getUsePool() && !isRedisClusterAware()) {
 			this.pool = createPool();
 		}
 
-		if (clusterConfig != null) {
+		if (isRedisClusterAware()) {
 			this.cluster = createCluster();
 		}
 	}
@@ -258,9 +381,10 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @since 1.4
 	 */
 	protected Pool<Jedis> createRedisSentinelPool(RedisSentinelConfiguration config) {
+
+		GenericObjectPoolConfig poolConfig = getPoolConfig() != null ? getPoolConfig() : new JedisPoolConfig();
 		return new JedisSentinelPool(config.getMaster().getName(), convertToJedisSentinelSet(config.getSentinels()),
-				getPoolConfig() != null ? getPoolConfig() : new JedisPoolConfig(), getTimeoutFrom(getShardInfo()),
-				getShardInfo().getPassword(), Protocol.DEFAULT_DATABASE, clientName);
+				poolConfig, getConnectTimeout(), getReadTimeout(), getPassword(), Protocol.DEFAULT_DATABASE, getClientName());
 	}
 
 	/**
@@ -271,13 +395,16 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 */
 	protected Pool<Jedis> createRedisPool() {
 
-		return new JedisPool(getPoolConfig(), getShardInfo().getHost(), getShardInfo().getPort(),
-				getTimeoutFrom(getShardInfo()), getShardInfo().getPassword(), Protocol.DEFAULT_DATABASE, clientName, useSsl);
+		return new JedisPool(getPoolConfig(), getHostName(), getPort(), getConnectTimeout(), getReadTimeout(),
+				getPassword(), Protocol.DEFAULT_DATABASE, getClientName(), isUseSsl(),
+				clientConfiguration.getSslSocketFactory().orElse(null), //
+				clientConfiguration.getSslParameters().orElse(null), //
+				clientConfiguration.getHostnameVerifier().orElse(null));
 	}
 
 	private JedisCluster createCluster() {
 
-		JedisCluster cluster = createCluster(this.clusterConfig, this.poolConfig);
+		JedisCluster cluster = createCluster(this.clusterConfig, getPoolConfig());
 		this.clusterCommandExecutor = new ClusterCommandExecutor(
 				new JedisClusterConnection.JedisClusterTopologyProvider(cluster),
 				new JedisClusterConnection.JedisClusterNodeResourceProvider(cluster), EXCEPTION_TRANSLATION);
@@ -301,11 +428,14 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			hostAndPort.add(new HostAndPort(node.getHost(), node.getPort()));
 		}
 
-		int redirects = clusterConfig.getMaxRedirects() != null ? clusterConfig.getMaxRedirects().intValue() : 5;
+		int redirects = clusterConfig.getMaxRedirects() != null ? clusterConfig.getMaxRedirects() : 5;
+
+		int connectTimeout = getConnectTimeout();
+		int readTimeout = getReadTimeout();
 
 		return StringUtils.hasText(getPassword())
-				? new JedisCluster(hostAndPort, timeout, timeout, redirects, password, poolConfig)
-				: new JedisCluster(hostAndPort, timeout, redirects, poolConfig);
+				? new JedisCluster(hostAndPort, connectTimeout, readTimeout, redirects, getPassword(), poolConfig)
+				: new JedisCluster(hostAndPort, connectTimeout, readTimeout, redirects, poolConfig);
 	}
 
 	/*
@@ -313,7 +443,9 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @see org.springframework.beans.factory.DisposableBean#destroy()
 	 */
 	public void destroy() {
-		if (usePool && pool != null) {
+
+		if (getUsePool() && pool != null) {
+
 			try {
 				pool.destroy();
 			} catch (Exception ex) {
@@ -321,12 +453,15 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			}
 			pool = null;
 		}
+
 		if (cluster != null) {
+
 			try {
 				cluster.close();
 			} catch (Exception ex) {
 				log.warn("Cannot properly close Jedis cluster", ex);
 			}
+
 			try {
 				clusterCommandExecutor.destroy();
 			} catch (Exception ex) {
@@ -341,13 +476,14 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 */
 	public RedisConnection getConnection() {
 
-		if (cluster != null) {
+		if (isRedisClusterAware()) {
 			return getClusterConnection();
 		}
 
 		Jedis jedis = fetchJedisConnector();
-		JedisConnection connection = (usePool ? new JedisConnection(jedis, pool, dbIndex, clientName)
-				: new JedisConnection(jedis, null, dbIndex, clientName));
+		String clientName = clientConfiguration.getClientName().orElse(null);
+		JedisConnection connection = (getUsePool() ? new JedisConnection(jedis, pool, getDatabase(), clientName)
+				: new JedisConnection(jedis, null, getDatabase(), clientName));
 		connection.setConvertPipelineAndTxResults(convertPipelineAndTxResults);
 		return postProcessConnection(connection);
 	}
@@ -359,7 +495,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	@Override
 	public RedisClusterConnection getClusterConnection() {
 
-		if (cluster == null) {
+		if (!isRedisClusterAware()) {
 			throw new InvalidDataAccessApiUsageException("Cluster is not configured!");
 		}
 		return new JedisClusterConnection(cluster, clusterCommandExecutor);
@@ -374,31 +510,23 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	}
 
 	/**
-	 * Returns the Redis hostName.
+	 * Returns the Redis hostname.
 	 *
 	 * @return the hostName.
 	 */
 	public String getHostName() {
-		return hostName;
+		return standaloneConfig.getHostName();
 	}
 
 	/**
-	 * Sets the Redis hostName.
+	 * Sets the Redis hostname.
 	 *
-	 * @param hostName the hostName to set.
+	 * @param hostName the hostname to set.
+	 * @deprecated since 2.0, configure the hostname using {@link RedisStandaloneConfiguration}.
 	 */
+	@Deprecated
 	public void setHostName(String hostName) {
-		this.hostName = hostName;
-	}
-
-	/**
-	 * Sets whether to use SSL.
-	 *
-	 * @param useSsl {@literal true} to use SSL.
-	 * @since 1.8
-	 */
-	public void setUseSsl(boolean useSsl) {
-		this.useSsl = useSsl;
+		standaloneConfig.setHostName(hostName);
 	}
 
 	/**
@@ -408,7 +536,20 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @since 1.8
 	 */
 	public boolean isUseSsl() {
-		return useSsl;
+		return clientConfiguration.useSsl();
+	}
+
+	/**
+	 * Sets whether to use SSL.
+	 *
+	 * @param useSsl {@literal true} to use SSL.
+	 * @since 1.8
+	 * @deprecated since 2.0, configure the SSL usage with {@link JedisClientConfiguration}.
+	 * @throws IllegalStateException if {@link JedisClientConfiguration} is immutable.
+	 */
+	@Deprecated
+	public void setUseSsl(boolean useSsl) {
+		getMutableConfiguration().setUseSsl(useSsl);
 	}
 
 	/**
@@ -417,16 +558,39 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @return password for authentication.
 	 */
 	public String getPassword() {
-		return password;
+
+		if (isRedisSentinelAware()) {
+			return sentinelConfig.getPassword();
+		}
+
+		if (isRedisClusterAware()) {
+			return clusterConfig.getPassword();
+		}
+
+		return standaloneConfig.getPassword();
 	}
 
 	/**
 	 * Sets the password used for authenticating with the Redis server.
 	 *
 	 * @param password the password to set.
+	 * @deprecated since 2.0, configure the password using {@link RedisStandaloneConfiguration},
+	 *             {@link RedisSentinelConfiguration} or {@link RedisClusterConfiguration}.
 	 */
+	@Deprecated
 	public void setPassword(String password) {
-		this.password = password;
+
+		if (isRedisSentinelAware()) {
+			sentinelConfig.setPassword(password);
+			return;
+		}
+
+		if (isRedisClusterAware()) {
+			clusterConfig.setPassword(password);
+			return;
+		}
+
+		standaloneConfig.setPassword(password);
 	}
 
 	/**
@@ -435,23 +599,27 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @return the Redis port.
 	 */
 	public int getPort() {
-		return port;
+		return standaloneConfig.getPort();
 	}
 
 	/**
 	 * Sets the port used to connect to the Redis instance.
 	 *
 	 * @param port the Redis port.
+	 * @deprecated since 2.0, configure the port using {@link RedisStandaloneConfiguration}.
 	 */
+	@Deprecated
 	public void setPort(int port) {
-		this.port = port;
+		standaloneConfig.setPort(port);
 	}
 
 	/**
 	 * Returns the shardInfo.
 	 *
 	 * @return the shardInfo.
+	 * @deprecated since 2.0.
 	 */
+	@Deprecated
 	public JedisShardInfo getShardInfo() {
 		return shardInfo;
 	}
@@ -460,9 +628,16 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * Sets the shard info for this factory.
 	 *
 	 * @param shardInfo the shardInfo to set.
+	 * @deprecated since 2.0, configure the individual properties from {@link JedisShardInfo} using
+	 *             {@link JedisClientConfiguration}.
+	 * @throws IllegalStateException if {@link JedisClientConfiguration} is immutable.
 	 */
+	@Deprecated
 	public void setShardInfo(JedisShardInfo shardInfo) {
+
 		this.shardInfo = shardInfo;
+		this.providedShardInfo = true;
+		getMutableConfiguration().setShardInfo(shardInfo);
 	}
 
 	/**
@@ -471,16 +646,21 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @return the timeout.
 	 */
 	public int getTimeout() {
-		return timeout;
+		return getReadTimeout();
 	}
 
 	/**
 	 * Sets the timeout.
 	 *
 	 * @param timeout the timeout to set.
+	 * @deprecated since 2.0, configure the timeout using {@link JedisClientConfiguration}.
+	 * @throws IllegalStateException if {@link JedisClientConfiguration} is immutable.
 	 */
+	@Deprecated
 	public void setTimeout(int timeout) {
-		this.timeout = timeout;
+
+		getMutableConfiguration().setReadTimeout(Duration.ofMillis(timeout));
+		getMutableConfiguration().setConnectTimeout(Duration.ofMillis(timeout));
 	}
 
 	/**
@@ -489,16 +669,19 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @return the use of connection pooling.
 	 */
 	public boolean getUsePool() {
-		return usePool;
+		return clientConfiguration.usePooling();
 	}
 
 	/**
 	 * Turns on or off the use of connection pooling.
 	 *
 	 * @param usePool the usePool to set.
+	 * @deprecated since 2.0, configure pooling usage with {@link JedisClientConfiguration}.
+	 * @throws IllegalStateException if {@link JedisClientConfiguration} is immutable.
 	 */
+	@Deprecated
 	public void setUsePool(boolean usePool) {
-		this.usePool = usePool;
+		getMutableConfiguration().setUsePooling(usePool);
 	}
 
 	/**
@@ -506,17 +689,20 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 *
 	 * @return the poolConfig
 	 */
-	public JedisPoolConfig getPoolConfig() {
-		return poolConfig;
+	public GenericObjectPoolConfig getPoolConfig() {
+		return clientConfiguration.getPoolConfig().orElse(null);
 	}
 
 	/**
 	 * Sets the pool configuration for this factory.
 	 *
 	 * @param poolConfig the poolConfig to set.
+	 * @deprecated since 2.0, configure {@link JedisPoolConfig} using {@link JedisClientConfiguration}.
+	 * @throws IllegalStateException if {@link JedisClientConfiguration} is immutable.
 	 */
+	@Deprecated
 	public void setPoolConfig(JedisPoolConfig poolConfig) {
-		this.poolConfig = poolConfig;
+		getMutableConfiguration().setPoolConfig(poolConfig);
 	}
 
 	/**
@@ -525,17 +711,32 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @return the database index.
 	 */
 	public int getDatabase() {
-		return dbIndex;
+
+		if (isRedisSentinelAware()) {
+			return sentinelConfig.getDatabase();
+		}
+
+		return standaloneConfig.getDatabase();
 	}
 
 	/**
 	 * Sets the index of the database used by this connection factory. Default is 0.
 	 *
 	 * @param index database index.
+	 * @deprecated since 2.0, configure the client name using {@link RedisSentinelConfiguration} or
+	 *             {@link RedisStandaloneConfiguration}.
 	 */
+	@Deprecated
 	public void setDatabase(int index) {
+
 		Assert.isTrue(index >= 0, "invalid DB index (a positive index required)");
-		this.dbIndex = index;
+
+		if (isRedisSentinelAware()) {
+			sentinelConfig.setDatabase(index);
+			return;
+		}
+
+		standaloneConfig.setDatabase(index);
 	}
 
 	/**
@@ -545,7 +746,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @since 1.8
 	 */
 	public String getClientName() {
-		return clientName;
+		return clientConfiguration.getClientName().orElse(null);
 	}
 
 	/**
@@ -553,9 +754,44 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 *
 	 * @param clientName the client name.
 	 * @since 1.8
+	 * @deprecated since 2.0, configure the client name using {@link JedisClientConfiguration}.
+	 * @throws IllegalStateException if {@link JedisClientConfiguration} is immutable.
 	 */
+	@Deprecated
 	public void setClientName(String clientName) {
-		this.clientName = clientName;
+		this.getMutableConfiguration().setClientName(clientName);
+	}
+
+	/**
+	 * @return the {@link JedisClientConfiguration}.
+	 * @since 2.0
+	 */
+	public JedisClientConfiguration getClientConfiguration() {
+		return clientConfiguration;
+	}
+
+	/**
+	 * @return the {@link RedisStandaloneConfiguration}.
+	 * @since 2.0
+	 */
+	public RedisStandaloneConfiguration getStandaloneConfiguration() {
+		return standaloneConfig;
+	}
+
+	/**
+	 * @return the {@link RedisStandaloneConfiguration}, may be {@literal null}.
+	 * @since 2.0
+	 */
+	public RedisSentinelConfiguration getSentinelConfiguration() {
+		return sentinelConfig;
+	}
+
+	/**
+	 * @return the {@link RedisClusterConfiguration}, may be {@literal null}.
+	 * @since 2.0
+	 */
+	public RedisClusterConfiguration getClusterConfiguration() {
+		return clusterConfig;
 	}
 
 	/**
@@ -588,6 +824,14 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 		return sentinelConfig != null;
 	}
 
+	/**
+	 * @return true when {@link RedisClusterConfiguration} is present.
+	 * @since 2.0
+	 */
+	public boolean isRedisClusterAware() {
+		return clusterConfig != null;
+	}
+
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisConnectionFactory#getSentinelConnection()
 	 */
@@ -607,7 +851,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 
 		for (RedisNode node : this.sentinelConfig.getSentinels()) {
 
-			Jedis jedis = new Jedis(node.getHost(), node.getPort());
+			Jedis jedis = new Jedis(node.getHost(), node.getPort(), getConnectTimeout(), getReadTimeout());
 
 			if (jedis.ping().equalsIgnoreCase("pong")) {
 
@@ -635,18 +879,176 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	}
 
 	private void potentiallySetClientName(Jedis jedis) {
-
-		if (StringUtils.hasText(clientName)) {
-			jedis.clientSetname(clientName);
-		}
+		clientConfiguration.getClientName().ifPresent(jedis::clientSetname);
 	}
 
 	private void setTimeoutOn(JedisShardInfo shardInfo, int timeout) {
 		ReflectionUtils.invokeMethod(SET_TIMEOUT_METHOD, shardInfo, timeout);
 	}
 
-	private int getTimeoutFrom(JedisShardInfo shardInfo) {
-		return (Integer) ReflectionUtils.invokeMethod(GET_TIMEOUT_METHOD, shardInfo);
+	private int getReadTimeout() {
+		return Math.toIntExact(clientConfiguration.getReadTimeout().toMillis());
 	}
 
+	private int getConnectTimeout() {
+		return Math.toIntExact(clientConfiguration.getConnectTimeout().toMillis());
+	}
+
+	private MutableJedisClientConfiguration getMutableConfiguration() {
+
+		Assert.state(clientConfiguration instanceof MutableJedisClientConfiguration,
+				() -> String.format("Client configuration must be instance of MutableJedisClientConfiguration but is %s",
+						ClassUtils.getShortName(clientConfiguration.getClass())));
+
+		return (MutableJedisClientConfiguration) clientConfiguration;
+	}
+
+	static class MutableJedisClientConfiguration implements JedisClientConfiguration {
+
+		private boolean useSsl;
+		private SSLSocketFactory sslSocketFactory;
+		private SSLParameters sslParameters;
+		private HostnameVerifier hostnameVerifier;
+		private boolean usePooling = true;
+		private GenericObjectPoolConfig poolConfig = new JedisPoolConfig();
+		private String clientName;
+		private Duration readTimeout = Duration.ofMillis(Protocol.DEFAULT_TIMEOUT);
+		private Duration connectTimeout = Duration.ofMillis(Protocol.DEFAULT_TIMEOUT);
+
+		public static JedisClientConfiguration create(JedisShardInfo shardInfo) {
+
+			MutableJedisClientConfiguration configuration = new MutableJedisClientConfiguration();
+
+			configuration.setShardInfo(shardInfo);
+
+			return configuration;
+		}
+
+		public static JedisClientConfiguration create(GenericObjectPoolConfig jedisPoolConfig) {
+
+			MutableJedisClientConfiguration configuration = new MutableJedisClientConfiguration();
+
+			configuration.setPoolConfig(jedisPoolConfig);
+
+			return configuration;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#useSsl()
+		 */
+		@Override
+		public boolean useSsl() {
+			return useSsl;
+		}
+
+		public void setUseSsl(boolean useSsl) {
+			this.useSsl = useSsl;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getSslSocketFactory()
+		 */
+		@Override
+		public Optional<SSLSocketFactory> getSslSocketFactory() {
+			return Optional.ofNullable(sslSocketFactory);
+		}
+
+		public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+			this.sslSocketFactory = sslSocketFactory;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getSslParameters()
+		 */
+		@Override
+		public Optional<SSLParameters> getSslParameters() {
+			return Optional.ofNullable(sslParameters);
+		}
+
+		public void setSslParameters(SSLParameters sslParameters) {
+			this.sslParameters = sslParameters;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getHostnameVerifier()
+		 */
+		@Override
+		public Optional<HostnameVerifier> getHostnameVerifier() {
+			return Optional.ofNullable(hostnameVerifier);
+		}
+
+		public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
+			this.hostnameVerifier = hostnameVerifier;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#usePooling()
+		 */
+		@Override
+		public boolean usePooling() {
+			return usePooling;
+		}
+
+		public void setUsePooling(boolean usePooling) {
+			this.usePooling = usePooling;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getPoolConfig()
+		 */
+		@Override
+		public Optional<GenericObjectPoolConfig> getPoolConfig() {
+			return Optional.ofNullable(poolConfig);
+		}
+
+		public void setPoolConfig(GenericObjectPoolConfig poolConfig) {
+			this.poolConfig = poolConfig;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getClientName()
+		 */
+		@Override
+		public Optional<String> getClientName() {
+			return Optional.ofNullable(clientName);
+		}
+
+		public void setClientName(String clientName) {
+			this.clientName = clientName;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getReadTimeout()
+		 */
+		@Override
+		public Duration getReadTimeout() {
+			return readTimeout;
+		}
+
+		public void setReadTimeout(Duration readTimeout) {
+			this.readTimeout = readTimeout;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getConnectTimeout()
+		 */
+		@Override
+		public Duration getConnectTimeout() {
+			return connectTimeout;
+		}
+
+		public void setConnectTimeout(Duration connectTimeout) {
+			this.connectTimeout = connectTimeout;
+		}
+
+		public void setShardInfo(JedisShardInfo shardInfo) {
+
+			setSslSocketFactory(shardInfo.getSslSocketFactory());
+			setSslParameters(shardInfo.getSslParameters());
+			setHostnameVerifier(shardInfo.getHostnameVerifier());
+			setUseSsl(shardInfo.getSsl());
+			setConnectTimeout(Duration.ofMillis(shardInfo.getConnectionTimeout()));
+			setReadTimeout(Duration.ofMillis(shardInfo.getSoTimeout()));
+		}
+	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -26,7 +26,6 @@ import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Protocol;
 import redis.clients.util.Pool;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -50,11 +49,19 @@ import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
 import org.springframework.data.redis.PassThroughExceptionTranslationStrategy;
 import org.springframework.data.redis.RedisConnectionFailureException;
-import org.springframework.data.redis.connection.*;
+import org.springframework.data.redis.connection.ClusterCommandExecutor;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisClusterConnection;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisNode;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.RedisSentinelConnection;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -81,19 +88,6 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	private final static Log log = LogFactory.getLog(JedisConnectionFactory.class);
 	private static final ExceptionTranslationStrategy EXCEPTION_TRANSLATION = new PassThroughExceptionTranslationStrategy(
 			JedisConverters.exceptionConverter());
-
-	private static final Method SET_TIMEOUT_METHOD;
-
-	static {
-
-		// We need to configure Jedis socket timeout via reflection since the method-name was changed between releases.
-		Method setTimeoutMethodCandidate = ReflectionUtils.findMethod(JedisShardInfo.class, "setTimeout", int.class);
-		if (setTimeoutMethodCandidate == null) {
-			// Jedis V 2.7.x changed the setTimeout method to setSoTimeout
-			setTimeoutMethodCandidate = ReflectionUtils.findMethod(JedisShardInfo.class, "setSoTimeout", int.class);
-		}
-		SET_TIMEOUT_METHOD = setTimeoutMethodCandidate;
-	}
 
 	private final JedisClientConfiguration clientConfiguration;
 	private JedisShardInfo shardInfo;
@@ -340,7 +334,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			int readTimeout = getReadTimeout();
 
 			if (readTimeout > 0) {
-				setTimeoutOn(shardInfo, readTimeout);
+				shardInfo.setSoTimeout(readTimeout);
 			}
 
 			getMutableConfiguration().setShardInfo(shardInfo);
@@ -526,7 +520,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @since 1.8
 	 */
 	public boolean isUseSsl() {
-		return clientConfiguration.useSsl();
+		return clientConfiguration.isUseSsl();
 	}
 
 	/**
@@ -663,7 +657,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @return the use of connection pooling.
 	 */
 	public boolean getUsePool() {
-		return clientConfiguration.usePooling();
+		return clientConfiguration.isUsePooling();
 	}
 
 	/**
@@ -876,10 +870,6 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 		clientConfiguration.getClientName().ifPresent(jedis::clientSetname);
 	}
 
-	private void setTimeoutOn(JedisShardInfo shardInfo, int timeout) {
-		ReflectionUtils.invokeMethod(SET_TIMEOUT_METHOD, shardInfo, timeout);
-	}
-
 	private int getReadTimeout() {
 		return Math.toIntExact(clientConfiguration.getReadTimeout().toMillis());
 	}
@@ -897,6 +887,11 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 		return (MutableJedisClientConfiguration) clientConfiguration;
 	}
 
+	/**
+	 * Mutable implementation of {@link JedisClientConfiguration}.
+	 *
+	 * @author Mark Paluch
+	 */
 	static class MutableJedisClientConfiguration implements JedisClientConfiguration {
 
 		private boolean useSsl;
@@ -912,26 +907,22 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 		public static JedisClientConfiguration create(JedisShardInfo shardInfo) {
 
 			MutableJedisClientConfiguration configuration = new MutableJedisClientConfiguration();
-
 			configuration.setShardInfo(shardInfo);
-
 			return configuration;
 		}
 
 		public static JedisClientConfiguration create(GenericObjectPoolConfig jedisPoolConfig) {
 
 			MutableJedisClientConfiguration configuration = new MutableJedisClientConfiguration();
-
 			configuration.setPoolConfig(jedisPoolConfig);
-
 			return configuration;
 		}
 
 		/* (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#useSsl()
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#isUseSsl()
 		 */
 		@Override
-		public boolean useSsl() {
+		public boolean isUseSsl() {
 			return useSsl;
 		}
 
@@ -939,7 +930,8 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			this.useSsl = useSsl;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getSslSocketFactory()
 		 */
 		@Override
@@ -951,7 +943,8 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			this.sslSocketFactory = sslSocketFactory;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getSslParameters()
 		 */
 		@Override
@@ -963,7 +956,8 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			this.sslParameters = sslParameters;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getHostnameVerifier()
 		 */
 		@Override
@@ -975,11 +969,12 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			this.hostnameVerifier = hostnameVerifier;
 		}
 
-		/* (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#usePooling()
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#isUsePooling()
 		 */
 		@Override
-		public boolean usePooling() {
+		public boolean isUsePooling() {
 			return usePooling;
 		}
 
@@ -987,7 +982,8 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			this.usePooling = usePooling;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getPoolConfig()
 		 */
 		@Override
@@ -999,7 +995,8 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			this.poolConfig = poolConfig;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getClientName()
 		 */
 		@Override
@@ -1011,7 +1008,8 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			this.clientName = clientName;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getReadTimeout()
 		 */
 		@Override
@@ -1023,7 +1021,8 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			this.readTimeout = readTimeout;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.jedis.JedisClientConfiguration#getConnectTimeout()
 		 */
 		@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
@@ -53,7 +53,7 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#useSsl()
 	 */
 	@Override
-	public boolean useSsl() {
+	public boolean isUseSsl() {
 		return useSsl;
 	}
 
@@ -93,7 +93,7 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getTimeout()
 	 */
 	@Override
-	public Duration getTimeout() {
+	public Duration getCommandTimeout() {
 		return timeout;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.resource.ClientResources;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Default implementation of {@literal LettuceClientConfiguration}.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
+
+	private final boolean useSsl;
+	private final boolean verifyPeer;
+	private final boolean startTls;
+	private final Optional<ClientResources> clientResources;
+	private final Optional<ClientOptions> clientOptions;
+	private final Duration timeout;
+	private final Duration shutdownTimeout;
+
+	DefaultLettuceClientConfiguration(boolean useSsl, boolean verifyPeer, boolean startTls,
+			ClientResources clientResources, ClientOptions clientOptions, Duration timeout, Duration shutdownTimeout) {
+
+		this.useSsl = useSsl;
+		this.verifyPeer = verifyPeer;
+		this.startTls = startTls;
+		this.clientResources = Optional.ofNullable(clientResources);
+		this.clientOptions = Optional.ofNullable(clientOptions);
+		this.timeout = timeout;
+		this.shutdownTimeout = shutdownTimeout;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#useSsl()
+	 */
+	@Override
+	public boolean useSsl() {
+		return useSsl;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isVerifyPeer()
+	 */
+	@Override
+	public boolean isVerifyPeer() {
+		return verifyPeer;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isStartTls()
+	 */
+	@Override
+	public boolean isStartTls() {
+		return startTls;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientResources()
+	 */
+	@Override
+	public Optional<ClientResources> getClientResources() {
+		return clientResources;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientOptions()
+	 */
+	@Override
+	public Optional<ClientOptions> getClientOptions() {
+		return clientOptions;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getTimeout()
+	 */
+	@Override
+	public Duration getTimeout() {
+		return timeout;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getShutdownTimeout()
+	 */
+	@Override
+	public Duration getShutdownTimeout() {
+		return shutdownTimeout;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -116,6 +116,13 @@ public interface LettuceClientConfiguration {
 		LettuceSslClientConfigurationBuilder useSsl();
 
 		/**
+		 * Use plaintext connections instead of SSL.
+		 *
+		 * @return {@link LettuceClientConfigurationBuilder}.
+		 */
+		LettuceClientConfigurationBuilder usePlaintext();
+
+		/**
 		 * Configure {@link ClientResources}.
 		 *
 		 * @param clientResources must not be {@literal null}.
@@ -223,6 +230,16 @@ public interface LettuceClientConfiguration {
 		public LettuceSslClientConfigurationBuilder useSsl() {
 
 			this.useSsl = true;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#usePlaintext()
+		 */
+		@Override
+		public LettuceClientConfigurationBuilder usePlaintext() {
+
+			this.useSsl = false;
 			return this;
 		}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.resource.ClientResources;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.util.Assert;
+
+/**
+ * Redis client configuration for lettuce. This configuration provides optional configuration elements such as
+ * {@link ClientResources} and {@link ClientOptions} specific to Lettuce client features.
+ * <p>
+ * Providing optional elements allows a more specific configuration of the client:
+ * <ul>
+ * <li>Whether to use SSL</li>
+ * <li>Whether to verify peers using SSL</li>
+ * <li>Whether to use StartTLS</li>
+ * <li>Optional {@link ClientResources}</li>
+ * <li>Optional {@link ClientOptions}</li>
+ * <li>Client {@link Duration timeout}</li>
+ * <li>Shutdown {@link Duration timeout}</li>
+ * </ul>
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ * @see org.springframework.data.redis.connection.RedisStandaloneConfiguration
+ * @see org.springframework.data.redis.connection.RedisSentinelConfiguration
+ * @see org.springframework.data.redis.connection.RedisClusterConfiguration
+ */
+public interface LettuceClientConfiguration {
+
+	/**
+	 * @return {@literal true} to use SSL, {@literal false} to use unencrypted connections.
+	 */
+	boolean useSsl();
+
+	/**
+	 * @return {@literal true} to verify peers when using {@link #useSsl() SSL}.
+	 */
+	boolean isVerifyPeer();
+
+	/**
+	 * @return {@literal true} to use Start TLS ({@code true} if the first write request shouldn't be encrypted).
+	 */
+	boolean isStartTls();
+
+	/**
+	 * @return the optional {@link ClientResources}.
+	 */
+	Optional<ClientResources> getClientResources();
+
+	/**
+	 * @return the optional {@link io.lettuce.core.ClientOptions}.
+	 */
+	Optional<ClientOptions> getClientOptions();
+
+	/**
+	 * @return the timeout.
+	 */
+	Duration getTimeout();
+
+	/**
+	 * @return the shutdown timeout used to close the client.
+	 * @see io.lettuce.core.AbstractRedisClient#shutdown(long, long, TimeUnit)
+	 */
+	Duration getShutdownTimeout();
+
+	/**
+	 * Creates a new {@link LettuceClientConfigurationBuilder} to build {@link LettuceClientConfiguration} to be used with
+	 * the Lettuce client.
+	 *
+	 * @return a new {@link LettuceClientConfigurationBuilder} to build {@link LettuceClientConfiguration}.
+	 */
+	static LettuceClientConfigurationBuilder builder() {
+		return new DefaultLettuceClientConfigurationBuilder();
+	}
+
+	/**
+	 * Creates an empty {@link LettuceClientConfiguration}.
+	 *
+	 * @return an empty {@link LettuceClientConfiguration}.
+	 */
+	static LettuceClientConfiguration create() {
+		return builder().build();
+	}
+
+	/**
+	 * Builder for {@link LettuceClientConfiguration}.
+	 */
+	interface LettuceClientConfigurationBuilder {
+
+		/**
+		 * Enable SSL connections.
+		 *
+		 * @return {@link LettuceSslClientConfigurationBuilder}.
+		 */
+		LettuceSslClientConfigurationBuilder useSsl();
+
+		/**
+		 * Configure {@link ClientResources}.
+		 *
+		 * @param clientResources must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		LettuceClientConfigurationBuilder clientResources(ClientResources clientResources);
+
+		/**
+		 * Configure {@link ClientOptions}.
+		 *
+		 * @param clientOptions must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 * @see ClientOptions
+		 * @see io.lettuce.core.cluster.ClusterClientOptions
+		 */
+		LettuceClientConfigurationBuilder clientOptions(ClientOptions clientOptions);
+
+		/**
+		 * Configure a timeout.
+		 *
+		 * @param timeout must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		LettuceClientConfigurationBuilder timeout(Duration timeout);
+
+		/**
+		 * Configure a shutdown timeout.
+		 *
+		 * @param shutdownTimeout must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 */
+		LettuceClientConfigurationBuilder shutdownTimeout(Duration shutdownTimeout);
+
+		/**
+		 * Build the {@link LettuceClientConfiguration} with the configuration applied from this builder.
+		 *
+		 * @return a new {@link LettuceClientConfiguration} object.
+		 */
+		LettuceClientConfiguration build();
+	}
+
+	/**
+	 * Builder for SSL-related {@link LettuceClientConfiguration}.
+	 */
+	interface LettuceSslClientConfigurationBuilder {
+
+		/**
+		 * Enable peer verification.
+		 *
+		 * @return {@literal this} builder.
+		 */
+		LettuceSslClientConfigurationBuilder verifyPeer();
+
+		/**
+		 * Enable/disable peer verification.
+		 *
+		 * @param verifyPeer {@literal true} to enable peer verification, {@literal false} to skip peer verification.
+		 * @return {@literal this} builder.
+		 */
+		LettuceSslClientConfigurationBuilder verifyPeer(boolean verifyPeer);
+
+		/**
+		 * Enable Start TLS to send the first bytes unencrypted.
+		 *
+		 * @return {@literal this} builder.
+		 */
+		LettuceSslClientConfigurationBuilder startTls();
+
+		/**
+		 * Return to {@link LettuceClientConfigurationBuilder}.
+		 *
+		 * @return {@link LettuceClientConfigurationBuilder}.
+		 */
+		LettuceClientConfigurationBuilder and();
+
+		/**
+		 * Build the {@link LettuceClientConfiguration} with the configuration applied from this builder.
+		 *
+		 * @return a new {@link LettuceClientConfiguration} object.
+		 */
+		LettuceClientConfiguration build();
+	}
+
+	/**
+	 * Default {@link LettuceClientConfigurationBuilder} implementation to build an immutable
+	 * {@link LettuceClientConfiguration}.
+	 */
+	class DefaultLettuceClientConfigurationBuilder
+			implements LettuceClientConfigurationBuilder, LettuceSslClientConfigurationBuilder {
+
+		private boolean useSsl;
+		private boolean verifyPeer = true;
+		private boolean startTls;
+		private ClientResources clientResources;
+		private ClientOptions clientOptions;
+		private Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
+		private Duration shutdownTimeout = Duration.ofSeconds(2);
+
+		private DefaultLettuceClientConfigurationBuilder() {}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#useSsl()
+		 */
+		@Override
+		public LettuceSslClientConfigurationBuilder useSsl() {
+
+			this.useSsl = true;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#verifyPeer()
+		 */
+		@Override
+		public LettuceSslClientConfigurationBuilder verifyPeer() {
+			return verifyPeer(true);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#verifyPeer(boolean)
+		 */
+		@Override
+		public LettuceSslClientConfigurationBuilder verifyPeer(boolean verifyPeer) {
+
+			this.verifyPeer = verifyPeer;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#startTls()
+		 */
+		@Override
+		public LettuceSslClientConfigurationBuilder startTls() {
+
+			this.startTls = true;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#and()
+		 */
+		@Override
+		public LettuceClientConfigurationBuilder and() {
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#clientResources(io.lettuce.core.resource.ClientResources)
+		 */
+		@Override
+		public LettuceClientConfigurationBuilder clientResources(ClientResources clientResources) {
+
+			Assert.notNull(clientResources, "ClientResources must not be null!");
+
+			this.clientResources = clientResources;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#clientOptions(io.lettuce.core.ClientOptions)
+		 */
+		@Override
+		public LettuceClientConfigurationBuilder clientOptions(ClientOptions clientOptions) {
+
+			Assert.notNull(clientOptions, "ClientOptions must not be null!");
+
+			this.clientOptions = clientOptions;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#timeout(java.time.Duration)
+		 */
+		@Override
+		public LettuceClientConfigurationBuilder timeout(Duration timeout) {
+
+			Assert.notNull(timeout, "Duration must not be null!");
+
+			this.timeout = timeout;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#shutdownTimeout(java.time.Duration)
+		 */
+		@Override
+		public LettuceClientConfigurationBuilder shutdownTimeout(Duration shutdownTimeout) {
+
+			Assert.notNull(timeout, "Duration must not be null!");
+
+			this.shutdownTimeout = shutdownTimeout;
+			return this;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#build()
+		 */
+		@Override
+		public LettuceClientConfiguration build() {
+			return new DefaultLettuceClientConfiguration(useSsl, verifyPeer, startTls, clientResources, clientOptions,
+					timeout, shutdownTimeout);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -409,7 +409,7 @@ public class LettuceConnectionFactory
 	 * @return use of SSL.
 	 */
 	public boolean isUseSsl() {
-		return clientConfiguration.useSsl();
+		return clientConfiguration.isUseSsl();
 	}
 
 	/**
@@ -800,10 +800,10 @@ public class LettuceConnectionFactory
 
 		getRedisPassword().toOptional().ifPresent(builder::withPassword);
 
-		builder.withSsl(clientConfiguration.useSsl());
+		builder.withSsl(clientConfiguration.isUseSsl());
 		builder.withVerifyPeer(clientConfiguration.isVerifyPeer());
 		builder.withStartTls(clientConfiguration.isStartTls());
-		builder.withTimeout(clientConfiguration.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
+		builder.withTimeout(clientConfiguration.getCommandTimeout().toMillis(), TimeUnit.MILLISECONDS);
 
 		return builder.build();
 	}
@@ -827,9 +827,14 @@ public class LettuceConnectionFactory
 	}
 
 	private long getClientTimeout() {
-		return clientConfiguration.getTimeout().toMillis();
+		return clientConfiguration.getCommandTimeout().toMillis();
 	}
 
+	/**
+	 * Mutable implementation of {@link LettuceClientConfiguration}.
+	 *
+	 * @author Mark Paluch
+	 */
 	static class MutableLettuceClientConfiguration implements LettuceClientConfiguration {
 
 		private boolean useSsl;
@@ -840,10 +845,10 @@ public class LettuceConnectionFactory
 		private Duration shutdownTimeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
 
 		/* (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#useSsl()
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isUseSsl()
 		 */
 		@Override
-		public boolean useSsl() {
+		public boolean isUseSsl() {
 			return useSsl;
 		}
 
@@ -899,7 +904,7 @@ public class LettuceConnectionFactory
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getTimeout()
 		 */
 		@Override
-		public Duration getTimeout() {
+		public Duration getCommandTimeout() {
 			return timeout;
 		}
 

--- a/src/test/java/org/springframework/data/redis/ConnectionFactoryTracker.java
+++ b/src/test/java/org/springframework/data/redis/ConnectionFactoryTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 package org.springframework.data.redis;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.beans.factory.DisposableBean;
@@ -26,6 +28,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
  * factory during setup and then call {@link #cleanUp()} through the <tt>@AfterClass</tt> method.
  *
  * @author Costin Leau
+ * @author Mark Paluch
  */
 public abstract class ConnectionFactoryTracker {
 
@@ -41,12 +44,14 @@ public abstract class ConnectionFactoryTracker {
 
 	public static void cleanUp() {
 		if (connFactories != null) {
-			for (Object connectionFactory : connFactories) {
+			List<Object> copy = new ArrayList<>(connFactories);
+			for (Object connectionFactory : copy) {
 				try {
 					if (connectionFactory instanceof DisposableBean) {
 						((DisposableBean) connectionFactory).destroy();
 						// System.out.println("Succesfully cleaned up factory " + connectionFactory);
 					}
+					connFactories.remove(connectionFactory);
 				} catch (Exception ex) {
 					System.err.println("Cannot clean factory " + connectionFactory + ex);
 				}

--- a/src/test/java/org/springframework/data/redis/connection/RedisPasswordUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisPasswordUnitTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link RedisPassword}.
+ *
+ * @author Mark Paluch
+ */
+public class RedisPasswordUnitTests {
+
+	@Test // DATAREDIS-574
+	public void shouldCreateFromEmptyString() {
+		assertThat(RedisPassword.of("").toOptional()).isEmpty();
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldCreateFromExistingString() {
+		assertThat(RedisPassword.of("foo").map(String::new)).contains("foo");
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldCreateFromEmptyCharArray() {
+		assertThat(RedisPassword.of("".toCharArray()).toOptional()).isEmpty();
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldCreateFromExistingCharArray() {
+		assertThat(RedisPassword.of("foo".toCharArray()).map(String::new)).contains("foo");
+	}
+
+	@Test // DATAREDIS-574
+	public void toStringShouldHideValue() {
+		assertThat(RedisPassword.of("foo".toCharArray()).toString()).startsWith("RedisPassword[***");
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/RedisPasswordUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisPasswordUnitTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  * Unit tests for {@link RedisPassword}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class RedisPasswordUnitTests {
 
@@ -48,6 +49,6 @@ public class RedisPasswordUnitTests {
 
 	@Test // DATAREDIS-574
 	public void toStringShouldHideValue() {
-		assertThat(RedisPassword.of("foo".toCharArray()).toString()).startsWith("RedisPassword[***");
+		assertThat(RedisPassword.of("foo".toCharArray()).toString()).startsWith("RedisPassword[**").doesNotContain("foo");
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.jedis;
+
+import static org.assertj.core.api.Assertions.*;
+
+import redis.clients.jedis.JedisPoolConfig;
+
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link JedisClientConfiguration}.
+ *
+ * @author Mark Paluch
+ */
+public class JedisClientConfigurationUnitTests {
+
+	@Test // DATAREDIS-574
+	public void shouldCreateEmptyConfiguration() {
+
+		JedisClientConfiguration configuration = JedisClientConfiguration.create();
+
+		assertThat(configuration.getClientName()).isEmpty();
+		assertThat(configuration.getConnectTimeout()).isEqualTo(Duration.ofSeconds(2));
+		assertThat(configuration.getReadTimeout()).isEqualTo(Duration.ofSeconds(2));
+		assertThat(configuration.getHostnameVerifier()).isEmpty();
+		assertThat(configuration.getPoolConfig()).isPresent();
+		assertThat(configuration.getSslParameters()).isEmpty();
+		assertThat(configuration.getSslSocketFactory()).isEmpty();
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldConfigureAllProperties() throws NoSuchAlgorithmException {
+
+		SSLParameters sslParameters = new SSLParameters();
+		SSLContext context = SSLContext.getDefault();
+		SSLSocketFactory socketFactory = context.getSocketFactory();
+		JedisPoolConfig poolConfig = new JedisPoolConfig();
+
+		JedisClientConfiguration configuration = JedisClientConfiguration.builder().useSsl() //
+				.hostnameVerifier(MyHostnameVerifier.INSTANCE) //
+				.sslParameters(sslParameters) //
+				.sslSocketFactory(socketFactory).and() //
+				.clientName("my-client") //
+				.connectTimeout(Duration.ofMinutes(10)) //
+				.readTimeout(Duration.ofHours(5)) //
+				.usePooling().poolConfig(poolConfig) //
+				.build();
+
+		assertThat(configuration.useSsl()).isTrue();
+		assertThat(configuration.getHostnameVerifier()).contains(MyHostnameVerifier.INSTANCE);
+		assertThat(configuration.getSslParameters()).contains(sslParameters);
+		assertThat(configuration.getSslSocketFactory()).contains(socketFactory);
+
+		assertThat(configuration.getClientName()).contains("my-client");
+		assertThat(configuration.getConnectTimeout()).isEqualTo(Duration.ofMinutes(10));
+		assertThat(configuration.getReadTimeout()).isEqualTo(Duration.ofHours(5));
+
+		assertThat(configuration.getPoolConfig()).contains(poolConfig);
+	}
+
+	static enum MyHostnameVerifier implements HostnameVerifier {
+
+		INSTANCE;
+
+		@Override
+		public boolean verify(String s, SSLSession sslSession) {
+			return false;
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
@@ -40,7 +40,7 @@ public class JedisClientConfigurationUnitTests {
 	@Test // DATAREDIS-574
 	public void shouldCreateEmptyConfiguration() {
 
-		JedisClientConfiguration configuration = JedisClientConfiguration.create();
+		JedisClientConfiguration configuration = JedisClientConfiguration.defaultConfiguration();
 
 		assertThat(configuration.getClientName()).isEmpty();
 		assertThat(configuration.getConnectTimeout()).isEqualTo(Duration.ofSeconds(2));
@@ -69,7 +69,7 @@ public class JedisClientConfigurationUnitTests {
 				.usePooling().poolConfig(poolConfig) //
 				.build();
 
-		assertThat(configuration.useSsl()).isTrue();
+		assertThat(configuration.isUseSsl()).isTrue();
 		assertThat(configuration.getHostnameVerifier()).contains(MyHostnameVerifier.INSTANCE);
 		assertThat(configuration.getSslParameters()).contains(sslParameters);
 		assertThat(configuration.getSslSocketFactory()).contains(socketFactory);
@@ -79,18 +79,6 @@ public class JedisClientConfigurationUnitTests {
 		assertThat(configuration.getReadTimeout()).isEqualTo(Duration.ofHours(5));
 
 		assertThat(configuration.getPoolConfig()).contains(poolConfig);
-	}
-
-	@Test // DATAREDIS-574
-	public void shouldAllowsConfigurationOverrides() {
-
-		JedisClientConfiguration configuration = JedisClientConfiguration.builder().useSsl() //
-				.and().usePlaintext() //
-				.usePooling().and().useUnpooledConnections() //
-				.build();
-
-		assertThat(configuration.useSsl()).isFalse();
-		assertThat(configuration.usePooling()).isFalse();
 	}
 
 	enum MyHostnameVerifier implements HostnameVerifier {

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
@@ -21,7 +21,6 @@ import redis.clients.jedis.JedisPoolConfig;
 
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -82,7 +81,19 @@ public class JedisClientConfigurationUnitTests {
 		assertThat(configuration.getPoolConfig()).contains(poolConfig);
 	}
 
-	static enum MyHostnameVerifier implements HostnameVerifier {
+	@Test // DATAREDIS-574
+	public void shouldAllowsConfigurationOverrides() {
+
+		JedisClientConfiguration configuration = JedisClientConfiguration.builder().useSsl() //
+				.and().usePlaintext() //
+				.usePooling().and().useUnpooledConnections() //
+				.build();
+
+		assertThat(configuration.useSsl()).isFalse();
+		assertThat(configuration.usePooling()).isFalse();
+	}
+
+	enum MyHostnameVerifier implements HostnameVerifier {
 
 		INSTANCE;
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
@@ -60,7 +60,7 @@ public class JedisConnectionFactoryIntegrationTests {
 
 		factory = new JedisConnectionFactory(
 				new RedisStandaloneConfiguration(SettingsUtils.getHost(), SettingsUtils.getPort()),
-				JedisClientConfiguration.create());
+				JedisClientConfiguration.defaultConfiguration());
 		factory.afterPropertiesSet();
 
 		assertThat(factory.getConnection().ping(), equalTo("PONG"));

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.jedis;
+
+import static org.hamcrest.core.IsEqual.*;
+import static org.junit.Assert.*;
+
+import redis.clients.jedis.JedisShardInfo;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.data.redis.SettingsUtils;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+
+/**
+ * Integration tests for {@link JedisConnectionFactory}.
+ *
+ * @author Mark Paluch
+ */
+public class JedisConnectionFactoryIntegrationTests {
+
+	private JedisConnectionFactory factory;
+
+	@After
+	public void tearDown() {
+
+		if (factory != null) {
+			factory.destroy();
+		}
+	}
+
+	@Test // DATAREDIS-574
+	public void shardInfoShouldOverrideFactorySettings() {
+
+		factory = new JedisConnectionFactory(new JedisShardInfo(SettingsUtils.getHost(), SettingsUtils.getPort()));
+		factory.setUsePool(false);
+		factory.setPassword("foo");
+		factory.setHostName("bar");
+		factory.setPort(1234);
+		factory.afterPropertiesSet();
+
+		assertThat(factory.getConnection().ping(), equalTo("PONG"));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldInitiaizeWithStandaloneConfiguration() {
+
+		factory = new JedisConnectionFactory(
+				new RedisStandaloneConfiguration(SettingsUtils.getHost(), SettingsUtils.getPort()),
+				JedisClientConfiguration.create());
+		factory.afterPropertiesSet();
+
+		assertThat(factory.getConnection().ping(), equalTo("PONG"));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
@@ -104,7 +104,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
 		envConfig.setPassword(RedisPassword.of("foo"));
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getPassword()).isEqualTo("foo");
 	}
@@ -115,7 +115,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
 		envConfig.setPassword(RedisPassword.of("foo"));
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword()).isEqualTo("bar");
@@ -128,7 +128,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
 		envConfig.setPassword(RedisPassword.of("foo"));
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getPassword()).isEqualTo("foo");
 	}
@@ -139,7 +139,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
 		envConfig.setPassword(RedisPassword.of("foo"));
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword()).isEqualTo("bar");
@@ -152,7 +152,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisClusterConfiguration envConfig = new RedisClusterConfiguration();
 		envConfig.setPassword(RedisPassword.of("foo"));
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getPassword()).isEqualTo("foo");
 	}
@@ -163,7 +163,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisClusterConfiguration envConfig = new RedisClusterConfiguration();
 		envConfig.setPassword(RedisPassword.of("foo"));
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword()).isEqualTo("bar");
@@ -176,7 +176,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
 		envConfig.setDatabase(2);
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getDatabase()).isEqualTo(2);
 	}
@@ -187,7 +187,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
 		envConfig.setDatabase(2);
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 		connectionFactory.setDatabase(3);
 
 		assertThat(connectionFactory.getDatabase()).isEqualTo(3);
@@ -200,7 +200,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
 		envConfig.setDatabase(2);
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getDatabase()).isEqualTo(2);
 	}
@@ -211,7 +211,7 @@ public class JedisConnectionFactoryUnitTests {
 		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
 		envConfig.setDatabase(2);
 
-		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.defaultConfiguration());
 		connectionFactory.setDatabase(3);
 
 		assertThat(connectionFactory.getDatabase()).isEqualTo(3);
@@ -250,7 +250,7 @@ public class JedisConnectionFactoryUnitTests {
 	public void shouldReturnStandaloneConfiguration() {
 
 		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
-		connectionFactory = new JedisConnectionFactory(configuration, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(configuration, JedisClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getStandaloneConfiguration()).isSameAs(configuration);
 		assertThat(connectionFactory.getSentinelConfiguration()).isNull();
@@ -261,7 +261,7 @@ public class JedisConnectionFactoryUnitTests {
 	public void shouldReturnSentinelConfiguration() {
 
 		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration();
-		connectionFactory = new JedisConnectionFactory(configuration, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(configuration, JedisClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getStandaloneConfiguration()).isNotNull();
 		assertThat(connectionFactory.getSentinelConfiguration()).isSameAs(configuration);
@@ -272,7 +272,7 @@ public class JedisConnectionFactoryUnitTests {
 	public void shouldReturnClusterConfiguration() {
 
 		RedisClusterConfiguration configuration = new RedisClusterConfiguration();
-		connectionFactory = new JedisConnectionFactory(configuration, JedisClientConfiguration.create());
+		connectionFactory = new JedisConnectionFactory(configuration, JedisClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getStandaloneConfiguration()).isNotNull();
 		assertThat(connectionFactory.getSentinelConfiguration()).isNull();
@@ -283,7 +283,7 @@ public class JedisConnectionFactoryUnitTests {
 	public void shouldDenyChangesToImmutableClientConfiguration() throws NoSuchAlgorithmException {
 
 		connectionFactory = new JedisConnectionFactory(new RedisStandaloneConfiguration(),
-				JedisClientConfiguration.create());
+				JedisClientConfiguration.defaultConfiguration());
 
 		connectionFactory.setClientName("foo");
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
@@ -34,6 +34,7 @@ import javax.net.ssl.SSLSocketFactory;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.Test;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -101,7 +102,7 @@ public class JedisConnectionFactoryUnitTests {
 	public void shouldReadStandalonePassword() {
 
 		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
 
@@ -112,20 +113,20 @@ public class JedisConnectionFactoryUnitTests {
 	public void shouldWriteStandalonePassword() {
 
 		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword()).isEqualTo("bar");
-		assertThat(envConfig.getPassword()).isEqualTo("bar");
+		assertThat(envConfig.getPassword()).isEqualTo(RedisPassword.of("bar"));
 	}
 
 	@Test // DATAREDIS-574
 	public void shouldReadSentinelPassword() {
 
 		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
 
@@ -136,20 +137,20 @@ public class JedisConnectionFactoryUnitTests {
 	public void shouldWriteSentinelPassword() {
 
 		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword()).isEqualTo("bar");
-		assertThat(envConfig.getPassword()).isEqualTo("bar");
+		assertThat(envConfig.getPassword()).isEqualTo(RedisPassword.of("bar"));
 	}
 
 	@Test // DATAREDIS-574
 	public void shouldReadClusterPassword() {
 
 		RedisClusterConfiguration envConfig = new RedisClusterConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
 
@@ -160,13 +161,13 @@ public class JedisConnectionFactoryUnitTests {
 	public void shouldWriteClusterPassword() {
 
 		RedisClusterConfiguration envConfig = new RedisClusterConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		connectionFactory = new JedisConnectionFactory(envConfig, JedisClientConfiguration.create());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword()).isEqualTo("bar");
-		assertThat(envConfig.getPassword()).isEqualTo("bar");
+		assertThat(envConfig.getPassword()).isEqualTo(RedisPassword.of("bar"));
 	}
 
 	@Test // DATAREDIS-574

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.resource.ClientResources;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link LettuceClientConfiguration}.
+ *
+ * @author Mark Paluch
+ */
+public class LettuceClientConfigurationUnitTests {
+
+	@Test // DATAREDIS-574
+	public void shouldCreateEmptyConfiguration() {
+
+		LettuceClientConfiguration configuration = LettuceClientConfiguration.create();
+
+		assertThat(configuration.useSsl()).isFalse();
+		assertThat(configuration.isVerifyPeer()).isTrue();
+		assertThat(configuration.isStartTls()).isFalse();
+		assertThat(configuration.getClientOptions()).isEmpty();
+		assertThat(configuration.getClientResources()).isEmpty();
+		assertThat(configuration.getTimeout()).isEqualTo(Duration.ofSeconds(60));
+		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofSeconds(2));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldConfigureAllProperties() {
+
+		ClientOptions clientOptions = ClientOptions.create();
+		ClientResources sharedClientResources = LettuceTestClientResources.getSharedClientResources();
+
+		LettuceClientConfiguration configuration = LettuceClientConfiguration.builder() //
+				.useSsl() //
+				.verifyPeer(false) //
+				.startTls().and() //
+				.clientOptions(clientOptions) //
+				.clientResources(sharedClientResources) //
+				.timeout(Duration.ofMinutes(5)) //
+				.shutdownTimeout(Duration.ofHours(2)) //
+				.build();
+
+		assertThat(configuration.useSsl()).isTrue();
+		assertThat(configuration.isVerifyPeer()).isFalse();
+		assertThat(configuration.isStartTls()).isTrue();
+		assertThat(configuration.getClientOptions()).contains(clientOptions);
+		assertThat(configuration.getClientResources()).contains(sharedClientResources);
+		assertThat(configuration.getTimeout()).isEqualTo(Duration.ofMinutes(5));
+		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofHours(2));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
@@ -69,4 +69,14 @@ public class LettuceClientConfigurationUnitTests {
 		assertThat(configuration.getTimeout()).isEqualTo(Duration.ofMinutes(5));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofHours(2));
 	}
+
+	@Test // DATAREDIS-574
+	public void shouldAllowsConfigurationOverrides() {
+
+		LettuceClientConfiguration configuration = LettuceClientConfiguration.builder() //
+				.useSsl().and().usePlaintext() //
+				.build();
+
+		assertThat(configuration.useSsl()).isFalse();
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
@@ -34,14 +34,14 @@ public class LettuceClientConfigurationUnitTests {
 	@Test // DATAREDIS-574
 	public void shouldCreateEmptyConfiguration() {
 
-		LettuceClientConfiguration configuration = LettuceClientConfiguration.create();
+		LettuceClientConfiguration configuration = LettuceClientConfiguration.defaultConfiguration();
 
-		assertThat(configuration.useSsl()).isFalse();
+		assertThat(configuration.isUseSsl()).isFalse();
 		assertThat(configuration.isVerifyPeer()).isTrue();
 		assertThat(configuration.isStartTls()).isFalse();
 		assertThat(configuration.getClientOptions()).isEmpty();
 		assertThat(configuration.getClientResources()).isEmpty();
-		assertThat(configuration.getTimeout()).isEqualTo(Duration.ofSeconds(60));
+		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofSeconds(60));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofSeconds(2));
 	}
 
@@ -53,30 +53,20 @@ public class LettuceClientConfigurationUnitTests {
 
 		LettuceClientConfiguration configuration = LettuceClientConfiguration.builder() //
 				.useSsl() //
-				.verifyPeer(false) //
+				.disablePeerVerification() //
 				.startTls().and() //
 				.clientOptions(clientOptions) //
 				.clientResources(sharedClientResources) //
-				.timeout(Duration.ofMinutes(5)) //
+				.commandTimeout(Duration.ofMinutes(5)) //
 				.shutdownTimeout(Duration.ofHours(2)) //
 				.build();
 
-		assertThat(configuration.useSsl()).isTrue();
+		assertThat(configuration.isUseSsl()).isTrue();
 		assertThat(configuration.isVerifyPeer()).isFalse();
 		assertThat(configuration.isStartTls()).isTrue();
 		assertThat(configuration.getClientOptions()).contains(clientOptions);
 		assertThat(configuration.getClientResources()).contains(sharedClientResources);
-		assertThat(configuration.getTimeout()).isEqualTo(Duration.ofMinutes(5));
+		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofMinutes(5));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofHours(2));
-	}
-
-	@Test // DATAREDIS-574
-	public void shouldAllowsConfigurationOverrides() {
-
-		LettuceClientConfiguration configuration = LettuceClientConfiguration.builder() //
-				.useSsl().and().usePlaintext() //
-				.build();
-
-		assertThat(configuration.useSsl()).isFalse();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -292,7 +292,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getPassword(), is(equalTo("foo")));
 	}
@@ -304,7 +304,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword(), is(equalTo("bar")));
@@ -318,7 +318,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getPassword(), is(equalTo("foo")));
 	}
@@ -330,7 +330,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword(), is(equalTo("bar")));
@@ -344,7 +344,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getPassword(), is(equalTo("foo")));
 	}
@@ -356,7 +356,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword(), is(equalTo("bar")));
@@ -370,7 +370,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setDatabase(2);
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getDatabase(), is(2));
 	}
@@ -382,7 +382,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setDatabase(2);
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 		connectionFactory.setDatabase(3);
 
 		assertThat(connectionFactory.getDatabase(), is(3));
@@ -396,7 +396,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setDatabase(2);
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getDatabase(), is(2));
 	}
@@ -408,7 +408,7 @@ public class LettuceConnectionFactoryUnitTests {
 		envConfig.setDatabase(2);
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 		connectionFactory.setDatabase(3);
 
 		assertThat(connectionFactory.getDatabase(), is(3));
@@ -423,11 +423,11 @@ public class LettuceConnectionFactoryUnitTests {
 
 		LettuceClientConfiguration configuration = LettuceClientConfiguration.builder() //
 				.useSsl() //
-				.verifyPeer(false) //
+				.disablePeerVerification() //
 				.startTls().and() //
 				.clientOptions(clientOptions) //
 				.clientResources(sharedClientResources) //
-				.timeout(Duration.ofMinutes(5)) //
+				.commandTimeout(Duration.ofMinutes(5)) //
 				.shutdownTimeout(Duration.ofHours(2)) //
 				.build();
 
@@ -449,7 +449,7 @@ public class LettuceConnectionFactoryUnitTests {
 
 		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(configuration,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getStandaloneConfiguration(), is(configuration));
 		assertThat(connectionFactory.getSentinelConfiguration(), is(nullValue()));
@@ -461,7 +461,7 @@ public class LettuceConnectionFactoryUnitTests {
 
 		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration();
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(configuration,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getStandaloneConfiguration(), is(notNullValue()));
 		assertThat(connectionFactory.getSentinelConfiguration(), is(configuration));
@@ -473,7 +473,7 @@ public class LettuceConnectionFactoryUnitTests {
 
 		RedisClusterConfiguration configuration = new RedisClusterConfiguration();
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(configuration,
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 
 		assertThat(connectionFactory.getStandaloneConfiguration(), is(notNullValue()));
 		assertThat(connectionFactory.getSentinelConfiguration(), is(nullValue()));
@@ -484,7 +484,7 @@ public class LettuceConnectionFactoryUnitTests {
 	public void shouldDenyChangesToImmutableClientConfiguration() throws NoSuchAlgorithmException {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(),
-				LettuceClientConfiguration.create());
+				LettuceClientConfiguration.defaultConfiguration());
 
 		connectionFactory.setUseSsl(false);
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -18,16 +18,21 @@ package org.springframework.data.redis.connection.lettuce;
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsEqual.*;
 import static org.hamcrest.core.IsInstanceOf.*;
+import static org.hamcrest.core.IsNull.*;
 import static org.junit.Assert.*;
 import static org.springframework.data.redis.connection.ClusterTestVariables.*;
 import static org.springframework.data.redis.connection.lettuce.LettuceTestClientResources.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
 import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.resource.ClientResources;
 
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
@@ -37,8 +42,11 @@ import org.junit.Test;
 import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 
 /**
+ * Unit tests for {@link LettuceConnectionFactory}.
+ *
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Balázs Németh
@@ -274,5 +282,209 @@ public class LettuceConnectionFactoryUnitTests {
 		for (RedisURI uri : initialUris) {
 			assertThat(uri.isVerifyPeer(), is(true));
 		}
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldReadStandalonePassword() {
+
+		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
+		envConfig.setPassword("foo");
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+
+		assertThat(connectionFactory.getPassword(), is(equalTo("foo")));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldWriteStandalonePassword() {
+
+		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
+		envConfig.setPassword("foo");
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+		connectionFactory.setPassword("bar");
+
+		assertThat(connectionFactory.getPassword(), is(equalTo("bar")));
+		assertThat(envConfig.getPassword(), is(equalTo("bar")));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldReadSentinelPassword() {
+
+		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
+		envConfig.setPassword("foo");
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+
+		assertThat(connectionFactory.getPassword(), is(equalTo("foo")));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldWriteSentinelPassword() {
+
+		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
+		envConfig.setPassword("foo");
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+		connectionFactory.setPassword("bar");
+
+		assertThat(connectionFactory.getPassword(), is(equalTo("bar")));
+		assertThat(envConfig.getPassword(), is(equalTo("bar")));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldReadClusterPassword() {
+
+		RedisClusterConfiguration envConfig = new RedisClusterConfiguration();
+		envConfig.setPassword("foo");
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+
+		assertThat(connectionFactory.getPassword(), is(equalTo("foo")));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldWriteClusterPassword() {
+
+		RedisClusterConfiguration envConfig = new RedisClusterConfiguration();
+		envConfig.setPassword("foo");
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+		connectionFactory.setPassword("bar");
+
+		assertThat(connectionFactory.getPassword(), is(equalTo("bar")));
+		assertThat(envConfig.getPassword(), is(equalTo("bar")));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldReadStandaloneDatabaseIndex() {
+
+		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
+		envConfig.setDatabase(2);
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+
+		assertThat(connectionFactory.getDatabase(), is(2));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldWriteStandaloneDatabaseIndex() {
+
+		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
+		envConfig.setDatabase(2);
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+		connectionFactory.setDatabase(3);
+
+		assertThat(connectionFactory.getDatabase(), is(3));
+		assertThat(envConfig.getDatabase(), is(3));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldReadSentinelDatabaseIndex() {
+
+		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
+		envConfig.setDatabase(2);
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+
+		assertThat(connectionFactory.getDatabase(), is(2));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldWriteSentinelDatabaseIndex() {
+
+		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
+		envConfig.setDatabase(2);
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
+				LettuceClientConfiguration.create());
+		connectionFactory.setDatabase(3);
+
+		assertThat(connectionFactory.getDatabase(), is(3));
+		assertThat(envConfig.getDatabase(), is(3));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldApplyClientConfiguration() {
+
+		ClientOptions clientOptions = ClientOptions.create();
+		ClientResources sharedClientResources = LettuceTestClientResources.getSharedClientResources();
+
+		LettuceClientConfiguration configuration = LettuceClientConfiguration.builder() //
+				.useSsl() //
+				.verifyPeer(false) //
+				.startTls().and() //
+				.clientOptions(clientOptions) //
+				.clientResources(sharedClientResources) //
+				.timeout(Duration.ofMinutes(5)) //
+				.shutdownTimeout(Duration.ofHours(2)) //
+				.build();
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(),
+				configuration);
+
+		assertThat(connectionFactory.getClientConfiguration(), is(configuration));
+
+		assertThat(connectionFactory.isUseSsl(), is(true));
+		assertThat(connectionFactory.isVerifyPeer(), is(false));
+		assertThat(connectionFactory.isStartTls(), is(true));
+		assertThat(connectionFactory.getClientResources(), is(sharedClientResources));
+		assertThat(connectionFactory.getTimeout(), is(Duration.ofMinutes(5).toMillis()));
+		assertThat(connectionFactory.getShutdownTimeout(), is(Duration.ofHours(2).toMillis()));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldReturnStandaloneConfiguration() {
+
+		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(configuration,
+				LettuceClientConfiguration.create());
+
+		assertThat(connectionFactory.getStandaloneConfiguration(), is(configuration));
+		assertThat(connectionFactory.getSentinelConfiguration(), is(nullValue()));
+		assertThat(connectionFactory.getClusterConfiguration(), is(nullValue()));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldReturnSentinelConfiguration() {
+
+		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration();
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(configuration,
+				LettuceClientConfiguration.create());
+
+		assertThat(connectionFactory.getStandaloneConfiguration(), is(notNullValue()));
+		assertThat(connectionFactory.getSentinelConfiguration(), is(configuration));
+		assertThat(connectionFactory.getClusterConfiguration(), is(nullValue()));
+	}
+
+	@Test // DATAREDIS-574
+	public void shouldReturnClusterConfiguration() {
+
+		RedisClusterConfiguration configuration = new RedisClusterConfiguration();
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(configuration,
+				LettuceClientConfiguration.create());
+
+		assertThat(connectionFactory.getStandaloneConfiguration(), is(notNullValue()));
+		assertThat(connectionFactory.getSentinelConfiguration(), is(nullValue()));
+		assertThat(connectionFactory.getClusterConfiguration(), is(configuration));
+	}
+
+	@Test(expected = IllegalStateException.class) // DATAREDIS-574
+	public void shouldDenyChangesToImmutableClientConfiguration() throws NoSuchAlgorithmException {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(),
+				LettuceClientConfiguration.create());
+
+		connectionFactory.setUseSsl(false);
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -41,6 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 
@@ -288,7 +289,7 @@ public class LettuceConnectionFactoryUnitTests {
 	public void shouldReadStandalonePassword() {
 
 		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
 				LettuceClientConfiguration.create());
@@ -300,21 +301,21 @@ public class LettuceConnectionFactoryUnitTests {
 	public void shouldWriteStandalonePassword() {
 
 		RedisStandaloneConfiguration envConfig = new RedisStandaloneConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
 				LettuceClientConfiguration.create());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword(), is(equalTo("bar")));
-		assertThat(envConfig.getPassword(), is(equalTo("bar")));
+		assertThat(envConfig.getPassword(), is(equalTo(RedisPassword.of("bar"))));
 	}
 
 	@Test // DATAREDIS-574
 	public void shouldReadSentinelPassword() {
 
 		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
 				LettuceClientConfiguration.create());
@@ -326,21 +327,21 @@ public class LettuceConnectionFactoryUnitTests {
 	public void shouldWriteSentinelPassword() {
 
 		RedisSentinelConfiguration envConfig = new RedisSentinelConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
 				LettuceClientConfiguration.create());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword(), is(equalTo("bar")));
-		assertThat(envConfig.getPassword(), is(equalTo("bar")));
+		assertThat(envConfig.getPassword(), is(equalTo(RedisPassword.of("bar"))));
 	}
 
 	@Test // DATAREDIS-574
 	public void shouldReadClusterPassword() {
 
 		RedisClusterConfiguration envConfig = new RedisClusterConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
 				LettuceClientConfiguration.create());
@@ -352,14 +353,14 @@ public class LettuceConnectionFactoryUnitTests {
 	public void shouldWriteClusterPassword() {
 
 		RedisClusterConfiguration envConfig = new RedisClusterConfiguration();
-		envConfig.setPassword("foo");
+		envConfig.setPassword(RedisPassword.of("foo"));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(envConfig,
 				LettuceClientConfiguration.create());
 		connectionFactory.setPassword("bar");
 
 		assertThat(connectionFactory.getPassword(), is(equalTo("bar")));
-		assertThat(envConfig.getPassword(), is(equalTo("bar")));
+		assertThat(envConfig.getPassword(), is(equalTo(RedisPassword.of("bar"))));
 	}
 
 	@Test // DATAREDIS-574

--- a/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
@@ -41,6 +41,7 @@ import org.springframework.oxm.xstream.XStreamMarshaller;
  * @author Jennifer Hickey
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 abstract public class AbstractOperationsTestParams {
 
@@ -71,46 +72,46 @@ abstract public class AbstractOperationsTestParams {
 		stringTemplate.setConnectionFactory(jedisConnectionFactory);
 		stringTemplate.afterPropertiesSet();
 
-		RedisTemplate<String, Long> longTemplate = new RedisTemplate<String, Long>();
+		RedisTemplate<String, Long> longTemplate = new RedisTemplate<>();
 		longTemplate.setKeySerializer(new StringRedisSerializer());
-		longTemplate.setValueSerializer(new GenericToStringSerializer<Long>(Long.class));
+		longTemplate.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		longTemplate.setConnectionFactory(jedisConnectionFactory);
 		longTemplate.afterPropertiesSet();
 
-		RedisTemplate<String, Double> doubleTemplate = new RedisTemplate<String, Double>();
+		RedisTemplate<String, Double> doubleTemplate = new RedisTemplate<>();
 		doubleTemplate.setKeySerializer(new StringRedisSerializer());
-		doubleTemplate.setValueSerializer(new GenericToStringSerializer<Double>(Double.class));
+		doubleTemplate.setValueSerializer(new GenericToStringSerializer<>(Double.class));
 		doubleTemplate.setConnectionFactory(jedisConnectionFactory);
 		doubleTemplate.afterPropertiesSet();
 
-		RedisTemplate<byte[], byte[]> rawTemplate = new RedisTemplate<byte[], byte[]>();
+		RedisTemplate<byte[], byte[]> rawTemplate = new RedisTemplate<>();
 		rawTemplate.setEnableDefaultSerializer(false);
 		rawTemplate.setConnectionFactory(jedisConnectionFactory);
 		rawTemplate.afterPropertiesSet();
 
-		RedisTemplate<String, Person> personTemplate = new RedisTemplate<String, Person>();
+		RedisTemplate<String, Person> personTemplate = new RedisTemplate<>();
 		personTemplate.setConnectionFactory(jedisConnectionFactory);
 		personTemplate.afterPropertiesSet();
 
 		OxmSerializer serializer = new OxmSerializer(xstream, xstream);
-		RedisTemplate<String, String> xstreamStringTemplate = new RedisTemplate<String, String>();
+		RedisTemplate<String, String> xstreamStringTemplate = new RedisTemplate<>();
 		xstreamStringTemplate.setConnectionFactory(jedisConnectionFactory);
 		xstreamStringTemplate.setDefaultSerializer(serializer);
 		xstreamStringTemplate.afterPropertiesSet();
 
-		RedisTemplate<String, Person> xstreamPersonTemplate = new RedisTemplate<String, Person>();
+		RedisTemplate<String, Person> xstreamPersonTemplate = new RedisTemplate<>();
 		xstreamPersonTemplate.setConnectionFactory(jedisConnectionFactory);
 		xstreamPersonTemplate.setValueSerializer(serializer);
 		xstreamPersonTemplate.afterPropertiesSet();
 
 		Jackson2JsonRedisSerializer<Person> jackson2JsonSerializer = new Jackson2JsonRedisSerializer<Person>(Person.class);
-		RedisTemplate<String, Person> jackson2JsonPersonTemplate = new RedisTemplate<String, Person>();
+		RedisTemplate<String, Person> jackson2JsonPersonTemplate = new RedisTemplate<>();
 		jackson2JsonPersonTemplate.setConnectionFactory(jedisConnectionFactory);
 		jackson2JsonPersonTemplate.setValueSerializer(jackson2JsonSerializer);
 		jackson2JsonPersonTemplate.afterPropertiesSet();
 
 		GenericJackson2JsonRedisSerializer genericJackson2JsonSerializer = new GenericJackson2JsonRedisSerializer();
-		RedisTemplate<String, Person> genericJackson2JsonPersonTemplate = new RedisTemplate<String, Person>();
+		RedisTemplate<String, Person> genericJackson2JsonPersonTemplate = new RedisTemplate<>();
 		genericJackson2JsonPersonTemplate.setConnectionFactory(jedisConnectionFactory);
 		genericJackson2JsonPersonTemplate.setValueSerializer(genericJackson2JsonSerializer);
 		genericJackson2JsonPersonTemplate.afterPropertiesSet();

--- a/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
@@ -26,6 +26,7 @@ import org.springframework.data.redis.PersonObjectFactory;
 import org.springframework.data.redis.RawObjectFactory;
 import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.StringObjectFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
@@ -46,6 +47,9 @@ abstract public class AbstractOperationsTestParams {
 	// DATAREDIS-241
 	public static Collection<Object[]> testParams() {
 
+		RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration(SettingsUtils.getHost(),
+				SettingsUtils.getPort());
+
 		ObjectFactory<String> stringFactory = new StringObjectFactory();
 		ObjectFactory<Long> longFactory = new LongObjectFactory();
 		ObjectFactory<Double> doubleFactory = new DoubleObjectFactory();
@@ -60,9 +64,7 @@ abstract public class AbstractOperationsTestParams {
 			throw new RuntimeException("Cannot init XStream", ex);
 		}
 
-		JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory();
-		jedisConnectionFactory.setPort(SettingsUtils.getPort());
-		jedisConnectionFactory.setHostName(SettingsUtils.getHost());
+		JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory(standaloneConfiguration);
 		jedisConnectionFactory.afterPropertiesSet();
 
 		RedisTemplate<String, String> stringTemplate = new StringRedisTemplate();


### PR DESCRIPTION
Add `JedisClientConfiguration` and `LettuceClientConfiguration` to abstract client-specific features with their configuration options. Client configurations are built with a builder that create immutable instances. Client configurations replace property storage within a `RedisConnectionFactory`. A `RedisConnectionFactory` created without a client configuration uses a mutable client configuration.

Lettuce:
```
LettuceClientConfiguration configuration = LettuceClientConfiguration.builder()
		.useSsl()
		.verifyPeer()
		.startTls().and()
		.clientOptions(clientOptions)
		.clientResources(sharedClientResources)
		.timeout(Duration.ofSeconds(10))
		.shutdownTimeout(Duration.ZERO)
		.build();

LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(
		new RedisStandaloneConfiguration(),
		configuration);
```

Jedis:
```
JedisClientConfiguration configuration = JedisClientConfiguration.builder()
		.useSsl()
		.hostnameVerifier(new MyHostnameVerifier())
		.sslParameters(sslParameters)
		.sslSocketFactory(socketFactory).and()
		.clientName("my-client")
		.connectTimeout(Duration.ofSeconds(10))
		.readTimeout(Duration.ofSeconds(5))
		.usePooling().poolConfig(poolConfig)
		.build();

JedisConnectionFactory connectionFactory = new JedisConnectionFactory(
		new RedisStandaloneConfiguration(),
		configuration);
```

Add `RedisStandaloneConfiguration` to be consistent with `RedisSentinelConfiguration` and `RedisClusterConfiguration` and extend environmental configuration with password and database (Standalone and Sentinel).

Remove system properties defined for surefire because they are not used and `javax.net.ssl.keyStore` causes exceptions when obtaining the default SSL context.

---

Related ticket: [DATAREDIS-574](https://jira.spring.io/browse/DATAREDIS-574).