### PR TITLE
DATAREDIS-645 - Introduce absent values in ReactiveStringCommands.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-645-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
@@ -245,6 +245,14 @@ public interface ReactiveRedisConnection extends Closeable {
 
 		private final I input;
 		private final O output;
+
+		/**
+		 * @return {@literal true} if the response is present. An absent {@link CommandResponse} maps to Redis
+		 *         {@literal (nil)}.
+		 */
+		public boolean isPresent() {
+			return true;
+		}
 	}
 
 	/**
@@ -264,6 +272,26 @@ public interface ReactiveRedisConnection extends Closeable {
 
 		public ByteBufferResponse(I input, ByteBuffer output) {
 			super(input, output);
+		}
+	}
+
+	/**
+	 * {@link CommandResponse} implementation for {@link ByteBuffer} responses for absent keys.
+	 */
+	class AbsentByteBufferResponse<I> extends ByteBufferResponse<I> {
+
+		private final static ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.wrap(new byte[0]);
+
+		public AbsentByteBufferResponse(I input) {
+			super(input, EMPTY_BYTE_BUFFER);
+		}
+
+		/* (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse#isPresent()
+		 */
+		@Override
+		public boolean isPresent() {
+			return false;
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
@@ -199,7 +199,8 @@ public interface ReactiveStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return get(Mono.just(new KeyCommand(key))).next().map(CommandResponse::getOutput);
+		return get(Mono.just(new KeyCommand(key))).next().filter(CommandResponse::isPresent)
+				.map(CommandResponse::getOutput);
 	}
 
 	/**
@@ -225,7 +226,8 @@ public interface ReactiveStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		return getSet(Mono.just(SetCommand.set(key).value(value))).next().map(ByteBufferResponse::getOutput);
+		return getSet(Mono.just(SetCommand.set(key).value(value))).next().filter(CommandResponse::isPresent)
+				.map(ByteBufferResponse::getOutput);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.reactivestreams.Publisher;
 import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.AbsentByteBufferResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBufferResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
@@ -113,7 +114,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 			}
 
 			return cmd.getset(command.getKey(), command.getValue()).map((value) -> new ByteBufferResponse<>(command, value))
-					.defaultIfEmpty(new ByteBufferResponse<>(command, EMPTY_BYTE_BUFFER));
+					.defaultIfEmpty(new AbsentByteBufferResponse<>(command));
 		}));
 	}
 
@@ -129,7 +130,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
 			return cmd.get(command.getKey()).map((value) -> new ByteBufferResponse<>(command, value))
-					.defaultIfEmpty(new ByteBufferResponse<>(command, EMPTY_BYTE_BUFFER));
+					.defaultIfEmpty(new AbsentByteBufferResponse<>(command));
 		}));
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
@@ -67,7 +67,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 
 			Assert.notNull(keys, "Keys must not be null!");
 
-			return cmd.mget(keys.stream().toArray(ByteBuffer[]::new)).map((value) -> value.getValueOrElse(EMPTY_BYTE_BUFFER))
+			return cmd.mget(keys.toArray(new ByteBuffer[0])).map((value) -> value.getValueOrElse(EMPTY_BYTE_BUFFER))
 					.collectList().map((values) -> new MultiValueResponse<>(keys, values));
 		}));
 	}
@@ -337,7 +337,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 
 			Mono<Long> result = null;
 			ByteBuffer destinationKey = command.getDestinationKey();
-			ByteBuffer[] sourceKeys = command.getKeys().stream().toArray(ByteBuffer[]::new);
+			ByteBuffer[] sourceKeys = command.getKeys().toArray(new ByteBuffer[0]);
 
 			switch (command.getBitOp()) {
 				case AND:
@@ -369,6 +369,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	 */
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> strLen(Publisher<KeyCommand> commands) {
+
 		return connection.execute(cmd -> {
 
 			return Flux.from(commands).flatMap(command -> {

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
@@ -20,7 +20,11 @@ import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsEqual.*;
 import static org.hamcrest.core.IsNull.*;
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.*;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.TestSubscriber;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -37,14 +41,11 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiVa
 import org.springframework.data.redis.connection.ReactiveStringCommands.SetCommand;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.core.types.Expiration;
-
 import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.TestSubscriber;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsTestsBase {
 
@@ -59,14 +60,13 @@ public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsT
 		assertThat(nativeCommands.get(KEY_1), is(equalTo(VALUE_2)));
 	}
 
-	@Test // DATAREDIS-525
+	@Test // DATAREDIS-525, DATAREDIS-645
 	public void getSetShouldReturnPreviousValueCorrectlyWhenNoExists() {
 
 		Mono<ByteBuffer> result = connection.stringCommands().getSet(KEY_1_BBUFFER, VALUE_2_BBUFFER);
 
 		ByteBuffer value = result.block();
-		assertThat(value, is(notNullValue()));
-		assertThat(value, is(equalTo(ByteBuffer.allocate(0))));
+		assertThat(value, is(nullValue()));
 		assertThat(nativeCommands.get(KEY_1), is(equalTo(VALUE_2)));
 	}
 
@@ -104,11 +104,11 @@ public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsT
 		assertThat(result.block(), is(equalTo(VALUE_1_BBUFFER)));
 	}
 
-	@Test // DATAREDIS-525
+	@Test // DATAREDIS-525, DATAREDIS-645
 	public void getShouldRetriveNullValueCorrectly() {
 
 		Mono<ByteBuffer> result = connection.stringCommands().get(KEY_1_BBUFFER);
-		assertThat(result.block(), is(equalTo(ByteBuffer.allocate(0))));
+		assertThat(result.block(), is(nullValue()));
 	}
 
 	@Test // DATAREDIS-525

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveValueOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveValueOperationsIntegrationTests.java
@@ -195,6 +195,8 @@ public class DefaultReactiveValueOperationsIntegrationTests<K, V> {
 		K key = keyFactory.instance();
 		V value = valueFactory.instance();
 
+		StepVerifier.create(valueOperations.get(key)).verifyComplete();
+
 		StepVerifier.create(valueOperations.set(key, value)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(valueOperations.get(key)).expectNext(value).verifyComplete();
@@ -206,6 +208,8 @@ public class DefaultReactiveValueOperationsIntegrationTests<K, V> {
 		K key = keyFactory.instance();
 		V value = valueFactory.instance();
 		V nextValue = valueFactory.instance();
+
+		StepVerifier.create(valueOperations.getAndSet(key, nextValue)).verifyComplete();
 
 		StepVerifier.create(valueOperations.set(key, value)).expectNext(true).verifyComplete();
 


### PR DESCRIPTION
We now return `AbsentByteBufferResponse` to indicate absence of a Redis key when retrieving the key as top-level element. `CommandResponse` indicates via `isPresent` its presence or absence of a response value. Omission of absent values can cause a stream with a different response structure compared to the request. Retaining the stream sequence is required for response to request correlation.

`GET` and `GETSET` commands use presence of `CommandResponse` to filter response emission. Both commands return a single element so absence does not interferes with the request structure.

Previously, we just returned an empty byte-array that caused downstream errors deserializing and emitting `null` values that are prohibited in Reactive Streams.

---

Related ticket: [DATAREDIS-645](https://jira.spring.io/browse/DATAREDIS-645)