### PR TITLE
DATAREDIS-618 - RedisServer getNumberOtherSentinels reading wrong pro…

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/RedisServer.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,8 @@ import org.springframework.util.StringUtils;
 /**
  * @author Christoph Strobl
  * @author Thomas Darimont
- * 
+ * @author Franjo Zilic
+ *
  * @since 1.4
  */
 public class RedisServer extends RedisNode {
@@ -44,7 +45,7 @@ public class RedisServer extends RedisNode {
 		ROLE_REPORTED_TIME("role-reported-time"), //
 		CONFIG_EPOCH("config-epoch"), //
 		NUMBER_SLAVES("num-slaves"), //
-		NUMBER_OTHER_SENTINELS("multi"), //
+		NUMBER_OTHER_SENTINELS("num-other-sentinels"), //
 		BUFFER_LENGTH("qbuf"), //
 		BUFFER_FREE_SPACE("qbuf-free"), //
 		OUTPUT_BUFFER_LENGTH("obl"), //

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
@@ -36,6 +36,7 @@ import org.springframework.data.redis.core.types.RedisClientInfo;
 
 /**
  * @author Christoph Strobl
+ * @author Franjo Zilic
  */
 public class JedisConvertersUnitTests {
 
@@ -93,6 +94,16 @@ public class JedisConvertersUnitTests {
 	@Test // DATAREDIS-330
 	public void convertsRedisServersCorrectlyWhenGivenNull() {
 		assertThat(JedisConverters.toListOfRedisServer(null), notNullValue());
+	}
+
+	@Test // DATAREDIS-618
+	public void covertsRedisServersCorrectlyForNumberOfOtherSentinels() {
+		Map<String, String> values = getRedisServerInfoMap("mymaster", 23697);
+		List<RedisServer> servers = JedisConverters.toListOfRedisServer(Collections.singletonList(values));
+
+		assertThat(servers.size(), is(1));
+		verifyRedisServerInfo(servers.get(0), values);
+		assertThat(servers.get(0).getNumberOtherSentinels(), is(2L));
 	}
 
 	/**


### PR DESCRIPTION
…perty

Changed property key for NUMBER_OTHER_SENTINELS to read "num-other-sentinels" instead of "multi" which is currently used.
