### PR TITLE
DATAREDIS-613 - Stream results instead of returning collections where possible.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ jdk:
 
 env:
   matrix:
-    - PROFILE=spring42
-    - PROFILE=spring42-next
-    - PROFILE=spring43-next
     - PROFILE=spring5-next
 
 addons:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-613-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
@@ -25,14 +25,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResult;
-import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
@@ -859,9 +857,8 @@ public interface ReactiveGeoCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
-	default Mono<List<GeoLocation<ByteBuffer>>> geoRadius(ByteBuffer key, Circle circle) {
-		return geoRadius(key, circle, null)
-				.map(res -> res.getContent().stream().map(GeoResult::getContent).collect(Collectors.toList()));
+	default Flux<GeoResult<GeoLocation<ByteBuffer>>> geoRadius(ByteBuffer key, Circle circle) {
+		return geoRadius(key, circle, null);
 	}
 
 	/**
@@ -873,14 +870,14 @@ public interface ReactiveGeoCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
-	default Mono<GeoResults<GeoLocation<ByteBuffer>>> geoRadius(ByteBuffer key, Circle circle,
+	default Flux<GeoResult<GeoLocation<ByteBuffer>>> geoRadius(ByteBuffer key, Circle circle,
 			GeoRadiusCommandArgs geoRadiusArgs) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(circle, "Circle must not be null!");
 
 		return geoRadius(Mono.just(GeoRadiusCommand.within(circle).withArgs(geoRadiusArgs).forKey(key))).next()
-				.map(CommandResponse::getOutput);
+				.flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -890,7 +887,7 @@ public interface ReactiveGeoCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
-	Flux<CommandResponse<GeoRadiusCommand, GeoResults<GeoLocation<ByteBuffer>>>> geoRadius(
+	Flux<CommandResponse<GeoRadiusCommand, Flux<GeoResult<GeoLocation<ByteBuffer>>>>> geoRadius(
 			Publisher<GeoRadiusCommand> commands);
 
 	/**
@@ -1184,9 +1181,9 @@ public interface ReactiveGeoCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
-	default Mono<List<GeoLocation<ByteBuffer>>> geoRadiusByMember(ByteBuffer key, ByteBuffer member, Distance distance) {
-		return geoRadiusByMember(key, member, distance, null)
-				.map(res -> res.getContent().stream().map(GeoResult::getContent).collect(Collectors.toList()));
+	default Flux<GeoResult<GeoLocation<ByteBuffer>>> geoRadiusByMember(ByteBuffer key, ByteBuffer member,
+			Distance distance) {
+		return geoRadiusByMember(key, member, distance, null);
 	}
 
 	/**
@@ -1198,7 +1195,7 @@ public interface ReactiveGeoCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
-	default Mono<GeoResults<GeoLocation<ByteBuffer>>> geoRadiusByMember(ByteBuffer key, ByteBuffer member,
+	default Flux<GeoResult<GeoLocation<ByteBuffer>>> geoRadiusByMember(ByteBuffer key, ByteBuffer member,
 			Distance distance, GeoRadiusCommandArgs geoRadiusArgs) {
 
 		Assert.notNull(key, "Key must not be null!");
@@ -1207,7 +1204,7 @@ public interface ReactiveGeoCommands {
 
 		return geoRadiusByMember(
 				Mono.just(GeoRadiusByMemberCommand.within(distance).from(member).forKey(key).withArgs(geoRadiusArgs))).next()
-						.map(CommandResponse::getOutput);
+						.flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -1217,6 +1214,6 @@ public interface ReactiveGeoCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
-	Flux<CommandResponse<GeoRadiusByMemberCommand, GeoResults<GeoLocation<ByteBuffer>>>> geoRadiusByMember(
+	Flux<CommandResponse<GeoRadiusByMemberCommand, Flux<GeoResult<GeoLocation<ByteBuffer>>>>> geoRadiusByMember(
 			Publisher<GeoRadiusByMemberCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
@@ -876,8 +876,8 @@ public interface ReactiveGeoCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(circle, "Circle must not be null!");
 
-		return geoRadius(Mono.just(GeoRadiusCommand.within(circle).withArgs(geoRadiusArgs).forKey(key))).next()
-				.flatMapMany(CommandResponse::getOutput);
+		return geoRadius(Mono.just(GeoRadiusCommand.within(circle).withArgs(geoRadiusArgs).forKey(key)))
+				.flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -1203,8 +1203,8 @@ public interface ReactiveGeoCommands {
 		Assert.notNull(distance, "Distance must not be null!");
 
 		return geoRadiusByMember(
-				Mono.just(GeoRadiusByMemberCommand.within(distance).from(member).forKey(key).withArgs(geoRadiusArgs))).next()
-						.flatMapMany(CommandResponse::getOutput);
+				Mono.just(GeoRadiusByMemberCommand.within(distance).from(member).forKey(key).withArgs(geoRadiusArgs)))
+						.flatMap(CommandResponse::getOutput);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -516,11 +516,11 @@ public interface ReactiveHashCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>
 	 */
-	default Mono<List<ByteBuffer>> hKeys(ByteBuffer key) {
+	default Flux<ByteBuffer> hKeys(ByteBuffer key) {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return hKeys(Mono.just(new KeyCommand(key))).next().map(MultiValueResponse::getOutput);
+		return hKeys(Mono.just(new KeyCommand(key))).next().flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -530,7 +530,7 @@ public interface ReactiveHashCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>
 	 */
-	Flux<MultiValueResponse<KeyCommand, ByteBuffer>> hKeys(Publisher<KeyCommand> commands);
+	Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> hKeys(Publisher<KeyCommand> commands);
 
 	/**
 	 * Get entry set (values) of hash at {@literal key}.
@@ -539,11 +539,11 @@ public interface ReactiveHashCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/hvals">Redis Documentation: HVALS</a>
 	 */
-	default Mono<List<ByteBuffer>> hVals(ByteBuffer key) {
+	default Flux<ByteBuffer> hVals(ByteBuffer key) {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return hVals(Mono.just(new KeyCommand(key))).next().map(MultiValueResponse::getOutput);
+		return hVals(Mono.just(new KeyCommand(key))).next().flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -553,7 +553,7 @@ public interface ReactiveHashCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/hvals">Redis Documentation: HVALS</a>
 	 */
-	Flux<MultiValueResponse<KeyCommand, ByteBuffer>> hVals(Publisher<KeyCommand> commands);
+	Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> hVals(Publisher<KeyCommand> commands);
 
 	/**
 	 * Get entire hash stored at {@literal key}.
@@ -562,11 +562,11 @@ public interface ReactiveHashCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
 	 */
-	default Mono<Map<ByteBuffer, ByteBuffer>> hGetAll(ByteBuffer key) {
+	default Flux<Map.Entry<ByteBuffer, ByteBuffer>> hGetAll(ByteBuffer key) {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return hGetAll(Mono.just(new KeyCommand(key))).next().map(CommandResponse::getOutput);
+		return hGetAll(Mono.just(new KeyCommand(key))).next().flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -576,5 +576,5 @@ public interface ReactiveHashCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
 	 */
-	Flux<CommandResponse<KeyCommand, Map<ByteBuffer, ByteBuffer>>> hGetAll(Publisher<KeyCommand> commands);
+	Flux<CommandResponse<KeyCommand, Flux<Map.Entry<ByteBuffer, ByteBuffer>>>> hGetAll(Publisher<KeyCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -520,7 +520,7 @@ public interface ReactiveHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return hKeys(Mono.just(new KeyCommand(key))).next().flatMapMany(CommandResponse::getOutput);
+		return hKeys(Mono.just(new KeyCommand(key))).flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -543,7 +543,7 @@ public interface ReactiveHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return hVals(Mono.just(new KeyCommand(key))).next().flatMapMany(CommandResponse::getOutput);
+		return hVals(Mono.just(new KeyCommand(key))).flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -566,7 +566,7 @@ public interface ReactiveHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return hGetAll(Mono.just(new KeyCommand(key))).next().flatMapMany(CommandResponse::getOutput);
+		return hGetAll(Mono.just(new KeyCommand(key))).flatMap(CommandResponse::getOutput);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveListCommands.java
@@ -272,8 +272,7 @@ public interface ReactiveListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return lRange(Mono.just(RangeCommand.key(key).fromIndex(start).toIndex(end))).next()
-				.flatMapMany(CommandResponse::getOutput);
+		return lRange(Mono.just(RangeCommand.key(key).fromIndex(start).toIndex(end))).flatMap(CommandResponse::getOutput);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveListCommands.java
@@ -30,7 +30,6 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBuf
 import org.springframework.data.redis.connection.ReactiveRedisConnection.Command;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
-import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.RangeCommand;
 import org.springframework.data.redis.connection.RedisListCommands.Position;
@@ -269,12 +268,12 @@ public interface ReactiveListCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
-	default Mono<List<ByteBuffer>> lRange(ByteBuffer key, long start, long end) {
+	default Flux<ByteBuffer> lRange(ByteBuffer key, long start, long end) {
 
 		Assert.notNull(key, "Key must not be null!");
 
 		return lRange(Mono.just(RangeCommand.key(key).fromIndex(start).toIndex(end))).next()
-				.map(MultiValueResponse::getOutput);
+				.flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -284,7 +283,7 @@ public interface ReactiveListCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
-	Flux<MultiValueResponse<RangeCommand, ByteBuffer>> lRange(Publisher<RangeCommand> commands);
+	Flux<CommandResponse<RangeCommand, Flux<ByteBuffer>>> lRange(Publisher<RangeCommand> commands);
 
 	/**
 	 * Trim list at {@literal key} to elements between {@literal begin} and {@literal end}.

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
@@ -29,8 +29,8 @@ import org.reactivestreams.Publisher;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.Command;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
-import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.util.Assert;
 
@@ -524,11 +524,11 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
-	default Mono<List<ByteBuffer>> sInter(Collection<ByteBuffer> keys) {
+	default Flux<ByteBuffer> sInter(Collection<ByteBuffer> keys) {
 
 		Assert.notNull(keys, "Keys must not be null!");
 
-		return sInter(Mono.just(SInterCommand.keys(keys))).next().map(MultiValueResponse::getOutput);
+		return sInter(Mono.just(SInterCommand.keys(keys))).next().flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -538,7 +538,7 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
-	Flux<MultiValueResponse<SInterCommand, ByteBuffer>> sInter(Publisher<SInterCommand> commands);
+	Flux<CommandResponse<SInterCommand, Flux<ByteBuffer>>> sInter(Publisher<SInterCommand> commands);
 
 	/**
 	 * {@code SINTERSTORE} command parameters.
@@ -668,11 +668,11 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
-	default Mono<List<ByteBuffer>> sUnion(Collection<ByteBuffer> keys) {
+	default Flux<ByteBuffer> sUnion(Collection<ByteBuffer> keys) {
 
 		Assert.notNull(keys, "Keys must not be null!");
 
-		return sUnion(Mono.just(SUnionCommand.keys(keys))).next().map(MultiValueResponse::getOutput);
+		return sUnion(Mono.just(SUnionCommand.keys(keys))).next().flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -682,7 +682,7 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
-	Flux<MultiValueResponse<SUnionCommand, ByteBuffer>> sUnion(Publisher<SUnionCommand> commands);
+	Flux<CommandResponse<SUnionCommand, Flux<ByteBuffer>>> sUnion(Publisher<SUnionCommand> commands);
 
 	/**
 	 * {@code SUNIONSTORE} command parameters.
@@ -812,11 +812,11 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
-	default Mono<List<ByteBuffer>> sDiff(Collection<ByteBuffer> keys) {
+	default Flux<ByteBuffer> sDiff(Collection<ByteBuffer> keys) {
 
 		Assert.notNull(keys, "Keys must not be null!");
 
-		return sDiff(Mono.just(SDiffCommand.keys(keys))).next().map(MultiValueResponse::getOutput);
+		return sDiff(Mono.just(SDiffCommand.keys(keys))).next().flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -826,7 +826,7 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
-	Flux<MultiValueResponse<SDiffCommand, ByteBuffer>> sDiff(Publisher<SDiffCommand> commands);
+	Flux<CommandResponse<SDiffCommand, Flux<ByteBuffer>>> sDiff(Publisher<SDiffCommand> commands);
 
 	/**
 	 * {@code SDIFFSTORE} command parameters.
@@ -913,11 +913,11 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
-	default Mono<List<ByteBuffer>> sMembers(ByteBuffer key) {
+	default Flux<ByteBuffer> sMembers(ByteBuffer key) {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return sMembers(Mono.just(new KeyCommand(key))).next().map(MultiValueResponse::getOutput);
+		return sMembers(Mono.just(new KeyCommand(key))).next().flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -927,7 +927,7 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
-	Flux<MultiValueResponse<KeyCommand, ByteBuffer>> sMembers(Publisher<KeyCommand> commands);
+	Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> sMembers(Publisher<KeyCommand> commands);
 
 	/**
 	 * {@code SRANDMEMBER} command parameters.
@@ -993,7 +993,7 @@ public interface ReactiveSetCommands {
 	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	default Mono<ByteBuffer> sRandMember(ByteBuffer key) {
-		return sRandMember(key, 1L).map(vals -> vals.isEmpty() ? null : vals.iterator().next());
+		return sRandMember(key, 1L).singleOrEmpty();
 	}
 
 	/**
@@ -1004,13 +1004,13 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
-	default Mono<List<ByteBuffer>> sRandMember(ByteBuffer key, Long count) {
+	default Flux<ByteBuffer> sRandMember(ByteBuffer key, Long count) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(count, "Count must not be null!");
 
 		return sRandMember(Mono.just(SRandMembersCommand.valueCount(count).from(key))).next()
-				.map(MultiValueResponse::getOutput);
+				.flatMapMany(CommandResponse::getOutput);
 	}
 
 	/**
@@ -1020,5 +1020,5 @@ public interface ReactiveSetCommands {
 	 * @return
 	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
-	Flux<MultiValueResponse<SRandMembersCommand, ByteBuffer>> sRandMember(Publisher<SRandMembersCommand> commands);
+	Flux<CommandResponse<SRandMembersCommand, Flux<ByteBuffer>>> sRandMember(Publisher<SRandMembersCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
@@ -528,7 +528,7 @@ public interface ReactiveSetCommands {
 
 		Assert.notNull(keys, "Keys must not be null!");
 
-		return sInter(Mono.just(SInterCommand.keys(keys))).next().flatMapMany(CommandResponse::getOutput);
+		return sInter(Mono.just(SInterCommand.keys(keys))).flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -672,7 +672,7 @@ public interface ReactiveSetCommands {
 
 		Assert.notNull(keys, "Keys must not be null!");
 
-		return sUnion(Mono.just(SUnionCommand.keys(keys))).next().flatMapMany(CommandResponse::getOutput);
+		return sUnion(Mono.just(SUnionCommand.keys(keys))).flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -816,7 +816,7 @@ public interface ReactiveSetCommands {
 
 		Assert.notNull(keys, "Keys must not be null!");
 
-		return sDiff(Mono.just(SDiffCommand.keys(keys))).next().flatMapMany(CommandResponse::getOutput);
+		return sDiff(Mono.just(SDiffCommand.keys(keys))).flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -917,7 +917,7 @@ public interface ReactiveSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return sMembers(Mono.just(new KeyCommand(key))).next().flatMapMany(CommandResponse::getOutput);
+		return sMembers(Mono.just(new KeyCommand(key))).flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -1009,8 +1009,7 @@ public interface ReactiveSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(count, "Count must not be null!");
 
-		return sRandMember(Mono.just(SRandMembersCommand.valueCount(count).from(key))).next()
-				.flatMapMany(CommandResponse::getOutput);
+		return sRandMember(Mono.just(SRandMembersCommand.valueCount(count).from(key))).flatMap(CommandResponse::getOutput);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
@@ -657,8 +657,7 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(range, "Range must not be null!");
 
 		return zRange(Mono.just(ZRangeCommand.valuesWithin(range).from(key))) //
-				.next() //
-				.flatMapMany(CommandResponse::getOutput).map(tuple -> ByteBuffer.wrap(tuple.getValue()));
+				.flatMap(CommandResponse::getOutput).map(tuple -> ByteBuffer.wrap(tuple.getValue()));
 	}
 
 	/**
@@ -673,8 +672,8 @@ public interface ReactiveZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return zRange(Mono.just(ZRangeCommand.valuesWithin(range).withScores().from(key))).next()
-				.flatMapMany(CommandResponse::getOutput);
+		return zRange(Mono.just(ZRangeCommand.valuesWithin(range).withScores().from(key)))
+				.flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -689,8 +688,8 @@ public interface ReactiveZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return zRange(Mono.just(ZRangeCommand.reverseValuesWithin(range).from(key))).next()
-				.flatMapMany(CommandResponse::getOutput).map(tuple -> ByteBuffer.wrap(tuple.getValue()));
+		return zRange(Mono.just(ZRangeCommand.reverseValuesWithin(range).from(key))).flatMap(CommandResponse::getOutput)
+				.map(tuple -> ByteBuffer.wrap(tuple.getValue()));
 	}
 
 	/**
@@ -705,8 +704,8 @@ public interface ReactiveZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return zRange(Mono.just(ZRangeCommand.reverseValuesWithin(range).withScores().from(key))).next()
-				.flatMapMany(CommandResponse::getOutput);
+		return zRange(Mono.just(ZRangeCommand.reverseValuesWithin(range).withScores().from(key)))
+				.flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -848,8 +847,7 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(range, "Range must not be null!");
 
 		return zRangeByScore(Mono.just(ZRangeByScoreCommand.scoresWithin(range).from(key))) //
-				.next() //
-				.flatMapMany(CommandResponse::getOutput) //
+				.flatMap(CommandResponse::getOutput) //
 				.map(tuple -> ByteBuffer.wrap(tuple.getValue()));
 	}
 
@@ -868,8 +866,7 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(range, "Range must not be null!");
 
 		return zRangeByScore(Mono.just(ZRangeByScoreCommand.scoresWithin(range).from(key).limitTo(limit))) //
-				.next() //
-				.flatMapMany(CommandResponse::getOutput) //
+				.flatMap(CommandResponse::getOutput) //
 				.map(tuple -> ByteBuffer.wrap(tuple.getValue()));
 	}
 
@@ -886,8 +883,8 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return zRangeByScore(Mono.just(ZRangeByScoreCommand.scoresWithin(range).withScores().from(key))).next()
-				.flatMapMany(CommandResponse::getOutput);
+		return zRangeByScore(Mono.just(ZRangeByScoreCommand.scoresWithin(range).withScores().from(key)))
+				.flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -905,7 +902,7 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(range, "Range must not be null!");
 
 		return zRangeByScore(Mono.just(ZRangeByScoreCommand.scoresWithin(range).withScores().from(key).limitTo(limit)))
-				.next().flatMapMany(CommandResponse::getOutput);
+				.flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -921,8 +918,7 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 
 		return zRangeByScore(Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).from(key))) //
-				.next() //
-				.flatMapMany(CommandResponse::getOutput) //
+				.flatMap(CommandResponse::getOutput) //
 				.map(tuple -> ByteBuffer.wrap(tuple.getValue()));
 	}
 
@@ -941,8 +937,7 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(range, "Range must not be null!");
 
 		return zRangeByScore(Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).from(key).limitTo(limit))) //
-				.next() //
-				.flatMapMany(CommandResponse::getOutput) //
+				.flatMap(CommandResponse::getOutput) //
 				.map(tuple -> ByteBuffer.wrap(tuple.getValue()));
 	}
 
@@ -959,8 +954,8 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return zRangeByScore(Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).withScores().from(key))).next()
-				.flatMapMany(CommandResponse::getOutput);
+		return zRangeByScore(Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).withScores().from(key)))
+				.flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -978,8 +973,8 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(range, "Range must not be null!");
 
 		return zRangeByScore(
-				Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).withScores().from(key).limitTo(limit))).next()
-						.flatMapMany(CommandResponse::getOutput);
+				Mono.just(ZRangeByScoreCommand.reverseScoresWithin(range).withScores().from(key).limitTo(limit)))
+						.flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -1736,8 +1731,8 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return zRangeByLex(Mono.just(ZRangeByLexCommand.stringsWithin(range).from(key).limitTo(limit))).next()
-				.flatMapMany(CommandResponse::getOutput);
+		return zRangeByLex(Mono.just(ZRangeByLexCommand.stringsWithin(range).from(key).limitTo(limit)))
+				.flatMap(CommandResponse::getOutput);
 	}
 
 	/**
@@ -1767,8 +1762,8 @@ public interface ReactiveZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return zRangeByLex(Mono.just(ZRangeByLexCommand.reverseStringsWithin(range).from(key).limitTo(limit))).next()
-				.flatMapMany(CommandResponse::getOutput);
+		return zRangeByLex(Mono.just(ZRangeByLexCommand.reverseStringsWithin(range).from(key).limitTo(limit)))
+				.flatMap(CommandResponse::getOutput);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveZSetOperations.java
@@ -22,9 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
@@ -151,150 +149,149 @@ public class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperatio
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#range(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<V>> range(K key, Range<Long> range) {
+	public Flux<V> range(K key, Range<Long> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRange(rawKey(key), range).map(this::readValueSet));
+		return createFlux(connection -> connection.zRange(rawKey(key), range).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#rangeWithScores(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<TypedTuple<V>>> rangeWithScores(K key, Range<Long> range) {
+	public Flux<TypedTuple<V>> rangeWithScores(K key, Range<Long> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRangeWithScores(rawKey(key), range).map(this::readTypedTupleSet));
+		return createFlux(connection -> connection.zRangeWithScores(rawKey(key), range).map(this::readTypedTuple));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#rangeByScore(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<V>> rangeByScore(K key, Range<Double> range) {
+	public Flux<V> rangeByScore(K key, Range<Double> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRangeByScore(rawKey(key), range).map(this::readValueSet));
+		return createFlux(connection -> connection.zRangeByScore(rawKey(key), range).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#rangeByScoreWithScores(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<TypedTuple<V>>> rangeByScoreWithScores(K key, Range<Double> range) {
+	public Flux<TypedTuple<V>> rangeByScoreWithScores(K key, Range<Double> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(
-				connection -> connection.zRangeByScoreWithScores(rawKey(key), range).map(this::readTypedTupleSet));
+		return createFlux(connection -> connection.zRangeByScoreWithScores(rawKey(key), range).map(this::readTypedTuple));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#rangeByScore(java.lang.Object, org.springframework.data.domain.Range, org.springframework.data.redis.connection.RedisZSetCommands.Limit)
 	 */
 	@Override
-	public Mono<Set<V>> rangeByScore(K key, Range<Double> range, Limit limit) {
+	public Flux<V> rangeByScore(K key, Range<Double> range, Limit limit) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRangeByScore(rawKey(key), range, limit).map(this::readValueSet));
+		return createFlux(connection -> connection.zRangeByScore(rawKey(key), range, limit).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#rangeByScoreWithScores(java.lang.Object, org.springframework.data.domain.Range, org.springframework.data.redis.connection.RedisZSetCommands.Limit)
 	 */
 	@Override
-	public Mono<Set<TypedTuple<V>>> rangeByScoreWithScores(K key, Range<Double> range, Limit limit) {
+	public Flux<TypedTuple<V>> rangeByScoreWithScores(K key, Range<Double> range, Limit limit) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 		Assert.notNull(limit, "Limit must not be null!");
 
-		return createMono(
-				connection -> connection.zRangeByScoreWithScores(rawKey(key), range, limit).map(this::readTypedTupleSet));
+		return createFlux(
+				connection -> connection.zRangeByScoreWithScores(rawKey(key), range, limit).map(this::readTypedTuple));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#reverseRange(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<V>> reverseRange(K key, Range<Long> range) {
+	public Flux<V> reverseRange(K key, Range<Long> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRevRange(rawKey(key), range).map(this::readValueSet));
+		return createFlux(connection -> connection.zRevRange(rawKey(key), range).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#reverseRangeWithScores(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<TypedTuple<V>>> reverseRangeWithScores(K key, Range<Long> range) {
+	public Flux<TypedTuple<V>> reverseRangeWithScores(K key, Range<Long> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRevRangeWithScores(rawKey(key), range).map(this::readTypedTupleSet));
+		return createFlux(connection -> connection.zRevRangeWithScores(rawKey(key), range).map(this::readTypedTuple));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#reverseRangeByScore(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<V>> reverseRangeByScore(K key, Range<Double> range) {
+	public Flux<V> reverseRangeByScore(K key, Range<Double> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRevRangeByScore(rawKey(key), range).map(this::readValueSet));
+		return createFlux(connection -> connection.zRevRangeByScore(rawKey(key), range).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#reverseRangeByScoreWithScores(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<TypedTuple<V>>> reverseRangeByScoreWithScores(K key, Range<Double> range) {
+	public Flux<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(
-				connection -> connection.zRevRangeByScoreWithScores(rawKey(key), range).map(this::readTypedTupleSet));
+		return createFlux(
+				connection -> connection.zRevRangeByScoreWithScores(rawKey(key), range).map(this::readTypedTuple));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#reverseRangeByScore(java.lang.Object, org.springframework.data.domain.Range, org.springframework.data.redis.connection.RedisZSetCommands.Limit)
 	 */
 	@Override
-	public Mono<Set<V>> reverseRangeByScore(K key, Range<Double> range, Limit limit) {
+	public Flux<V> reverseRangeByScore(K key, Range<Double> range, Limit limit) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRevRangeByScore(rawKey(key), range, limit).map(this::readValueSet));
+		return createFlux(connection -> connection.zRevRangeByScore(rawKey(key), range, limit).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#reverseRangeByScoreWithScores(java.lang.Object, org.springframework.data.domain.Range, org.springframework.data.redis.connection.RedisZSetCommands.Limit)
 	 */
 	@Override
-	public Mono<Set<TypedTuple<V>>> reverseRangeByScoreWithScores(K key, Range<Double> range, Limit limit) {
+	public Flux<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range, Limit limit) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 		Assert.notNull(limit, "Limit must not be null!");
 
-		return createMono(
-				connection -> connection.zRevRangeByScoreWithScores(rawKey(key), range, limit).map(this::readTypedTupleSet));
+		return createFlux(
+				connection -> connection.zRevRangeByScoreWithScores(rawKey(key), range, limit).map(this::readTypedTuple));
 	}
 
 	/* (non-Javadoc)
@@ -418,50 +415,50 @@ public class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperatio
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#rangeByLex(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<V>> rangeByLex(K key, Range<String> range) {
+	public Flux<V> rangeByLex(K key, Range<String> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRangeByLex(rawKey(key), range).map(this::readValueSet));
+		return createFlux(connection -> connection.zRangeByLex(rawKey(key), range).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#rangeByLex(java.lang.Object, org.springframework.data.domain.Range, org.springframework.data.redis.connection.RedisZSetCommands.Limit)
 	 */
 	@Override
-	public Mono<Set<V>> rangeByLex(K key, Range<String> range, Limit limit) {
+	public Flux<V> rangeByLex(K key, Range<String> range, Limit limit) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 		Assert.notNull(limit, "Limit must not be null!");
 
-		return createMono(connection -> connection.zRangeByLex(rawKey(key), range, limit).map(this::readValueSet));
+		return createFlux(connection -> connection.zRangeByLex(rawKey(key), range, limit).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#reverseRangeByLex(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override
-	public Mono<Set<V>> reverseRangeByLex(K key, Range<String> range) {
+	public Flux<V> reverseRangeByLex(K key, Range<String> range) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 
-		return createMono(connection -> connection.zRevRangeByLex(rawKey(key), range).map(this::readValueSet));
+		return createFlux(connection -> connection.zRevRangeByLex(rawKey(key), range).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#reverseRangeByLex(java.lang.Object, org.springframework.data.domain.Range, org.springframework.data.redis.connection.RedisZSetCommands.Limit)
 	 */
 	@Override
-	public Mono<Set<V>> reverseRangeByLex(K key, Range<String> range, Limit limit) {
+	public Flux<V> reverseRangeByLex(K key, Range<String> range, Limit limit) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null!");
 		Assert.notNull(limit, "Limit must not be null!");
 
-		return createMono(connection -> connection.zRevRangeByLex(rawKey(key), range, limit).map(this::readValueSet));
+		return createFlux(connection -> connection.zRevRangeByLex(rawKey(key), range, limit).map(this::readValue));
 	}
 
 	/* (non-Javadoc)
@@ -480,6 +477,13 @@ public class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperatio
 		Assert.notNull(function, "Function must not be null!");
 
 		return template.createMono(connection -> function.apply(connection.zSetCommands()));
+	}
+
+	private <T> Flux<T> createFlux(Function<ReactiveZSetCommands, Publisher<T>> function) {
+
+		Assert.notNull(function, "Function must not be null!");
+
+		return template.createFlux(connection -> function.apply(connection.zSetCommands()));
 	}
 
 	private ByteBuffer rawKey(K key) {
@@ -504,25 +508,7 @@ public class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperatio
 		return serializationContext.getValueSerializationPair().read(buffer);
 	}
 
-	private Set<V> readValueSet(Collection<ByteBuffer> raw) {
-
-		Set<V> result = new LinkedHashSet<>(raw.size());
-
-		for (ByteBuffer buffer : raw) {
-			result.add(readValue(buffer));
-		}
-
-		return result;
-	}
-
-	private Set<TypedTuple<V>> readTypedTupleSet(Collection<Tuple> raw) {
-
-		Set<TypedTuple<V>> result = new LinkedHashSet<>(raw.size());
-
-		for (Tuple tuple : raw) {
-			result.add(new DefaultTypedTuple<>(readValue(ByteBuffer.wrap(tuple.getValue())), tuple.getScore()));
-		}
-
-		return result;
+	private TypedTuple<V> readTypedTuple(Tuple raw) {
+		return new DefaultTypedTuple<>(readValue(ByteBuffer.wrap(raw.getValue())), raw.getScore());
 	}
 }

--- a/src/main/java/org/springframework/data/redis/core/ReactiveGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveGeoOperations.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.reactivestreams.Publisher;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
-import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.GeoResult;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
@@ -35,6 +35,7 @@ import org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusComma
  * Reactive Redis operations for geo commands.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @see <a href="http://redis.io/commands#geo">Redis Documentation: Geo Commands</a>
  * @since 2.0
  */
@@ -162,7 +163,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
-	Mono<List<GeoLocation<M>>> geoRadius(K key, Circle within);
+	Flux<GeoResult<GeoLocation<M>>> geoRadius(K key, Circle within);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying {@link GeoRadiusCommandArgs}.
@@ -173,7 +174,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
-	Mono<GeoResults<GeoLocation<M>>> geoRadius(K key, Circle within, GeoRadiusCommandArgs args);
+	Flux<GeoResult<GeoLocation<M>>> geoRadius(K key, Circle within, GeoRadiusCommandArgs args);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -185,7 +186,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
-	Mono<List<GeoLocation<M>>> geoRadiusByMember(K key, M member, double radius);
+	Flux<GeoResult<GeoLocation<M>>> geoRadiusByMember(K key, M member, double radius);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -197,7 +198,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
-	Mono<List<GeoLocation<M>>> geoRadiusByMember(K key, M member, Distance distance);
+	Flux<GeoResult<GeoLocation<M>>> geoRadiusByMember(K key, M member, Distance distance);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -210,7 +211,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
-	Mono<GeoResults<GeoLocation<M>>> geoRadiusByMember(K key, M member, Distance distance, GeoRadiusCommandArgs args);
+	Flux<GeoResult<GeoLocation<M>>> geoRadiusByMember(K key, M member, Distance distance, GeoRadiusCommandArgs args);
 
 	/**
 	 * Remove the {@literal member}s.

--- a/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.core;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Collection;
@@ -25,6 +26,7 @@ import java.util.Map;
  * Redis map specific operations working on a hash.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  */
 public interface ReactiveHashOperations<H, HK, HV> {
@@ -91,7 +93,7 @@ public interface ReactiveHashOperations<H, HK, HV> {
 	 * @param key must not be {@literal null}.
 	 * @return
 	 */
-	Mono<List<HK>> keys(H key);
+	Flux<HK> keys(H key);
 
 	/**
 	 * Get size of hash at {@code key}.
@@ -134,7 +136,7 @@ public interface ReactiveHashOperations<H, HK, HV> {
 	 * @param key must not be {@literal null}.
 	 * @return
 	 */
-	Mono<List<HV>> values(H key);
+	Flux<HV> values(H key);
 
 	/**
 	 * Get entire hash stored at {@code key}.
@@ -142,7 +144,7 @@ public interface ReactiveHashOperations<H, HK, HV> {
 	 * @param key must not be {@literal null}.
 	 * @return
 	 */
-	Mono<Map<HK, HV>> entries(H key);
+	Flux<Map.Entry<HK, HV>> entries(H key);
 
 	/**
 	 * Removes the given {@literal key}.

--- a/src/main/java/org/springframework/data/redis/core/ReactiveListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveListOperations.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.core;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
@@ -25,6 +26,8 @@ import java.util.List;
  * Redis list specific operations.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
+ * @see <a href="http://redis.io/commands#list">Redis Documentation: List Commands</a>
  * @since 2.0
  */
 public interface ReactiveListOperations<K, V> {
@@ -38,7 +41,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
-	Mono<List<V>> range(K key, long start, long end);
+	Flux<V> range(K key, long start, long end);
 
 	/**
 	 * Trim list at {@code key} to elements between {@code start} and {@code end}.

--- a/src/main/java/org/springframework/data/redis/core/ReactiveSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveSetOperations.java
@@ -15,16 +15,17 @@
  */
 package org.springframework.data.redis.core;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Redis set specific operations.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
+ * @see <a href="http://redis.io/commands#set">Redis Documentation: Set Commands</a>
  * @since 2.0
  */
 public interface ReactiveSetOperations<K, V> {
@@ -96,7 +97,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
-	Mono<Set<V>> intersect(K key, K otherKey);
+	Flux<V> intersect(K key, K otherKey);
 
 	/**
 	 * Returns the members intersecting all given sets at {@code key} and {@code otherKeys}.
@@ -106,7 +107,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
-	Mono<Set<V>> intersect(K key, Collection<K> otherKeys);
+	Flux<V> intersect(K key, Collection<K> otherKeys);
 
 	/**
 	 * Intersect all given sets at {@code key} and {@code otherKey} and store result in {@code destKey}.
@@ -138,7 +139,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
-	Mono<Set<V>> union(K key, K otherKey);
+	Flux<V> union(K key, K otherKey);
 
 	/**
 	 * Union all sets at given {@code keys} and {@code otherKeys}.
@@ -148,7 +149,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
-	Mono<Set<V>> union(K key, Collection<K> otherKeys);
+	Flux<V> union(K key, Collection<K> otherKeys);
 
 	/**
 	 * Union all sets at given {@code key} and {@code otherKey} and store result in {@code destKey}.
@@ -180,7 +181,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
-	Mono<Set<V>> difference(K key, K otherKey);
+	Flux<V> difference(K key, K otherKey);
 
 	/**
 	 * Diff all sets for given {@code key} and {@code otherKeys}.
@@ -190,7 +191,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
-	Mono<Set<V>> difference(K key, Collection<K> otherKeys);
+	Flux<V> difference(K key, Collection<K> otherKeys);
 
 	/**
 	 * Diff all sets for given {@code key} and {@code otherKey} and store result in {@code destKey}.
@@ -221,7 +222,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
-	Mono<Set<V>> members(K key);
+	Flux<V> members(K key);
 
 	/**
 	 * Get random element from set at {@code key}.
@@ -240,7 +241,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
-	Mono<Set<V>> distinctRandomMembers(K key, long count);
+	Flux<V> distinctRandomMembers(K key, long count);
 
 	/**
 	 * Get {@code count} random elements from set at {@code key}.
@@ -250,7 +251,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
-	Mono<List<V>> randomMembers(K key, long count);
+	Flux<V> randomMembers(K key, long count);
 
 	/**
 	 * Removes the given {@literal key}.

--- a/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.data.redis.core;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Collection;
-import java.util.Set;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
@@ -29,6 +29,8 @@ import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
  * Redis ZSet/sorted set specific operations.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
+ * @see <a href="http://redis.io/commands#zset">Redis Documentation: Sorted Set Commands</a>
  * @since 2.0
  */
 public interface ReactiveZSetOperations<K, V> {
@@ -103,7 +105,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
-	Mono<Set<V>> range(K key, Range<Long> range);
+	Flux<V> range(K key, Range<Long> range);
 
 	/**
 	 * Get set of {@link Tuple}s between {@code start} and {@code end} from sorted set.
@@ -113,7 +115,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
-	Mono<Set<TypedTuple<V>>> rangeWithScores(K key, Range<Long> range);
+	Flux<TypedTuple<V>> rangeWithScores(K key, Range<Long> range);
 
 	/**
 	 * Get elements where score is between {@code min} and {@code max} from sorted set.
@@ -123,7 +125,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
-	Mono<Set<V>> rangeByScore(K key, Range<Double> range);
+	Flux<V> rangeByScore(K key, Range<Double> range);
 
 	/**
 	 * Get set of {@link Tuple}s where score is between {@code min} and {@code max} from sorted set.
@@ -133,7 +135,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
-	Mono<Set<TypedTuple<V>>> rangeByScoreWithScores(K key, Range<Double> range);
+	Flux<TypedTuple<V>> rangeByScoreWithScores(K key, Range<Double> range);
 
 	/**
 	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
@@ -145,7 +147,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
-	Mono<Set<V>> rangeByScore(K key, Range<Double> range, Limit limit);
+	Flux<V> rangeByScore(K key, Range<Double> range, Limit limit);
 
 	/**
 	 * Get set of {@link Tuple}s in range from {@code start} to {@code end} where score is between {@code min} and
@@ -157,7 +159,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
-	Mono<Set<TypedTuple<V>>> rangeByScoreWithScores(K key, Range<Double> range, Limit limit);
+	Flux<TypedTuple<V>> rangeByScoreWithScores(K key, Range<Double> range, Limit limit);
 
 	/**
 	 * Get elements in range from {@code start} to {@code end} from sorted set ordered from high to low.
@@ -167,7 +169,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
-	Mono<Set<V>> reverseRange(K key, Range<Long> range);
+	Flux<V> reverseRange(K key, Range<Long> range);
 
 	/**
 	 * Get set of {@link Tuple}s in range from {@code start} to {@code end} from sorted set ordered from high to low.
@@ -177,7 +179,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
-	Mono<Set<TypedTuple<V>>> reverseRangeWithScores(K key, Range<Long> range);
+	Flux<TypedTuple<V>> reverseRangeWithScores(K key, Range<Long> range);
 
 	/**
 	 * Get elements where score is between {@code min} and {@code max} from sorted set ordered from high to low.
@@ -187,7 +189,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
-	Mono<Set<V>> reverseRangeByScore(K key, Range<Double> range);
+	Flux<V> reverseRangeByScore(K key, Range<Double> range);
 
 	/**
 	 * Get set of {@link Tuple} where score is between {@code min} and {@code max} from sorted set ordered from high to
@@ -198,7 +200,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
-	Mono<Set<TypedTuple<V>>> reverseRangeByScoreWithScores(K key, Range<Double> range);
+	Flux<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range);
 
 	/**
 	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
@@ -210,7 +212,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
-	Mono<Set<V>> reverseRangeByScore(K key, Range<Double> range, Limit limit);
+	Flux<V> reverseRangeByScore(K key, Range<Double> range, Limit limit);
 
 	/**
 	 * Get set of {@link Tuple} in range from {@code start} to {@code end} where score is between {@code min} and
@@ -222,7 +224,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
-	Mono<Set<TypedTuple<V>>> reverseRangeByScoreWithScores(K key, Range<Double> range, Limit limit);
+	Flux<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range, Limit limit);
 
 	/**
 	 * Count number of elements within sorted set with scores between {@code min} and {@code max}.
@@ -325,7 +327,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param range must not be {@literal null}.
 	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
-	Mono<Set<V>> rangeByLex(K key, Range<String> range);
+	Flux<V> rangeByLex(K key, Range<String> range);
 
 	/**
 	 * Get all elements {@literal n} elements, where {@literal n = } {@link Limit#getCount()}, starting at
@@ -338,7 +340,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
-	Mono<Set<V>> rangeByLex(K key, Range<String> range, Limit limit);
+	Flux<V> rangeByLex(K key, Range<String> range, Limit limit);
 
 	/**
 	 * Get all elements with reverse lexicographical ordering from {@literal ZSET} at {@code key} with a value between
@@ -348,7 +350,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param range must not be {@literal null}.
 	 * @see <a href="http://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
 	 */
-	Mono<Set<V>> reverseRangeByLex(K key, Range<String> range);
+	Flux<V> reverseRangeByLex(K key, Range<String> range);
 
 	/**
 	 * Get all elements {@literal n} elements, where {@literal n = } {@link Limit#getCount()}, starting at
@@ -361,7 +363,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return
 	 * @see <a href="http://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
 	 */
-	Mono<Set<V>> reverseRangeByLex(K key, Range<String> range, Limit limit);
+	Flux<V> reverseRangeByLex(K key, Range<String> range, Limit limit);
 
 	/**
 	 * Removes the given {@literal key}.

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.*;
 import static org.hamcrest.collection.IsIterableContainingInOrder.*;
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsEqual.*;
 import static org.hamcrest.core.IsNull.*;
 import static org.junit.Assert.*;
+
+import reactor.test.StepVerifier;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -170,8 +171,9 @@ public class LettuceReactiveHashCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
 		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
 
-		assertThat(connection.hashCommands().hKeys(KEY_1_BBUFFER).block(),
-				containsInAnyOrder(FIELD_1_BBUFFER, FIELD_2_BBUFFER, FIELD_3_BBUFFER));
+		StepVerifier.create(connection.hashCommands().hKeys(KEY_1_BBUFFER)) //
+				.expectNext(FIELD_1_BBUFFER, FIELD_2_BBUFFER, FIELD_3_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -181,8 +183,9 @@ public class LettuceReactiveHashCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
 		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
 
-		assertThat(connection.hashCommands().hVals(KEY_1_BBUFFER).block(),
-				containsInAnyOrder(VALUE_1_BBUFFER, VALUE_2_BBUFFER, VALUE_3_BBUFFER));
+		StepVerifier.create(connection.hashCommands().hVals(KEY_1_BBUFFER))
+				.expectNext(VALUE_1_BBUFFER, VALUE_2_BBUFFER, VALUE_3_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -197,6 +200,11 @@ public class LettuceReactiveHashCommandsTests extends LettuceReactiveCommandsTes
 		expected.put(FIELD_2_BBUFFER, VALUE_2_BBUFFER);
 		expected.put(FIELD_3_BBUFFER, VALUE_3_BBUFFER);
 
-		assertThat(connection.hashCommands().hGetAll(KEY_1_BBUFFER).block(), is(equalTo(expected)));
+		StepVerifier.create(connection.hashCommands().hGetAll(KEY_1_BBUFFER).buffer(3)) //
+				.consumeNextWith(list -> {
+					assertTrue(list.containsAll(expected.entrySet()));
+				}) //
+				.verifyComplete();
+
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommandTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommandTests.java
@@ -101,7 +101,7 @@ public class LettuceReactiveListCommandTests extends LettuceReactiveCommandsTest
 
 		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
 
-		assertThat(connection.listCommands().lRange(KEY_1_BBUFFER, 1, 2).block(),
+		assertThat(connection.listCommands().lRange(KEY_1_BBUFFER, 1, 2).toIterable(),
 				contains(VALUE_2_BBUFFER, VALUE_3_BBUFFER));
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
@@ -19,6 +19,8 @@ import static org.hamcrest.core.Is.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
+import reactor.test.StepVerifier;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -85,8 +87,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRange(KEY_1_BBUFFER, new Range<Long>(1L, 2L)).block(),
-				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER, VALUE_3_BBUFFER));
+		StepVerifier.create(connection.zSetCommands().zRange(KEY_1_BBUFFER, new Range<Long>(1L, 2L))) //
+				.expectNext(VALUE_2_BBUFFER, VALUE_3_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -96,9 +99,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRangeWithScores(KEY_1_BBUFFER, new Range<Long>(1L, 2L)).block(),
-				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D),
-						new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)));
+		StepVerifier.create(connection.zSetCommands().zRangeWithScores(KEY_1_BBUFFER, new Range<Long>(1L, 2L))) //
+				.expectNext(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D), new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -108,8 +111,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRevRange(KEY_1_BBUFFER, new Range<Long>(1L, 2L)).block(),
-				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER, VALUE_1_BBUFFER));
+		StepVerifier.create(connection.zSetCommands().zRevRange(KEY_1_BBUFFER, new Range<Long>(1L, 2L))) //
+				.expectNext(VALUE_2_BBUFFER, VALUE_1_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -119,9 +123,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRevRangeWithScores(KEY_1_BBUFFER, new Range<Long>(1L, 2L)).block(),
-				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D),
-						new DefaultTuple(VALUE_1_BBUFFER.array(), 1D)));
+		StepVerifier.create(connection.zSetCommands().zRevRangeWithScores(KEY_1_BBUFFER, new Range<Long>(1L, 2L))) //
+				.expectNext(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D), new DefaultTuple(VALUE_1_BBUFFER.array(), 1D)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -131,8 +135,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D)).block(),
-				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER, VALUE_3_BBUFFER));
+		StepVerifier.create(connection.zSetCommands().zRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D))) //
+				.expectNext(VALUE_2_BBUFFER, VALUE_3_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -142,8 +147,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true)).block(),
-				IsIterableContainingInOrder.contains(VALUE_3_BBUFFER));
+		StepVerifier.create(connection.zSetCommands().zRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true))) //
+				.expectNext(VALUE_3_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -153,8 +159,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false)).block(),
-				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER));
+		StepVerifier.create(connection.zSetCommands().zRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false))) //
+				.expectNext(VALUE_2_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -164,9 +171,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D)).block(),
-				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D),
-						new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)));
+		StepVerifier.create(connection.zSetCommands().zRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D))) //
+				.expectNext(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D), new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -176,9 +183,10 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(
-				connection.zSetCommands().zRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true)).block(),
-				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)));
+		StepVerifier
+				.create(connection.zSetCommands().zRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true))) //
+				.expectNext(new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -188,9 +196,10 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(
-				connection.zSetCommands().zRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false)).block(),
-				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)));
+		StepVerifier
+				.create(connection.zSetCommands().zRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false))) //
+				.expectNext(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -200,8 +209,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRevRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D)).block(),
-				IsIterableContainingInOrder.contains(VALUE_3_BBUFFER, VALUE_2_BBUFFER));
+		StepVerifier.create(connection.zSetCommands().zRevRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D))) //
+				.expectNext(VALUE_3_BBUFFER, VALUE_2_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -211,8 +221,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRevRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true)).block(),
-				IsIterableContainingInOrder.contains(VALUE_3_BBUFFER));
+		StepVerifier.create(connection.zSetCommands().zRevRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true))) //
+				.expectNext(VALUE_3_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -222,8 +233,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRevRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false)).block(),
-				IsIterableContainingInOrder.contains(VALUE_2_BBUFFER));
+		StepVerifier.create(connection.zSetCommands().zRevRangeByScore(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false))) //
+				.expectNext(VALUE_2_BBUFFER) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -233,9 +245,9 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D)).block(),
-				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_3_BBUFFER.array(), 3D),
-						new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)));
+		StepVerifier.create(connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D))) //
+				.expectNext(new DefaultTuple(VALUE_3_BBUFFER.array(), 3D), new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -245,9 +257,10 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(
-				connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true)).block(),
-				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)));
+		StepVerifier
+				.create(connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, false, true))) //
+				.expectNext(new DefaultTuple(VALUE_3_BBUFFER.array(), 3D)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -257,9 +270,10 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
 		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
 
-		assertThat(
-				connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false)).block(),
-				IsIterableContainingInOrder.contains(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)));
+		StepVerifier
+				.create(connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false))) //
+				.expectNext(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -443,14 +457,17 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 0D, "f");
 		nativeCommands.zadd(KEY_1, 0D, "g");
 
-		assertThat(connection.zSetCommands().zRangeByLex(KEY_1_BBUFFER, new Range<>("", "c")).block(),
+		assertThat(connection.zSetCommands().zRangeByLex(KEY_1_BBUFFER, new Range<>("", "c")).collectList().block(),
 				IsIterableContainingInOrder.contains(ByteBuffer.wrap("a".getBytes()), ByteBuffer.wrap("b".getBytes()),
 						ByteBuffer.wrap("c".getBytes())));
 
-		assertThat(connection.zSetCommands().zRangeByLex(KEY_1_BBUFFER, new Range<>("", "c", true, false)).block(),
+		assertThat(
+				connection.zSetCommands().zRangeByLex(KEY_1_BBUFFER, new Range<>("", "c", true, false)).collectList().block(),
 				IsIterableContainingInOrder.contains(ByteBuffer.wrap("a".getBytes()), ByteBuffer.wrap("b".getBytes())));
 
-		assertThat(connection.zSetCommands().zRangeByLex(KEY_1_BBUFFER, new Range<>("aaa", "g", true, false)).block(),
+		assertThat(
+				connection.zSetCommands().zRangeByLex(KEY_1_BBUFFER, new Range<>("aaa", "g", true, false)).collectList()
+						.block(),
 				IsIterableContainingInOrder.contains(ByteBuffer.wrap("b".getBytes()), ByteBuffer.wrap("c".getBytes()),
 						ByteBuffer.wrap("d".getBytes()), ByteBuffer.wrap("e".getBytes()), ByteBuffer.wrap("f".getBytes())));
 	}
@@ -466,14 +483,18 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 		nativeCommands.zadd(KEY_1, 0D, "f");
 		nativeCommands.zadd(KEY_1, 0D, "g");
 
-		assertThat(connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("", "c")).block(),
+		assertThat(connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("", "c")).collectList().block(),
 				IsIterableContainingInOrder.contains(ByteBuffer.wrap("c".getBytes()), ByteBuffer.wrap("b".getBytes()),
 						ByteBuffer.wrap("a".getBytes())));
 
-		assertThat(connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("", "c", true, false)).block(),
+		assertThat(
+				connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("", "c", true, false)).collectList()
+						.block(),
 				IsIterableContainingInOrder.contains(ByteBuffer.wrap("b".getBytes()), ByteBuffer.wrap("a".getBytes())));
 
-		assertThat(connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("aaa", "g", true, false)).block(),
+		assertThat(
+				connection.zSetCommands().zRevRangeByLex(KEY_1_BBUFFER, new Range<>("aaa", "g", true, false)).collectList()
+						.block(),
 				IsIterableContainingInOrder.contains(ByteBuffer.wrap("f".getBytes()), ByteBuffer.wrap("e".getBytes()),
 						ByteBuffer.wrap("d".getBytes()), ByteBuffer.wrap("c".getBytes()), ByteBuffer.wrap("b".getBytes())));
 	}

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveGeoOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveGeoOperationsIntegrationTests.java
@@ -139,7 +139,9 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		memberCoordinateMap.put(valueFactory.instance(), POINT_PALERMO);
 		memberCoordinateMap.put(valueFactory.instance(), POINT_CATANIA);
 
-		StepVerifier.create(geoOperations.geoAdd(key, memberCoordinateMap)).expectNext(2L).verifyComplete();
+		StepVerifier.create(geoOperations.geoAdd(key, memberCoordinateMap)) //
+				.expectNext(2L) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -150,7 +152,9 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		List<GeoLocation<V>> geoLocations = Arrays.asList(new GeoLocation<>(valueFactory.instance(), POINT_ARIGENTO),
 				new GeoLocation<>(valueFactory.instance(), POINT_PALERMO));
 
-		StepVerifier.create(geoOperations.geoAdd(key, geoLocations)).expectNext(2L).verifyComplete();
+		StepVerifier.create(geoOperations.geoAdd(key, geoLocations)) //
+				.expectNext(2L) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -165,8 +169,9 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 
 		Flux<List<GeoLocation<V>>> geoLocations = Flux.just(batch1, batch2);
 
-		StepVerifier.create(geoOperations.geoAdd(key, geoLocations)).expectNext(2L).expectNext(1L).expectComplete()
-				.verify();
+		StepVerifier.create(geoOperations.geoAdd(key, geoLocations)).expectNext(2L) //
+				.expectNext(1L) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -179,11 +184,13 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
 		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoDist(key, member1, member2)).consumeNextWith(actual -> {
+		StepVerifier.create(geoOperations.geoDist(key, member1, member2)) //
+				.consumeNextWith(actual -> {
 
-			assertThat(actual.getValue()).isCloseTo(DISTANCE_PALERMO_CATANIA_METERS, offset(0.005));
-			assertThat(actual.getUnit()).isEqualTo("m");
-		}).verifyComplete();
+					assertThat(actual.getValue()).isCloseTo(DISTANCE_PALERMO_CATANIA_METERS, offset(0.005));
+					assertThat(actual.getUnit()).isEqualTo("m");
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -196,11 +203,13 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
 		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoDist(key, member1, member2, Metrics.KILOMETERS)).consumeNextWith(actual -> {
+		StepVerifier.create(geoOperations.geoDist(key, member1, member2, Metrics.KILOMETERS)) //
+				.consumeNextWith(actual -> {
 
-			assertThat(actual.getValue()).isCloseTo(DISTANCE_PALERMO_CATANIA_KILOMETERS, offset(0.005));
-			assertThat(actual.getUnit()).isEqualTo("km");
-		}).verifyComplete();
+					assertThat(actual.getValue()).isCloseTo(DISTANCE_PALERMO_CATANIA_KILOMETERS, offset(0.005));
+					assertThat(actual.getUnit()).isEqualTo("km");
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -213,8 +222,7 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(geoOperations.geoHash(key, v1)) //
 				.expectNext("sqc8b49rny0") //
-				.expectComplete() //
-				.verify();
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -230,8 +238,7 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(geoOperations.geoHash(key, v1, v3, v2)) //
 				.expectNext(Arrays.asList("sqc8b49rny0", null, "sqdtr74hyu0")) //
-				.expectComplete() //
-				.verify();
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -247,8 +254,8 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 
 					assertThat(actual.getX()).isCloseTo(POINT_PALERMO.getX(), offset(0.005));
 					assertThat(actual.getY()).isCloseTo(POINT_PALERMO.getY(), offset(0.005));
-				}).expectComplete() //
-				.verify();
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -270,8 +277,8 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 
 					assertThat(actual.get(1)).isNull();
 					assertThat(actual.get(2)).isNotNull();
-				}).expectComplete() //
-				.verify();
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-438
@@ -284,8 +291,9 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
 		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS))))
-				.consumeNextWith(actual -> assertThat(actual).hasSize(2)).verifyComplete();
+		StepVerifier.create(geoOperations.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)))) //
+				.expectNextCount(2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -298,16 +306,20 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
 		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)),
-				newGeoRadiusArgs().includeDistance().sortDescending())).consumeNextWith(actual -> {
-					assertThat(actual).hasSize(2);
+		StepVerifier
+				.create(geoOperations.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)),
+						newGeoRadiusArgs().includeDistance().sortDescending())) //
+				.consumeNextWith(actual -> {
 
-					assertThat(actual.getContent().get(0).getDistance().getValue()).isCloseTo(190.4424d, offset(0.005));
-					assertThat(actual.getContent().get(0).getContent().getName()).isEqualTo(member1);
+					assertThat(actual.getDistance().getValue()).isCloseTo(190.4424d, offset(0.005));
+					assertThat(actual.getContent().getName()).isEqualTo(member1);
+				}) //
+				.consumeNextWith(actual -> {
 
-					assertThat(actual.getContent().get(1).getDistance().getValue()).isCloseTo(56.4413d, offset(0.005));
-					assertThat(actual.getContent().get(1).getContent().getName()).isEqualTo(member2);
-				}).verifyComplete();
+					assertThat(actual.getDistance().getValue()).isCloseTo(56.4413d, offset(0.005));
+					assertThat(actual.getContent().getName()).isEqualTo(member2);
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-438
@@ -320,10 +332,9 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
 		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS))))
-				.consumeNextWith(actual -> assertThat(actual).hasSize(2)) //
-				.expectComplete() //
-				.verify();
+		StepVerifier.create(geoOperations.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)))) //
+				.expectNextCount(2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -340,14 +351,12 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(geoOperations.geoRadiusByMember(key, member3, 100_000)) //
 				.consumeNextWith(actual -> {
-
-					assertThat(actual).hasSize(2);
-
-					assertThat(actual.get(0).getName()).isEqualTo(member3);
-					assertThat(actual.get(1).getName()).isEqualTo(member1);
+					assertThat(actual.getContent().getName()).isEqualTo(member3);
 				}) //
-				.expectComplete() //
-				.verify();
+				.consumeNextWith(actual -> {
+					assertThat(actual.getContent().getName()).isEqualTo(member1);
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -362,14 +371,14 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
 		geoOperations.geoAdd(key, POINT_ARIGENTO, member3).block();
 
-		StepVerifier.create(geoOperations.geoRadiusByMember(key, member3, new Distance(100D, KILOMETERS)))
+		StepVerifier.create(geoOperations.geoRadiusByMember(key, member3, new Distance(100D, KILOMETERS))) //
 				.consumeNextWith(actual -> {
-
-					assertThat(actual).hasSize(2);
-
-					assertThat(actual.get(0).getName()).isEqualTo(member3);
-					assertThat(actual.get(1).getName()).isEqualTo(member1);
-				}).verifyComplete();
+					assertThat(actual.getContent().getName()).isEqualTo(member3);
+				}) //
+				.consumeNextWith(actual -> {
+					assertThat(actual.getContent().getName()).isEqualTo(member1);
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -384,17 +393,20 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
 		geoOperations.geoAdd(key, POINT_ARIGENTO, member3).block();
 
-		StepVerifier.create(geoOperations.geoRadiusByMember(key, member3, new Distance(100D, KILOMETERS),
-				newGeoRadiusArgs().includeDistance().sortDescending())).consumeNextWith(actual -> {
+		StepVerifier
+				.create(geoOperations.geoRadiusByMember(key, member3, new Distance(100D, KILOMETERS),
+						newGeoRadiusArgs().includeDistance().sortDescending())) //
+				.consumeNextWith(actual -> {
 
-					assertThat(actual).hasSize(2);
+					assertThat(actual.getDistance().getValue()).isCloseTo(90.9778, offset(0.005));
+					assertThat(actual.getContent().getName()).isEqualTo(member1);
+				}) //
+				.consumeNextWith(actual -> {
 
-					assertThat(actual.getContent().get(0).getDistance().getValue()).isCloseTo(90.9778, offset(0.005));
-					assertThat(actual.getContent().get(0).getContent().getName()).isEqualTo(member1);
-
-					assertThat(actual.getContent().get(1).getDistance().getValue()).isCloseTo(0.0, offset(0.005));
-					assertThat(actual.getContent().get(1).getContent().getName()).isEqualTo(member3);
-				}).verifyComplete();
+					assertThat(actual.getDistance().getValue()).isCloseTo(0.0, offset(0.005));
+					assertThat(actual.getContent().getName()).isEqualTo(member3);
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -407,8 +419,11 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
 		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoRemove(key, member1)).expectNext(1L).verifyComplete();
-		StepVerifier.create(geoOperations.geoPos(key, member1)).verifyComplete();
+		StepVerifier.create(geoOperations.geoRemove(key, member1)) //
+				.expectNext(1L) //
+				.verifyComplete();
+		StepVerifier.create(geoOperations.geoPos(key, member1)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -419,7 +434,10 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 
 		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
 
-		StepVerifier.create(geoOperations.delete(key)).expectNext(true).verifyComplete();
-		StepVerifier.create(geoOperations.geoPos(key, member1)).verifyComplete();
+		StepVerifier.create(geoOperations.delete(key)) //
+				.expectNext(true) //
+				.verifyComplete();
+		StepVerifier.create(geoOperations.geoPos(key, member1)) //
+				.verifyComplete();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
@@ -22,8 +22,10 @@ import reactor.test.StepVerifier;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -120,7 +122,10 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		HV hashvalue2 = hashValueFactory.instance();
 
 		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
-		StepVerifier.create(hashOperations.remove(key, hashkey1, hashkey2)).expectNext(2L).verifyComplete();
+
+		StepVerifier.create(hashOperations.remove(key, hashkey1, hashkey2)) //
+				.expectNext(2L) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -130,11 +135,17 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		HK hashkey = hashKeyFactory.instance();
 		HV hashvalue = hashValueFactory.instance();
 
-		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)).expectNext(true).verifyComplete();
+		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)) //
+				.expectNext(true) //
+				.verifyComplete();
 
-		StepVerifier.create(hashOperations.hasKey(key, hashkey)).expectNext(true).verifyComplete();
-		StepVerifier.create(hashOperations.hasKey(key, hashKeyFactory.instance())).expectNext(false).expectComplete()
-				.verify();
+		StepVerifier.create(hashOperations.hasKey(key, hashkey)) //
+				.expectNext(true) //
+				.verifyComplete();
+
+		StepVerifier.create(hashOperations.hasKey(key, hashKeyFactory.instance())) //
+				.expectNext(false) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -144,9 +155,13 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		HK hashkey = hashKeyFactory.instance();
 		HV hashvalue = hashValueFactory.instance();
 
-		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)).expectNext(true).verifyComplete();
+		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)) //
+				.expectNext(true) //
+				.verifyComplete();
 
-		StepVerifier.create(hashOperations.get(key, hashkey)).expectNextCount(1).verifyComplete();
+		StepVerifier.create(hashOperations.get(key, hashkey)) //
+				.expectNextCount(1) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -163,9 +178,11 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 
 		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
 
-		StepVerifier.create(hashOperations.multiGet(key, Arrays.asList(hashkey1, hashkey2))).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(2).containsSequence(hashvalue1, hashvalue2);
-		}).verifyComplete();
+		StepVerifier.create(hashOperations.multiGet(key, Arrays.asList(hashkey1, hashkey2))) //
+				.consumeNextWith(actual -> {
+					assertThat(actual).hasSize(2).containsSequence(hashvalue1, hashvalue2);
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -177,9 +194,17 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		HK hashkey = hashKeyFactory.instance();
 		HV hashvalue = (HV) "1";
 
-		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)).expectNext(true).verifyComplete();
-		StepVerifier.create(hashOperations.increment(key, hashkey, 1L)).expectNext(2L).verifyComplete();
-		StepVerifier.create(hashOperations.get(key, hashkey)).expectNext((HV) "2").verifyComplete();
+		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)) //
+				.expectNext(true) //
+				.verifyComplete();
+
+		StepVerifier.create(hashOperations.increment(key, hashkey, 1L)) //
+				.expectNext(2L) //
+				.verifyComplete();
+
+		StepVerifier.create(hashOperations.get(key, hashkey)) //
+				.expectNext((HV) "2") //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -192,9 +217,17 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		HK hashkey = hashKeyFactory.instance();
 		HV hashvalue = (HV) "1";
 
-		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)).expectNext(true).verifyComplete();
-		StepVerifier.create(hashOperations.increment(key, hashkey, 1.1d)).expectNext(2.1d).verifyComplete();
-		StepVerifier.create(hashOperations.get(key, hashkey)).expectNext((HV) "2.1").verifyComplete();
+		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)) //
+				.expectNext(true) //
+				.verifyComplete();
+
+		StepVerifier.create(hashOperations.increment(key, hashkey, 1.1d)) //
+				.expectNext(2.1d) //
+				.verifyComplete();
+
+		StepVerifier.create(hashOperations.get(key, hashkey)) //
+				.expectNext((HV) "2.1") //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -211,9 +244,9 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 
 		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
 
-		StepVerifier.create(hashOperations.keys(key)).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(2).contains(hashkey1, hashkey2);
-		}).verifyComplete();
+		StepVerifier.create(hashOperations.keys(key).buffer(2)) //
+				.consumeNextWith(list -> assertThat(list).containsExactlyInAnyOrder(hashkey1, hashkey2)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -228,7 +261,9 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 
 		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
 
-		StepVerifier.create(hashOperations.size(key)).expectNext(2L).verifyComplete();
+		StepVerifier.create(hashOperations.size(key)) //
+				.expectNext(2L) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -243,8 +278,13 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 
 		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
 
-		StepVerifier.create(hashOperations.hasKey(key, hashkey1)).expectNext(true).verifyComplete();
-		StepVerifier.create(hashOperations.hasKey(key, hashkey2)).expectNext(true).verifyComplete();
+		StepVerifier.create(hashOperations.hasKey(key, hashkey1)) //
+				.expectNext(true) //
+				.verifyComplete();
+
+		StepVerifier.create(hashOperations.hasKey(key, hashkey2)) //
+				.expectNext(true) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -254,7 +294,9 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		HK hashkey = hashKeyFactory.instance();
 		HV hashvalue = hashValueFactory.instance();
 
-		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)).expectNext(true).verifyComplete();
+		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)) //
+				.expectNext(true) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -265,9 +307,13 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		HV hashvalue = hashValueFactory.instance();
 		HV hashvalue2 = hashValueFactory.instance();
 
-		StepVerifier.create(hashOperations.putIfAbsent(key, hashkey, hashvalue)).expectNext(true).verifyComplete();
-		StepVerifier.create(hashOperations.putIfAbsent(key, hashkey, hashvalue2)).expectNext(false).expectComplete()
-				.verify();
+		StepVerifier.create(hashOperations.putIfAbsent(key, hashkey, hashvalue)) //
+				.expectNext(true) //
+				.verifyComplete();
+
+		StepVerifier.create(hashOperations.putIfAbsent(key, hashkey, hashvalue2)) //
+				.expectNext(false) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -284,9 +330,9 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 
 		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
 
-		StepVerifier.create(hashOperations.values(key)).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(2).contains(hashvalue1, hashvalue2);
-		}).verifyComplete();
+		StepVerifier.create(hashOperations.values(key)) //
+				.expectNextCount(2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -303,9 +349,15 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 
 		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
 
-		StepVerifier.create(hashOperations.entries(key)).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(2).containsEntry(hashkey1, hashvalue1).containsEntry(hashkey2, hashvalue2);
-		}).verifyComplete();
+		StepVerifier.create(hashOperations.entries(key).buffer(2)) //
+				.consumeNextWith(list -> {
+
+					Entry<HK, HV> entry1 = Collections.singletonMap(hashkey1, hashvalue1).entrySet().iterator().next();
+					Entry<HK, HV> entry2 = Collections.singletonMap(hashkey2, hashvalue2).entrySet().iterator().next();
+
+					assertThat(list).containsExactlyInAnyOrder(entry1, entry2);
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -315,10 +367,17 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		HK hashkey = hashKeyFactory.instance();
 		HV hashvalue = hashValueFactory.instance();
 
-		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)).expectNext(true).verifyComplete();
-		StepVerifier.create(hashOperations.delete(key)).expectNext(true).verifyComplete();
+		StepVerifier.create(hashOperations.put(key, hashkey, hashvalue)) //
+				.expectNext(true) //
+				.verifyComplete();
 
-		StepVerifier.create(hashOperations.size(key)).expectNext(0L).verifyComplete();
+		StepVerifier.create(hashOperations.delete(key)) //
+				.expectNext(true) //
+				.verifyComplete();
+
+		StepVerifier.create(hashOperations.size(key)) //
+				.expectNext(0L) //
+				.verifyComplete();
 	}
 
 	private void putAll(K key, HK hashkey1, HV hashvalue1, HK hashkey2, HV hashvalue2) {
@@ -327,6 +386,8 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		map.put(hashkey1, hashvalue1);
 		map.put(hashkey2, hashvalue2);
 
-		StepVerifier.create(hashOperations.putAll(key, map)).expectNext(true).verifyComplete();
+		StepVerifier.create(hashOperations.putAll(key, map)) //
+				.expectNext(true) //
+				.verifyComplete();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveListOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveListOperationsIntegrationTests.java
@@ -17,7 +17,6 @@ package org.springframework.data.redis.core;
 
 import static org.junit.Assume.*;
 
-import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
@@ -95,11 +94,17 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 		V value1 = valueFactory.instance();
 		V value2 = valueFactory.instance();
 
-		StepVerifier.create(listOperations.rightPushAll(key, value1, value2)).expectNext(2L).verifyComplete();
+		StepVerifier.create(listOperations.rightPushAll(key, value1, value2)) //
+				.expectNext(2L) //
+				.verifyComplete();
 
-		StepVerifier.create(listOperations.trim(key, 0, 0)).expectNext(true).verifyComplete();
+		StepVerifier.create(listOperations.trim(key, 0, 0)) //
+				.expectNext(true) //
+				.verifyComplete();
 
-		StepVerifier.create(listOperations.size(key)).expectNext(1L).verifyComplete();
+		StepVerifier.create(listOperations.size(key)) //
+				.expectNext(1L) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -108,9 +113,17 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 		K key = keyFactory.instance();
 		V value1 = valueFactory.instance();
 
-		StepVerifier.create(listOperations.size(key)).expectNext(0L).verifyComplete();
-		StepVerifier.create(listOperations.rightPush(key, value1)).expectNext(1L).verifyComplete();
-		StepVerifier.create(listOperations.size(key)).expectNext(1L).verifyComplete();
+		StepVerifier.create(listOperations.size(key)) //
+				.expectNext(0L) //
+				.verifyComplete();
+
+		StepVerifier.create(listOperations.rightPush(key, value1)) //
+				.expectNext(1L) //
+				.verifyComplete();
+
+		StepVerifier.create(listOperations.size(key)) //
+				.expectNext(1L) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -122,11 +135,18 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 		V value1 = valueFactory.instance();
 		V value2 = valueFactory.instance();
 
-		StepVerifier.create(listOperations.leftPush(key, value1)).expectNext(1L).verifyComplete();
-		StepVerifier.create(listOperations.leftPush(key, value2)).expectNext(2L).verifyComplete();
+		StepVerifier.create(listOperations.leftPush(key, value1)) //
+				.expectNext(1L) //
+				.verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value2)
-				.expectNext(value1).verifyComplete();
+		StepVerifier.create(listOperations.leftPush(key, value2)) //
+				.expectNext(2L) //
+				.verifyComplete();
+
+		StepVerifier.create(listOperations.range(key, 0, -1)) //
+				.expectNext(value2) //
+				.expectNext(value1) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -138,10 +158,14 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 		V value1 = valueFactory.instance();
 		V value2 = valueFactory.instance();
 
-		StepVerifier.create(listOperations.leftPushAll(key, value1, value2)).expectNext(2L).verifyComplete();
+		StepVerifier.create(listOperations.leftPushAll(key, value1, value2)) //
+				.expectNext(2L) //
+				.verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value2)
-				.expectNext(value1).verifyComplete();
+		StepVerifier.create(listOperations.range(key, 0, -1)) //
+				.expectNext(value2) //
+				.expectNext(value1) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -151,9 +175,17 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 		V value1 = valueFactory.instance();
 		V value2 = valueFactory.instance();
 
-		StepVerifier.create(listOperations.leftPushIfPresent(key, value1)).expectNext(0L).verifyComplete();
-		StepVerifier.create(listOperations.leftPush(key, value1)).expectNext(1L).verifyComplete();
-		StepVerifier.create(listOperations.leftPushIfPresent(key, value2)).expectNext(2L).verifyComplete();
+		StepVerifier.create(listOperations.leftPushIfPresent(key, value1)) //
+				.expectNext(0L) //
+				.verifyComplete();
+
+		StepVerifier.create(listOperations.leftPush(key, value1)) //
+				.expectNext(1L) //
+				.verifyComplete();
+
+		StepVerifier.create(listOperations.leftPushIfPresent(key, value2)) //
+				.expectNext(2L) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -166,12 +198,19 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 		V value2 = valueFactory.instance();
 		V value3 = valueFactory.instance();
 
-		StepVerifier.create(listOperations.leftPushAll(key, value1, value2)).expectNext(2L).verifyComplete();
+		StepVerifier.create(listOperations.leftPushAll(key, value1, value2)) //
+				.expectNext(2L) //
+				.verifyComplete();
 
-		StepVerifier.create(listOperations.leftPush(key, value1, value3)).expectNext(3L).verifyComplete();
+		StepVerifier.create(listOperations.leftPush(key, value1, value3)) //
+				.expectNext(3L) //
+				.verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value2)
-				.expectNext(value3).expectNext(value1).verifyComplete();
+		StepVerifier.create(listOperations.range(key, 0, -1)) //
+				.expectNext(value2) //
+				.expectNext(value3) //
+				.expectNext(value1) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -183,11 +222,17 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 		V value1 = valueFactory.instance();
 		V value2 = valueFactory.instance();
 
-		StepVerifier.create(listOperations.rightPush(key, value1)).expectNext(1L).verifyComplete();
-		StepVerifier.create(listOperations.rightPush(key, value2)).expectNext(2L).verifyComplete();
+		StepVerifier.create(listOperations.rightPush(key, value1)) //
+				.expectNext(1L) //
+				.verifyComplete();
+		StepVerifier.create(listOperations.rightPush(key, value2)) //
+				.expectNext(2L) //
+				.verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value1)
-				.expectNext(value2).verifyComplete();
+		StepVerifier.create(listOperations.range(key, 0, -1)) //
+				.expectNext(value1) //
+				.expectNext(value2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -201,8 +246,10 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.rightPushAll(key, value1, value2)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value1)
-				.expectNext(value2).verifyComplete();
+		StepVerifier.create(listOperations.range(key, 0, -1)) //
+				.expectNext(value1) //
+				.expectNext(value2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -231,8 +278,11 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.rightPush(key, value1, value3)).expectNext(3L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value1)
-				.expectNext(value3).expectNext(value2).verifyComplete();
+		StepVerifier.create(listOperations.range(key, 0, -1)) //
+				.expectNext(value1) //
+				.expectNext(value3) //
+				.expectNext(value2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -248,8 +298,10 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.set(key, 1, value1)).expectNext(true).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value1)
-				.expectNext(value1).verifyComplete();
+		StepVerifier.create(listOperations.range(key, 0, -1)) //
+				.expectNext(value1) //
+				.expectNext(value1) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -265,7 +317,8 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.remove(key, 1, value1)).expectNext(1L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value2)
+		StepVerifier.create(listOperations.range(key, 0, -1)) //
+				.expectNext(value2) //
 				.verifyComplete();
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveSetOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveSetOperationsIntegrationTests.java
@@ -18,11 +18,13 @@ package org.springframework.data.redis.core;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assume.*;
 
+import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -173,9 +175,11 @@ public class DefaultReactiveSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(setOperations.add(key, onlyInKey, shared)).expectNext(2L).verifyComplete();
 		StepVerifier.create(setOperations.add(otherKey, onlyInOtherKey, shared)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(setOperations.intersect(key, otherKey)).consumeNextWith(actual -> {
-			assertThat(actual).contains(shared);
-		}).verifyComplete();
+		StepVerifier.create(setOperations.intersect(key, otherKey)) //
+				.consumeNextWith(actual -> {
+					assertThat(actual).isEqualTo(shared);
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -213,9 +217,11 @@ public class DefaultReactiveSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(setOperations.add(key, onlyInKey, shared)).expectNext(2L).verifyComplete();
 		StepVerifier.create(setOperations.add(otherKey, onlyInOtherKey, shared)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(setOperations.difference(key, otherKey)).consumeNextWith(actual -> {
-			assertThat(actual).contains(onlyInKey);
-		}).verifyComplete();
+		StepVerifier.create(setOperations.difference(key, otherKey)) //
+				.consumeNextWith(actual -> {
+					assertThat(actual).isEqualTo(onlyInKey);
+				}) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -253,9 +259,9 @@ public class DefaultReactiveSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(setOperations.add(key, onlyInKey, shared)).expectNext(2L).verifyComplete();
 		StepVerifier.create(setOperations.add(otherKey, onlyInOtherKey, shared)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(setOperations.union(key, otherKey)).consumeNextWith(actual -> {
-			assertThat(actual).contains(onlyInKey, shared, onlyInOtherKey);
-		}).verifyComplete();
+		StepVerifier.create(setOperations.union(key, otherKey)) //
+				.expectNextCount(3) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -289,8 +295,8 @@ public class DefaultReactiveSetOperationsIntegrationTests<K, V> {
 		V value2 = valueFactory.instance();
 
 		StepVerifier.create(setOperations.add(key, value1, value2)).expectNext(2L).verifyComplete();
-		StepVerifier.create(setOperations.members(key)).expectNext(new HashSet<V>(Arrays.asList(value1, value2)))
-				.verifyComplete();
+		StepVerifier.create(setOperations.members(key)) //
+				.consumeNextWith(actual -> assertThat(actual).isIn(value1, value2)).expectNextCount(1).verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -320,9 +326,7 @@ public class DefaultReactiveSetOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(setOperations.add(key, value1, value2)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(setOperations.randomMembers(key, 3)).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(3);
-		}).verifyComplete();
+		StepVerifier.create(setOperations.randomMembers(key, 3)).expectNextCount(3).verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -336,9 +340,9 @@ public class DefaultReactiveSetOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(setOperations.add(key, value1, value2)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(setOperations.distinctRandomMembers(key, 2)).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(2);
-		}).verifyComplete();
+		StepVerifier.create(setOperations.distinctRandomMembers(key, 2)) //
+				.expectNextCount(2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveZSetOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveZSetOperationsIntegrationTests.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.redis.core;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assume.*;
 
 import reactor.test.StepVerifier;
@@ -186,9 +185,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, value2, 10)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.range(key, new Range<>(0L, 0L))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(value2);
-				}).verifyComplete();
+				.expectNext(value2) //
+				.verifyComplete();
 
 	}
 
@@ -205,9 +203,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, value2, 10)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.rangeWithScores(key, new Range<>(0L, 0L))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(new DefaultTypedTuple<>(value2, 10d));
-				}).verifyComplete();
+				.expectNext(new DefaultTypedTuple<>(value2, 10d)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -223,9 +220,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, value2, 10)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.rangeByScore(key, new Range<>(9d, 11d))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(value2);
-				}).verifyComplete();
+				.expectNext(value2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -241,9 +237,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, value2, 10)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.rangeByScoreWithScores(key, new Range<>(9d, 11d))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(new DefaultTypedTuple<>(value2, 10d));
-				}).verifyComplete();
+				.expectNext(new DefaultTypedTuple<>(value2, 10d)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -261,9 +256,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier
 				.create(zSetOperations.rangeByScore(key, new Range<>(0d, 100d), //
 						Limit.limit().offset(1).count(10))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(value1);
-				}).verifyComplete();
+				.expectNext(value1) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -281,9 +275,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier
 				.create(zSetOperations.rangeByScoreWithScores(key, new Range<>(0d, 100d), //
 						Limit.limit().offset(1).count(10))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(new DefaultTypedTuple<>(value1, 42.1));
-				}).verifyComplete();
+				.expectNext(new DefaultTypedTuple<>(value1, 42.1)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -299,9 +292,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, value2, 10)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.reverseRange(key, new Range<>(0L, 0L))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(value1);
-				}).verifyComplete();
+				.expectNext(value1) //
+				.verifyComplete();
 
 	}
 
@@ -318,9 +310,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, value2, 10)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.reverseRangeWithScores(key, new Range<>(0L, 0L))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(new DefaultTypedTuple<>(value1, 42.1));
-				}).verifyComplete();
+				.expectNext(new DefaultTypedTuple<>(value1, 42.1)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -336,9 +327,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, value2, 10)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.reverseRangeByScore(key, new Range<>(9d, 11d))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(value2);
-				}).verifyComplete();
+				.expectNext(value2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -354,9 +344,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, value2, 10)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.reverseRangeByScoreWithScores(key, new Range<>(9d, 11d))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(new DefaultTypedTuple<V>(value2, 10d));
-				}).verifyComplete();
+				.expectNext(new DefaultTypedTuple<V>(value2, 10d)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -374,9 +363,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier
 				.create(zSetOperations.reverseRangeByScore(key, new Range<>(0d, 100d), //
 						Limit.limit().offset(1).count(10))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(value2);
-				}).verifyComplete();
+				.expectNext(value2) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -394,9 +382,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier
 				.create(zSetOperations.reverseRangeByScoreWithScores(key, new Range<>(0d, 100d), //
 						Limit.limit().offset(1).count(10))) //
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(new DefaultTypedTuple<>(value2, 10d));
-				}).verifyComplete();
+				.expectNext(new DefaultTypedTuple<>(value2, 10d)) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -454,9 +441,7 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, value2, 10)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.removeRange(key, new Range<>(0L, 0L))).expectNext(1L).verifyComplete();
-		StepVerifier.create(zSetOperations.range(key, new Range<>(0L, 5L))).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(1).contains(value1);
-		}).verifyComplete();
+		StepVerifier.create(zSetOperations.range(key, new Range<>(0L, 5L))).expectNext(value1).verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -473,9 +458,9 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(zSetOperations.removeRangeByScore(key, new Range<>(9d, 11d))).expectNext(1L).expectComplete()
 				.verify();
-		StepVerifier.create(zSetOperations.range(key, new Range<>(0L, 5L))).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(1).contains(value1);
-		}).verifyComplete();
+		StepVerifier.create(zSetOperations.range(key, new Range<>(0L, 5L))) //
+				.expectNext(value1) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -496,9 +481,7 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(otherKey, shared, 11)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(zSetOperations.unionAndStore(key, otherKey, destKey)).expectNext(3L).verifyComplete();
-		StepVerifier.create(zSetOperations.range(destKey, new Range<>(0L, 100L))).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(3);
-		}).verifyComplete();
+		StepVerifier.create(zSetOperations.range(destKey, new Range<>(0L, 100L))).expectNextCount(3).verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -520,9 +503,10 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(zSetOperations.intersectAndStore(key, otherKey, destKey)).expectNext(1L).expectComplete()
 				.verify();
-		StepVerifier.create(zSetOperations.range(destKey, new Range<>(0L, 5L))).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(1);
-		}).verifyComplete();
+
+		StepVerifier.create(zSetOperations.range(destKey, new Range<>(0L, 5L))) //
+				.expectNextCount(1) //
+				.verifyComplete();
 
 	}
 
@@ -538,9 +522,9 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, a, 10)).expectNext(true).verifyComplete();
 		StepVerifier.create(zSetOperations.add(key, b, 11)).expectNext(true).verifyComplete();
 
-		StepVerifier.create(zSetOperations.rangeByLex(key, new Range<>("a", "a"))).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(1).contains(a);
-		}).verifyComplete();
+		StepVerifier.create(zSetOperations.rangeByLex(key, new Range<>("a", "a"))) //
+				.expectNext(a) //
+				.verifyComplete();
 
 	}
 
@@ -556,15 +540,13 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, a, 10)).expectNext(true).verifyComplete();
 		StepVerifier.create(zSetOperations.add(key, b, 11)).expectNext(true).verifyComplete();
 
-		StepVerifier.create(zSetOperations.rangeByLex(key, new Range<>("a", "z"), Limit.limit().offset(0).count(10)))
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(2).contains(a, b);
-				}).verifyComplete();
+		StepVerifier.create(zSetOperations.rangeByLex(key, new Range<>("a", "z"), Limit.limit().offset(0).count(10))) //
+				.expectNext(a, b) //
+				.verifyComplete();
 
-		StepVerifier.create(zSetOperations.rangeByLex(key, new Range<>("a", "z"), Limit.limit().offset(1).count(10)))
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(b);
-				}).verifyComplete();
+		StepVerifier.create(zSetOperations.rangeByLex(key, new Range<>("a", "z"), Limit.limit().offset(1).count(10))) //
+				.expectNext(b) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -579,9 +561,9 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, a, 10)).expectNext(true).verifyComplete();
 		StepVerifier.create(zSetOperations.add(key, b, 11)).expectNext(true).verifyComplete();
 
-		StepVerifier.create(zSetOperations.reverseRangeByLex(key, new Range<>("a", "a"))).consumeNextWith(actual -> {
-			assertThat(actual).hasSize(1).contains(a);
-		}).verifyComplete();
+		StepVerifier.create(zSetOperations.reverseRangeByLex(key, new Range<>("a", "a"))) //
+				.expectNext(a) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -596,15 +578,13 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 		StepVerifier.create(zSetOperations.add(key, a, 10)).expectNext(true).verifyComplete();
 		StepVerifier.create(zSetOperations.add(key, b, 11)).expectNext(true).verifyComplete();
 
-		StepVerifier.create(zSetOperations.reverseRangeByLex(key, new Range<>("a", "z"), Limit.limit().offset(0).count(10)))
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(2).contains(b, a);
-				}).verifyComplete();
+		StepVerifier.create(zSetOperations.reverseRangeByLex(key, new Range<>("a", "z"), Limit.limit().offset(0).count(10))) //
+				.expectNext(b, a) //
+				.verifyComplete();
 
-		StepVerifier.create(zSetOperations.reverseRangeByLex(key, new Range<>("a", "z"), Limit.limit().offset(1).count(10)))
-				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(1).contains(a);
-				}).verifyComplete();
+		StepVerifier.create(zSetOperations.reverseRangeByLex(key, new Range<>("a", "z"), Limit.limit().offset(1).count(10))) //
+				.expectNext(a) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602
@@ -617,6 +597,8 @@ public class DefaultReactiveZSetOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(zSetOperations.delete(key)).expectNext(true).verifyComplete();
 
-		StepVerifier.create(zSetOperations.size(key)).expectNext(0L).verifyComplete();
+		StepVerifier.create(zSetOperations.size(key)) //
+				.expectNext(0L) //
+				.verifyComplete();
 	}
 }


### PR DESCRIPTION
Allow streaming where possible without breaking Redis API contract. This means we keep the list collection for those operations potentially returning `NULL` to indicate a value is not present but was requested (eg. MGET).