### PR TITLE
DATAREDIS-508 - Support Redis Cluster Pub/Sub using Lettuce.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-508-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -798,11 +798,10 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
-	private StatefulRedisPubSubConnection<byte[], byte[]> switchToPubSub() {
+	protected StatefulRedisPubSubConnection<byte[], byte[]> switchToPubSub() {
+
 		close();
-		// open a pubsub one
 		return ((RedisClient) client).connectPubSub(CODEC);
-		// return ((RedisClient) client).connectPubSub(CODEC);
 	}
 
 	void pipeline(LettuceResult result) {
@@ -892,7 +891,6 @@ public class LettuceConnection extends AbstractRedisConnection {
 					((StatefulRedisConnection<byte[], byte[]>) asyncDedicatedConn).sync().select(dbIndex);
 				}
 			}
-
 		}
 
 		if (asyncDedicatedConn instanceof StatefulRedisConnection) {

--- a/src/test/java/org/springframework/data/redis/listener/PubSubResubscribeTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubResubscribeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.listener;
 
 import static org.junit.Assert.*;
@@ -45,6 +44,8 @@ import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.RedisTestProfileValueSource;
 import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.TestCondition;
+import org.springframework.data.redis.connection.ClusterTestVariables;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -113,7 +114,16 @@ public class PubSubResubscribeTests {
 		lettuceConnFactory.setValidateConnection(true);
 		lettuceConnFactory.afterPropertiesSet();
 
-		return Arrays.asList(new Object[][] { { jedisConnFactory }, { lettuceConnFactory } });
+		LettuceConnectionFactory lettuceClusterConnFactory = new LettuceConnectionFactory(
+				new RedisClusterConfiguration().clusterNode(ClusterTestVariables.CLUSTER_NODE_1));
+		lettuceClusterConnFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		lettuceClusterConnFactory.setPort(port);
+		lettuceClusterConnFactory.setHostName(host);
+		lettuceClusterConnFactory.setValidateConnection(true);
+		lettuceClusterConnFactory.afterPropertiesSet();
+
+		return Arrays
+				.asList(new Object[][] { { jedisConnFactory }, { lettuceConnFactory }, { lettuceClusterConnFactory } });
 	}
 
 	@Before
@@ -251,7 +261,7 @@ public class PubSubResubscribeTests {
 	/**
 	 * Validates the behavior of {@link RedisMessageListenerContainer} when it needs to spin up a thread executing its
 	 * PatternSubscriptionTask
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test


### PR DESCRIPTION
We now use Lettuce's Redis Cluster Pub/Sub connection to create Pub/Sub connections in a cluster.

---

Related ticket: [DATAREDIS-508](https://jira.spring.io/browse/DATAREDIS-508).