### PR TITLE
DATAREDIS-656 - Reduce default LettuceConnectionFactory shutdown timeout to 100ms.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-656-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -223,11 +223,11 @@ public interface LettuceClientConfiguration {
 		private ClientResources clientResources;
 		private ClientOptions clientOptions;
 		private Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
-		private Duration shutdownTimeout = Duration.ofSeconds(2);
+		private Duration shutdownTimeout = Duration.ofMillis(100);
 
 		private DefaultLettuceClientConfigurationBuilder() {}
 
-		/*d
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#useSsl()
 		 */
@@ -239,7 +239,7 @@ public interface LettuceClientConfiguration {
 		}
 
 		/*
-		 *(non-Javadoc)
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#disablePeerVerification()
 		 */
 		@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -851,7 +851,7 @@ public class LettuceConnectionFactory
 		private boolean startTls;
 		private ClientResources clientResources;
 		private Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
-		private Duration shutdownTimeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
+		private Duration shutdownTimeout = Duration.ofMillis(100);
 
 		/* (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isUseSsl()

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
@@ -42,7 +42,7 @@ public class LettuceClientConfigurationUnitTests {
 		assertThat(configuration.getClientOptions()).isEmpty();
 		assertThat(configuration.getClientResources()).isEmpty();
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofSeconds(60));
-		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofSeconds(2));
+		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofMillis(100));
 	}
 
 	@Test // DATAREDIS-574


### PR DESCRIPTION
Reducing the default to 100 milliseconds is a good compromise to retain a quiet time in for parallel execution and optimize for default, single-threaded execution (such as test execution or regular application shutdown). The shutdown timeout can be adjusted to fit specific application needs.

Previously, `LettuceConnectionFactory` used different defaults: 2 seconds if used `LettuceClientConfiguration` and 60 seconds without `LettuceClientConfiguration`. In any case, defaults delay shutdown and cause severe delays in total. The driver default of two seconds provides enough time to complete long-running tasks before the actual thread pool shutdown.

---

Related ticket: [DATAREDIS-656](https://jira.spring.io/browse/DATAREDIS-656).