### PR TITLE
DATAREDIS-624 - Upgrade to Reactor 3.1 and Lettuce 5.0 Snapshots.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
 		<pool>2.2</pool>
-		<lettuce>5.0.0.Beta1</lettuce>
+		<lettuce>5.0.0.BUILD-SNAPSHOT</lettuce>
 		<jedis>2.9.0</jedis>
 		<multithreadedtc>1.01</multithreadedtc>
 	</properties>
@@ -78,8 +78,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>biz.paluch.redis</groupId>
-			<artifactId>lettuce</artifactId>
+			<groupId>io.lettuce</groupId>
+			<artifactId>lettuce-core</artifactId>
 			<version>${lettuce}</version>
 			<optional>true</optional>
 		</dependency>
@@ -252,6 +252,13 @@
 		<repository>
 			<id>spring-libs-snapshot</id>
 			<url>https://repo.spring.io/libs-snapshot</url>
+		</repository>
+		<repository>
+			<id>oss-sonatype-snapsho</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-624-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
@@ -417,7 +417,7 @@ public interface ReactiveGeoCommands {
 		Assert.notNull(member, "Member must not be null!");
 
 		return geoHash(key, Collections.singletonList(member)) //
-				.then(vals -> vals.isEmpty() ? Mono.empty() : Mono.justOrEmpty(vals.iterator().next()));
+				.flatMap(vals -> vals.isEmpty() ? Mono.empty() : Mono.justOrEmpty(vals.iterator().next()));
 	}
 
 	/**
@@ -524,7 +524,7 @@ public interface ReactiveGeoCommands {
 		Assert.notNull(member, "Member must not be null!");
 
 		return geoPos(key, Collections.singletonList(member))
-				.then(vals -> vals.isEmpty() ? Mono.empty() : Mono.justOrEmpty(vals.iterator().next()));
+				.flatMap(vals -> vals.isEmpty() ? Mono.empty() : Mono.justOrEmpty(vals.iterator().next()));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClient.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,11 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.RedisURI;
-import com.lambdaworks.redis.api.StatefulRedisConnection;
-import com.lambdaworks.redis.api.async.RedisAsyncCommands;
-import com.lambdaworks.redis.codec.RedisCodec;
-import com.lambdaworks.redis.pubsub.StatefulRedisPubSubConnection;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 
 /**
  * Extension of {@link RedisClient} that calls auth on all new connections using the supplied credentials
@@ -43,7 +42,7 @@ public class AuthenticatingRedisClient extends RedisClient {
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.lambdaworks.redis.RedisClient#connect(com.lambdaworks.redis.codec.RedisCodec)
+	 * @see io.lettuce.core.RedisClient#connect(io.lettuce.core.codec.RedisCodec)
 	 */
 	@Override
 	public <K, V> StatefulRedisConnection<K, V> connect(RedisCodec<K, V> codec) {
@@ -52,7 +51,7 @@ public class AuthenticatingRedisClient extends RedisClient {
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.lambdaworks.redis.RedisClient#connectPubSub(com.lambdaworks.redis.codec.RedisCodec)
+	 * @see io.lettuce.core.RedisClient#connectPubSub(io.lettuce.core.codec.RedisCodec)
 	 */
 	@Override
 	public <K, V> StatefulRedisPubSubConnection<K, V> connectPubSub(RedisCodec<K, V> codec) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,12 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.resource.ClientResources;
+
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.pool2.BasePooledObjectFactory;
@@ -27,12 +33,6 @@ import org.springframework.data.redis.connection.PoolException;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.RedisURI;
-import com.lambdaworks.redis.api.StatefulConnection;
-import com.lambdaworks.redis.api.StatefulRedisConnection;
-import com.lambdaworks.redis.resource.ClientResources;
 
 /**
  * Default implementation of {@link LettucePool}.

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.KeyValue;
+import io.lettuce.core.RedisException;
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.SlotHash;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+import io.lettuce.core.cluster.models.partitions.Partitions;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,17 +66,6 @@ import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
-
-import com.lambdaworks.redis.KeyValue;
-import com.lambdaworks.redis.RedisException;
-import com.lambdaworks.redis.api.StatefulConnection;
-import com.lambdaworks.redis.cluster.RedisClusterClient;
-import com.lambdaworks.redis.cluster.SlotHash;
-import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
-import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
-import com.lambdaworks.redis.cluster.models.partitions.Partitions;
-import com.lambdaworks.redis.codec.ByteArrayCodec;
-import com.lambdaworks.redis.codec.RedisCodec;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -15,6 +15,14 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisException;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.resource.ClientResources;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -29,18 +37,19 @@ import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
 import org.springframework.data.redis.PassThroughExceptionTranslationStrategy;
 import org.springframework.data.redis.RedisConnectionFailureException;
-import org.springframework.data.redis.connection.*;
+import org.springframework.data.redis.connection.ClusterCommandExecutor;
+import org.springframework.data.redis.connection.Pool;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisClusterConnection;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisNode;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.RedisSentinelConnection;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
-
-import com.lambdaworks.redis.AbstractRedisClient;
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.RedisException;
-import com.lambdaworks.redis.RedisURI;
-import com.lambdaworks.redis.api.StatefulRedisConnection;
-import com.lambdaworks.redis.cluster.RedisClusterClient;
-import com.lambdaworks.redis.resource.ClientResources;
 
 /**
  * Connection factory creating <a href="http://github.com/mp911de/lettuce">Lettuce</a>-based connections.
@@ -211,11 +220,11 @@ public class LettuceConnectionFactory
 	 */
 	@Override
 	public LettuceReactiveRedisClusterConnection getReactiveClusterConnection() {
-		if(!isClusterAware()) {
+		if (!isClusterAware()) {
 			throw new InvalidDataAccessApiUsageException("Cluster is not configured!");
 		}
 
-		return new LettuceReactiveRedisClusterConnection((RedisClusterClient)client);
+		return new LettuceReactiveRedisClusterConnection((RedisClusterClient) client);
 	}
 
 	public void initConnection() {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceExceptionConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceExceptionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,13 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisCommandInterruptedException;
+import io.lettuce.core.RedisCommandTimeoutException;
+import io.lettuce.core.RedisConnectionException;
+import io.lettuce.core.RedisException;
+import io.netty.channel.ChannelException;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -23,14 +30,6 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.RedisSystemException;
-
-import com.lambdaworks.redis.RedisCommandExecutionException;
-import com.lambdaworks.redis.RedisCommandInterruptedException;
-import com.lambdaworks.redis.RedisCommandTimeoutException;
-import com.lambdaworks.redis.RedisConnectionException;
-import com.lambdaworks.redis.RedisException;
-
-import io.netty.channel.ChannelException;
 
 /**
  * Converts Lettuce Exceptions to {@link DataAccessException}s

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.pubsub.RedisPubSubListener;
+
 import org.springframework.data.redis.connection.DefaultMessage;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.util.Assert;
-
-import com.lambdaworks.redis.pubsub.RedisPubSubListener;
 
 /**
  * MessageListener wrapper around Lettuce {@link RedisPubSubListener}.

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePool.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.data.redis.connection.lettuce;
 
-import org.springframework.data.redis.connection.Pool;
+import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.api.StatefulConnection;
 
-import com.lambdaworks.redis.AbstractRedisClient;
-import com.lambdaworks.redis.api.StatefulConnection;
+import org.springframework.data.redis.connection.Pool;
 
 /**
  * Pool of Lettuce {@link StatefulConnection}s

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.RedisException;
+import io.lettuce.core.api.reactive.RedisKeyReactiveCommands;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -29,9 +30,6 @@ import org.springframework.data.redis.connection.ReactiveClusterKeyCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
 import org.springframework.data.redis.connection.RedisClusterNode;
 import org.springframework.util.Assert;
-
-import com.lambdaworks.redis.RedisException;
-import com.lambdaworks.redis.api.reactive.RedisKeyReactiveCommands;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
@@ -88,7 +88,7 @@ public class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommand
 				return super.rename(Mono.just(command));
 			}
 
-			Flux<Boolean> result = cmd.dump(command.getKey())
+			Mono<Boolean> result = cmd.dump(command.getKey())
 					.otherwiseIfEmpty(Mono.error(new RedisSystemException("Cannot rename key that does not exist",
 							new RedisException("ERR no such key."))))
 					.flatMap(value -> cmd.restore(command.getNewName(), 0, value).flatMap(res -> cmd.del(command.getKey())))
@@ -114,7 +114,7 @@ public class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommand
 				return super.renameNX(Mono.just(command));
 			}
 
-			Flux<Boolean> result = cmd.exists(command.getNewName()).flatMap(exists -> {
+			Mono<Boolean> result = cmd.exists(command.getNewName()).flatMap(exists -> {
 
 				if (exists == 1) {
 					return Mono.just(Boolean.FALSE);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
@@ -78,7 +78,7 @@ public class LettuceReactiveClusterListCommands extends LettuceReactiveListComma
 				return super.rPopLPush(Mono.just(command));
 			}
 
-			Flux<ByteBuffer> result = cmd.rpop(command.getKey())
+			Mono<ByteBuffer> result = cmd.rpop(command.getKey())
 					.flatMap(value -> cmd.lpush(command.getDestination(), value).map(x -> value));
 
 			return result.map(value -> new ByteBufferResponse<>(command, value));

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
@@ -224,7 +224,7 @@ public class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommand
 				return super.sMove(Mono.just(command));
 			}
 
-			Flux<Boolean> result = cmd.exists(command.getKey())
+			Mono<Boolean> result = cmd.exists(command.getKey())
 					.flatMap(nrKeys -> nrKeys == 0 ? Mono.empty() : cmd.sismember(command.getKey(), command.getValue()))
 					.flatMap(exists -> {
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.GeoArgs;
+import io.lettuce.core.GeoCoordinates;
+import io.lettuce.core.GeoWithin;
+import io.lettuce.core.Value;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -34,14 +41,6 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.Numeric
 import org.springframework.data.redis.connection.RedisGeoCommands;
 import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
 import org.springframework.util.Assert;
-
-import com.lambdaworks.redis.GeoArgs;
-import com.lambdaworks.redis.GeoCoordinates;
-import com.lambdaworks.redis.GeoWithin;
-import com.lambdaworks.redis.Value;
-
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.KeyValue;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -31,11 +35,6 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiVa
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
-
-import com.lambdaworks.redis.KeyValue;
-
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.api.reactive.RedisKeyReactiveCommands;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -31,8 +32,6 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyComm
 import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.util.Assert;
-
-import com.lambdaworks.redis.api.reactive.RedisKeyReactiveCommands;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
@@ -15,19 +15,18 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
+import reactor.core.publisher.Flux;
+
 import java.nio.ByteBuffer;
 
 import org.springframework.data.redis.connection.ReactiveRedisClusterConnection;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
-import com.lambdaworks.redis.api.reactive.RedisReactiveCommands;
-import com.lambdaworks.redis.cluster.RedisClusterClient;
-import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
-import com.lambdaworks.redis.cluster.api.reactive.RedisClusterReactiveCommands;
-
-import reactor.core.publisher.Flux;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,25 +15,33 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
+import io.lettuce.core.codec.RedisCodec;
+import reactor.core.publisher.Flux;
+
 import java.nio.ByteBuffer;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
-import org.springframework.data.redis.connection.*;
+import org.springframework.data.redis.connection.ReactiveGeoCommands;
+import org.springframework.data.redis.connection.ReactiveHashCommands;
+import org.springframework.data.redis.connection.ReactiveHyperLogLogCommands;
+import org.springframework.data.redis.connection.ReactiveKeyCommands;
+import org.springframework.data.redis.connection.ReactiveListCommands;
+import org.springframework.data.redis.connection.ReactiveNumberCommands;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveSetCommands;
+import org.springframework.data.redis.connection.ReactiveStringCommands;
+import org.springframework.data.redis.connection.ReactiveZSetCommands;
 import org.springframework.util.Assert;
-
-import com.lambdaworks.redis.AbstractRedisClient;
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.api.StatefulConnection;
-import com.lambdaworks.redis.api.StatefulRedisConnection;
-import com.lambdaworks.redis.cluster.RedisClusterClient;
-import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
-import com.lambdaworks.redis.cluster.api.reactive.RedisClusterReactiveCommands;
-import com.lambdaworks.redis.codec.RedisCodec;
-
-import reactor.core.publisher.Flux;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,10 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.SetArgs;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -28,11 +32,6 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.Numeric
 import org.springframework.data.redis.connection.ReactiveRedisConnection.RangeCommand;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
 import org.springframework.util.Assert;
-
-import com.lambdaworks.redis.SetArgs;
-
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
@@ -15,6 +15,13 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.Range;
+import io.lettuce.core.Range.Boundary;
+import io.lettuce.core.ScoredValue;
+import io.lettuce.core.ZAddArgs;
+import io.lettuce.core.ZStoreArgs;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.protocol.LettuceCharsets;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -36,14 +43,6 @@ import org.springframework.data.util.DirectFieldAccessFallbackBeanWrapper;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
-
-import com.lambdaworks.redis.Range;
-import com.lambdaworks.redis.Range.Boundary;
-import com.lambdaworks.redis.ScoredValue;
-import com.lambdaworks.redis.ZAddArgs;
-import com.lambdaworks.redis.ZStoreArgs;
-import com.lambdaworks.redis.codec.StringCodec;
-import com.lambdaworks.redis.protocol.LettuceCharsets;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,12 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI.Builder;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
+import io.lettuce.core.sentinel.api.sync.RedisSentinelCommands;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -25,12 +31,6 @@ import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.RedisSentinelConnection;
 import org.springframework.data.redis.connection.RedisServer;
 import org.springframework.util.Assert;
-
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.RedisURI.Builder;
-import com.lambdaworks.redis.resource.ClientResources;
-import com.lambdaworks.redis.sentinel.api.StatefulRedisSentinelConnection;
-import com.lambdaworks.redis.sentinel.api.sync.RedisSentinelCommands;
 
 /**
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.connection.util.AbstractSubscription;
-
-import com.lambdaworks.redis.pubsub.StatefulRedisPubSubConnection;
 
 /**
  * Message subscription on top of Lettuce.

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveGeoOperations.java
@@ -240,7 +240,7 @@ public class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations
 		Assert.notNull(within, "Circle must not be null!");
 
 		return createMono(connection -> connection.geoRadius(rawKey(key), within) //
-				.flatMap(Flux::fromIterable) //
+				.flatMapMany(Flux::fromIterable) //
 				.map(location -> new GeoLocation<>(readValue(location.getName()), location.getPoint())) //
 				.collectList());
 	}
@@ -256,7 +256,7 @@ public class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations
 		Assert.notNull(args, "GeoRadiusCommandArgs must not be null!");
 
 		return createMono(connection -> connection.geoRadius(rawKey(key), within, args) //
-				.flatMap(Flux::fromIterable) //
+				.flatMapMany(Flux::fromIterable) //
 				.map(geoResult -> new GeoResult<>(
 						new GeoLocation<>(readValue(geoResult.getContent().getName()), geoResult.getContent().getPoint()),
 						geoResult.getDistance())) //
@@ -274,7 +274,7 @@ public class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations
 		Assert.notNull(member, "Member must not be null!");
 
 		return createMono(connection -> connection.geoRadiusByMember(rawKey(key), rawValue(member), new Distance(radius)) //
-				.flatMap(Flux::fromIterable) //
+				.flatMapMany(Flux::fromIterable) //
 				.map(geoLocation -> new GeoLocation<>(readValue(geoLocation.getName()), geoLocation.getPoint())) //
 				.collectList());
 	}
@@ -290,7 +290,7 @@ public class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations
 		Assert.notNull(distance, "Distance must not be null!");
 
 		return createMono(connection -> connection.geoRadiusByMember(rawKey(key), rawValue(member), distance) //
-				.flatMap(Flux::fromIterable) //
+				.flatMapMany(Flux::fromIterable) //
 				.map(geoLocation -> new GeoLocation<>(readValue(geoLocation.getName()), geoLocation.getPoint())) //
 				.collectList());
 	}
@@ -308,7 +308,7 @@ public class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations
 		Assert.notNull(args, "GeoRadiusCommandArgs must not be null!");
 
 		return createMono(connection -> connection.geoRadiusByMember(rawKey(key), rawValue(member), distance, args) //
-				.flatMap(Flux::fromIterable) //
+				.flatMapMany(Flux::fromIterable) //
 				.map(geoResult -> new GeoResult<>(
 						new GeoLocation<>(readValue(geoResult.getContent().getName()), geoResult.getContent().getPoint()),
 						geoResult.getDistance())) //

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
@@ -74,7 +74,7 @@ public class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOpe
 		return createMono(connection -> Flux.fromArray(hashKeys) //
 				.map(o -> (HK) o).map(this::rawHashKey) //
 				.collectList() //
-				.then(hks -> connection.hDel(rawKey(key), hks)));
+				.flatMap(hks -> connection.hDel(rawKey(key), hks)));
 	}
 
 	/* (non-Javadoc)
@@ -116,7 +116,7 @@ public class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOpe
 		return createMono(connection -> Flux.fromIterable(hashKeys) //
 				.map(this::rawHashKey) //
 				.collectList() //
-				.then(hks -> connection.hMGet(rawKey(key), hks)).map(this::deserializeHashValues));
+				.flatMap(hks -> connection.hMGet(rawKey(key), hks)).map(this::deserializeHashValues));
 	}
 
 	/* (non-Javadoc)
@@ -156,7 +156,7 @@ public class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOpe
 		Assert.notNull(key, "Key must not be null!");
 
 		return createMono(connection -> connection.hKeys(rawKey(key)) //
-				.flatMap(Flux::fromIterable) //
+				.flatMapMany(Flux::fromIterable) //
 				.map(this::readHashKey) //
 				.collectList());
 	}
@@ -221,7 +221,7 @@ public class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOpe
 		Assert.notNull(key, "Key must not be null!");
 
 		return createMono(connection -> connection.hVals(rawKey(key)) //
-				.flatMap(Flux::fromIterable) //
+				.flatMapMany(Flux::fromIterable) //
 				.map(this::readHashValue) //
 				.collectList());
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClientTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisException;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.RedisException;
-import com.lambdaworks.redis.api.StatefulRedisConnection;
-import com.lambdaworks.redis.pubsub.StatefulRedisPubSubConnection;
 
 /**
  * Integration test of {@link AuthenticatingRedisClient}. Enable requirepass and comment out the @Ignore to run.

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolTests.java
@@ -19,6 +19,10 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
+import io.lettuce.core.RedisException;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
@@ -29,10 +33,6 @@ import org.junit.Test;
 import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.connection.PoolException;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
-
-import com.lambdaworks.redis.RedisException;
-import com.lambdaworks.redis.RedisURI;
-import com.lambdaworks.redis.api.StatefulRedisConnection;
 
 /**
  * Unit test of {@link DefaultLettucePool}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -26,6 +26,11 @@ import static org.springframework.data.redis.connection.RedisGeoCommands.Distanc
 import static org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs.*;
 import static org.springframework.data.redis.core.ScanOptions.*;
 
+import io.lettuce.core.RedisURI.Builder;
+import io.lettuce.core.api.sync.RedisHLLCommands;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
+
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
@@ -69,11 +74,6 @@ import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.test.util.MinimumRedisVersionRule;
 import org.springframework.data.redis.test.util.RedisClusterRule;
 import org.springframework.test.annotation.IfProfileValue;
-
-import com.lambdaworks.redis.RedisURI.Builder;
-import com.lambdaworks.redis.api.sync.RedisHLLCommands;
-import com.lambdaworks.redis.cluster.RedisClusterClient;
-import com.lambdaworks.redis.cluster.api.sync.RedisAdvancedClusterCommands;
 
 /**
  * @author Christoph Strobl

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
@@ -23,6 +23,13 @@ import static org.mockito.Mockito.*;
 import static org.springframework.data.redis.connection.ClusterTestVariables.*;
 import static org.springframework.data.redis.test.util.MockitoUtils.*;
 
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+import io.lettuce.core.cluster.models.partitions.Partitions;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode.NodeFlag;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,13 +44,6 @@ import org.springframework.data.redis.connection.ClusterCommandExecutor;
 import org.springframework.data.redis.connection.ClusterNodeResourceProvider;
 import org.springframework.data.redis.connection.RedisClusterCommands.AddSlots;
 import org.springframework.data.redis.connection.RedisClusterNode;
-
-import com.lambdaworks.redis.RedisURI;
-import com.lambdaworks.redis.cluster.RedisClusterClient;
-import com.lambdaworks.redis.cluster.api.async.RedisClusterAsyncCommands;
-import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
-import com.lambdaworks.redis.cluster.models.partitions.Partitions;
-import com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode.NodeFlag;
 
 /**
  * @author Christoph Strobl
@@ -75,19 +75,19 @@ public class LettuceClusterConnectionUnitTests {
 
 		Partitions partitions = new Partitions();
 
-		com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode partition1 = new com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode();
+		io.lettuce.core.cluster.models.partitions.RedisClusterNode partition1 = new io.lettuce.core.cluster.models.partitions.RedisClusterNode();
 		partition1.setNodeId(CLUSTER_NODE_1.getId());
 		partition1.setConnected(true);
 		partition1.setFlags(Collections.singleton(NodeFlag.MASTER));
 		partition1.setUri(RedisURI.create("redis://" + CLUSTER_HOST + ":" + MASTER_NODE_1_PORT));
 
-		com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode partition2 = new com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode();
+		io.lettuce.core.cluster.models.partitions.RedisClusterNode partition2 = new io.lettuce.core.cluster.models.partitions.RedisClusterNode();
 		partition2.setNodeId(CLUSTER_NODE_2.getId());
 		partition2.setConnected(true);
 		partition2.setFlags(Collections.singleton(NodeFlag.MASTER));
 		partition2.setUri(RedisURI.create("redis://" + CLUSTER_HOST + ":" + MASTER_NODE_2_PORT));
 
-		com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode partition3 = new com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode();
+		io.lettuce.core.cluster.models.partitions.RedisClusterNode partition3 = new io.lettuce.core.cluster.models.partitions.RedisClusterNode();
 		partition3.setNodeId(CLUSTER_NODE_3.getId());
 		partition3.setConnected(true);
 		partition3.setFlags(Collections.singleton(NodeFlag.MASTER));
@@ -184,9 +184,9 @@ public class LettuceClusterConnectionUnitTests {
 	@Test // DATAREDIS-315
 	public void keysShouldBeRunOnAllClusterNodes() {
 
-		when(clusterConnection1Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]>emptyList());
-		when(clusterConnection2Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]>emptyList());
-		when(clusterConnection3Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]>emptyList());
+		when(clusterConnection1Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]> emptyList());
+		when(clusterConnection2Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]> emptyList());
+		when(clusterConnection3Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]> emptyList());
 
 		byte[] pattern = LettuceConverters.toBytes("*");
 
@@ -200,7 +200,7 @@ public class LettuceClusterConnectionUnitTests {
 	@Test // DATAREDIS-315
 	public void keysShouldOnlyBeRunOnDedicatedNodeWhenPinned() {
 
-		when(clusterConnection2Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]>emptyList());
+		when(clusterConnection2Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]> emptyList());
 
 		byte[] pattern = LettuceConverters.toBytes("*");
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -20,7 +20,10 @@ import static org.hamcrest.core.IsEqual.*;
 import static org.hamcrest.core.IsNull.*;
 import static org.junit.Assert.*;
 
-import com.lambdaworks.redis.api.reactive.BaseRedisReactiveCommands;
+import io.lettuce.core.RedisException;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.reactive.BaseRedisReactiveCommands;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -33,10 +36,6 @@ import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.connection.DefaultStringRedisConnection;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.StringRedisConnection;
-import org.springframework.data.repository.util.QueryExecutionConverters;
-
-import com.lambdaworks.redis.RedisException;
-import com.lambdaworks.redis.api.async.RedisAsyncCommands;
 
 /**
  * Integration test of {@link LettuceConnectionFactory}
@@ -330,8 +329,6 @@ public class LettuceConnectionFactoryTests {
 
 		ConnectionFactoryTracker.add(factory);
 
-		assertThat(factory.getReactiveConnection()
-				.execute(BaseRedisReactiveCommands::ping)
-				.blockFirst(), is("PONG"));
+		assertThat(factory.getReactiveConnection().execute(BaseRedisReactiveCommands::ping).blockFirst(), is("PONG"));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -23,6 +23,11 @@ import static org.springframework.data.redis.connection.ClusterTestVariables.*;
 import static org.springframework.data.redis.connection.lettuce.LettuceTestClientResources.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
+import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.cluster.RedisClusterClient;
+
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
@@ -32,11 +37,6 @@ import org.junit.Test;
 import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
-
-import com.lambdaworks.redis.AbstractRedisClient;
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.RedisURI;
-import com.lambdaworks.redis.cluster.RedisClusterClient;
 
 /**
  * @author Christoph Strobl

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 import static org.springframework.data.redis.SpinBarrier.*;
 
+import io.lettuce.core.api.async.RedisAsyncCommands;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -48,8 +50,6 @@ import org.springframework.data.redis.test.util.RelaxedJUnit4ClassRunner;
 import org.springframework.data.redis.test.util.RequiresRedisSentinel;
 import org.springframework.test.annotation.IfProfileValue;
 import org.springframework.test.context.ContextConfiguration;
-
-import com.lambdaworks.redis.api.async.RedisAsyncCommands;
 
 /**
  * Integration test of {@link LettuceConnection}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionUnitTestSuite.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionUnitTestSuite.java
@@ -17,6 +17,12 @@ package org.springframework.data.redis.connection.lettuce;
 
 import static org.mockito.Mockito.*;
 
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.codec.RedisCodec;
+
 import java.lang.reflect.InvocationTargetException;
 
 import org.junit.Before;
@@ -28,12 +34,6 @@ import org.springframework.data.redis.connection.AbstractConnectionUnitTestBase;
 import org.springframework.data.redis.connection.RedisServerCommands.ShutdownOption;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionUnitTestSuite.LettuceConnectionUnitTests;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionUnitTestSuite.LettucePipelineConnectionUnitTests;
-
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.api.StatefulRedisConnection;
-import com.lambdaworks.redis.api.async.RedisAsyncCommands;
-import com.lambdaworks.redis.api.sync.RedisCommands;
-import com.lambdaworks.redis.codec.RedisCodec;
 
 /**
  * @author Christoph Strobl

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
@@ -23,6 +23,11 @@ import static org.junit.Assert.*;
 import static org.springframework.data.redis.connection.ClusterTestVariables.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.SetArgs;
+import io.lettuce.core.cluster.models.partitions.Partitions;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode.NodeFlag;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,11 +41,6 @@ import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 
-import com.lambdaworks.redis.RedisURI;
-import com.lambdaworks.redis.SetArgs;
-import com.lambdaworks.redis.cluster.models.partitions.Partitions;
-import com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode.NodeFlag;
-
 /**
  * @author Christoph Strobl
  */
@@ -50,13 +50,14 @@ public class LettuceConvertersUnitTests {
 
 	@Test // DATAREDIS-268
 	public void convertingEmptyStringToListOfRedisClientInfoShouldReturnEmptyList() {
-		assertThat(LettuceConverters.toListOfRedisClientInformation(""), equalTo(Collections.<RedisClientInfo>emptyList()));
+		assertThat(LettuceConverters.toListOfRedisClientInformation(""),
+				equalTo(Collections.<RedisClientInfo> emptyList()));
 	}
 
 	@Test // DATAREDIS-268
 	public void convertingNullToListOfRedisClientInfoShouldReturnEmptyList() {
 		assertThat(LettuceConverters.toListOfRedisClientInformation(null),
-				equalTo(Collections.<RedisClientInfo>emptyList()));
+				equalTo(Collections.<RedisClientInfo> emptyList()));
 	}
 
 	@Test // DATAREDIS-268
@@ -80,12 +81,12 @@ public class LettuceConvertersUnitTests {
 
 		Partitions partitions = new Partitions();
 
-		com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode partition = new com.lambdaworks.redis.cluster.models.partitions.RedisClusterNode();
+		io.lettuce.core.cluster.models.partitions.RedisClusterNode partition = new io.lettuce.core.cluster.models.partitions.RedisClusterNode();
 		partition.setNodeId(CLUSTER_NODE_1.getId());
 		partition.setConnected(true);
 		partition.setFlags(new HashSet<NodeFlag>(Arrays.asList(NodeFlag.MASTER, NodeFlag.MYSELF)));
 		partition.setUri(RedisURI.create("redis://" + CLUSTER_HOST + ":" + MASTER_NODE_1_PORT));
-		partition.setSlots(Arrays.<Integer>asList(1, 2, 3, 4, 5));
+		partition.setSlots(Arrays.<Integer> asList(1, 2, 3, 4, 5));
 
 		partitions.addPartition(partition);
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
@@ -18,14 +18,14 @@ package org.springframework.data.redis.connection.lettuce;
 import static org.hamcrest.core.Is.*;
 import static org.junit.Assume.*;
 
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
+import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.springframework.data.redis.test.util.LettuceRedisClusterClientProvider;
-
-import com.lambdaworks.redis.api.sync.RedisCommands;
-import com.lambdaworks.redis.cluster.api.sync.RedisAdvancedClusterCommands;
-import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
 
 /**
  * @author Christoph Strobl

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,13 @@ package org.springframework.data.redis.connection.lettuce;
 import static org.hamcrest.core.Is.*;
 import static org.junit.Assume.*;
 
+import io.lettuce.core.AbstractRedisClient;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
+import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -29,13 +36,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
 import org.springframework.data.redis.test.util.LettuceRedisClusterClientProvider;
-
-import com.lambdaworks.redis.AbstractRedisClient;
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.api.sync.RedisCommands;
-import com.lambdaworks.redis.cluster.RedisClusterClient;
-import com.lambdaworks.redis.cluster.api.sync.RedisAdvancedClusterCommands;
-import com.lambdaworks.redis.cluster.api.sync.RedisClusterCommands;
 
 /**
  * @author Christoph Strobl

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
+import io.lettuce.core.SetArgs;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -34,8 +35,6 @@ import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
-
-import com.lambdaworks.redis.SetArgs;
 
 /**
  * Integration tests for {@link LettuceReactiveKeyCommands}.

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnectionUnitTests.java
@@ -17,6 +17,11 @@ package org.springframework.data.redis.connection.lettuce;
 
 import static org.mockito.Mockito.*;
 
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
+import io.lettuce.core.sentinel.api.sync.RedisSentinelCommands;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -29,11 +34,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.RedisNode.RedisNodeBuilder;
 import org.springframework.data.redis.connection.RedisServer;
-
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.RedisFuture;
-import com.lambdaworks.redis.sentinel.api.StatefulRedisSentinelConnection;
-import com.lambdaworks.redis.sentinel.api.sync.RedisSentinelCommands;
 
 /**
  * @author Christoph Strobl
@@ -86,7 +86,7 @@ public class LettuceSentinelConnectionUnitTests {
 	@Test // DATAREDIS-348
 	public void mastersShouldReadMastersCorrectly() {
 
-		when(sentinelCommandsMock.masters()).thenReturn(Collections.<Map<String, String>>emptyList());
+		when(sentinelCommandsMock.masters()).thenReturn(Collections.<Map<String, String>> emptyList());
 		connection.masters();
 		verify(sentinelCommandsMock, times(1)).masters();
 	}
@@ -94,7 +94,7 @@ public class LettuceSentinelConnectionUnitTests {
 	@Test // DATAREDIS-348
 	public void shouldReadSlavesCorrectly() {
 
-		when(sentinelCommandsMock.slaves(MASTER_ID)).thenReturn(Collections.<Map<String, String>>emptyList());
+		when(sentinelCommandsMock.slaves(MASTER_ID)).thenReturn(Collections.<Map<String, String>> emptyList());
 		connection.slaves(MASTER_ID);
 		verify(sentinelCommandsMock, times(1)).slaves(eq(MASTER_ID));
 	}
@@ -102,7 +102,7 @@ public class LettuceSentinelConnectionUnitTests {
 	@Test // DATAREDIS-348
 	public void shouldReadSlavesCorrectlyWhenGivenNamedNode() {
 
-		when(sentinelCommandsMock.slaves(MASTER_ID)).thenReturn(Collections.<Map<String, String>>emptyList());
+		when(sentinelCommandsMock.slaves(MASTER_ID)).thenReturn(Collections.<Map<String, String>> emptyList());
 		connection.slaves(new RedisNodeBuilder().withName(MASTER_ID).build());
 		verify(sentinelCommandsMock, times(1)).slaves(eq(MASTER_ID));
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSubscriptionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSubscriptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.springframework.data.redis.connection.lettuce;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+import io.lettuce.core.pubsub.api.sync.RedisPubSubCommands;
+
 import java.util.Collection;
 
 import org.junit.Before;
@@ -25,9 +28,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.connection.RedisInvalidSubscriptionException;
-
-import com.lambdaworks.redis.pubsub.StatefulRedisPubSubConnection;
-import com.lambdaworks.redis.pubsub.api.sync.RedisPubSubCommands;
 
 /**
  * Unit test of {@link LettuceSubscription}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceTestClientResources.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceTestClientResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
-import java.util.concurrent.TimeUnit;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.resource.DefaultClientResources;
 
-import com.lambdaworks.redis.resource.ClientResources;
-import com.lambdaworks.redis.resource.DefaultClientResources;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Client-Resources suitable for testing. Uses {@link TestEventLoopGroupProvider} to preserve the event loop groups

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/TestEventLoopGroupProvider.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/TestEventLoopGroupProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
-import java.util.concurrent.TimeUnit;
-
-import com.lambdaworks.redis.resource.DefaultEventLoopGroupProvider;
-
+import io.lettuce.core.resource.DefaultEventLoopGroupProvider;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 
+import java.util.concurrent.TimeUnit;
+
 /**
- * A {@link com.lambdaworks.redis.resource.EventLoopGroupProvider} suitable for testing. Preserves the event loop groups
+ * A {@link io.lettuce.core.resource.EventLoopGroupProvider} suitable for testing. Preserves the event loop groups
  * between tests. Every time a new {@link TestEventLoopGroupProvider} instance is created, a
  * {@link Runtime#addShutdownHook(Thread) shutdown hook} is added to close the resources.
  * 

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveListOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveListOperationsIntegrationTests.java
@@ -125,7 +125,7 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 		StepVerifier.create(listOperations.leftPush(key, value1)).expectNext(1L).verifyComplete();
 		StepVerifier.create(listOperations.leftPush(key, value2)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMap(Flux::fromIterable)).expectNext(value2)
+		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value2)
 				.expectNext(value1).verifyComplete();
 	}
 
@@ -140,7 +140,7 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.leftPushAll(key, value1, value2)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMap(Flux::fromIterable)).expectNext(value2)
+		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value2)
 				.expectNext(value1).verifyComplete();
 	}
 
@@ -170,7 +170,7 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.leftPush(key, value1, value3)).expectNext(3L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMap(Flux::fromIterable)).expectNext(value2)
+		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value2)
 				.expectNext(value3).expectNext(value1).verifyComplete();
 	}
 
@@ -186,7 +186,7 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 		StepVerifier.create(listOperations.rightPush(key, value1)).expectNext(1L).verifyComplete();
 		StepVerifier.create(listOperations.rightPush(key, value2)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMap(Flux::fromIterable)).expectNext(value1)
+		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value1)
 				.expectNext(value2).verifyComplete();
 	}
 
@@ -201,7 +201,7 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.rightPushAll(key, value1, value2)).expectNext(2L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMap(Flux::fromIterable)).expectNext(value1)
+		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value1)
 				.expectNext(value2).verifyComplete();
 	}
 
@@ -231,7 +231,7 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.rightPush(key, value1, value3)).expectNext(3L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMap(Flux::fromIterable)).expectNext(value1)
+		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value1)
 				.expectNext(value3).expectNext(value2).verifyComplete();
 	}
 
@@ -248,7 +248,7 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.set(key, 1, value1)).expectNext(true).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMap(Flux::fromIterable)).expectNext(value1)
+		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value1)
 				.expectNext(value1).verifyComplete();
 	}
 
@@ -265,7 +265,7 @@ public class DefaultReactiveListOperationsIntegrationTests<K, V> {
 
 		StepVerifier.create(listOperations.remove(key, 1, value1)).expectNext(1L).verifyComplete();
 
-		StepVerifier.create(listOperations.range(key, 0, -1).flatMap(Flux::fromIterable)).expectNext(value2)
+		StepVerifier.create(listOperations.range(key, 0, -1).flatMapMany(Flux::fromIterable)).expectNext(value2)
 				.verifyComplete();
 	}
 

--- a/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClientProvider.java
+++ b/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClientProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package org.springframework.data.redis.test.util;
 
-import org.junit.rules.ExternalResource;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
 
-import com.lambdaworks.redis.RedisClient;
-import com.lambdaworks.redis.RedisURI;
+import org.junit.rules.ExternalResource;
 import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
 
 /**
@@ -32,7 +32,7 @@ public class LettuceRedisClientProvider extends ExternalResource {
 	RedisClient client;
 
 	@Override
-	protected void before()  {
+	protected void before() {
 
 		try {
 			super.before();
@@ -40,7 +40,8 @@ public class LettuceRedisClientProvider extends ExternalResource {
 			throwable.printStackTrace();
 		}
 
-		client = RedisClient.create(LettuceTestClientResources.getSharedClientResources(), RedisURI.builder().withHost(host).withPort(port).build());
+		client = RedisClient.create(LettuceTestClientResources.getSharedClientResources(),
+				RedisURI.builder().withHost(host).withPort(port).build());
 	}
 
 	@Override
@@ -50,7 +51,7 @@ public class LettuceRedisClientProvider extends ExternalResource {
 	}
 
 	public RedisClient getClient() {
-		if(client == null) {
+		if (client == null) {
 			before();
 		}
 		return client;
@@ -58,7 +59,7 @@ public class LettuceRedisClientProvider extends ExternalResource {
 
 	public void destroy() {
 
-		if(client != null) {
+		if (client != null) {
 			after();
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClusterClientProvider.java
+++ b/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClusterClientProvider.java
@@ -1,21 +1,5 @@
 /*
- * Copyright 2016. the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +18,9 @@ package org.springframework.data.redis.test.util;
 import org.junit.rules.ExternalResource;
 import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
 
-import com.lambdaworks.redis.RedisURI;
-import com.lambdaworks.redis.cluster.RedisClusterClient;
-import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 
 /**
  * @author Christoph Strobl

--- a/src/test/java/reactor/test/TestSubscriber.java
+++ b/src/test/java/reactor/test/TestSubscriber.java
@@ -37,8 +37,6 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import reactor.core.Fuseable;
-import reactor.core.Receiver;
-import reactor.core.Trackable;
 import reactor.core.publisher.Operators;
 
 /**
@@ -95,7 +93,7 @@ import reactor.core.publisher.Operators;
  * @author Stephane Maldini
  * @author Brian Clozel
  */
-public class TestSubscriber<T> implements Subscriber<T>, Subscription, Trackable, Receiver {
+public class TestSubscriber<T> implements Subscriber<T>, Subscription {
 
 	/**
 	 * Default timeout for waiting next values to be received
@@ -839,17 +837,14 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Trackable
 		}
 	}
 
-	@Override
 	public final boolean isCancelled() {
 		return s == Operators.cancelledSubscription();
 	}
 
-	@Override
 	public final boolean isStarted() {
 		return s != null;
 	}
 
-	@Override
 	public final boolean isTerminated() {
 		return isCancelled();
 	}
@@ -953,7 +948,6 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Trackable
 		}
 	}
 
-	@Override
 	public final long requestedFromDownstream() {
 		return requested;
 	}
@@ -969,7 +963,6 @@ public class TestSubscriber<T> implements Subscriber<T>, Subscription, Trackable
 		return this;
 	}
 
-	@Override
 	public Subscription upstream() {
 		return s;
 	}


### PR DESCRIPTION
Reactor 3.1 changes:

- `Mono.then` -> `flatMap`
- `Mono.flatMap` -> `flatMapMany`.

Lettuce 5.0 changes:
- dependency change `biz.paluch.redis:lettuce` -> `io.lettuce:lettuce-core`
- package change: `com.lambdaworks.redis` -> `io.lettuce.core`.