### PR TITLE
Feature/fix redis cache

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,12 @@
+<!--
+
 Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
 Make sure that:
+
+-->
 
 - [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
 - [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
 - [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
 - [ ] You submit test cases (unit or integration tests) that back your changes.
 - [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
-- [ ] You provide your full name and an email address registered with your GitHub account. If you’re a first-time submitter, make sure you have completed the [Contributor’s License Agreement form](https://support.springsource.com/spring_committer_signup).

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,26 @@
 language: java
+
 jdk:
   - oraclejdk8
+
 env:
   matrix:
     - PROFILE=spring42
     - PROFILE=spring42-next
     - PROFILE=spring43-next
     - PROFILE=spring5-next
+
+addons:
+  apt:
+    packages:
+    - oracle-java8-installer
+
 cache:
   directories:
     - $HOME/.m2
+
 sudo: false
+
 install: true
+
 script: travis_wait make test SPRING_PROFILE=${PROFILE}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REDIS_VERSION:=3.2.0
+REDIS_VERSION:=3.2.6
 SPRING_PROFILE?=ci
 
 #######
@@ -25,6 +25,8 @@ work/redis-%.conf:
 
 	echo port $* >> $@
 	echo daemonize yes >> $@
+	echo protected-mode no >> $@
+	echo notify-keyspace-events Ex >> $@
 	echo pidfile $(shell pwd)/work/redis-$*.pid >> $@
 	echo logfile $(shell pwd)/work/redis-$*.log >> $@
 	echo save \"\" >> $@
@@ -36,6 +38,8 @@ work/redis-6379.conf:
 
 	echo port 6379 >> $@
 	echo daemonize yes >> $@
+	echo protected-mode no >> $@
+	echo notify-keyspace-events Ex >> $@
 	echo pidfile $(shell pwd)/work/redis-6379.pid >> $@
 	echo logfile $(shell pwd)/work/redis-6379.log >> $@
 	echo save \"\" >> $@
@@ -57,6 +61,7 @@ work/sentinel-%.conf:
 
 	echo port $* >> $@
 	echo daemonize yes >> $@
+	echo protected-mode no >> $@
 	echo bind 0.0.0.0 >> $@
 	echo pidfile $(shell pwd)/work/sentinel-$*.pid >> $@
 	echo logfile $(shell pwd)/work/sentinel-$*.log >> $@
@@ -80,6 +85,7 @@ work/cluster-%.conf:
 	@mkdir -p $(@D)
 
 	echo port $* >> $@
+	echo protected-mode no >> $@
 	echo cluster-enabled yes  >> $@
 	echo cluster-config-file $(shell pwd)/work/nodes-$*.conf  >> $@
 	echo cluster-node-timeout 5  >> $@

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Here are some ways for you to get involved in the community:
 * Create [JIRA](https://jira.spring.io/browse/DATAREDIS) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
 * Watch for upcoming articles on Spring by [subscribing](https://spring.io/blog) to spring.io.
 
+Before we accept a non-trivial patch or pull request we will need you to [sign the Contributor License Agreement](https://cla.pivotal.io/sign/spring). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request.
+
 Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, read the Spring Framework [contributor guidelines] (https://github.com/spring-projects/spring-framework/blob/master/CONTRIBUTING.md).
 
 # Staying in touch

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.RELEASE</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.2.BUILD-SNAPSHOT</version>
+		<version>1.9.2.RELEASE</version>
 	</parent>
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.2.BUILD-SNAPSHOT</springdata.keyvalue>
+		<springdata.keyvalue>1.2.2.RELEASE</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -275,8 +275,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.RELEASE</version>
 	</parent>
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.0.BUILD-SNAPSHOT</springdata.keyvalue>
+		<springdata.keyvalue>1.2.0.RELEASE</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -275,8 +275,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.1.BUILD-SNAPSHOT</version>
+		<version>1.9.1.RELEASE</version>
 	</parent>
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.1.BUILD-SNAPSHOT</springdata.keyvalue>
+		<springdata.keyvalue>1.2.1.RELEASE</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -275,8 +275,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.RC1</version>
+	<version>1.8.0.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.0.RC1</version>
+		<version>1.9.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.0.RC1</springdata.keyvalue>
+		<springdata.keyvalue>1.2.0.BUILD-SNAPSHOT</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -275,8 +275,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-milestone</id>
-			<url>https://repo.spring.io/libs-milestone</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.3.BUILD-SNAPSHOT</version>
+	<version>1.8.3.RELEASE</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.3.BUILD-SNAPSHOT</version>
+		<version>1.9.3.RELEASE</version>
 	</parent>
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.3.BUILD-SNAPSHOT</springdata.keyvalue>
+		<springdata.keyvalue>1.2.3.RELEASE</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -275,8 +275,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.2.RELEASE</version>
+		<version>1.9.3.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.2.RELEASE</springdata.keyvalue>
+		<springdata.keyvalue>1.2.3.BUILD-SNAPSHOT</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -275,8 +275,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.0.RELEASE</version>
+		<version>1.9.1.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.0.RELEASE</springdata.keyvalue>
+		<springdata.keyvalue>1.2.1.BUILD-SNAPSHOT</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -275,8 +275,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.1.BUILD-SNAPSHOT</version>
+	<version>1.8.1.RELEASE</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.1.RELEASE</version>
+	<version>1.8.2.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.0.BUILD-SNAPSHOT</version>
+		<version>1.9.0.RC1</version>
 	</parent>
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.0.BUILD-SNAPSHOT</springdata.keyvalue>
+		<springdata.keyvalue>1.2.0.RC1</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -275,8 +275,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-milestone</id>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.RELEASE</version>
+	<version>1.8.1.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.2.BUILD-SNAPSHOT</version>
+	<version>1.8.2.RELEASE</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.9.1.RELEASE</version>
+		<version>1.9.2.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
 		<dist.key>DATAREDIS</dist.key>
-		<springdata.keyvalue>1.2.1.RELEASE</springdata.keyvalue>
+		<springdata.keyvalue>1.2.2.BUILD-SNAPSHOT</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -275,8 +275,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.2.RELEASE</version>
+	<version>1.8.3.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.0.BUILD-SNAPSHOT</version>
+	<version>1.8.0.RC1</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -6,9 +6,14 @@ New and noteworthy in the latest releases.
 [[new-in-1.8.0]]
 == New in Spring Data Redis 1.8
 
+* Upgrade to Jedis 2.9.
+* Upgrade to `Lettuce` 4.2 (Note: Lettuce 4.2 requires Java 8).
 * Support for Redis http://redis.io/commands#geo[GEO] commands.
 * Support for Geospatial Indexes using Spring Data Repository abstractions (see <<redis.repositories.indexes.geospatial>>).
-* Upgrade to `Lettuce` 4.2. Lettuce 4.2 requires Java 8.
+* `MappingRedisConverter` based `HashMapper` implementation (see <<redis.hashmappers.root>>).
+* Support for `PartialUpdate` in repository support (see <<redis.repositories.partial-updates>>).
+* SSL support for connections to Redis cluster.
+* Support for `client name` via `ConnectionFactory` when using Jedis.
 
 [[new-in-1.7.0]]
 == New in Spring Data Redis 1.7

--- a/src/main/asciidoc/reference/redis.adoc
+++ b/src/main/asciidoc/reference/redis.adoc
@@ -353,6 +353,7 @@ public void useCallback() {
 
 From the framework perspective, the data stored in Redis is just bytes. While Redis itself supports various types, for the most part these refer to the way the data is stored rather than what it represents. It is up to the user to decide whether the information gets translated into Strings or any other objects. The conversion between the user (custom) types and raw data (and vice-versa) is handled in Spring Data Redis through the `RedisSerializer` interface (package `org.springframework.data.redis.serializer`) which as the name implies, takes care of the serialization process. Multiple implementations are available out of the box, two of which have been already mentioned before in this documentation: the `StringRedisSerializer` and the `JdkSerializationRedisSerializer`. However one can use `OxmSerializer` for Object/XML mapping through Spring 3 http://docs.spring.io/spring/docs/current/spring-framework-reference/html/oxm.html[OXM] support or either `JacksonJsonRedisSerializer`, `Jackson2JsonRedisSerializer` or `GenericJackson2JsonRedisSerializer` for storing data in http://en.wikipedia.org/wiki/JSON[JSON] format. Do note that the storage format is not limited only to values - it can be used for keys, values or hashes without any restrictions.[[redis:serializer]]
 
+[[redis.hashmappers.root]]
 == Hash mapping
 
 Data can be stored using various data structures within Redis. You already learned about `Jackson2JsonRedisSerializer` which can convert objects

--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -181,7 +181,8 @@ public class RedisCache extends AbstractValueAdaptingCache {
 			return null;
 		}
 
-		return new RedisCacheElement(cacheKey, fromStoreValue(lookup(cacheKey)));
+		Object storeValue = lookup(cacheKey);
+		return (storeValue != null ? new RedisCacheElement(cacheKey,fromStoreValue(storeValue)) : null);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 package org.springframework.data.redis.cache;
-
-import static org.springframework.util.Assert.*;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -41,7 +39,6 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.ObjectUtils;
 
 /**
  * Cache implementation on top of Redis.
@@ -142,8 +139,9 @@ public class RedisCache extends AbstractValueAdaptingCache {
 	 */
 	public <T> T get(final Object key, final Callable<T> valueLoader) {
 
-		BinaryRedisCacheElement rce = new BinaryRedisCacheElement(
-				new RedisCacheElement(getRedisCacheKey(key), new StoreTranslatingCallable(valueLoader)), cacheValueAccessor);
+		RedisCacheElement cacheElement = new RedisCacheElement(getRedisCacheKey(key),
+				new StoreTranslatingCallable(valueLoader)).expireAfter(cacheMetadata.getDefaultExpiration());
+		BinaryRedisCacheElement rce = new BinaryRedisCacheElement(cacheElement, cacheValueAccessor);
 
 		ValueWrapper val = get(key);
 		if (val != null) {

--- a/src/main/java/org/springframework/data/redis/connection/ClusterCommandExecutor.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterCommandExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,9 +73,9 @@ public class ClusterCommandExecutor implements DisposableBean {
 	public ClusterCommandExecutor(ClusterTopologyProvider topologyProvider, ClusterNodeResourceProvider resourceProvider,
 			ExceptionTranslationStrategy exceptionTranslation) {
 
-		Assert.notNull(topologyProvider);
-		Assert.notNull(resourceProvider);
-		Assert.notNull(exceptionTranslation);
+		Assert.notNull(topologyProvider, "ClusterTopologyProvider must not be null!");
+		Assert.notNull(resourceProvider, "ClusterNodeResourceProvider must not be null!");
+		Assert.notNull(exceptionTranslation, "ExceptionTranslationStrategy must not be null!");
 
 		this.topologyProvider = topologyProvider;
 		this.resourceProvider = resourceProvider;

--- a/src/main/java/org/springframework/data/redis/connection/HyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/HyperLogLogCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.data.redis.connection;
  * {@literal HyperLogLog} specific commands supported by Redis.
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.5
  */
 public interface HyperLogLogCommands {
@@ -26,25 +27,28 @@ public interface HyperLogLogCommands {
 	/**
 	 * Adds given {@literal values} to the HyperLogLog stored at given {@literal key}.
 	 * 
-	 * @param key
-	 * @param values
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
 	 */
 	Long pfAdd(byte[] key, byte[]... values);
 
 	/**
 	 * Return the approximated cardinality of the structures observed by the HyperLogLog at {@literal key(s)}.
 	 * 
-	 * @param keys
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
 	 */
 	Long pfCount(byte[]... keys);
 
 	/**
 	 * Merge N different HyperLogLogs at {@literal sourceKeys} into a single {@literal destinationKey}.
 	 * 
-	 * @param destinationKey
-	 * @param sourceKeys
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sourceKeys must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
 	 */
 	void pfMerge(byte[] destinationKey, byte[]... sourceKeys);
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ public interface RedisClusterCommands {
 	 * Retrieve cluster node information such as {@literal id}, {@literal host}, {@literal port} and {@literal slots}.
 	 * 
 	 * @return never {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-nodes">Redis Documentation: CLUSTER NODES</a>
 	 */
 	Iterable<RedisClusterNode> clusterGetNodes();
 
@@ -44,6 +45,7 @@ public interface RedisClusterCommands {
 	 * 
 	 * @param master must not be {@literal null}.
 	 * @return never {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-slaves">Redis Documentation: CLUSTER SLAVES</a>
 	 */
 	Collection<RedisClusterNode> clusterGetSlaves(RedisClusterNode master);
 
@@ -51,6 +53,7 @@ public interface RedisClusterCommands {
 	 * Retrieve information about masters and their connected slaves.
 	 * 
 	 * @return never {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-slaves">Redis Documentation: CLUSTER SLAVES</a>
 	 */
 	Map<RedisClusterNode, Collection<RedisClusterNode>> clusterGetMasterSlaveMap();
 
@@ -59,6 +62,7 @@ public interface RedisClusterCommands {
 	 * 
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="https://redis.io/commands/cluster-keyslot">Redis Documentation: CLUSTER KEYSLOT</a>
 	 */
 	Integer clusterGetSlotForKey(byte[] key);
 
@@ -82,6 +86,7 @@ public interface RedisClusterCommands {
 	 * Get cluster information.
 	 * 
 	 * @return
+	 * @see <a href="https://redis.io/commands/cluster-info">Redis Documentation: CLUSTER INFO</a>
 	 */
 	ClusterInfo clusterGetClusterInfo();
 
@@ -90,6 +95,7 @@ public interface RedisClusterCommands {
 	 * 
 	 * @param node must not be {@literal null}.
 	 * @param slots
+	 * @see <a href="https://redis.io/commands/cluster-addslots">Redis Documentation: CLUSTER ADDSLOTS</a>
 	 */
 	void clusterAddSlots(RedisClusterNode node, int... slots);
 
@@ -98,6 +104,7 @@ public interface RedisClusterCommands {
 	 * 
 	 * @param node must not be {@literal null}.
 	 * @param range must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-addslots">Redis Documentation: CLUSTER ADDSLOTS</a>
 	 */
 	void clusterAddSlots(RedisClusterNode node, SlotRange range);
 
@@ -106,6 +113,7 @@ public interface RedisClusterCommands {
 	 * 
 	 * @param slot
 	 * @return
+	 * @see <a href="https://redis.io/commands/cluster-countkeysinslot">Redis Documentation: CLUSTER COUNTKEYSINSLOT</a>
 	 */
 	Long clusterCountKeysInSlot(int slot);
 
@@ -114,6 +122,7 @@ public interface RedisClusterCommands {
 	 * 
 	 * @param node must not be {@literal null}.
 	 * @param slots
+	 * @see <a href="https://redis.io/commands/cluster-delslots">Redis Documentation: CLUSTER DELSLOTS</a>
 	 */
 	void clusterDeleteSlots(RedisClusterNode node, int... slots);
 
@@ -122,6 +131,7 @@ public interface RedisClusterCommands {
 	 * 
 	 * @param node must not be {@literal null}.
 	 * @param range must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-delslots">Redis Documentation: CLUSTER DELSLOTS</a>
 	 */
 	void clusterDeleteSlotsInRange(RedisClusterNode node, SlotRange range);
 
@@ -129,6 +139,7 @@ public interface RedisClusterCommands {
 	 * Remove given {@literal node} from cluster.
 	 * 
 	 * @param node must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-forget">Redis Documentation: CLUSTER FORGET</a>
 	 */
 	void clusterForget(RedisClusterNode node);
 
@@ -137,6 +148,7 @@ public interface RedisClusterCommands {
 	 *
 	 * @param node must contain {@link RedisClusterNode#getHost() host} and {@link RedisClusterNode#getPort()} and must
 	 *          not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-meet">Redis Documentation: CLUSTER MEET</a>
 	 */
 	void clusterMeet(RedisClusterNode node);
 
@@ -144,6 +156,7 @@ public interface RedisClusterCommands {
 	 * @param node must not be {@literal null}.
 	 * @param slot
 	 * @param mode must not be{@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-setslot">Redis Documentation: CLUSTER SETSLOT</a>
 	 */
 	void clusterSetSlot(RedisClusterNode node, int slot, AddSlots mode);
 
@@ -153,6 +166,7 @@ public interface RedisClusterCommands {
 	 * @param slot
 	 * @param count must not be {@literal null}.
 	 * @return
+	 * @see <a href="https://redis.io/commands/cluster-getkeysinslot">Redis Documentation: CLUSTER GETKEYSINSLOT</a>
 	 */
 	List<byte[]> clusterGetKeysInSlot(int slot, Integer count);
 
@@ -161,6 +175,7 @@ public interface RedisClusterCommands {
 	 * 
 	 * @param master must not be {@literal null}.
 	 * @param slave must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-replicate">Redis Documentation: CLUSTER REPLICATE</a>
 	 */
 	void clusterReplicate(RedisClusterNode master, RedisClusterNode slave);
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisConnectionCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisConnectionCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,34 +20,32 @@ package org.springframework.data.redis.connection;
  * 
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface RedisConnectionCommands {
 
 	/**
 	 * Select the DB with given positive {@code dbIndex}.
-	 * <p>
-	 * See http://redis.io/commands/select
-	 * 
-	 * @param dbIndex
+	 *
+	 * @param dbIndex the database index.
+	 * @see <a href="http://redis.io/commands/select">Redis Documentation: SELECT</a>
 	 */
 	void select(int dbIndex);
 
 	/**
 	 * Returns {@code message} via server roundtrip.
-	 * <p>
-	 * See http://redis.io/commands/echo
-	 * 
-	 * @param message
+	 *
+	 * @param message the message to echo.
 	 * @return
+	 * @see <a href="http://redis.io/commands/echo">Redis Documentation: ECHO</a>
 	 */
 	byte[] echo(byte[] message);
 
 	/**
 	 * Test connection.
-	 * <p>
-	 * See http://redis.io/commands/ping
-	 * 
+	 *
 	 * @return Server response message - usually {@literal PONG}.
+	 * @see <a href="http://redis.io/commands/ping">Redis Documentation: PING</a>
 	 */
 	String ping();
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.redis.connection;
 
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -28,14 +31,12 @@ import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Point;
 import org.springframework.util.Assert;
 
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 /**
  * Geo-specific Redis commands.
  *
  * @author Ninad Divadkar
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.8
  */
 public interface RedisGeoCommands {
@@ -47,7 +48,7 @@ public interface RedisGeoCommands {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(byte[] key, Point point, byte[] member);
 
@@ -57,7 +58,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(byte[] key, GeoLocation<byte[]> location);
 
@@ -67,7 +68,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(byte[] key, Map<byte[], Point> memberCoordinateMap);
 
@@ -77,7 +78,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(byte[] key, Iterable<GeoLocation<byte[]>> locations);
 
@@ -88,7 +89,7 @@ public interface RedisGeoCommands {
 	 * @param member1 must not be {@literal null}.
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">http://redis.io/commands/geodist</a>
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	Distance geoDist(byte[] key, byte[] member1, byte[] member2);
 
@@ -100,7 +101,7 @@ public interface RedisGeoCommands {
 	 * @param member2 must not be {@literal null}.
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">http://redis.io/commands/geodist</a>
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	Distance geoDist(byte[] key, byte[] member1, byte[] member2, Metric metric);
 
@@ -110,7 +111,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geohash">http://redis.io/commands/geohash</a>
+	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	List<String> geoHash(byte[] key, byte[]... members);
 
@@ -120,7 +121,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geopos">http://redis.io/commands/geopos</a>
+	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	List<Point> geoPos(byte[] key, byte[]... members);
 
@@ -130,7 +131,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within);
 
@@ -141,7 +142,7 @@ public interface RedisGeoCommands {
 	 * @param within must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args);
 
@@ -153,7 +154,7 @@ public interface RedisGeoCommands {
 	 * @param member must not be {@literal null}.
 	 * @param radius
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, double radius);
 
@@ -165,7 +166,7 @@ public interface RedisGeoCommands {
 	 * @param member must not be {@literal null}.
 	 * @param radius must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius);
 
@@ -178,7 +179,7 @@ public interface RedisGeoCommands {
 	 * @param radius must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,
 			GeoRadiusCommandArgs args);
@@ -189,6 +190,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return Number of elements removed.
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	Long geoRemove(byte[] key, byte[]... members);
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,146 +27,147 @@ import org.springframework.data.redis.core.ScanOptions;
  * 
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface RedisHashCommands {
 
 	/**
 	 * Set the {@code value} of a hash {@code field}.
 	 * 
-	 * @see http://redis.io/commands/hset
-	 * @param key
-	 * @param field
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/hset">Redis Documentation: HSET</a>
 	 */
 	Boolean hSet(byte[] key, byte[] field, byte[] value);
 
 	/**
 	 * Set the {@code value} of a hash {@code field} only if {@code field} does not exist.
 	 * 
-	 * @see http://redis.io/commands/hsetnx
-	 * @param key
-	 * @param field
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/hsetnx">Redis Documentation: HSETNX</a>
 	 */
 	Boolean hSetNX(byte[] key, byte[] field, byte[] value);
 
 	/**
 	 * Get value for given {@code field} from hash at {@code key}.
 	 * 
-	 * @see http://redis.io/commands/hget
-	 * @param key
-	 * @param field
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/hget">Redis Documentation: HGET</a>
 	 */
 	byte[] hGet(byte[] key, byte[] field);
 
 	/**
 	 * Get values for given {@code fields} from hash at {@code key}.
 	 * 
-	 * @see http://redis.io/commands/hmget
-	 * @param key
-	 * @param fields
+	 * @param key must not be {@literal null}.
+	 * @param fields must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/hmget">Redis Documentation: HMGET</a>
 	 */
 	List<byte[]> hMGet(byte[] key, byte[]... fields);
 
 	/**
 	 * Set multiple hash fields to multiple values using data provided in {@code hashes}
 	 * 
-	 * @see http://redis.io/commands/hmset
-	 * @param key
-	 * @param hashes
+	 * @param key must not be {@literal null}.
+	 * @param hashes must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/hmset">Redis Documentation: HMSET</a>
 	 */
 	void hMSet(byte[] key, Map<byte[], byte[]> hashes);
 
 	/**
 	 * Increment {@code value} of a hash {@code field} by the given {@code delta}.
 	 * 
-	 * @see http://redis.io/commands/hincrby
-	 * @param key
-	 * @param field
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
 	 * @param delta
 	 * @return
+	 * @see <a href="http://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
 	 */
 	Long hIncrBy(byte[] key, byte[] field, long delta);
 
 	/**
 	 * Increment {@code value} of a hash {@code field} by the given {@code delta}.
 	 * 
-	 * @see http://redis.io/commands/hincrbyfloat
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @param field
 	 * @param delta
 	 * @return
+	 * @see <a href="http://redis.io/commands/hincrbyfloat">Redis Documentation: HINCRBYFLOAT</a>
 	 */
 	Double hIncrBy(byte[] key, byte[] field, double delta);
 
 	/**
 	 * Determine if given hash {@code field} exists.
 	 * 
-	 * @see http://redis.io/commands/hexits
-	 * @param key
-	 * @param field
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/hexits">Redis Documentation: HEXISTS</a>
 	 */
 	Boolean hExists(byte[] key, byte[] field);
 
 	/**
 	 * Delete given hash {@code fields}.
-	 * 
-	 * @see http://redis.io/commands/hdel
-	 * @param key
-	 * @param fields
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param fields must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/hdel">Redis Documentation: HDEL</a>
 	 */
 	Long hDel(byte[] key, byte[]... fields);
 
 	/**
 	 * Get size of hash at {@code key}.
 	 * 
-	 * @see http://redis.io/commands/hlen
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/hlen">Redis Documentation: HLEN</a>
 	 */
 	Long hLen(byte[] key);
 
 	/**
 	 * Get key set (fields) of hash at {@code key}.
 	 * 
-	 * @see http://redis.io/commands/h?
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>?
 	 */
 	Set<byte[]> hKeys(byte[] key);
 
 	/**
 	 * Get entry set (values) of hash at {@code field}.
 	 * 
-	 * @see http://redis.io/commands/hvals
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/hvals">Redis Documentation: HVALS</a>
 	 */
 	List<byte[]> hVals(byte[] key);
 
 	/**
 	 * Get entire hash stored at {@code key}.
 	 * 
-	 * @see http://redis.io/commands/hgetall
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
 	 */
 	Map<byte[], byte[]> hGetAll(byte[] key);
 
 	/**
 	 * Use a {@link Cursor} to iterate over entries in hash at {@code key}.
 	 * 
-	 * @since 1.4
-	 * @see http://redis.io/commands/scan
-	 * @param key
-	 * @param options
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
 	 * @return
+	 * @since 1.4
+	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
 	 */
 	Cursor<Map.Entry<byte[], byte[]>> hScan(byte[] key, ScanOptions options);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,235 +33,213 @@ public interface RedisKeyCommands {
 
 	/**
 	 * Determine if given {@code key} exists.
-	 * <p>
-	 * See http://redis.io/commands/exists
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
 	 */
 	Boolean exists(byte[] key);
 
 	/**
 	 * Delete given {@code keys}.
-	 * <p>
-	 * See http://redis.io/commands/del
-	 * 
-	 * @param keys
+	 *
+	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed.
+	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	Long del(byte[]... keys);
 
 	/**
 	 * Determine the type stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/type
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/type">Redis Documentation: TYPE</a>
 	 */
 	DataType type(byte[] key);
 
 	/**
 	 * Find all keys matching the given {@code pattern}.
-	 * <p>
-	 * See http://redis.io/commands/keys
-	 * 
-	 * @param pattern
+	 *
+	 * @param pattern must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
 	 */
 	Set<byte[]> keys(byte[] pattern);
 
 	/**
 	 * Use a {@link Cursor} to iterate over keys.
-	 * <p>
-	 * See http://redis.io/commands/scan
-	 * 
-	 * @param options
+	 *
+	 * @param options must not be {@literal null}.
 	 * @return
 	 * @since 1.4
+	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 */
 	Cursor<byte[]> scan(ScanOptions options);
 
 	/**
 	 * Return a random key from the keyspace.
-	 * <p>
-	 * See http://redis.io/commands/randomkey
-	 * 
+	 *
 	 * @return
+	 * @see <a href="http://redis.io/commands/randomkey">Redis Documentation: RANDOMKEY</a>
 	 */
 	byte[] randomKey();
 
 	/**
-	 * Rename key {@code oleName} to {@code newName}.
-	 * <p>
-	 * See http://redis.io/commands/rename
-	 * 
-	 * @param oldName
-	 * @param newName
+	 * Rename key {@code oldName} to {@code newName}.
+	 *
+	 * @param oldName must not be {@literal null}.
+	 * @param newName must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/rename">Redis Documentation: RENAME</a>
 	 */
 	void rename(byte[] oldName, byte[] newName);
 
 	/**
-	 * Rename key {@code oleName} to {@code newName} only if {@code newName} does not exist.
-	 * <p>
-	 * See http://redis.io/commands/renamenx
-	 * 
-	 * @param oldName
-	 * @param newName
+	 * Rename key {@code oldName} to {@code newName} only if {@code newName} does not exist.
+	 *
+	 * @param oldName must not be {@literal null}.
+	 * @param newName must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
 	 */
 	Boolean renameNX(byte[] oldName, byte[] newName);
 
 	/**
 	 * Set time to live for given {@code key} in seconds.
-	 * <p>
-	 * See http://redis.io/commands/expire
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param seconds
 	 * @return
+	 * @see <a href="http://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
 	 */
 	Boolean expire(byte[] key, long seconds);
 
 	/**
 	 * Set time to live for given {@code key} in milliseconds.
-	 * <p>
-	 * See http://redis.io/commands/pexpire
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param millis
 	 * @return
+	 * @see <a href="http://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
 	 */
 	Boolean pExpire(byte[] key, long millis);
 
 	/**
 	 * Set the expiration for given {@code key} as a {@literal UNIX} timestamp.
-	 * <p>
-	 * See http://redis.io/commands/expireat
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param unixTime
 	 * @return
+	 * @see <a href="http://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
 	 */
 	Boolean expireAt(byte[] key, long unixTime);
 
 	/**
 	 * Set the expiration for given {@code key} as a {@literal UNIX} timestamp in milliseconds.
-	 * <p>
-	 * See http://redis.io/commands/pexpireat
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param unixTimeInMillis
 	 * @return
+	 * @see <a href="http://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
 	 */
 	Boolean pExpireAt(byte[] key, long unixTimeInMillis);
 
 	/**
 	 * Remove the expiration from given {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/persist
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/persist">Redis Documentation: PERSIST</a>
 	 */
 	Boolean persist(byte[] key);
 
 	/**
 	 * Move given {@code key} to database with {@code index}.
-	 * <p>
-	 * See http://redis.io/commands/move
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param dbIndex
 	 * @return
+	 * @see <a href="http://redis.io/commands/move">Redis Documentation: MOVE</a>
 	 */
 	Boolean move(byte[] key, int dbIndex);
 
 	/**
 	 * Get the time to live for {@code key} in seconds.
-	 * <p>
-	 * See http://redis.io/commands/ttl
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 */
 	Long ttl(byte[] key);
 
 	/**
 	 * Get the time to live for {@code key} in and convert it to the given {@link TimeUnit}.
-	 * <p>
-	 * See http://redis.io/commands/ttl
 	 *
-	 * @param key
-	 * @param timeUnit
+	 * @param key must not be {@literal null}.
+	 * @param timeUnit must not be {@literal null}.
 	 * @return
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 */
 	Long ttl(byte[] key, TimeUnit timeUnit);
 
 	/**
 	 * Get the precise time to live for {@code key} in milliseconds.
-	 * <p>
-	 * See http://redis.io/commands/pttl
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
 	 */
 	Long pTtl(byte[] key);
 
 	/**
 	 * Get the precise time to live for {@code key} in and convert it to the given {@link TimeUnit}.
-	 * <p>
-	 * See http://redis.io/commands/pttl
 	 *
-	 * @param key
-	 * @param timeUnit
+	 * @param key must not be {@literal null}.
+	 * @param timeUnit must not be {@literal null}.
 	 * @return
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
 	 */
 	Long pTtl(byte[] key, TimeUnit timeUnit);
 
 	/**
 	 * Sort the elements for {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/sort
-	 * 
-	 * @param key
-	 * @param params
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param params must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	List<byte[]> sort(byte[] key, SortParameters params);
 
 	/**
 	 * Sort the elements for {@code key} and store result in {@code storeKey}.
-	 * <p>
-	 * See http://redis.io/commands/sort
-	 * 
-	 * @param key
-	 * @param params
-	 * @param storeKey
-	 * @return
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param params must not be {@literal null}.
+	 * @param storeKey must not be {@literal null}.
+	 * @return number of values.
+	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	Long sort(byte[] key, SortParameters params, byte[] storeKey);
 
 	/**
 	 * Retrieve serialized version of the value stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/dump
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/dump">Redis Documentation: DUMP</a>
 	 */
 	byte[] dump(byte[] key);
 
 	/**
 	 * Create {@code key} using the {@code serializedValue}, previously obtained using {@link #dump(byte[])}.
-	 * <p>
-	 * See http://redis.io/commands/restore
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param ttlInMillis
-	 * @param serializedValue
+	 * @param serializedValue must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/restore">Redis Documentation: RESTORE</a>
 	 */
 	void restore(byte[] key, long ttlInMillis, byte[] serializedValue);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisListCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.List;
  * 
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface RedisListCommands {
 
@@ -34,194 +35,180 @@ public interface RedisListCommands {
 
 	/**
 	 * Append {@code values} to {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/rpush
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
+	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	Long rPush(byte[] key, byte[]... values);
 
 	/**
 	 * Prepend {@code values} to {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/lpush
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	Long lPush(byte[] key, byte[]... values);
 
 	/**
-	 * Append {@code} values to {@code key} only if the list exists.
-	 * <p>
-	 * See http://redis.io/commands/rpushx
-	 * 
-	 * @param key
+	 * Append {@code values} to {@code key} only if the list exists.
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
 	 */
 	Long rPushX(byte[] key, byte[] value);
 
 	/**
 	 * Prepend {@code values} to {@code key} only if the list exists.
-	 * <p>
-	 * See http://redis.io/commands/lpushx
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
 	 */
 	Long lPushX(byte[] key, byte[] value);
 
 	/**
 	 * Get the size of list stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/llen
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
 	 */
 	Long lLen(byte[] key);
 
 	/**
-	 * Get elements between {@code begin} and {@code end} from list at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/lrange
-	 * 
-	 * @param key
-	 * @param begin
+	 * Get elements between {@code start} and {@code end} from list at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
-	List<byte[]> lRange(byte[] key, long begin, long end);
+	List<byte[]> lRange(byte[] key, long start, long end);
 
 	/**
-	 * Trim list at {@code key} to elements between {@code begin} and {@code end}.
-	 * <p>
-	 * See http://redis.io/commands/ltrim
-	 * 
-	 * @param key
-	 * @param begin
+	 * Trim list at {@code key} to elements between {@code start} and {@code end}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
 	 * @param end
+	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
 	 */
-	void lTrim(byte[] key, long begin, long end);
+	void lTrim(byte[] key, long start, long end);
 
 	/**
 	 * Get element at {@code index} form list at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/lindex
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @return
+	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
 	 */
 	byte[] lIndex(byte[] key, long index);
 
 	/**
 	 * Insert {@code value} {@link Position#BEFORE} or {@link Position#AFTER} existing {@code pivot} for {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/linsert
-	 * 
-	 * @param key
-	 * @param where
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param where must not be {@literal null}.
 	 * @param pivot
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
 	 */
 	Long lInsert(byte[] key, Position where, byte[] pivot, byte[] value);
 
 	/**
 	 * Set the {@code value} list element at {@code index}.
-	 * <p>
-	 * See http://redis.io/commands/lset
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @param value
+	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
 	 */
 	void lSet(byte[] key, long index, byte[] value);
 
 	/**
 	 * Removes the first {@code count} occurrences of {@code value} from the list stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/lrem
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param count
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 */
 	Long lRem(byte[] key, long count, byte[] value);
 
 	/**
 	 * Removes and returns first element in list stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/lpop
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
 	 */
 	byte[] lPop(byte[] key);
 
 	/**
 	 * Removes and returns last element in list stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/rpop
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
 	 */
 	byte[] rPop(byte[] key);
 
 	/**
-	 * Removes and returns first element from lists stored at {@code keys} (see: {@link #lPop(byte[])}). <br>
+	 * Removes and returns first element from lists stored at {@code keys}. <br>
 	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
-	 * <p>
-	 * See http://redis.io/commands/blpop
-	 * 
+	 *
 	 * @param timeout
-	 * @param keys
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see #lPop(byte[])
 	 */
 	List<byte[]> bLPop(int timeout, byte[]... keys);
 
 	/**
-	 * Removes and returns last element from lists stored at {@code keys} (see: {@link #rPop(byte[])}). <br>
+	 * Removes and returns last element from lists stored at {@code keys}. <br>
 	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
-	 * <p>
-	 * See http://redis.io/commands/brpop
-	 * 
+	 *
 	 * @param timeout
-	 * @param keys
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see #rPop(byte[])
 	 */
 	List<byte[]> bRPop(int timeout, byte[]... keys);
 
 	/**
 	 * Remove the last element from list at {@code srcKey}, append it to {@code dstKey} and return its value.
-	 * <p>
-	 * See http://redis.io/commands/rpoplpush
-	 * 
-	 * @param srcKey
-	 * @param dstKey
+	 *
+	 * @param srcKey must not be {@literal null}.
+	 * @param dstKey must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
 	 */
 	byte[] rPopLPush(byte[] srcKey, byte[] dstKey);
 
 	/**
-	 * Remove the last element from list at {@code srcKey}, append it to {@code dstKey} and return its value (see
-	 * {@link #rPopLPush(byte[], byte[])}). <br>
+	 * Remove the last element from list at {@code srcKey}, append it to {@code dstKey} and return its value.
+	 * <br>
 	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
-	 * <p>
-	 * See http://redis.io/commands/brpoplpush
-	 * 
+	 *
 	 * @param timeout
-	 * @param srcKey
-	 * @param dstKey
+	 * @param srcKey must not be {@literal null}.
+	 * @param dstKey must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 * @see #rPopLPush(byte[], byte[])
 	 */
 	byte[] bRPopLPush(int timeout, byte[] srcKey, byte[] dstKey);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisPubSubCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisPubSubCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.data.redis.connection;
  * PubSub-specific Redis commands.
  * 
  * @author Costin Leau
+ * @author Mark Paluch
  */
 public interface RedisPubSubCommands {
 
@@ -39,9 +40,10 @@ public interface RedisPubSubCommands {
 	/**
 	 * Publishes the given message to the given channel.
 	 * 
-	 * @param channel the channel to publish to
+	 * @param channel the channel to publish to, must not be {@literal null}.
 	 * @param message message to publish
 	 * @return the number of clients that received the message
+	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
 	 */
 	Long publish(byte[] channel, byte[] message);
 
@@ -51,8 +53,9 @@ public interface RedisPubSubCommands {
 	 * <p>
 	 * Note that this operation is blocking and the current thread starts waiting for new messages immediately.
 	 * 
-	 * @param listener message listener
-	 * @param channels channel names
+	 * @param listener message listener, must not be {@literal null}.
+	 * @param channels channel names, must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/subscribe">Redis Documentation: SUBSCRIBE</a>
 	 */
 	void subscribe(MessageListener listener, byte[]... channels);
 
@@ -63,8 +66,9 @@ public interface RedisPubSubCommands {
 	 * <p>
 	 * Note that this operation is blocking and the current thread starts waiting for new messages immediately.
 	 * 
-	 * @param listener message listener
-	 * @param patterns channel name patterns
+	 * @param listener message listener, must not be {@literal null}.
+	 * @param patterns channel name patterns, must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
 	 */
 	void pSubscribe(MessageListener listener, byte[]... patterns);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisScriptingCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,81 +23,77 @@ import java.util.List;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author David Liu
+ * @author Mark Paluch
  */
 public interface RedisScriptingCommands {
 
 	/**
 	 * Flush lua script cache.
-	 * <p>
-	 * See http://redis.io/commands/script-flush
+	 * 
+	 * @see <a href="http://redis.io/commands/script-flush">Redis Documentation: SCRIPT FLUSH</a>
 	 */
 	void scriptFlush();
 
 	/**
 	 * Kill current lua script execution.
-	 * <p>
-	 * See http://redis.io/commands/script-kill
+	 * 
+	 * @see <a href="http://redis.io/commands/script-kill">Redis Documentation: SCRIPT KILL</a>
 	 */
 	void scriptKill();
 
 	/**
 	 * Load lua script into scripts cache, without executing it.<br>
-	 * Execute the script by calling {@link #evalSha(String, ReturnType, int, byte[])}.
-	 * <p>
-	 * See http://redis.io/commands/script-load
-	 * 
-	 * @param script
+	 * Execute the script by calling {@link #evalSha(byte[], ReturnType, int, byte[]...)}.
+	 *
+	 * @param script must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/script-load">Redis Documentation: SCRIPT LOAD</a>
 	 */
 	String scriptLoad(byte[] script);
 
 	/**
 	 * Check if given {@code scriptShas} exist in script cache.
-	 * <p>
-	 * See http://redis.io/commands/script-exits
-	 * 
+	 *
 	 * @param scriptShas
 	 * @return one entry per given scriptSha in returned list.
+	 * @see <a href="http://redis.io/commands/script-exists">Redis Documentation: SCRIPT EXISTS</a>
 	 */
 	List<Boolean> scriptExists(String... scriptShas);
 
 	/**
 	 * Evaluate given {@code script}.
-	 * <p>
-	 * See http://redis.io/commands/eval
-	 * 
-	 * @param script
-	 * @param returnType
+	 *
+	 * @param script must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
 	 * @param numKeys
-	 * @param keysAndArgs
+	 * @param keysAndArgs must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/eval">Redis Documentation: EVAL</a>
 	 */
 	<T> T eval(byte[] script, ReturnType returnType, int numKeys, byte[]... keysAndArgs);
 
 	/**
 	 * Evaluate given {@code scriptSha}.
-	 * <p>
-	 * See http://redis.io/commands/evalsha
-	 * 
-	 * @param scriptSha
-	 * @param returnType
+	 *
+	 * @param scriptSha must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
 	 * @param numKeys
-	 * @param keysAndArgs
+	 * @param keysAndArgs must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
 	 */
 	<T> T evalSha(String scriptSha, ReturnType returnType, int numKeys, byte[]... keysAndArgs);
 
 	/**
 	 * Evaluate given {@code scriptSha}.
-	 * <p>
-	 * See http://redis.io/commands/evalsha
-	 * 
-	 * @param scriptSha
-	 * @param returnType
+	 *
+	 * @param scriptSha must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
 	 * @param numKeys
-	 * @param keysAndArgs
+	 * @param keysAndArgs must not be {@literal null}.
 	 * @return
 	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
 	 */
 	<T> T evalSha(byte[] scriptSha, ReturnType returnType, int numKeys, byte[]... keysAndArgs);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,12 @@ package org.springframework.data.redis.connection;
 import java.util.Collection;
 
 /**
+ * Redis Sentinel-specific commands.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.4
+ * @see <a href="https://redis.io/topics/sentinel">Redis Sentinel Documentation</a>
  */
 public interface RedisSentinelCommands {
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,7 +158,7 @@ public class RedisSentinelConfiguration {
 	 */
 	public void setMaster(NamedNode master) {
 
-		notNull("Sentinel master node must not be 'null'.");
+		notNull(master, "Sentinel master node must not be 'null'.");
 		this.master = master;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisServer.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,8 @@ import org.springframework.util.StringUtils;
 /**
  * @author Christoph Strobl
  * @author Thomas Darimont
- * 
+ * @author Franjo Zilic
+ *
  * @since 1.4
  */
 public class RedisServer extends RedisNode {
@@ -44,7 +45,7 @@ public class RedisServer extends RedisNode {
 		ROLE_REPORTED_TIME("role-reported-time"), //
 		CONFIG_EPOCH("config-epoch"), //
 		NUMBER_SLAVES("num-slaves"), //
-		NUMBER_OTHER_SENTINELS("multi"), //
+		NUMBER_OTHER_SENTINELS("num-other-sentinels"), //
 		BUFFER_LENGTH("qbuf"), //
 		BUFFER_FREE_SPACE("qbuf-free"), //
 		OUTPUT_BUFFER_LENGTH("obl"), //

--- a/src/main/java/org/springframework/data/redis/connection/RedisServer.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisServer.java
@@ -24,7 +24,6 @@ import org.springframework.util.StringUtils;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Franjo Zilic
- *
  * @since 1.4
  */
 public class RedisServer extends RedisNode {
@@ -65,7 +64,7 @@ public class RedisServer extends RedisNode {
 
 	/**
 	 * Creates a new {@link RedisServer} with the given {@code host}, {@code port}.
-	 * 
+	 *
 	 * @param host must not be {@literal null}
 	 * @param port
 	 */
@@ -75,7 +74,7 @@ public class RedisServer extends RedisNode {
 
 	/**
 	 * Creates a new {@link RedisServer} with the given {@code host}, {@code port} and {@code properties}.
-	 * 
+	 *
 	 * @param host must not be {@literal null}
 	 * @param port
 	 * @param properties may be {@literal null}
@@ -95,7 +94,7 @@ public class RedisServer extends RedisNode {
 
 	/**
 	 * Creates a new {@link RedisServer} from the given properties.
-	 * 
+	 *
 	 * @param properties
 	 * @return
 	 */

--- a/src/main/java/org/springframework/data/redis/connection/RedisServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisServerCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.data.redis.core.types.RedisClientInfo;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public interface RedisServerCommands {
 
@@ -42,133 +43,125 @@ public interface RedisServerCommands {
 
 	/**
 	 * Start an {@literal Append Only File} rewrite process on server.
-	 * <p>
-	 * See http://redis.io/commands/bgrewriteaof
 	 * 
 	 * @deprecated As of 1.3, use {@link #bgReWriteAof}.
+	 * @see <a href="http://redis.io/commands/bgrewriteaof">Redis Documentation: BGREWRITEAOF</a>
 	 */
 	@Deprecated
 	void bgWriteAof();
 
 	/**
 	 * Start an {@literal Append Only File} rewrite process on server.
-	 * <p>
-	 * See http://redis.io/commands/bgrewriteaof
-	 * 
+	 *
 	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/bgrewriteaof">Redis Documentation: BGREWRITEAOF</a>
 	 */
 	void bgReWriteAof();
 
 	/**
 	 * Start background saving of db on server.
-	 * <p>
-	 * See http://redis.io/commands/bgsave
+	 *
+	 * @see <a href="http://redis.io/commands/bgsave">Redis Documentation: BGSAVE</a>
 	 */
 	void bgSave();
 
 	/**
 	 * Get time of last {@link #bgSave()} operation in seconds.
-	 * <p>
-	 * See http://redis.io/commands/lastsave
-	 * 
+	 *
 	 * @return
+	 * @see <a href="http://redis.io/commands/lastsave">Redis Documentation: LASTSAVE</a>
 	 */
 	Long lastSave();
 
 	/**
 	 * Synchronous save current db snapshot on server.
-	 * <p>
-	 * See http://redis.io/commands/save
+	 *
+	 * @see <a href="http://redis.io/commands/save">Redis Documentation: SAVE</a>
 	 */
 	void save();
 
 	/**
 	 * Get the total number of available keys in currently selected database.
-	 * <p>
-	 * See http://redis.io/commands/dbsize
-	 * 
+	 *
 	 * @return
+	 * @see <a href="http://redis.io/commands/dbsize">Redis Documentation: DBSIZE</a>
 	 */
 	Long dbSize();
 
 	/**
 	 * Delete all keys of the currently selected database.
-	 * <p>
-	 * See http://redis.io/commands/flushdb
+	 *
+	 * @see <a href="http://redis.io/commands/flushdb">Redis Documentation: FLUSHDB</a>
 	 */
 	void flushDb();
 
 	/**
 	 * Delete all <b>all keys</b> from <b>all databases</b>.
-	 * <p>
-	 * See http://redis.io/commands/flushall
+	 *
+	 * @see <a href="http://redis.io/commands/flushall">Redis Documentation: FLUSHALL</a>
 	 */
 	void flushAll();
 
 	/**
 	 * Load {@literal default} server information like
 	 * <ul>
-	 * <li>mempory</li>
+	 * <li>memory</li>
 	 * <li>cpu utilization</li>
 	 * <li>replication</li>
 	 * </ul>
 	 * <p>
-	 * See http://redis.io/commands/info
 	 * 
 	 * @return
+	 * @see <a href="http://redis.io/commands/info">Redis Documentation: INFO</a>
 	 */
 	Properties info();
 
 	/**
 	 * Load server information for given {@code selection}.
-	 * <p>
-	 * See http://redis.io/commands/info
-	 * 
+	 *
 	 * @return
+	 * @see <a href="http://redis.io/commands/info">Redis Documentation: INFO</a>
 	 */
 	Properties info(String section);
 
 	/**
 	 * Shutdown server.
-	 * <p>
-	 * See http://redis.io/commands/shutdown
+	 *
+	 * @see <a href="http://redis.io/commands/shutdown">Redis Documentation: SHUTDOWN</a>
 	 */
 	void shutdown();
 
 	/**
 	 * Shutdown server.
-	 * <p>
-	 * See http://redis.io/commands/shutdown
-	 * 
+	 *
+	 * @see <a href="http://redis.io/commands/shutdown">Redis Documentation: SHUTDOWN</a>
 	 * @since 1.3
 	 */
 	void shutdown(ShutdownOption option);
 
 	/**
 	 * Load configuration parameters for given {@code pattern} from server.
-	 * <p>
-	 * See http://redis.io/commands/config-get
-	 * 
+	 *
 	 * @param pattern
 	 * @return
+	 * @see <a href="http://redis.io/commands/config-get">Redis Documentation: CONFIG GET</a>
 	 */
 	List<String> getConfig(String pattern);
 
 	/**
 	 * Set server configuration for {@code param} to {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/config-set
-	 * 
+	 *
 	 * @param param
 	 * @param value
+	 * @see <a href="http://redis.io/commands/config-set">Redis Documentation: CONFIG SET</a>
 	 */
 	void setConfig(String param, String value);
 
 	/**
 	 * Reset statistic counters on server. <br>
 	 * Counters can be retrieved using {@link #info()}.
-	 * <p>
-	 * See http://redis.io/commands/config-resetstat
+	 *
+	 * @see <a href="http://redis.io/commands/config-resetstat">Redis Documentation: CONFIG RESETSTAT</a>
 	 */
 	void resetConfigStats();
 
@@ -177,6 +170,7 @@ public interface RedisServerCommands {
 	 * 
 	 * @return current server time in milliseconds.
 	 * @since 1.1
+	 * @see <a href="http://redis.io/commands/time">Redis Documentation: TIME</a>
 	 */
 	Long time();
 
@@ -186,6 +180,7 @@ public interface RedisServerCommands {
 	 * @param host of connection to close.
 	 * @param port of connection to close
 	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/client-kill">Redis Documentation: CLIENT KILL</a>
 	 */
 	void killClient(String host, int port);
 
@@ -194,14 +189,14 @@ public interface RedisServerCommands {
 	 * 
 	 * @param name
 	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/client-setname">Redis Documentation: CLIENT SETNAME</a>
 	 */
 	void setClientName(byte[] name);
 
 	/**
 	 * Returns the name of the current connection.
-	 * <p>
-	 * See http://redis.io/commands/client-getname
-	 * 
+	 *
+	 * @see <a href="http://redis.io/commands/client-getname">Redis Documentation: CLIENT GETNAME</a>
 	 * @return
 	 * @since 1.3
 	 */
@@ -209,50 +204,55 @@ public interface RedisServerCommands {
 
 	/**
 	 * Request information and statistics about connected clients.
-	 * <p>
-	 * See http://redis.io/commands/client-list
-	 * 
+	 *
 	 * @return {@link List} of {@link RedisClientInfo} objects.
 	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/client-list">Redis Documentation: CLIENT LIST</a>
 	 */
 	List<RedisClientInfo> getClientList();
 
 	/**
 	 * Change redis replication setting to new master.
-	 * <p>
-	 * See http://redis.io/commands/slaveof
-	 * 
-	 * @param host
+	 *
+	 * @param host must not be {@literal null}.
 	 * @param port
 	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
 	 */
 	void slaveOf(String host, int port);
 
 	/**
 	 * Change server into master.
-	 * <p>
-	 * See http://redis.io/commands/slaveof
-	 * 
+	 *
 	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
 	 */
 	void slaveOfNoOne();
 
 	/**
+	 * Atomically transfer a key from a source Redis instance to a destination Redis instance. On success the key is
+	 * deleted from the original instance and is guaranteed to exist in the target instance.
+	 * 
 	 * @param key must not be {@literal null}.
 	 * @param target must not be {@literal null}.
 	 * @param dbIndex
 	 * @param option can be {@literal null}. Defaulted to {@link MigrateOption#COPY}.
 	 * @since 1.7
+	 * @see <a href="http://redis.io/commands/migrate">Redis Documentation: MIGRATE</a>
 	 */
 	void migrate(byte[] key, RedisNode target, int dbIndex, MigrateOption option);
 
 	/**
+	 * Atomically transfer a key from a source Redis instance to a destination Redis instance. On success the key is
+	 * deleted from the original instance and is guaranteed to exist in the target instance.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param target must not be {@literal null}.
 	 * @param dbIndex
 	 * @param option can be {@literal null}. Defaulted to {@link MigrateOption#COPY}.
 	 * @param timeout
 	 * @since 1.7
+	 * @see <a href="http://redis.io/commands/migrate">Redis Documentation: MIGRATE</a>
 	 */
 	void migrate(byte[] key, RedisNode target, int dbIndex, MigrateOption option, long timeout);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSetCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,177 +26,162 @@ import org.springframework.data.redis.core.ScanOptions;
  * 
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface RedisSetCommands {
 
 	/**
 	 * Add given {@code values} to set at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/sadd
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
+	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 */
 	Long sAdd(byte[] key, byte[]... values);
 
 	/**
 	 * Remove given {@code values} from set at {@code key} and return the number of removed elements.
-	 * <p>
-	 * See http://redis.io/commands/srem
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
+	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 */
 	Long sRem(byte[] key, byte[]... values);
 
 	/**
 	 * Remove and return a random member from set at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/spop
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	byte[] sPop(byte[] key);
 
 	/**
 	 * Move {@code value} from {@code srcKey} to {@code destKey}
-	 * <p>
-	 * See http://redis.io/commands/smove
-	 * 
-	 * @param srcKey
-	 * @param destKey
+	 *
+	 * @param srcKey must not be {@literal null}.
+	 * @param destKey  must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
 	 */
 	Boolean sMove(byte[] srcKey, byte[] destKey, byte[] value);
 
 	/**
 	 * Get size of set at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/scard
-	 * 
-	 * @param key
+	 *
+	 * @param key  must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
 	 */
 	Long sCard(byte[] key);
 
 	/**
 	 * Check if set at {@code key} contains {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/sismember
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
 	 */
 	Boolean sIsMember(byte[] key, byte[] value);
 
 	/**
 	 * Returns the members intersecting all given sets at {@code keys}.
-	 * <p>
-	 * See http://redis.io/commands/sinter
-	 * 
-	 * @param keys
+	 *
+	 * @param keys  must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	Set<byte[]> sInter(byte[]... keys);
 
 	/**
 	 * Intersect all given sets at {@code keys} and store result in {@code destKey}.
-	 * <p>
-	 * See http://redis.io/commands/sinterstore
-	 * 
-	 * @param destKey
-	 * @param keys
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	Long sInterStore(byte[] destKey, byte[]... keys);
 
 	/**
 	 * Union all sets at given {@code keys}.
-	 * <p>
-	 * See http://redis.io/commands/sunion
-	 * 
-	 * @param keys
+	 *
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	Set<byte[]> sUnion(byte[]... keys);
 
 	/**
 	 * Union all sets at given {@code keys} and store result in {@code destKey}.
-	 * <p>
-	 * See http://redis.io/commands/sunionstore
-	 * 
-	 * @param destKey
-	 * @param keys
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param keys  must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	Long sUnionStore(byte[] destKey, byte[]... keys);
 
 	/**
 	 * Diff all sets for given {@code keys}.
-	 * <p>
-	 * See http://redis.io/commands/sdiff
-	 * 
-	 * @param keys
+	 *
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	Set<byte[]> sDiff(byte[]... keys);
 
 	/**
-	 * Diff all sets for given {@code keys} and store result in {@code destKey}
-	 * <p>
-	 * See http://redis.io/commands/sdiffstore
-	 * 
-	 * @param destKey
-	 * @param keys
+	 * Diff all sets for given {@code keys} and store result in {@code destKey}.
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	Long sDiffStore(byte[] destKey, byte[]... keys);
 
 	/**
 	 * Get all elements of set at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/smembers
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
 	Set<byte[]> sMembers(byte[] key);
 
 	/**
 	 * Get random element from set at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/srandmember
-	 * 
-	 * @param key
+	 *
+	 * @param key  must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	byte[] sRandMember(byte[] key);
 
 	/**
 	 * Get {@code count} random elements from set at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/srandmember
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param count
 	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	List<byte[]> sRandMember(byte[] key, long count);
 
 	/**
 	 * Use a {@link Cursor} to iterate over elements in set at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/scan
-	 * 
-	 * @since 1.4
-	 * @param key
-	 * @param options
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
 	 * @return
+	 * @since 1.4
+	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 */
 	Cursor<byte[]> sScan(byte[] key, ScanOptions options);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,264 +35,240 @@ public interface RedisStringCommands {
 
 	/**
 	 * Get the value of {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/get
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
 	 */
 	byte[] get(byte[] key);
 
 	/**
-	 * Set value of {@code key} and return its old value.
-	 * <p>
-	 * See http://redis.io/commands/getset
-	 * 
+	 * Set {@code value} of {@code key} and return its old value.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
 	 */
 	byte[] getSet(byte[] key, byte[] value);
 
 	/**
-	 * Get the values of all given {@code keys}.
-	 * <p>
-	 * See http://redis.io/commands/mget
-	 * 
-	 * @param keys
+	 * Get multiple {@code keys}. Values are returned in the order of the requested keys.
+	 *
+	 * @param keys  must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/mget">Redis Documentation: MGET</a>
 	 */
 	List<byte[]> mGet(byte[]... keys);
 
 	/**
 	 * Set {@code value} for {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/set
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	void set(byte[] key, byte[] value);
 
 	/**
 	 * Set {@code value} for {@code key} applying timeouts from {@code expiration} if set and inserting/updating values
 	 * depending on {@code option}.
-	 * <p>
-	 * See http://redis.io/commands/set
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @param expiration can be {@literal null}. Defaulted to {@link Expiration#persistent()}.
 	 * @param option can be {@literal null}. Defaulted to {@link SetOption#UPSERT}.
 	 * @since 1.7
+	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	void set(byte[] key, byte[] value, Expiration expiration, SetOption option);
 
 	/**
 	 * Set {@code value} for {@code key}, only if {@code key} does not exist.
-	 * <p>
-	 * See http://redis.io/commands/setnx
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
 	 */
 	Boolean setNX(byte[] key, byte[] value);
 
 	/**
 	 * Set the {@code value} and expiration in {@code seconds} for {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/setex
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param seconds
 	 * @param value must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 */
 	void setEx(byte[] key, long seconds, byte[] value);
 
 	/**
 	 * Set the {@code value} and expiration in {@code milliseconds} for {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/psetex
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param milliseconds
 	 * @param value must not be {@literal null}.
 	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
 	 */
 	void pSetEx(byte[] key, long milliseconds, byte[] value);
 
 	/**
 	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple}.
-	 * <p>
-	 * See http://redis.io/commands/mset
-	 * 
-	 * @param tuple
+	 *
+	 * @param tuple  must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
 	 */
 	void mSet(Map<byte[], byte[]> tuple);
 
 	/**
 	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple} only if the provided key does
 	 * not exist.
-	 * <p>
-	 * See http://redis.io/commands/msetnx
-	 * 
-	 * @param tuple
+	 *
+	 * @param tuple must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
 	 */
 	Boolean mSetNX(Map<byte[], byte[]> tuple);
 
 	/**
-	 * Increment value of {@code key} by 1.
-	 * <p>
-	 * See http://redis.io/commands/incr
-	 * 
+	 * Increment an integer value stored as string value of {@code key} by 1.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
 	 */
 	Long incr(byte[] key);
 
 	/**
-	 * Increment value of {@code key} by {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/incrby
-	 * 
+	 * Increment an integer value stored of {@code key} by {@code delta}.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
 	 */
 	Long incrBy(byte[] key, long value);
 
 	/**
-	 * Increment value of {@code key} by {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/incrbyfloat
-	 * 
+	 * Increment a floating point number value of {@code key} by {@code delta}.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
 	 */
 	Double incrBy(byte[] key, double value);
 
 	/**
-	 * Decrement value of {@code key} by 1.
-	 * <p>
-	 * See http://redis.io/commands/decr
-	 * 
+	 * Decrement an integer value stored as string value of {@code key} by 1.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/decr">Redis Documentation: DECR</a>
 	 */
 	Long decr(byte[] key);
 
 	/**
-	 * Increment value of {@code key} by {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/decrby
-	 * 
+	 * Decrement an integer value stored as string value of {@code key} by {@code value}.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
 	 */
 	Long decrBy(byte[] key, long value);
 
 	/**
 	 * Append a {@code value} to {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/append
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
 	 */
 	Long append(byte[] key, byte[] value);
 
 	/**
 	 * Get a substring of value of {@code key} between {@code begin} and {@code end}.
-	 * <p>
-	 * See http://redis.io/commands/getrange
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param begin
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
 	 */
 	byte[] getRange(byte[] key, long begin, long end);
 
 	/**
 	 * Overwrite parts of {@code key} starting at the specified {@code offset} with given {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/setrange
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @param offset
+	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
 	 */
 	void setRange(byte[] key, byte[] value, long offset);
 
 	/**
 	 * Get the bit value at {@code offset} of value at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/getbit
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param offset
 	 * @return
+	 * @see <a href="http://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
 	 */
 	Boolean getBit(byte[] key, long offset);
 
 	/**
 	 * Sets the bit at {@code offset} in value stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/setbit
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param offset
 	 * @param value
 	 * @return the original bit value stored at {@code offset}.
+	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
 	 */
 	Boolean setBit(byte[] key, long offset, boolean value);
 
 	/**
 	 * Count the number of set bits (population counting) in value stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/bitcount
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 */
 	Long bitCount(byte[] key);
 
 	/**
 	 * Count the number of set bits (population counting) of value stored at {@code key} between {@code begin} and
 	 * {@code end}.
-	 * <p>
-	 * See http://redis.io/commands/bitcount
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param begin
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 */
 	Long bitCount(byte[] key, long begin, long end);
 
 	/**
 	 * Perform bitwise operations between strings.
-	 * <p>
-	 * See http://redis.io/commands/bitop
-	 * 
-	 * @param op
-	 * @param destination
-	 * @param keys
+	 *
+	 * @param op  must not be {@literal null}.
+	 * @param destination must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/bitop">Redis Documentation: BITOP</a>
 	 */
 	Long bitOp(BitOperation op, byte[] destination, byte[]... keys);
 
 	/**
 	 * Get the length of the value stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/strlen
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
 	 */
 	Long strLen(byte[] key);
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisTxCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisTxCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.List;
  * 
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface RedisTxCommands {
 
@@ -29,40 +30,39 @@ public interface RedisTxCommands {
 	 * Mark the start of a transaction block. <br>
 	 * Commands will be queued and can then be executed by calling {@link #exec()} or rolled back using {@link #discard()}
 	 * <p>
-	 * See http://redis.io/commands/multi
+	 * 
+	 * @see <a href="http://redis.io/commands/multi">Redis Documentation: MULTI</a>
 	 */
 	void multi();
 
 	/**
 	 * Executes all queued commands in a transaction started with {@link #multi()}. <br>
-	 * If used along with {@link #watch(byte[])} the operation will fail if any of watched keys has been modified.
-	 * <p>
-	 * See http://redis.io/commands/exec
-	 * 
+	 * If used along with {@link #watch(byte[]...)} the operation will fail if any of watched keys has been modified.
+	 *
 	 * @return List of replies for each executed command.
+	 * @see <a href="http://redis.io/commands/exec">Redis Documentation: EXEC</a>
 	 */
 	List<Object> exec();
 
 	/**
 	 * Discard all commands issued after {@link #multi()}.
-	 * <p>
-	 * See http://redis.io/commands/discard
+	 * 
+	 * @see <a href="http://redis.io/commands/discard">Redis Documentation: DISCARD</a>
 	 */
 	void discard();
 
 	/**
 	 * Watch given {@code keys} for modifications during transaction started with {@link #multi()}.
-	 * <p>
-	 * See http://redis.io/commands/watch
-	 * 
-	 * @param keys
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/watch">Redis Documentation: WATCH</a>
 	 */
 	void watch(byte[]... keys);
 
 	/**
-	 * Flushes all the previously {@link #watch(byte[])} keys.
-	 * <p>
-	 * See http://redis.io/commands/unwatch
+	 * Flushes all the previously {@link #watch(byte[]...)} keys.
+	 * 
+	 * @see <a href="http://redis.io/commands/unwatch">Redis Documentation: UNWATCH</a>
 	 */
 	void unwatch();
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author David Liu
+ * @author Mark Paluch
  */
 public interface RedisZSetCommands {
 
@@ -202,162 +203,150 @@ public interface RedisZSetCommands {
 		public int getOffset() {
 			return offset;
 		}
-
 	}
 
 	/**
 	 * Add {@code value} to a sorted set at {@code key}, or update its {@code score} if it already exists.
-	 * <p>
-	 * See http://redis.io/commands/zadd
-	 * 
-	 * @param key
-	 * @param score
-	 * @param value
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param score the score.
+	 * @param value the value.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	Boolean zAdd(byte[] key, double score, byte[] value);
 
 	/**
 	 * Add {@code tuples} to a sorted set at {@code key}, or update its {@code score} if it already exists.
-	 * <p>
-	 * See http://redis.io/commands/zadd
-	 * 
-	 * @param key
-	 * @param tuples
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param tuples must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	Long zAdd(byte[] key, Set<Tuple> tuples);
 
 	/**
 	 * Remove {@code values} from sorted set. Return number of removed elements.
-	 * <p>
-	 * See http://redis.io/commands/zrem
-	 * 
-	 * @param key
-	 * @param values
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	Long zRem(byte[] key, byte[]... values);
 
 	/**
 	 * Increment the score of element with {@code value} in sorted set by {@code increment}.
-	 * <p>
-	 * See http://redis.io/commands/zincrby
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param increment
-	 * @param value
+	 * @param value the value.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 */
 	Double zIncrBy(byte[] key, double increment, byte[] value);
 
 	/**
 	 * Determine the index of element with {@code value} in a sorted set.
-	 * <p>
-	 * See http://redis.io/commands/zrank
-	 * 
-	 * @param key
-	 * @param value
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value the value.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
 	 */
 	Long zRank(byte[] key, byte[] value);
 
 	/**
 	 * Determine the index of element with {@code value} in a sorted set when scored high to low.
-	 * <p>
-	 * See http://redis.io/commands/zrevrank
-	 * 
-	 * @param key
-	 * @param value
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value the value.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 */
 	Long zRevRank(byte[] key, byte[] value);
 
 	/**
-	 * Get elements between {@code begin} and {@code end} from sorted set.
-	 * <p>
-	 * See http://redis.io/commands/zrange
-	 * 
-	 * @param key
-	 * @param begin
+	 * Get elements between {@code start} and {@code end} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
-	Set<byte[]> zRange(byte[] key, long begin, long end);
+	Set<byte[]> zRange(byte[] key, long start, long end);
 
 	/**
-	 * Get set of {@link Tuple}s between {@code begin} and {@code end} from sorted set.
-	 * <p>
-	 * See http://redis.io/commands/zrange
-	 * 
-	 * @param key
-	 * @param begin
+	 * Get set of {@link Tuple}s between {@code start} and {@code end} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
-	Set<Tuple> zRangeWithScores(byte[] key, long begin, long end);
+	Set<Tuple> zRangeWithScores(byte[] key, long start, long end);
 
 	/**
 	 * Get elements where score is between {@code min} and {@code max} from sorted set.
-	 * <p>
-	 * See http://redis.io/commands/zrangebyscore
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<byte[]> zRangeByScore(byte[] key, double min, double max);
 
 	/**
 	 * Get set of {@link Tuple}s where score is between {@code Range#min} and {@code Range#max} from sorted set.
 	 * 
-	 * @param key
-	 * @param range
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<Tuple> zRangeByScoreWithScores(byte[] key, Range range);
 
 	/**
 	 * Get set of {@link Tuple}s where score is between {@code min} and {@code max} from sorted set.
-	 * <p>
-	 * See http://redis.io/commands/zrangebyscore
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<Tuple> zRangeByScoreWithScores(byte[] key, double min, double max);
 
 	/**
-	 * Get elements in range from {@code begin} to {@code end} where score is between {@code min} and {@code max} from
+	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
 	 * sorted set.
-	 * <p>
-	 * See http://redis.io/commands/zrangebyscore
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @param offset
 	 * @param count
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<byte[]> zRangeByScore(byte[] key, double min, double max, long offset, long count);
 
 	/**
-	 * Get set of {@link Tuple}s in range from {@code begin} to {@code end} where score is between {@code min} and
+	 * Get set of {@link Tuple}s in range from {@code start} to {@code end} where score is between {@code min} and
 	 * {@code max} from sorted set.
-	 * <p>
-	 * See http://redis.io/commands/zrangebyscore
-	 * 
+	 *
 	 * @param key
 	 * @param min
 	 * @param max
 	 * @param offset
 	 * @param count
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<Tuple> zRangeByScoreWithScores(byte[] key, double min, double max, long offset, long count);
 
@@ -365,47 +354,45 @@ public interface RedisZSetCommands {
 	 * Get set of {@link Tuple}s in range from {@code Limit#offset} to {@code Limit#offset + Limit#count} where score is
 	 * between {@code Range#min} and {@code Range#max} from sorted set.
 	 * 
-	 * @param key
-	 * @param range
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @param limit
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<Tuple> zRangeByScoreWithScores(byte[] key, Range range, Limit limit);
 
 	/**
-	 * Get elements in range from {@code begin} to {@code end} from sorted set ordered from high to low.
-	 * <p>
-	 * See http://redis.io/commands/zrevrange
-	 * 
-	 * @param key
-	 * @param begin
+	 * Get elements in range from {@code start} to {@code end} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
-	Set<byte[]> zRevRange(byte[] key, long begin, long end);
+	Set<byte[]> zRevRange(byte[] key, long start, long end);
 
 	/**
-	 * Get set of {@link Tuple}s in range from {@code begin} to {@code end} from sorted set ordered from high to low.
-	 * <p>
-	 * See http://redis.io/commands/zrevrange
-	 * 
-	 * @param key
-	 * @param begin
+	 * Get set of {@link Tuple}s in range from {@code start} to {@code end} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
-	Set<Tuple> zRevRangeWithScores(byte[] key, long begin, long end);
+	Set<Tuple> zRevRangeWithScores(byte[] key, long start, long end);
 
 	/**
 	 * Get elements where score is between {@code min} and {@code max} from sorted set ordered from high to low.
-	 * <p>
-	 * See http://redis.io/commands/zrevrange
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	Set<byte[]> zRevRangeByScore(byte[] key, double min, double max);
 
@@ -413,306 +400,303 @@ public interface RedisZSetCommands {
 	 * Get elements where score is between {@code Range#min} and {@code Range#max} from sorted set ordered from high to
 	 * low.
 	 * 
-	 * @param key
-	 * @param range
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Set<byte[]> zRevRangeByScore(byte[] key, Range range);
 
 	/**
 	 * Get set of {@link Tuple} where score is between {@code min} and {@code max} from sorted set ordered from high to
 	 * low.
-	 * <p>
-	 * See http://redis.io/commands/zrevrange
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Set<Tuple> zRevRangeByScoreWithScores(byte[] key, double min, double max);
 
 	/**
-	 * Get elements in range from {@code begin} to {@code end} where score is between {@code min} and {@code max} from
+	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
 	 * sorted set ordered high -> low.
-	 * <p>
-	 * See http://redis.io/commands/zrevrangebyscore
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @param offset
 	 * @param count
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Set<byte[]> zRevRangeByScore(byte[] key, double min, double max, long offset, long count);
 
 	/**
 	 * Get elements in range from {@code Limit#offset} to {@code Limit#offset + Limit#count} where score is between
 	 * {@code Range#min} and {@code Range#max} from sorted set ordered high -> low.
-	 * 
-	 * @param key
-	 * @param range
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @param limit
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Set<byte[]> zRevRangeByScore(byte[] key, Range range, Limit limit);
 
 	/**
-	 * Get set of {@link Tuple} in range from {@code begin} to {@code end} where score is between {@code min} and
+	 * Get set of {@link Tuple} in range from {@code start} to {@code end} where score is between {@code min} and
 	 * {@code max} from sorted set ordered high -> low.
-	 * <p>
-	 * See http://redis.io/commands/zrevrangebyscore
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @param offset
 	 * @param count
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Set<Tuple> zRevRangeByScoreWithScores(byte[] key, double min, double max, long offset, long count);
 
 	/**
 	 * Get set of {@link Tuple} where score is between {@code Range#min} and {@code Range#max} from sorted set ordered
 	 * from high to low.
-	 * 
-	 * @param key
-	 * @param range
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Set<Tuple> zRevRangeByScoreWithScores(byte[] key, Range range);
 
 	/**
 	 * Get set of {@link Tuple} in range from {@code Limit#offset} to {@code Limit#count} where score is between
 	 * {@code Range#min} and {@code Range#max} from sorted set ordered high -> low.
-	 * 
-	 * @param key
-	 * @param range
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @param limit
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Set<Tuple> zRevRangeByScoreWithScores(byte[] key, Range range, Limit limit);
 
 	/**
 	 * Count number of elements within sorted set with scores between {@code min} and {@code max}.
-	 * <p>
-	 * See http://redis.io/commands/zcount
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @return
+	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	Long zCount(byte[] key, double min, double max);
 
 	/**
 	 * Count number of elements within sorted set with scores between {@code Range#min} and {@code Range#max}.
-	 * 
-	 * @param key
-	 * @param min
-	 * @param max
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	Long zCount(byte[] key, Range range);
 
 	/**
 	 * Get the size of sorted set with {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/zcard
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 */
 	Long zCard(byte[] key);
 
 	/**
 	 * Get the score of element with {@code value} from sorted set with key {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/zrem
 	 * 
-	 * @param key
-	 * @param value
+	 * @param key must not be {@literal null}.
+	 * @param value the value.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	Double zScore(byte[] key, byte[] value);
 
 	/**
-	 * Remove elements in range between {@code begin} and {@code end} from sorted set with {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/zremrange
+	 * Remove elements in range between {@code start} and {@code end} from sorted set with {@code key}.
 	 * 
-	 * @param key
-	 * @param begin
+	 * @param key must not be {@literal null}.
+	 * @param start
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
 	 */
-	Long zRemRange(byte[] key, long begin, long end);
+	Long zRemRange(byte[] key, long start, long end);
 
 	/**
 	 * Remove elements with scores between {@code min} and {@code max} from sorted set with {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/zremrangebyscore
-	 * 
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @return
+	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	Long zRemRangeByScore(byte[] key, double min, double max);
 
 	/**
 	 * Remove elements with scores between {@code Range#min} and {@code Range#max} from sorted set with {@code key}.
-	 * 
-	 * @param key
-	 * @param range
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	Long zRemRangeByScore(byte[] key, Range range);
 
 	/**
 	 * Union sorted {@code sets} and store result in destination {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/zunionstore
-	 * 
-	 * @param destKey
-	 * @param sets
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	Long zUnionStore(byte[] destKey, byte[]... sets);
 
 	/**
 	 * Union sorted {@code sets} and store result in destination {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/zunionstore
-	 * 
-	 * @param destKey
-	 * @param aggregate
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
 	 * @param weights
-	 * @param sets
+	 * @param sets must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets);
 
 	/**
 	 * Intersect sorted {@code sets} and store result in destination {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/zinterstore
-	 * 
-	 * @param destKey
-	 * @param sets
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	Long zInterStore(byte[] destKey, byte[]... sets);
 
 	/**
 	 * Intersect sorted {@code sets} and store result in destination {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/zinterstore
-	 * 
-	 * @param destKey
-	 * @param sets
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @param weights
+	 * @param sets must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets);
 
 	/**
 	 * Use a {@link Cursor} to iterate over elements in sorted set at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/scan
-	 * 
-	 * @since 1.4
-	 * @param key
-	 * @param options
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
 	 * @return
+	 * @since 1.4
+	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
 	 */
 	Cursor<Tuple> zScan(byte[] key, ScanOptions options);
 
 	/**
 	 * Get elements where score is between {@code min} and {@code max} from sorted set.
-	 * <p>
-	 * See http://redis.io/commands/zrangebyscore
-	 * 
-	 * @since 1.5
-	 * @param key
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @return
+	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<byte[]> zRangeByScore(byte[] key, String min, String max);
 
 	/**
 	 * Get elements where score is between {@code Range#min} and {@code Range#max} from sorted set.
-	 * 
-	 * @param key
-	 * @param range
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<byte[]> zRangeByScore(byte[] key, Range range);
 
 	/**
-	 * Get elements in range from {@code begin} to {@code end} where score is between {@code min} and {@code max} from
+	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
 	 * sorted set.
-	 * <p>
-	 * See http://redis.io/commands/zrangebyscore
-	 * 
-	 * @since 1.5
-	 * @param key
-	 * @param min
-	 * @param max
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min must not be {@literal null}.
+	 * @param max must not be {@literal null}.
 	 * @param offset
 	 * @param count
 	 * @return
+	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<byte[]> zRangeByScore(byte[] key, String min, String max, long offset, long count);
 
 	/**
 	 * Get elements in range from {@code Limit#count} to {@code Limit#offset} where score is between {@code Range#min} and
 	 * {@code Range#max} from sorted set.
-	 * 
-	 * @param key
-	 * @param range
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
 	 * @param limit
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Set<byte[]> zRangeByScore(byte[] key, Range range, Limit limit);
 
 	/**
 	 * Get all the elements in the sorted set at {@literal key} in lexicographical ordering.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Set<byte[]> zRangeByLex(byte[] key);
 
 	/**
 	 * Get all the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Set<byte[]> zRangeByLex(byte[] key, Range range);
 
 	/**
 	 * Get all the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering. Result is
 	 * limited via {@link Limit}.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @param range can be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Set<byte[]> zRangeByLex(byte[] key, Range range, Limit limit);
 

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,765 +57,1525 @@ public interface StringRedisConnection extends RedisConnection {
 		String getValueAsString();
 	}
 
+	/**
+	 * 'Native' or 'raw' execution of the given command along-side the given arguments. The command is executed as is,
+	 * with as little 'interpretation' as possible - it is up to the caller to take care of any processing of arguments or
+	 * the result.
+	 *
+	 * @param command Command to execute
+	 * @param args Possible command arguments (may be null)
+	 * @return execution result.
+	 * @see RedisCommands#execute(String, byte[]...)
+	 */
 	Object execute(String command, String... args);
 
+	/**
+	 * 'Native' or 'raw' execution of the given command along-side the given arguments. The command is executed as is,
+	 * with as little 'interpretation' as possible - it is up to the caller to take care of any processing of arguments or
+	 * the result.
+	 *
+	 * @param command Command to execute
+	 * @return execution result.
+	 * @see RedisCommands#execute(String, byte[]...)
+	 */
 	Object execute(String command);
 
 	/**
 	 * Determine if given {@code key} exists.
-	 * <p>
-	 * See http://redis.io/commands/exists
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
+	 * @see RedisKeyCommands#exists(byte[])
 	 */
 	Boolean exists(String key);
 
 	/**
 	 * Delete given {@code keys}.
-	 * <p>
-	 * See http://redis.io/commands/del
 	 *
-	 * @param keys
+	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed.
+	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see RedisKeyCommands#del(byte[]...)
 	 */
 	Long del(String... keys);
 
 	/**
 	 * Determine the type stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/type
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/type">Redis Documentation: TYPE</a>
+	 * @see RedisKeyCommands#type(byte[])
 	 */
 	DataType type(String key);
 
 	/**
 	 * Find all keys matching the given {@code pattern}.
-	 * <p>
-	 * See http://redis.io/commands/keys
 	 *
-	 * @param pattern
+	 * @param pattern must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
+	 * @see RedisKeyCommands#keys(byte[])
 	 */
 	Collection<String> keys(String pattern);
 
 	/**
 	 * Rename key {@code oleName} to {@code newName}.
-	 * <p>
-	 * See http://redis.io/commands/rename
 	 *
-	 * @param oldName
-	 * @param newName
+	 * @param oldName must not be {@literal null}.
+	 * @param newName must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/rename">Redis Documentation: RENAME</a>
+	 * @see RedisKeyCommands#rename(byte[], byte[])
 	 */
 	void rename(String oldName, String newName);
 
 	/**
 	 * Rename key {@code oleName} to {@code newName} only if {@code newName} does not exist.
-	 * <p>
-	 * See http://redis.io/commands/renamenx
 	 *
-	 * @param oldName
-	 * @param newName
+	 * @param oldName must not be {@literal null}.
+	 * @param newName must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
+	 * @see RedisKeyCommands#renameNX(byte[], byte[])
 	 */
 	Boolean renameNX(String oldName, String newName);
 
 	/**
 	 * Set time to live for given {@code key} in seconds.
-	 * <p>
-	 * See http://redis.io/commands/expire
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @param seconds
 	 * @return
+	 * @see <a href="http://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
+	 * @see RedisKeyCommands#expire(byte[], long)
 	 */
 	Boolean expire(String key, long seconds);
 
 	/**
 	 * Set time to live for given {@code key} in milliseconds.
-	 * <p>
-	 * See http://redis.io/commands/pexpire
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @param millis
 	 * @return
+	 * @see <a href="http://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
+	 * @see RedisKeyCommands#pExpire(byte[], long)
 	 */
 	Boolean pExpire(String key, long millis);
 
 	/**
 	 * Set the expiration for given {@code key} as a {@literal UNIX} timestamp.
-	 * <p>
-	 * See http://redis.io/commands/expireat
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @param unixTime
 	 * @return
+	 * @see <a href="http://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
+	 * @see RedisKeyCommands#expireAt(byte[], long)
 	 */
 	Boolean expireAt(String key, long unixTime);
 
 	/**
 	 * Set the expiration for given {@code key} as a {@literal UNIX} timestamp in milliseconds.
-	 * <p>
-	 * See http://redis.io/commands/pexpireat
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @param unixTimeInMillis
 	 * @return
+	 * @see <a href="http://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
+	 * @see RedisKeyCommands#pExpireAt(byte[], long)
 	 */
 	Boolean pExpireAt(String key, long unixTimeInMillis);
 
 	/**
 	 * Remove the expiration from given {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/persist
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/persist">Redis Documentation: PERSIST</a>
+	 * @see RedisKeyCommands#persist(byte[])
 	 */
 	Boolean persist(String key);
 
 	/**
 	 * Move given {@code key} to database with {@code index}.
-	 * <p>
-	 * See http://redis.io/commands/move
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @param dbIndex
 	 * @return
+	 * @see <a href="http://redis.io/commands/move">Redis Documentation: MOVE</a>
+	 * @see RedisKeyCommands#move(byte[], int)
 	 */
 	Boolean move(String key, int dbIndex);
 
 	/**
 	 * Get the time to live for {@code key} in seconds.
-	 * <p>
-	 * See http://redis.io/commands/ttl
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see RedisKeyCommands#ttl(byte[])
 	 */
 	Long ttl(String key);
 
 	/**
 	 * Get the time to live for {@code key} in and convert it to the given {@link TimeUnit}.
-	 * <p>
-	 * See http://redis.io/commands/ttl
 	 *
-	 * @param key
-	 * @param timeUnit
+	 * @param key must not be {@literal null}.
+	 * @param timeUnit must not be {@literal null}.
 	 * @return
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see RedisKeyCommands#ttl(byte[], TimeUnit)
 	 */
 	Long ttl(String key, TimeUnit timeUnit);
 
 	/**
 	 * Get the precise time to live for {@code key} in milliseconds.
-	 * <p>
-	 * See http://redis.io/commands/pttl
 	 *
-	 * @param key
+	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
+	 * @see RedisKeyCommands#pTtl(byte[])
 	 */
 	Long pTtl(String key);
 
 	/**
 	 * Get the precise time to live for {@code key} in and convert it to the given {@link TimeUnit}.
-	 * <p>
-	 * See http://redis.io/commands/pttl
 	 *
-	 * @param key
-	 * @param timeUnit
+	 * @param key must not be {@literal null}.
+	 * @param timeUnit must not be {@literal null}.
 	 * @return
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
+	 * @see RedisKeyCommands#pTtl(byte[], TimeUnit)
 	 */
 	Long pTtl(String key, TimeUnit timeUnit);
 
+	/**
+	 * Returns {@code message} via server roundtrip.
+	 *
+	 * @param message the message to echo.
+	 * @return
+	 * @see <a href="http://redis.io/commands/echo">Redis Documentation: ECHO</a>
+	 * @see RedisConnectionCommands#echo(byte[])
+	 */
 	String echo(String message);
 
-	// sort commands
+	/**
+	 * Sort the elements for {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param params must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 */
 	List<String> sort(String key, SortParameters params);
 
+	/**
+	 * Sort the elements for {@code key} and store result in {@code storeKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param params must not be {@literal null}.
+	 * @param storeKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 */
 	Long sort(String key, SortParameters params, String storeKey);
+
+	// -------------------------------------------------------------------------
+	// Methods dealing with values/Redis strings
+	// -------------------------------------------------------------------------
 
 	/**
 	 * Get the value of {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/get
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 * @see RedisStringCommands#get(byte[])
 	 */
 	String get(String key);
 
 	/**
-	 * Set value of {@code key} and return its old value.
-	 * <p>
-	 * See http://redis.io/commands/getset
+	 * Set {@code value} of {@code key} and return its old value.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 * @see RedisStringCommands#getSet(byte[], byte[])
 	 */
 	String getSet(String key, String value);
 
 	/**
-	 * Get the values of all given {@code keys}.
-	 * <p>
-	 * See http://redis.io/commands/mget
+	 * Get multiple {@code keys}. Values are returned in the order of the requested keys.
 	 *
-	 * @param keys
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/mget">Redis Documentation: MGET</a>
+	 * @see RedisStringCommands#mGet(byte[]...)
 	 */
 	List<String> mGet(String... keys);
 
 	/**
 	 * Set {@code value} for {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/set
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see RedisStringCommands#set(byte[], byte[])
 	 */
 	void set(String key, String value);
 
 	/**
 	 * Set {@code value} for {@code key} applying timeouts from {@code expiration} if set and inserting/updating values
 	 * depending on {@code option}.
-	 * <p>
-	 * See http://redis.io/commands/set
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @param expiration can be {@literal null}. Defaulted to {@link Expiration#persistent()}.
 	 * @param option can be {@literal null}. Defaulted to {@link SetOption#UPSERT}.
 	 * @since 1.7
+	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see RedisStringCommands#set(byte[], byte[], Expiration, SetOption)
 	 */
 	void set(String key, String value, Expiration expiration, SetOption option);
 
 	/**
 	 * Set {@code value} for {@code key}, only if {@code key} does not exist.
-	 * <p>
-	 * See http://redis.io/commands/setnx
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 * @see RedisStringCommands#setNX(byte[], byte[])
 	 */
 	Boolean setNX(String key, String value);
 
 	/**
 	 * Set the {@code value} and expiration in {@code seconds} for {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/setex
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param seconds
 	 * @param value must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see RedisStringCommands#setEx(byte[], long, byte[])
 	 */
 	void setEx(String key, long seconds, String value);
 
 	/**
 	 * Set the {@code value} and expiration in {@code milliseconds} for {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/psetex
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param milliseconds
 	 * @param value must not be {@literal null}.
 	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
+	 * @see RedisStringCommands#pSetEx(byte[], long, byte[])
 	 */
 	void pSetEx(String key, long milliseconds, String value);
 
 	/**
 	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple}.
-	 * <p>
-	 * See http://redis.io/commands/mset
 	 *
-	 * @param tuple
+	 * @param tuple must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 * @see RedisStringCommands#mSet(Map)
 	 */
 	void mSetString(Map<String, String> tuple);
 
 	/**
 	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple} only if the provided key does
 	 * not exist.
-	 * <p>
-	 * See http://redis.io/commands/msetnx
 	 *
-	 * @param tuple
+	 * @param tuple must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
+	 * @see RedisStringCommands#mSetNX(Map)
 	 */
 	Boolean mSetNXString(Map<String, String> tuple);
 
 	/**
-	 * Increment value of {@code key} by 1.
-	 * <p>
-	 * See http://redis.io/commands/incr
+	 * Increment an integer value stored as string value of {@code key} by 1.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 * @see RedisStringCommands#incr(byte[])
 	 */
 	Long incr(String key);
 
 	/**
-	 * Increment value of {@code key} by {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/incrby
+	 * Increment an integer value stored of {@code key} by {@code delta}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
+	 * @see RedisStringCommands#incrBy(byte[], long)
 	 */
 	Long incrBy(String key, long value);
 
 	/**
-	 * Increment value of {@code key} by {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/incrbyfloat
+	 * Increment a floating point number value of {@code key} by {@code delta}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
+	 * @see RedisStringCommands#incrBy(byte[], double)
 	 */
 	Double incrBy(String key, double value);
 
 	/**
-	 * Decrement value of {@code key} by 1.
-	 * <p>
-	 * See http://redis.io/commands/decr
+	 * Decrement an integer value stored as string value of {@code key} by 1.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/decr">Redis Documentation: DECR</a>
+	 * @see RedisStringCommands#decr(byte[])
 	 */
 	Long decr(String key);
 
 	/**
-	 * Increment value of {@code key} by {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/decrby
+	 * Decrement an integer value stored as string value of {@code key} by {@code value}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
+	 * @see RedisStringCommands#decrBy(byte[], long)
 	 */
 	Long decrBy(String key, long value);
 
 	/**
 	 * Append a {@code value} to {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/append
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
+	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 * @see RedisStringCommands#append(byte[], byte[])
 	 */
 	Long append(String key, String value);
 
 	/**
-	 * Get a substring of value of {@code key} between {@code begin} and {@code end}.
-	 * <p>
-	 * See http://redis.io/commands/getrange
+	 * Get a substring of value of {@code key} between {@code start} and {@code end}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param start
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 * @see RedisStringCommands#getRange(byte[], long, long)
 	 */
 	String getRange(String key, long start, long end);
 
 	/**
 	 * Overwrite parts of {@code key} starting at the specified {@code offset} with given {@code value}.
-	 * <p>
-	 * See http://redis.io/commands/setrange
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @param offset
+	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 * @see RedisStringCommands#setRange(byte[], byte[], long)
 	 */
 	void setRange(String key, String value, long offset);
 
 	/**
 	 * Get the bit value at {@code offset} of value at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/getbit
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param offset
 	 * @return
+	 * @see <a href="http://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
+	 * @see RedisStringCommands#getBit(byte[], long)
 	 */
 	Boolean getBit(String key, long offset);
 
 	/**
 	 * Sets the bit at {@code offset} in value stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/setbit
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param offset
 	 * @param value
 	 * @return the original bit value stored at {@code offset}.
+	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
+	 * @see RedisStringCommands#setBit(byte[], long, boolean)
 	 */
 	Boolean setBit(String key, long offset, boolean value);
 
 	/**
 	 * Count the number of set bits (population counting) in value stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/bitcount
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see RedisStringCommands#bitCount(byte[])
 	 */
 	Long bitCount(String key);
 
 	/**
-	 * Count the number of set bits (population counting) of value stored at {@code key} between {@code begin} and
+	 * Count the number of set bits (population counting) of value stored at {@code key} between {@code start} and
 	 * {@code end}.
-	 * <p>
-	 * See http://redis.io/commands/bitcount
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param begin
+	 * @param start
 	 * @param end
 	 * @return
+	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see RedisStringCommands#bitCount(byte[], long, long)
 	 */
-	Long bitCount(String key, long begin, long end);
+	Long bitCount(String key, long start, long end);
 
 	/**
 	 * Perform bitwise operations between strings.
-	 * <p>
-	 * See http://redis.io/commands/bitop
 	 *
-	 * @param op
-	 * @param destination
-	 * @param keys
+	 * @param op must not be {@literal null}.
+	 * @param destination must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/bitop">Redis Documentation: BITOP</a>
+	 * @see RedisStringCommands#bitOp(BitOperation, byte[], byte[]...)
 	 */
 	Long bitOp(BitOperation op, String destination, String... keys);
 
 	/**
 	 * Get the length of the value stored at {@code key}.
-	 * <p>
-	 * See http://redis.io/commands/strlen
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
+	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 * @see RedisStringCommands#strLen(byte[])
 	 */
 	Long strLen(String key);
 
+	// -------------------------------------------------------------------------
+	// Methods dealing with Redis Lists
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Append {@code values} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see RedisListCommands#rPush(byte[], byte[]...)
+	 */
 	Long rPush(String key, String... values);
 
+	/**
+	 * Prepend {@code values} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see RedisListCommands#lPush(byte[], byte[]...)
+	 */
 	Long lPush(String key, String... values);
 
+	/**
+	 * Append {@code values} to {@code key} only if the list exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
+	 * @see RedisListCommands#rPushX(byte[], byte[])
+	 */
 	Long rPushX(String key, String value);
 
+	/**
+	 * Prepend {@code values} to {@code key} only if the list exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
+	 * @see RedisListCommands#lPushX(byte[], byte[])
+	 */
 	Long lPushX(String key, String value);
 
+	/**
+	 * Get the size of list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 * @see RedisListCommands#lLen(byte[])
+	 */
 	Long lLen(String key);
 
+	/**
+	 * Get elements between {@code start} and {@code end} from list at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 * @see RedisListCommands#lRange(byte[], long, long)
+	 */
 	List<String> lRange(String key, long start, long end);
 
+	/**
+	 * Trim list at {@code key} to elements between {@code start} and {@code end}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 * @see RedisListCommands#lTrim(byte[], long, long)
+	 */
 	void lTrim(String key, long start, long end);
 
+	/**
+	 * Get element at {@code index} form list at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param index
+	 * @return
+	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 * @see RedisListCommands#lIndex(byte[], long)
+	 */
 	String lIndex(String key, long index);
 
+	/**
+	 * Insert {@code value} {@link Position#BEFORE} or {@link Position#AFTER} existing {@code pivot} for {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param where must not be {@literal null}.
+	 * @param pivot
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
+	 * @see RedisListCommands#lIndex(byte[], long)
+	 */
 	Long lInsert(String key, Position where, String pivot, String value);
 
+	/**
+	 * Set the {@code value} list element at {@code index}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param index
+	 * @param value
+	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 * @see RedisListCommands#lSet(byte[], long, byte[])
+	 */
 	void lSet(String key, long index, String value);
 
+	/**
+	 * Removes the first {@code count} occurrences of {@code value} from the list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param count
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see RedisListCommands#lRem(byte[], long, byte[])
+	 */
 	Long lRem(String key, long count, String value);
 
+	/**
+	 * Removes and returns first element in list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 * @see RedisListCommands#lPop(byte[])
+	 */
 	String lPop(String key);
 
+	/**
+	 * Removes and returns last element in list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 * @see RedisListCommands#rPop(byte[])
+	 */
 	String rPop(String key);
 
+	/**
+	 * Removes and returns first element from lists stored at {@code keys} (see: {@link #lPop(byte[])}). <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param timeout
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see RedisListCommands#bLPop(int, byte[]...)
+	 */
 	List<String> bLPop(int timeout, String... keys);
 
+	/**
+	 * Removes and returns last element from lists stored at {@code keys} (see: {@link #rPop(byte[])}). <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param timeout
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see RedisListCommands#bRPop(int, byte[]...)
+	 */
 	List<String> bRPop(int timeout, String... keys);
 
+	/**
+	 * Remove the last element from list at {@code srcKey}, append it to {@code dstKey} and return its value.
+	 *
+	 * @param srcKey must not be {@literal null}.
+	 * @param dstKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
+	 * @see RedisListCommands#rPopLPush(byte[], byte[])
+	 */
 	String rPopLPush(String srcKey, String dstKey);
 
+	/**
+	 * Remove the last element from list at {@code srcKey}, append it to {@code dstKey} and return its value (see
+	 * {@link #rPopLPush(byte[], byte[])}). <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param timeout
+	 * @param srcKey must not be {@literal null}.
+	 * @param dstKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 * @see RedisListCommands#bRPopLPush(int, byte[], byte[])
+	 */
 	String bRPopLPush(int timeout, String srcKey, String dstKey);
 
+	// -------------------------------------------------------------------------
+	// Methods dealing with Redis Sets
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Add given {@code values} to set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see RedisSetCommands#sAdd(byte[], byte[]...)
+	 */
 	Long sAdd(String key, String... values);
 
+	/**
+	 * Remove given {@code values} from set at {@code key} and return the number of removed elements.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see RedisSetCommands#sRem(byte[], byte[]...)
+	 */
 	Long sRem(String key, String... values);
 
+	/**
+	 * Remove and return a random member from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see RedisSetCommands#sPop(byte[])
+	 */
 	String sPop(String key);
 
+	/**
+	 * Move {@code value} from {@code srcKey} to {@code destKey}
+	 *
+	 * @param srcKey must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 * @see RedisSetCommands#sMove(byte[], byte[], byte[])
+	 */
 	Boolean sMove(String srcKey, String destKey, String value);
 
+	/**
+	 * Get size of set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 * @see RedisSetCommands#sCard(byte[])
+	 */
 	Long sCard(String key);
 
+	/**
+	 * Check if set at {@code key} contains {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 * @see RedisSetCommands#sIsMember(byte[], byte[])
+	 */
 	Boolean sIsMember(String key, String value);
 
+	/**
+	 * Returns the members intersecting all given sets at {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see RedisSetCommands#sInter(byte[]...)
+	 */
 	Set<String> sInter(String... keys);
 
+	/**
+	 * Intersect all given sets at {@code keys} and store result in {@code destKey}.
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see RedisSetCommands#sInterStore(byte[], byte[]...)
+	 */
 	Long sInterStore(String destKey, String... keys);
 
+	/**
+	 * Union all sets at given {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see RedisSetCommands#sUnion(byte[]...)
+	 */
 	Set<String> sUnion(String... keys);
 
+	/**
+	 * Union all sets at given {@code keys} and store result in {@code destKey}.
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see RedisSetCommands#sUnionStore(byte[], byte[]...)
+	 */
 	Long sUnionStore(String destKey, String... keys);
 
+	/**
+	 * Diff all sets for given {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see RedisSetCommands#sDiff(byte[]...)
+	 */
 	Set<String> sDiff(String... keys);
 
+	/**
+	 * Diff all sets for given {@code keys} and store result in {@code destKey}.
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see RedisSetCommands#sDiffStore(byte[], byte[]...)
+	 */
 	Long sDiffStore(String destKey, String... keys);
 
+	/**
+	 * Get all elements of set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 * @see RedisSetCommands#sMembers(byte[])
+	 */
 	Set<String> sMembers(String key);
 
+	/**
+	 * Get random element from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see RedisSetCommands#sRandMember(byte[])
+	 */
 	String sRandMember(String key);
 
+	/**
+	 * Get {@code count} random elements from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see RedisSetCommands#sRem(byte[], byte[]...)
+	 */
 	List<String> sRandMember(String key, long count);
 
-	Boolean zAdd(String key, double score, String value);
-
-	Long zAdd(String key, Set<StringTuple> tuples);
-
-	Long zRem(String key, String... values);
-
-	Double zIncrBy(String key, double increment, String value);
-
-	Long zRank(String key, String value);
-
-	Long zRevRank(String key, String value);
-
-	Set<String> zRange(String key, long start, long end);
-
-	Set<StringTuple> zRangeWithScores(String key, long start, long end);
-
-	Set<String> zRevRange(String key, long start, long end);
-
-	Set<StringTuple> zRevRangeWithScores(String key, long start, long end);
-
-	Set<String> zRevRangeByScore(String key, double min, double max);
-
-	Set<StringTuple> zRevRangeByScoreWithScores(String key, double min, double max);
-
-	Set<String> zRevRangeByScore(String key, double min, double max, long offset, long count);
-
-	Set<StringTuple> zRevRangeByScoreWithScores(String key, double min, double max, long offset, long count);
-
-	Set<String> zRangeByScore(String key, double min, double max);
-
-	Set<StringTuple> zRangeByScoreWithScores(String key, double min, double max);
-
-	Set<String> zRangeByScore(String key, double min, double max, long offset, long count);
-
-	Set<StringTuple> zRangeByScoreWithScores(String key, double min, double max, long offset, long count);
-
-	Long zCount(String key, double min, double max);
-
-	Long zCard(String key);
-
-	Double zScore(String key, String value);
-
-	Long zRemRange(String key, long start, long end);
-
-	Long zRemRangeByScore(String key, double min, double max);
-
-	Long zUnionStore(String destKey, String... sets);
-
-	Long zUnionStore(String destKey, Aggregate aggregate, int[] weights, String... sets);
-
-	Long zInterStore(String destKey, String... sets);
-
-	Long zInterStore(String destKey, Aggregate aggregate, int[] weights, String... sets);
-
-	Boolean hSet(String key, String field, String value);
-
-	Boolean hSetNX(String key, String field, String value);
-
-	String hGet(String key, String field);
-
-	List<String> hMGet(String key, String... fields);
-
-	void hMSet(String key, Map<String, String> hashes);
-
-	Long hIncrBy(String key, String field, long delta);
-
-	Double hIncrBy(String key, String field, double delta);
-
-	Boolean hExists(String key, String field);
-
-	Long hDel(String key, String... fields);
-
-	Long hLen(String key);
-
-	Set<String> hKeys(String key);
-
-	List<String> hVals(String key);
-
-	Map<String, String> hGetAll(String key);
-
-	Long publish(String channel, String message);
-
-	void subscribe(MessageListener listener, String... channels);
-
-	void pSubscribe(MessageListener listener, String... patterns);
-
-	String scriptLoad(String script);
-
-	<T> T eval(String script, ReturnType returnType, int numKeys, String... keysAndArgs);
-
-	<T> T evalSha(String scriptSha1, ReturnType returnType, int numKeys, String... keysAndArgs);
-
 	/**
-	 * Assign given {@code name} to connection using registered {@link RedisSerializer} for name conversion.
-	 * 
-	 * @param name
-	 * @see #setClientName(byte[])
-	 * @since 1.3
-	 */
-	void setClientName(String name);
-
-	/**
-	 * @see RedisConnection#getClientList()
-	 * @since 1.3
-	 */
-	List<RedisClientInfo> getClientList();
-
-	/**
-	 * @since 1.4
-	 * @see RedisHashCommands#hScan(byte[], ScanOptions)
+	 * Use a {@link Cursor} to iterate over elements in set at {@code key}.
+	 *
 	 * @param key must not be {@literal null}.
-	 * @param options
+	 * @param options must not be {@literal null}.
 	 * @return
-	 */
-	Cursor<Map.Entry<String, String>> hScan(String key, ScanOptions options);
-
-	/**
 	 * @since 1.4
+	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 * @see RedisSetCommands#sScan(byte[], ScanOptions)
-	 * @param key must not be {@literal null}.
-	 * @param options
-	 * @return
 	 */
 	Cursor<String> sScan(String key, ScanOptions options);
 
-	/**
-	 * @since 1.4
-	 * @see RedisZSetCommands#zScan(byte[], ScanOptions)
-	 * @param key must not be {@literal null}.
-	 * @param options
-	 * @return
-	 */
-	Cursor<StringTuple> zScan(String key, ScanOptions options);
+	// -------------------------------------------------------------------------
+	// Methods dealing with Redis Sorted Sets
+	// -------------------------------------------------------------------------
 
 	/**
-	 * @since 1.5
+	 * Add {@code value} to a sorted set at {@code key}, or update its {@code score} if it already exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param score the score.
+	 * @param value the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see RedisZSetCommands#zAdd(byte[], double, byte[])
+	 */
+	Boolean zAdd(String key, double score, String value);
+
+	/**
+	 * Add {@code tuples} to a sorted set at {@code key}, or update its {@code score} if it already exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param tuples the tuples.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see RedisZSetCommands#zAdd(byte[], Set)
+	 */
+	Long zAdd(String key, Set<StringTuple> tuples);
+
+	/**
+	 * Remove {@code values} from sorted set. Return number of removed elements.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see RedisZSetCommands#zRem(byte[], byte[]...)
+	 */
+	Long zRem(String key, String... values);
+
+	/**
+	 * Increment the score of element with {@code value} in sorted set by {@code increment}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param increment
+	 * @param value the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 * @see RedisZSetCommands#zIncrBy(byte[], double, byte[])
+	 */
+	Double zIncrBy(String key, double increment, String value);
+
+	/**
+	 * Determine the index of element with {@code value} in a sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 * @see RedisZSetCommands#zRank(byte[], byte[])
+	 */
+	Long zRank(String key, String value);
+
+	/**
+	 * Determine the index of element with {@code value} in a sorted set when scored high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 * @see RedisZSetCommands#zRevRank(byte[], byte[])
+	 */
+	Long zRevRank(String key, String value);
+
+	/**
+	 * Get elements between {@code start} and {@code end} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see RedisZSetCommands#zRange(byte[], long, long)
+	 */
+	Set<String> zRange(String key, long start, long end);
+
+	/**
+	 * Get set of {@link Tuple}s between {@code start} and {@code end} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see RedisZSetCommands#zRangeWithScores(byte[], long, long)
+	 */
+	Set<StringTuple> zRangeWithScores(String key, long start, long end);
+
+	/**
+	 * Get elements where score is between {@code min} and {@code max} from sorted set.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRangeByScore(byte[], double, double)
 	 */
-	Set<byte[]> zRangeByScore(String key, String min, String max);
+	Set<String> zRangeByScore(String key, double min, double max);
 
 	/**
-	 * @since 1.5
+	 * Get set of {@link Tuple}s where score is between {@code min} and {@code max} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRangeByScoreWithScores(byte[], double, double)
+	 */
+	Set<StringTuple> zRangeByScoreWithScores(String key, double min, double max);
+
+	/**
+	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
+	 * sorted set.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param min
 	 * @param max
 	 * @param offset
 	 * @param count
 	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRangeByScore(byte[], double, double, long, long)
+	 */
+	Set<String> zRangeByScore(String key, double min, double max, long offset, long count);
+
+	/**
+	 * Get set of {@link Tuple}s in range from {@code start} to {@code end} where score is between {@code min} and
+	 * {@code max} from sorted set.
+	 *
+	 * @param key
+	 * @param min
+	 * @param max
+	 * @param offset
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRangeByScoreWithScores(byte[], double, double, long, long)
+	 */
+	Set<StringTuple> zRangeByScoreWithScores(String key, double min, double max, long offset, long count);
+
+	/**
+	 * Get elements in range from {@code start} to {@code end} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see RedisZSetCommands#zRevRange(byte[], long, long)
+	 */
+	Set<String> zRevRange(String key, long start, long end);
+
+	/**
+	 * Get set of {@link Tuple}s in range from {@code start} to {@code end} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see RedisZSetCommands#zRevRangeWithScores(byte[], long, long)
+	 */
+	Set<StringTuple> zRevRangeWithScores(String key, long start, long end);
+
+	/**
+	 * Get elements where score is between {@code min} and {@code max} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see RedisZSetCommands#zRevRangeByScore(byte[], double, double)
+	 */
+	Set<String> zRevRangeByScore(String key, double min, double max);
+
+	/**
+	 * Get set of {@link Tuple} where score is between {@code min} and {@code max} from sorted set ordered from high to
+	 * low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRevRangeByScoreWithScores(byte[], double, double)
+	 */
+	Set<StringTuple> zRevRangeByScoreWithScores(String key, double min, double max);
+
+	/**
+	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
+	 * sorted set ordered high -> low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @param offset
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRevRangeByScore(byte[], double, double, long, long)
+	 */
+	Set<String> zRevRangeByScore(String key, double min, double max, long offset, long count);
+
+	/**
+	 * Get set of {@link Tuple} in range from {@code start} to {@code end} where score is between {@code min} and
+	 * {@code max} from sorted set ordered high -> low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @param offset
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRevRangeByScoreWithScores(byte[], double, double, long, long)
+	 */
+	Set<StringTuple> zRevRangeByScoreWithScores(String key, double min, double max, long offset, long count);
+
+	/**
+	 * Count number of elements within sorted set with scores between {@code min} and {@code max}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see RedisZSetCommands#zCount(byte[], double, double)
+	 */
+	Long zCount(String key, double min, double max);
+
+	/**
+	 * Get the size of sorted set with {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see RedisZSetCommands#zCard(byte[])
+	 */
+	Long zCard(String key);
+
+	/**
+	 * Get the score of element with {@code value} from sorted set with key {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see RedisZSetCommands#zScore(byte[], byte[])
+	 */
+	Double zScore(String key, String value);
+
+	/**
+	 * Remove elements in range between {@code start} and {@code end} from sorted set with {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 * @see RedisZSetCommands#zRemRange(byte[], long, long)
+	 */
+	Long zRemRange(String key, long start, long end);
+
+	/**
+	 * Remove elements with scores between {@code min} and {@code max} from sorted set with {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRemRangeByScore(byte[], double, double)
+	 */
+	Long zRemRangeByScore(String key, double min, double max);
+
+	/**
+	 * Union sorted {@code sets} and store result in destination {@code key}.
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see RedisZSetCommands#zUnionStore(byte[], byte[]...)
+	 */
+	Long zUnionStore(String destKey, String... sets);
+
+	/**
+	 * Union sorted {@code sets} and store result in destination {@code key}.
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @param weights
+	 * @param sets must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see RedisZSetCommands#zUnionStore(byte[], Aggregate, int[], byte[]...)
+	 */
+	Long zUnionStore(String destKey, Aggregate aggregate, int[] weights, String... sets);
+
+	/**
+	 * Intersect sorted {@code sets} and store result in destination {@code key}.
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see RedisZSetCommands#zInterStore(byte[], byte[]...)
+	 */
+	Long zInterStore(String destKey, String... sets);
+
+	/**
+	 * Intersect sorted {@code sets} and store result in destination {@code key}.
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @param weights
+	 * @param sets must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see RedisZSetCommands#zInterStore(byte[], Aggregate, int[], byte[]...)
+	 */
+	Long zInterStore(String destKey, Aggregate aggregate, int[] weights, String... sets);
+
+	/**
+	 * Use a {@link Cursor} to iterate over elements in sorted set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return
+	 * @since 1.4
+	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @see RedisZSetCommands#zScan(byte[], ScanOptions)
+	 */
+	Cursor<StringTuple> zScan(String key, ScanOptions options);
+
+	/**
+	 * Get elements where score is between {@code min} and {@code max} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min must not be {@literal null}.
+	 * @param max must not be {@literal null}.
+	 * @return
+	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRangeByScore(byte[], String, String)
+	 */
+	Set<byte[]> zRangeByScore(String key, String min, String max);
+
+	/**
+	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
+	 * sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min must not be {@literal null}.
+	 * @param max must not be {@literal null}.
+	 * @param offset
+	 * @param count
+	 * @return
+	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see RedisZSetCommands#zRangeByScore(byte[], double, double, long, long)
 	 */
 	Set<byte[]> zRangeByScore(String key, String min, String max, long offset, long count);
 
 	/**
-	 * Adds given {@literal values} to the HyperLogLog stored at given {@literal key}.
-	 * 
-	 * @param key must not be {@literal null}.
-	 * @param values
-	 * @return
-	 * @since 1.5
-	 */
-	Long pfAdd(String key, String... values);
-
-	/**
-	 * @param keys
-	 * @return
-	 * @since 1.5
-	 */
-	Long pfCount(String... keys);
-
-	/**
-	 * @param destinationKey
-	 * @param sourceKeys
-	 * @since 1.5
-	 */
-	void pfMerge(String destinationKey, String... sourceKeys);
-
-	/**
-	 * Get all elements in the sorted set at {@literal key} in lexicographical ordering.
-	 * 
+	 * Get all the elements in the sorted set at {@literal key} in lexicographical ordering.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see RedisZSetCommands#zRangeByLex(byte[])
 	 */
 	Set<String> zRangeByLex(String key);
 
 	/**
-	 * Get the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering
-	 * 
+	 * Get all the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering.
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see RedisZSetCommands#zRangeByLex(byte[], Range)
 	 */
 	Set<String> zRangeByLex(String key, Range range);
 
 	/**
-	 * Get the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering. Result is
+	 * Get all the elements in {@link Range} from the sorted set at {@literal key} in lexicographical ordering. Result is
 	 * limited via {@link Limit}.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @param range can be {@literal null}.
 	 * @return
 	 * @since 1.6
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see RedisZSetCommands#zRangeByLex(byte[], Range, Limit)
 	 */
 	Set<String> zRangeByLex(String key, Range range, Limit limit);
 
+	// -------------------------------------------------------------------------
+	// Methods dealing with Redis Hashes
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Set the {@code value} of a hash {@code field}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/hset">Redis Documentation: HSET</a>
+	 * @see RedisHashCommands#hSet(byte[], byte[], byte[])
+	 */
+	Boolean hSet(String key, String field, String value);
+
+	/**
+	 * Set the {@code value} of a hash {@code field} only if {@code field} does not exist.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/hsetnx">Redis Documentation: HSETNX</a>
+	 * @see RedisHashCommands#hSetNX(byte[], byte[], byte[])
+	 */
+	Boolean hSetNX(String key, String field, String value);
+
+	/**
+	 * Get value for given {@code field} from hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hget">Redis Documentation: HGET</a>
+	 * @see RedisHashCommands#hGet(byte[], byte[])
+	 */
+	String hGet(String key, String field);
+
+	/**
+	 * Get values for given {@code fields} from hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param fields must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hmget">Redis Documentation: HMGET</a>
+	 * @see RedisHashCommands#hMGet(byte[], byte[]...)
+	 */
+	List<String> hMGet(String key, String... fields);
+
+	/**
+	 * Set multiple hash fields to multiple values using data provided in {@code hashes}
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param hashes must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/hmset">Redis Documentation: HMSET</a>
+	 * @see RedisHashCommands#hMGet(byte[], byte[]...)
+	 */
+	void hMSet(String key, Map<String, String> hashes);
+
+	/**
+	 * Increment {@code value} of a hash {@code field} by the given {@code delta}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @param delta
+	 * @return
+	 * @see <a href="http://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
+	 * @see RedisHashCommands#hIncrBy(byte[], byte[], long)
+	 */
+	Long hIncrBy(String key, String field, long delta);
+
+	/**
+	 * Increment {@code value} of a hash {@code field} by the given {@code delta}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field
+	 * @param delta
+	 * @return
+	 * @see <a href="http://redis.io/commands/hincrbyfloat">Redis Documentation: HINCRBYFLOAT</a>
+	 * @see RedisHashCommands#hIncrBy(byte[], byte[], double)
+	 */
+	Double hIncrBy(String key, String field, double delta);
+
+	/**
+	 * Determine if given hash {@code field} exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hexits">Redis Documentation: HEXISTS</a>
+	 * @see RedisHashCommands#hExists(byte[], byte[])
+	 */
+	Boolean hExists(String key, String field);
+
+	/**
+	 * Delete given hash {@code fields}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param fields must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hdel">Redis Documentation: HDEL</a>
+	 * @see RedisHashCommands#hDel(byte[], byte[]...)
+	 */
+	Long hDel(String key, String... fields);
+
+	/**
+	 * Get size of hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hlen">Redis Documentation: HLEN</a>
+	 * @see RedisHashCommands#hLen(byte[])
+	 */
+	Long hLen(String key);
+
+	/**
+	 * Get key set (fields) of hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>?
+	 * @see RedisHashCommands#hKeys(byte[])
+	 */
+	Set<String> hKeys(String key);
+
+	/**
+	 * Get entry set (values) of hash at {@code field}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hvals">Redis Documentation: HVALS</a>
+	 * @see RedisHashCommands#hVals(byte[])
+	 */
+	List<String> hVals(String key);
+
+	/**
+	 * Get entire hash stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
+	 * @see RedisHashCommands#hGetAll(byte[])
+	 */
+	Map<String, String> hGetAll(String key);
+
+	/**
+	 * Use a {@link Cursor} to iterate over entries in hash at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return
+	 * @since 1.4
+	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @see RedisHashCommands#hScan(byte[], ScanOptions)
+	 */
+	Cursor<Map.Entry<String, String>> hScan(String key, ScanOptions options);
+
+	// -------------------------------------------------------------------------
+	// Methods dealing with HyperLogLog
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Adds given {@literal values} to the HyperLogLog stored at given {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
+	 * @see HyperLogLogCommands#pfAdd(byte[], byte[]...)
+	 */
+	Long pfAdd(String key, String... values);
+
+	/**
+	 * Return the approximated cardinality of the structures observed by the HyperLogLog at {@literal key(s)}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
+	 * @see HyperLogLogCommands#pfCount(byte[]...)
+	 */
+	Long pfCount(String... keys);
+
+	/**
+	 * Merge N different HyperLogLogs at {@literal sourceKeys} into a single {@literal destinationKey}.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sourceKeys must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
+	 * @see HyperLogLogCommands#pfMerge(byte[], byte[]...)
+	 */
+	void pfMerge(String destinationKey, String... sourceKeys);
+
+	// -------------------------------------------------------------------------
+	// Methods dealing with Redis Geo-Indexes
+	// -------------------------------------------------------------------------
+
 	/**
 	 * Add {@link Point} with given member {@literal name} to {@literal key}.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see RedisGeoCommands#geoAdd(byte[], Point, byte[])
 	 */
 	Long geoAdd(String key, Point point, String member);
 
 	/**
 	 * Add {@link GeoLocation} to {@literal key}.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see RedisGeoCommands#geoAdd(byte[], GeoLocation)
 	 */
 	Long geoAdd(String key, GeoLocation<String> location);
 
 	/**
 	 * Add {@link Map} of member / {@link Point} pairs to {@literal key}.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see RedisGeoCommands#geoAdd(byte[], Map)
 	 */
 	Long geoAdd(String key, Map<String, Point> memberCoordinateMap);
 
 	/**
 	 * Add {@link GeoLocation}s to {@literal key}
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see RedisGeoCommands#geoAdd(byte[], Iterable)
 	 */
 	Long geoAdd(String key, Iterable<GeoLocation<String>> locations);
 
@@ -826,8 +1586,9 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param member1 must not be {@literal null}.
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">http://redis.io/commands/geodist</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see RedisGeoCommands#geoDist(byte[], byte[], byte[])
 	 */
 	Distance geoDist(String key, String member1, String member2);
 
@@ -839,8 +1600,9 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param member2 must not be {@literal null}.
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">http://redis.io/commands/geodist</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see RedisGeoCommands#geoDist(byte[], byte[], byte[], Metric)
 	 */
 	Distance geoDist(String key, String member1, String member2, Metric metric);
 
@@ -850,8 +1612,9 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geohash">http://redis.io/commands/geohash</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see RedisGeoCommands#geoHash(byte[], byte[]...)
 	 */
 	List<String> geoHash(String key, String... members);
 
@@ -861,8 +1624,9 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geopos">http://redis.io/commands/geopos</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see RedisGeoCommands#geoPos(byte[], byte[]...)
 	 */
 	List<Point> geoPos(String key, String... members);
 
@@ -872,8 +1636,9 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see RedisGeoCommands#geoRadius(byte[], Circle)
 	 */
 	GeoResults<GeoLocation<String>> geoRadius(String key, Circle within);
 
@@ -884,8 +1649,9 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param within must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see RedisGeoCommands#geoRadius(byte[], Circle, GeoRadiusCommandArgs)
 	 */
 	GeoResults<GeoLocation<String>> geoRadius(String key, Circle within, GeoRadiusCommandArgs args);
 
@@ -897,8 +1663,9 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param member must not be {@literal null}.
 	 * @param radius
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see RedisGeoCommands#geoRadiusByMember(byte[], byte[], double)
 	 */
 	GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, double radius);
 
@@ -910,8 +1677,9 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param member must not be {@literal null}.
 	 * @param radius must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see RedisGeoCommands#geoRadiusByMember(byte[], byte[], Distance)
 	 */
 	GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, Distance radius);
 
@@ -924,8 +1692,9 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param radius must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
 	 * @since 1.8
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see RedisGeoCommands#geoRadiusByMember(byte[], byte[], Distance, GeoRadiusCommandArgs)
 	 */
 	GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, Distance radius,
 			GeoRadiusCommandArgs args);
@@ -935,8 +1704,114 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
-	 * @return Number of members elements removed.
 	 * @since 1.8
+	 * @return Number of members elements removed.
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see RedisGeoCommands#geoRemove(byte[], byte[]...)
 	 */
 	Long geoRemove(String key, String... members);
+
+	// -------------------------------------------------------------------------
+	// Methods dealing with Redis Pub/Sub
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Publishes the given message to the given channel.
+	 *
+	 * @param channel the channel to publish to, must not be {@literal null}.
+	 * @param message message to publish
+	 * @return the number of clients that received the message
+	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 * @see RedisPubSubCommands#publish(byte[], byte[])
+	 */
+	Long publish(String channel, String message);
+
+	/**
+	 * Subscribes the connection to the given channels. Once subscribed, a connection enters listening mode and can only
+	 * subscribe to other channels or unsubscribe. No other commands are accepted until the connection is unsubscribed.
+	 * <p>
+	 * Note that this operation is blocking and the current thread starts waiting for new messages immediately.
+	 *
+	 * @param listener message listener, must not be {@literal null}.
+	 * @param channels channel names, must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/subscribe">Redis Documentation: SUBSCRIBE</a>
+	 * @see RedisPubSubCommands#subscribe(MessageListener, byte[]...)
+	 */
+	void subscribe(MessageListener listener, String... channels);
+
+	/**
+	 * Subscribes the connection to all channels matching the given patterns. Once subscribed, a connection enters
+	 * listening mode and can only subscribe to other channels or unsubscribe. No other commands are accepted until the
+	 * connection is unsubscribed.
+	 * <p>
+	 * Note that this operation is blocking and the current thread starts waiting for new messages immediately.
+	 *
+	 * @param listener message listener, must not be {@literal null}.
+	 * @param patterns channel name patterns, must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
+	 * @see RedisPubSubCommands#pSubscribe(MessageListener, byte[]...)
+	 */
+	void pSubscribe(MessageListener listener, String... patterns);
+
+	// -------------------------------------------------------------------------
+	// Methods dealing with Redis Lua Scripting
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Load lua script into scripts cache, without executing it.<br>
+	 * Execute the script by calling {@link #evalSha(byte[], ReturnType, int, byte[]...)}.
+	 *
+	 * @param script must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/script-load">Redis Documentation: SCRIPT LOAD</a>
+	 * @see RedisScriptingCommands#scriptLoad(byte[])
+	 */
+	String scriptLoad(String script);
+
+	/**
+	 * Evaluate given {@code script}.
+	 *
+	 * @param script must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
+	 * @param numKeys
+	 * @param keysAndArgs must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/eval">Redis Documentation: EVAL</a>
+	 * @see RedisScriptingCommands#eval(byte[], ReturnType, int, byte[]...)
+	 */
+	<T> T eval(String script, ReturnType returnType, int numKeys, String... keysAndArgs);
+
+	/**
+	 * Evaluate given {@code scriptSha}.
+	 *
+	 * @param scriptSha must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
+	 * @param numKeys
+	 * @param keysAndArgs must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
+	 * @see RedisScriptingCommands#evalSha(String, ReturnType, int, byte[]...)
+	 */
+	<T> T evalSha(String scriptSha, ReturnType returnType, int numKeys, String... keysAndArgs);
+
+	/**
+	 * Assign given name to current connection.
+	 *
+	 * @param name
+	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/client-setname">Redis Documentation: CLIENT SETNAME</a>
+	 * @see RedisServerCommands#setClientName(byte[])
+	 */
+	void setClientName(String name);
+
+	/**
+	 * Request information and statistics about connected clients.
+	 *
+	 * @return {@link List} of {@link RedisClientInfo} objects.
+	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/client-list">Redis Documentation: CLIENT LIST</a>
+	 * @see RedisServerCommands#getClientList()
+	 */
+	List<RedisClientInfo> getClientList();
+
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -607,7 +607,7 @@ public class JedisClusterConnection implements RedisClusterConnection {
 	@Override
 	public List<byte[]> mGet(byte[]... keys) {
 
-		Assert.noNullElements(keys);
+		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
 		if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
 			return cluster.mget(keys);

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1036,7 +1036,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	}
 
 	public Boolean pExpire(byte[] key, long millis) {
-		
+
 		Assert.notNull(key, "Key must not be null!");
 
 		try {
@@ -1055,9 +1055,9 @@ public class JedisConnection extends AbstractRedisConnection {
 	}
 
 	public Boolean pExpireAt(byte[] key, long unixTimeInMillis) {
-		
+
 		Assert.notNull(key, "Key must not be null!");
-		
+
 		try {
 			if (isPipelined()) {
 				pipeline(new JedisResult(pipeline.pexpireAt(key, unixTimeInMillis), JedisConverters.longToBoolean()));

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -818,15 +818,10 @@ public class JedisConnection extends AbstractRedisConnection {
 
 	public Boolean expire(byte[] key, long seconds) {
 
-		/*
-		 *  @see DATAREDIS-286 to avoid overflow in Jedis
-		 *  
-		 *  TODO Remove this workaround when we upgrade to a Jedis version that contains a 
-		 *  fix for: https://github.com/xetorthio/jedis/pull/575
-		 */
-		if (seconds > Integer.MAX_VALUE) {
+		Assert.notNull(key, "Key must not be null!");
 
-			return pExpireAt(key, time() + TimeUnit.SECONDS.toMillis(seconds));
+		if (seconds > Integer.MAX_VALUE) {
+			return pExpire(key, TimeUnit.SECONDS.toMillis(seconds));
 		}
 
 		try {
@@ -845,6 +840,9 @@ public class JedisConnection extends AbstractRedisConnection {
 	}
 
 	public Boolean expireAt(byte[] key, long unixTime) {
+
+		Assert.notNull(key, "Key must not be null!");
+
 		try {
 			if (isPipelined()) {
 				pipeline(new JedisResult(pipeline.expireAt(key, unixTime), JedisConverters.longToBoolean()));
@@ -1038,6 +1036,8 @@ public class JedisConnection extends AbstractRedisConnection {
 	}
 
 	public Boolean pExpire(byte[] key, long millis) {
+		
+		Assert.notNull(key, "Key must not be null!");
 
 		try {
 			if (isPipelined()) {
@@ -1055,6 +1055,9 @@ public class JedisConnection extends AbstractRedisConnection {
 	}
 
 	public Boolean pExpireAt(byte[] key, long unixTimeInMillis) {
+		
+		Assert.notNull(key, "Key must not be null!");
+		
 		try {
 			if (isPipelined()) {
 				pipeline(new JedisResult(pipeline.pexpireAt(key, unixTimeInMillis), JedisConverters.longToBoolean()));

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -68,6 +68,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
 
 import redis.clients.jedis.BinaryJedis;
 import redis.clients.jedis.BinaryJedisPubSub;
@@ -149,6 +150,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	private volatile JedisSubscription subscription;
 	private volatile Pipeline pipeline;
 	private final int dbIndex;
+	private final String clientName;
 	private boolean convertPipelineAndTxResults = true;
 	private List<FutureResult<Response<?>>> pipelinedResults = new ArrayList<FutureResult<Response<?>>>();
 	private Queue<FutureResult<Response<?>>> txResults = new LinkedList<FutureResult<Response<?>>>();
@@ -192,15 +194,30 @@ public class JedisConnection extends AbstractRedisConnection {
 	 *
 	 * @param jedis
 	 * @param pool can be null, if no pool is used
+	 * @param dbIndex
 	 */
 	public JedisConnection(Jedis jedis, Pool<Jedis> pool, int dbIndex) {
-		this.jedis = jedis;
+		this(jedis, pool, dbIndex, null);
+	}
+
+	/**
+	 * Constructs a new <code>JedisConnection</code> instance backed by a jedis pool.
+	 *
+	 * @param jedis
+	 * @param pool can be null, if no pool is used
+	 * @param dbIndex
+	 * @param clientName the client name, can be {@literal null}.
+	 * @since 1.8
+	 */
+	protected JedisConnection(Jedis jedis, Pool<Jedis> pool, int dbIndex, String clientName) {
+
 		// extract underlying connection for batch operations
 		client = (Client) ReflectionUtils.getField(CLIENT_FIELD, jedis);
 
+		this.jedis = jedis;
 		this.pool = pool;
-
 		this.dbIndex = dbIndex;
+		this.clientName = clientName;
 
 		// select the db
 		// if this fail, do manual clean-up before propagating the exception
@@ -3988,7 +4005,14 @@ public class JedisConnection extends AbstractRedisConnection {
 	}
 
 	protected Jedis getJedis(RedisNode node) {
-		return new Jedis(node.getHost(), node.getPort());
+
+		Jedis jedis = new Jedis(node.getHost(), node.getPort());
+
+		if (StringUtils.hasText(clientName)) {
+			jedis.clientSetname(clientName);
+		}
+
+		return jedis;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -193,9 +193,12 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			if (usePool && pool != null) {
 				return pool.getResource();
 			}
+
 			Jedis jedis = new Jedis(getShardInfo());
 			// force initialization (see Jedis issue #82)
 			jedis.connect();
+
+			potentiallySetClientName(jedis);
 			return jedis;
 		} catch (Exception ex) {
 			throw new RedisConnectionFailureException("Cannot get Jedis connection", ex);
@@ -343,8 +346,8 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 		}
 
 		Jedis jedis = fetchJedisConnector();
-		JedisConnection connection = (usePool ? new JedisConnection(jedis, pool, dbIndex)
-				: new JedisConnection(jedis, null, dbIndex));
+		JedisConnection connection = (usePool ? new JedisConnection(jedis, pool, dbIndex, clientName)
+				: new JedisConnection(jedis, null, dbIndex, clientName));
 		connection.setConvertPipelineAndTxResults(convertPipelineAndTxResults);
 		return postProcessConnection(connection);
 	}
@@ -373,7 +376,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Returns the Redis hostName.
 	 * 
-	 * @return Returns the hostName
+	 * @return the hostName.
 	 */
 	public String getHostName() {
 		return hostName;
@@ -382,7 +385,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Sets the Redis hostName.
 	 * 
-	 * @param hostName The hostName to set.
+	 * @param hostName the hostName to set.
 	 */
 	public void setHostName(String hostName) {
 		this.hostName = hostName;
@@ -401,7 +404,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Returns whether to use SSL.
 	 *
-	 * @return use of SSL
+	 * @return use of SSL.
 	 * @since 1.8
 	 */
 	public boolean isUseSsl() {
@@ -411,7 +414,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Returns the password used for authenticating with the Redis server.
 	 * 
-	 * @return password for authentication
+	 * @return password for authentication.
 	 */
 	public String getPassword() {
 		return password;
@@ -420,7 +423,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Sets the password used for authenticating with the Redis server.
 	 * 
-	 * @param password the password to set
+	 * @param password the password to set.
 	 */
 	public void setPassword(String password) {
 		this.password = password;
@@ -429,7 +432,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Returns the port used to connect to the Redis instance.
 	 * 
-	 * @return Redis port.
+	 * @return the Redis port.
 	 */
 	public int getPort() {
 		return port;
@@ -438,7 +441,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Sets the port used to connect to the Redis instance.
 	 * 
-	 * @param port Redis port
+	 * @param port the Redis port.
 	 */
 	public void setPort(int port) {
 		this.port = port;
@@ -447,7 +450,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Returns the shardInfo.
 	 * 
-	 * @return Returns the shardInfo
+	 * @return the shardInfo.
 	 */
 	public JedisShardInfo getShardInfo() {
 		return shardInfo;
@@ -456,7 +459,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Sets the shard info for this factory.
 	 * 
-	 * @param shardInfo The shardInfo to set.
+	 * @param shardInfo the shardInfo to set.
 	 */
 	public void setShardInfo(JedisShardInfo shardInfo) {
 		this.shardInfo = shardInfo;
@@ -465,14 +468,16 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Returns the timeout.
 	 * 
-	 * @return Returns the timeout
+	 * @return the timeout.
 	 */
 	public int getTimeout() {
 		return timeout;
 	}
 
 	/**
-	 * @param timeout The timeout to set.
+	 * Sets the timeout.
+	 *
+	 * @param timeout the timeout to set.
 	 */
 	public void setTimeout(int timeout) {
 		this.timeout = timeout;
@@ -481,7 +486,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Indicates the use of a connection pool.
 	 * 
-	 * @return Returns the use of connection pooling.
+	 * @return the use of connection pooling.
 	 */
 	public boolean getUsePool() {
 		return usePool;
@@ -490,7 +495,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Turns on or off the use of connection pooling.
 	 * 
-	 * @param usePool The usePool to set.
+	 * @param usePool the usePool to set.
 	 */
 	public void setUsePool(boolean usePool) {
 		this.usePool = usePool;
@@ -499,7 +504,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Returns the poolConfig.
 	 * 
-	 * @return Returns the poolConfig
+	 * @return the poolConfig
 	 */
 	public JedisPoolConfig getPoolConfig() {
 		return poolConfig;
@@ -508,7 +513,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Sets the pool configuration for this factory.
 	 * 
-	 * @param poolConfig The poolConfig to set.
+	 * @param poolConfig the poolConfig to set.
 	 */
 	public void setPoolConfig(JedisPoolConfig poolConfig) {
 		this.poolConfig = poolConfig;
@@ -517,7 +522,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Returns the index of the database.
 	 * 
-	 * @return Returns the database index
+	 * @return the database index.
 	 */
 	public int getDatabase() {
 		return dbIndex;
@@ -526,26 +531,28 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Sets the index of the database used by this connection factory. Default is 0.
 	 * 
-	 * @param index database index
+	 * @param index database index.
 	 */
 	public void setDatabase(int index) {
 		Assert.isTrue(index >= 0, "invalid DB index (a positive index required)");
 		this.dbIndex = index;
 	}
-	
+
 	/**
 	 * Returns the client name.
-	 * 
-	 * @return Returns the client name
+	 *
+	 * @return the client name.
+	 * @since 1.8
 	 */
 	public String getClientName() {
 		return clientName;
 	}
 
 	/**
-	 * Sets the client name used by this connection factory. Default is empty.
-	 * 
-	 * @param clientName client name
+	 * Sets the client name used by this connection factory. Defaults to none which does not set a client name.
+	 *
+	 * @param clientName the client name.
+	 * @since 1.8
 	 */
 	public void setClientName(String clientName) {
 		this.clientName = clientName;
@@ -554,9 +561,9 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Specifies if pipelined results should be converted to the expected data type. If false, results of
 	 * {@link JedisConnection#closePipeline()} and {@link JedisConnection#exec()} will be of the type returned by the
-	 * Jedis driver
+	 * Jedis driver.
 	 * 
-	 * @return Whether or not to convert pipeline and tx results
+	 * @return Whether or not to convert pipeline and tx results.
 	 */
 	public boolean getConvertPipelineAndTxResults() {
 		return convertPipelineAndTxResults;
@@ -565,9 +572,9 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	/**
 	 * Specifies if pipelined results should be converted to the expected data type. If false, results of
 	 * {@link JedisConnection#closePipeline()} and {@link JedisConnection#exec()} will be of the type returned by the
-	 * Jedis driver
+	 * Jedis driver.
 	 * 
-	 * @param convertPipelineAndTxResults Whether or not to convert pipeline and tx results
+	 * @param convertPipelineAndTxResults Whether or not to convert pipeline and tx results.
 	 */
 	public void setConvertPipelineAndTxResults(boolean convertPipelineAndTxResults) {
 		this.convertPipelineAndTxResults = convertPipelineAndTxResults;
@@ -597,14 +604,19 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	private Jedis getActiveSentinel() {
 
 		Assert.notNull(this.sentinelConfig);
+
 		for (RedisNode node : this.sentinelConfig.getSentinels()) {
+
 			Jedis jedis = new Jedis(node.getHost(), node.getPort());
+
 			if (jedis.ping().equalsIgnoreCase("pong")) {
+
+				potentiallySetClientName(jedis);
 				return jedis;
 			}
 		}
 
-		throw new InvalidDataAccessResourceUsageException("no sentinel found");
+		throw new InvalidDataAccessResourceUsageException("No Sentinel found");
 	}
 
 	private Set<String> convertToJedisSentinelSet(Collection<RedisNode> nodes) {
@@ -620,6 +632,13 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 			}
 		}
 		return convertedNodes;
+	}
+
+	private void potentiallySetClientName(Jedis jedis) {
+
+		if (StringUtils.hasText(clientName)) {
+			jedis.clientSetname(clientName);
+		}
 	}
 
 	private void setTimeoutOn(JedisShardInfo shardInfo, int timeout) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -294,7 +294,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 */
 	protected JedisCluster createCluster(RedisClusterConfiguration clusterConfig, GenericObjectPoolConfig poolConfig) {
 
-		Assert.notNull("Cluster configuration must not be null!");
+		Assert.notNull(clusterConfig, "Cluster configuration must not be null!");
 
 		Set<HostAndPort> hostAndPort = new HashSet<HostAndPort>();
 		for (RedisNode node : clusterConfig.getClusterNodes()) {
@@ -603,7 +603,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 
 	private Jedis getActiveSentinel() {
 
-		Assert.notNull(this.sentinelConfig);
+		Assert.notNull(this.sentinelConfig, "SentinelConfig must not be null!");
 
 		for (RedisNode node : this.sentinelConfig.getSentinels()) {
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -63,6 +63,7 @@ import redis.clients.util.Pool;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Fu Jian
  */
 public class JedisConnectionFactory implements InitializingBean, DisposableBean, RedisConnectionFactory {
 
@@ -101,6 +102,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	private Pool<Jedis> pool;
 	private JedisPoolConfig poolConfig = new JedisPoolConfig();
 	private int dbIndex = 0;
+	private String clientName;
 	private boolean convertPipelineAndTxResults = true;
 	private RedisSentinelConfiguration sentinelConfig;
 	private RedisClusterConfiguration clusterConfig;
@@ -255,7 +257,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	protected Pool<Jedis> createRedisSentinelPool(RedisSentinelConfiguration config) {
 		return new JedisSentinelPool(config.getMaster().getName(), convertToJedisSentinelSet(config.getSentinels()),
 				getPoolConfig() != null ? getPoolConfig() : new JedisPoolConfig(), getTimeoutFrom(getShardInfo()),
-				getShardInfo().getPassword());
+				getShardInfo().getPassword(), Protocol.DEFAULT_DATABASE, clientName);
 	}
 
 	/**
@@ -267,7 +269,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	protected Pool<Jedis> createRedisPool() {
 
 		return new JedisPool(getPoolConfig(), getShardInfo().getHost(), getShardInfo().getPort(),
-				getTimeoutFrom(getShardInfo()), getShardInfo().getPassword(), useSsl);
+				getTimeoutFrom(getShardInfo()), getShardInfo().getPassword(), Protocol.DEFAULT_DATABASE, clientName, useSsl);
 	}
 
 	private JedisCluster createCluster() {
@@ -529,6 +531,24 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	public void setDatabase(int index) {
 		Assert.isTrue(index >= 0, "invalid DB index (a positive index required)");
 		this.dbIndex = index;
+	}
+	
+	/**
+	 * Returns the client name.
+	 * 
+	 * @return Returns the client name
+	 */
+	public String getClientName() {
+		return clientName;
+	}
+
+	/**
+	 * Sets the client name used by this connection factory. Default is empty.
+	 * 
+	 * @param clientName client name
+	 */
+	public void setClientName(String clientName) {
+		this.clientName = clientName;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -334,7 +334,7 @@ abstract public class JedisConverters extends Converters {
 	}
 
 	public static LIST_POSITION toListPosition(Position source) {
-		Assert.notNull("list positions are mandatory");
+		Assert.notNull(source, "list positions are mandatory");
 		return (Position.AFTER.equals(source) ? LIST_POSITION.AFTER : LIST_POSITION.BEFORE);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisUtils.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,7 +216,7 @@ public abstract class JedisUtils {
 	}
 
 	static LIST_POSITION convertPosition(Position where) {
-		Assert.notNull("list positions are mandatory");
+		Assert.notNull(where, "list positions are mandatory");
 		return (Position.AFTER.equals(where) ? LIST_POSITION.AFTER : LIST_POSITION.BEFORE);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jredis/JredisConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public class JredisConnectionFactory implements InitializingBean, DisposableBean
 
 	public void afterPropertiesSet() {
 		if (connectionSpec == null && pool == null) {
-			Assert.hasText(hostName);
+			Assert.hasText(hostName, "Redis host name must not be null!");
 			connectionSpec = DefaultConnectionSpec.newSpec(hostName, port, dbIndex, DEFAULT_REDIS_PASSWORD);
 			connectionSpec.setConnectionFlag(Connection.Flag.RELIABLE, false);
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -257,7 +257,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Returns the current host.
 	 *
-	 * @return the host
+	 * @return the host.
 	 */
 	public String getHostName() {
 		return hostName;
@@ -266,7 +266,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Sets the host.
 	 *
-	 * @param host the host to set
+	 * @param host the host to set.
 	 */
 	public void setHostName(String host) {
 		this.hostName = host;
@@ -275,7 +275,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Returns the current port.
 	 *
-	 * @return the port
+	 * @return the port.
 	 */
 	public int getPort() {
 		return port;
@@ -284,7 +284,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Sets the port.
 	 *
-	 * @param port the port to set
+	 * @param port the port to set.
 	 */
 	public void setPort(int port) {
 		this.port = port;
@@ -293,7 +293,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Returns the connection timeout (in milliseconds).
 	 *
-	 * @return connection timeout
+	 * @return connection timeout.
 	 */
 	public long getTimeout() {
 		return timeout;
@@ -302,14 +302,14 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Sets the connection timeout (in milliseconds).
 	 *
-	 * @param timeout connection timeout
+	 * @param timeout connection timeout.
 	 */
 	public void setTimeout(long timeout) {
 		this.timeout = timeout;
 	}
 
 	/**
-	 * Sets to use SSL connection
+	 * Sets to use SSL connection.
 	 *
 	 * @param useSsl {@literal true} to use SSL.
 	 */
@@ -320,7 +320,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Returns whether to use SSL.
 	 *
-	 * @return use of SSL
+	 * @return use of SSL.
 	 */
 	public boolean isUseSsl() {
 		return useSsl;
@@ -338,7 +338,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Returns whether to verify certificate validity/hostname check when SSL is used.
 	 *
-	 * @return verify peers when using SSL
+	 * @return verify peers when using SSL.
 	 */
 	public boolean isVerifyPeer() {
 		return verifyPeer;
@@ -347,7 +347,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Returns whether to issue a StartTLS.
 	 *
-	 * @return use of StartTLS
+	 * @return use of StartTLS.
 	 */
 	public boolean isStartTls() {
 		return startTls;
@@ -365,7 +365,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Indicates if validation of the native Lettuce connection is enabled.
 	 *
-	 * @return connection validation enabled
+	 * @return connection validation enabled.
 	 */
 	public boolean getValidateConnection() {
 		return validateConnection;
@@ -382,7 +382,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	 * only be used if connection sharing is enabled and there is code that is actively closing the native Lettuce
 	 * connection.
 	 *
-	 * @param validateConnection enable connection validation
+	 * @param validateConnection enable connection validation.
 	 */
 	public void setValidateConnection(boolean validateConnection) {
 		this.validateConnection = validateConnection;
@@ -391,7 +391,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Indicates if multiple {@link LettuceConnection}s should share a single native connection.
 	 *
-	 * @return native connection shared
+	 * @return native connection shared.
 	 */
 	public boolean getShareNativeConnection() {
 		return shareNativeConnection;
@@ -401,7 +401,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	 * Enables multiple {@link LettuceConnection}s to share a single native connection. If set to false, every operation
 	 * on {@link LettuceConnection} will open and close a socket.
 	 *
-	 * @param shareNativeConnection enable connection sharing
+	 * @param shareNativeConnection enable connection sharing.
 	 */
 	public void setShareNativeConnection(boolean shareNativeConnection) {
 		this.shareNativeConnection = shareNativeConnection;
@@ -410,7 +410,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Returns the index of the database.
 	 *
-	 * @return Returns the database index
+	 * @return the database index.
 	 */
 	public int getDatabase() {
 		return dbIndex;
@@ -429,7 +429,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Returns the password used for authenticating with the Redis server.
 	 *
-	 * @return password for authentication
+	 * @return password for authentication.
 	 */
 	public String getPassword() {
 		return password;
@@ -447,7 +447,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Returns the shutdown timeout for shutting down the RedisClient (in milliseconds).
 	 *
-	 * @return shutdown timeout
+	 * @return shutdown timeout.
 	 * @since 1.6
 	 */
 	public long getShutdownTimeout() {
@@ -457,7 +457,7 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Sets the shutdown timeout for shutting down the RedisClient (in milliseconds).
 	 *
-	 * @param shutdownTimeout the shutdown timeout
+	 * @param shutdownTimeout the shutdown timeout.
 	 * @since 1.6
 	 */
 	public void setShutdownTimeout(long shutdownTimeout) {
@@ -488,9 +488,9 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Specifies if pipelined results should be converted to the expected data type. If false, results of
 	 * {@link LettuceConnection#closePipeline()} and {LettuceConnection#exec()} will be of the type returned by the
-	 * Lettuce driver
+	 * Lettuce driver.
 	 *
-	 * @return Whether or not to convert pipeline and tx results
+	 * @return Whether or not to convert pipeline and tx results.
 	 */
 	public boolean getConvertPipelineAndTxResults() {
 		return convertPipelineAndTxResults;
@@ -499,12 +499,28 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 	/**
 	 * Specifies if pipelined and transaction results should be converted to the expected data type. If false, results of
 	 * {@link LettuceConnection#closePipeline()} and {LettuceConnection#exec()} will be of the type returned by the
-	 * Lettuce driver
+	 * Lettuce driver.
 	 *
-	 * @param convertPipelineAndTxResults Whether or not to convert pipeline and tx results
+	 * @param convertPipelineAndTxResults Whether or not to convert pipeline and tx results.
 	 */
 	public void setConvertPipelineAndTxResults(boolean convertPipelineAndTxResults) {
 		this.convertPipelineAndTxResults = convertPipelineAndTxResults;
+	}
+
+	/**
+	 * @return true when {@link RedisSentinelConfiguration} is present.
+	 * @since 1.5
+	 */
+	public boolean isRedisSentinelAware() {
+		return sentinelConfiguration != null;
+	}
+
+	/**
+	 * @return true when {@link RedisClusterConfiguration} is present.
+	 * @since 1.7
+	 */
+	public boolean isClusterAware() {
+		return clusterConfiguration != null;
 	}
 
 	protected StatefulRedisConnection<byte[], byte[]> getSharedConnection() {
@@ -602,21 +618,6 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 		builder.withTimeout(timeout, TimeUnit.MILLISECONDS);
 
 		return builder.build();
-	}
-
-	/**
-	 * @return true when {@link RedisSentinelConfiguration} is present.
-	 * @since 1.5
-	 */
-	public boolean isRedisSentinelAware() {
-		return sentinelConfiguration != null;
-	}
-
-	/**
-	 * @return since 1.7
-	 */
-	public boolean isClusterAware() {
-		return clusterConfiguration != null;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -453,7 +453,7 @@ abstract public class LettuceConverters extends Converters {
 	}
 
 	public static boolean toBoolean(Position where) {
-		Assert.notNull("list positions are mandatory");
+		Assert.notNull(where, "list positions are mandatory");
 		return (Position.AFTER.equals(where) ? false : true);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/srp/SrpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -234,7 +234,7 @@ public class SrpConnection extends AbstractRedisConnection {
 
 	SrpConnection(RedisClient client) {
 
-		Assert.notNull(client);
+		Assert.notNull(client, "RedisClient must not be null!");
 		this.client = client;
 		this.queue = new ArrayBlockingQueue<SrpConnection>(50);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/srp/SrpConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/srp/SrpConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -387,7 +387,7 @@ abstract public class SrpConverters extends Converters {
 	}
 
 	public static byte[] toBytes(Position source) {
-		Assert.notNull("list positions are mandatory");
+		Assert.notNull(source, "list positions are mandatory");
 		return (Position.AFTER.equals(source) ? AFTER : BEFORE);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/srp/SrpUtils.java
+++ b/src/main/java/org/springframework/data/redis/connection/srp/SrpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,7 +138,7 @@ abstract class SrpUtils {
 	}
 
 	static byte[] convertPosition(Position where) {
-		Assert.notNull("list positions are mandatory");
+		Assert.notNull(where, "list positions are mandatory");
 		return (Position.AFTER.equals(where) ? AFTER : BEFORE);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/util/AbstractSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/util/AbstractSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public abstract class AbstractSubscription implements Subscription {
 	 * @param patterns
 	 */
 	protected AbstractSubscription(MessageListener listener, byte[][] channels, byte[][] patterns) {
-		Assert.notNull(listener);
+		Assert.notNull(listener, "MessageListener must not be null!");
 		this.listener = listener;
 
 		synchronized (this.channels) {

--- a/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(Point point, M member);
 
@@ -50,7 +50,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * 
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(GeoLocation<M> location);
 
@@ -59,7 +59,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * 
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(Map<M, Point> memberCoordinateMap);
 
@@ -68,7 +68,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * 
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(Iterable<GeoLocation<M>> locations);
 
@@ -78,7 +78,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member1 must not be {@literal null}.
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">http://redis.io/commands/geodist</a>
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	Distance geoDist(M member1, M member2);
 
@@ -89,7 +89,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member2 must not be {@literal null}.
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">http://redis.io/commands/geodist</a>
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	Distance geoDist(M member1, M member2, Metric metric);
 
@@ -98,7 +98,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * 
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geohash">http://redis.io/commands/geohash</a>
+	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	List<String> geoHash(M... members);
 
@@ -107,7 +107,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * 
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geopos">http://redis.io/commands/geopos</a>
+	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	List<Point> geoPos(M... members);
 
@@ -116,7 +116,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * 
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadius(Circle within);
 
@@ -126,7 +126,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param within must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadius(Circle within, GeoRadiusCommandArgs args);
 
@@ -137,7 +137,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member must not be {@literal null}.
 	 * @param radius
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius);
 
@@ -148,7 +148,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member must not be {@literal null}.
 	 * @param distance must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance);
 
@@ -160,7 +160,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param distance must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance, GeoRadiusCommandArgs args);
 

--- a/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,16 +26,20 @@ import java.util.Set;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Ninad Divadkar
+ * @author Mark Paluch
  */
 public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 
 	/**
+	 * Delete given hash {@code keys} at the bound key.
+	 *
+	 * @param keys must not be {@literal null}.
 	 * @return
 	 */
-	RedisOperations<H, ?> getOperations();
+	Long delete(Object... keys);
 
 	/**
-	 * Determine if given hash {@code key} exists.
+	 * Determine if given hash {@code key} exists at the bound key.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
@@ -43,7 +47,23 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 	Boolean hasKey(Object key);
 
 	/**
-	 * Increment {@code value} of a hash {@code key} by the given {@code delta}.
+	 * Get value for given {@code key} from the hash at the bound key.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	HV get(Object key);
+
+	/**
+	 * Get values for given {@code keys} from the hash at the bound key.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 */
+	List<HV> multiGet(Collection<HK> keys);
+
+	/**
+	 * Increment {@code value} of a hash {@code key} by the given {@code delta} at the bound key.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param delta
@@ -52,7 +72,7 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 	Long increment(HK key, long delta);
 
 	/**
-	 * Increment {@code value} of a hash {@code key} by the given {@code delta}.
+	 * Increment {@code value} of a hash {@code key} by the given {@code delta} at the bound key.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param delta
@@ -61,15 +81,28 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 	Double increment(HK key, double delta);
 
 	/**
-	 * Get value for given {@code key} from the hash.
+	 * Get key set (fields) of hash at the bound key.
 	 *
-	 * @param key must not be {@literal null}.
 	 * @return
 	 */
-	HV get(Object key);
+	Set<HK> keys();
 
 	/**
-	 * Set the {@code value} of a hash {@code key}.
+	 * Get size of hash at the bound key.
+	 *
+	 * @return
+	 */
+	Long size();
+
+	/**
+	 * Set multiple hash fields to multiple values using data provided in {@code m} at the bound key.
+	 *
+	 * @param m must not be {@literal null}.
+	 */
+	void putAll(Map<? extends HK, ? extends HV> m);
+
+	/**
+	 * Set the {@code value} of a hash {@code key} at the bound key.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
@@ -86,51 +119,14 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 	Boolean putIfAbsent(HK key, HV value);
 
 	/**
-	 * Get values for given {@code keys} from the hash.
-	 *
-	 * @param keys must not be {@literal null}.
-	 * @return
-	 */
-	List<HV> multiGet(Collection<HK> keys);
-
-	/**
-	 * Set multiple hash fields to multiple values using data provided in {@code m}.
-	 *
-	 * @param m must not be {@literal null}.
-	 */
-	void putAll(Map<? extends HK, ? extends HV> m);
-
-	/**
-	 * Get key set (fields) of the hash.
-	 *
-	 * @return
-	 */
-	Set<HK> keys();
-
-	/**
-	 * Get entry set (values) of hash.
+	 * Get entry set (values) of hash at the bound key.
 	 *
 	 * @return
 	 */
 	List<HV> values();
 
 	/**
-	 * Get size of the hash.
-	 *
-	 * @return
-	 */
-	Long size();
-
-	/**
-	 * Delete given hash {@code keys}.
-	 *
-	 * @param keys must not be {@literal null}.
-	 * @return
-	 */
-	Long delete(Object... keys);
-
-	/**
-	 * Get entire hash.
+	 * Get entire hash at the bound key.
 	 *
 	 * @return
 	 */
@@ -144,4 +140,9 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 	 * @since 1.4
 	 */
 	Cursor<Map.Entry<HK, HV>> scan(ScanOptions options);
+
+	/**
+	 * @return
+	 */
+	RedisOperations<H, ?> getOperations();
 }

--- a/src/main/java/org/springframework/data/redis/core/BoundKeyOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundKeyOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,12 @@ import org.springframework.data.redis.connection.DataType;
  * Operations over a Redis key. Useful for executing common key-'bound' operations to all implementations.
  * <p>
  * As the rest of the APIs, if the underlying connection is pipelined or queued/in multi mode, all methods will return
- * null.
+ * {@literal null}.
  * <p>
  * 
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface BoundKeyOperations<K> {
 

--- a/src/main/java/org/springframework/data/redis/core/BoundListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundListOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,44 +22,174 @@ import java.util.concurrent.TimeUnit;
  * List operations bound to a certain key.
  * 
  * @author Costin Leau
+ * @author Mark Paluch
  */
 public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 
-	RedisOperations<K, V> getOperations();
-
+	/**
+	 * Get elements between {@code begin} and {@code end} from list at the bound key.
+	 *
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 */
 	List<V> range(long start, long end);
 
+	/**
+	 * Trim list at the bound key to elements between {@code start} and {@code end}.
+	 *
+	 * @param start
+	 * @param end
+	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 */
 	void trim(long start, long end);
 
+	/**
+	 * Get the size of list stored at the bound key.
+	 *
+	 * @return
+	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 */
 	Long size();
 
+	/**
+	 * Prepend {@code value} to the bound key.
+	 *
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 */
 	Long leftPush(V value);
 
+	/**
+	 * Prepend {@code values} to the bound key.
+	 *
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 */
 	Long leftPushAll(V... values);
 
+	/**
+	 * Prepend {@code values} to the bound key only if the list exists.
+	 *
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
+	 */
 	Long leftPushIfPresent(V value);
 
+	/**
+	 * Prepend {@code values} to the bound key before {@code value}.
+	 *
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 */
 	Long leftPush(V pivot, V value);
 
+	/**
+	 * Append {@code value} to the bound key.
+	 *
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 */
 	Long rightPush(V value);
 
+	/**
+	 * Append {@code values} to the bound key.
+	 *
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 */
 	Long rightPushAll(V... values);
 
+	/**
+	 * Append {@code values} to the bound key only if the list exists.
+	 *
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
+	 */
 	Long rightPushIfPresent(V value);
 
+	/**
+	 * Append {@code values} to the bound key before {@code value}.
+	 *
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: RPUSH</a>
+	 */
 	Long rightPush(V pivot, V value);
 
-	V leftPop();
+	/**
+	 * Set the {@code value} list element at {@code index}.
+	 *
+	 * @param index
+	 * @param value
+	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 */
+	void set(long index, V value);
 
-	V leftPop(long timeout, TimeUnit unit);
+	/**
+	 * Removes the first {@code count} occurrences of {@code value} from the list stored at the bound key.
+	 *
+	 * @param count
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 */
+	Long remove(long count, Object value);
 
-	V rightPop();
-
-	V rightPop(long timeout, TimeUnit unit);
-
-	Long remove(long i, Object value);
-
+	/**
+	 * Get element at {@code index} form list at the bound key.
+	 *
+	 * @param index
+	 * @return
+	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 */
 	V index(long index);
 
-	void set(long index, V value);
+	/**
+	 * Removes and returns first element in list stored at the bound key.
+	 *
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 */
+	V leftPop();
+
+	/**
+	 * Removes and returns first element from lists stored at the bound key . <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param timeout
+	 * @param unit must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 */
+	V leftPop(long timeout, TimeUnit unit);
+
+	/**
+	 * Removes and returns last element in list stored at the bound key.
+	 *
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 */
+	V rightPop();
+
+	/**
+	 * Removes and returns last element from lists stored at the bound key. <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param timeout
+	 * @param unit must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 */
+	V rightPop(long timeout, TimeUnit unit);
+
+	RedisOperations<K, V> getOperations();
 }

--- a/src/main/java/org/springframework/data/redis/core/BoundSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundSetOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.core;
 
 import java.util.Collection;
@@ -24,54 +23,210 @@ import java.util.Set;
  * Set operations bound to a certain key.
  * 
  * @author Costin Leau
+ * @author Mark Paluch
  */
 public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 
-	RedisOperations<K, V> getOperations();
-
-	Set<V> diff(K key);
-
-	Set<V> diff(Collection<K> keys);
-
-	void diffAndStore(K key, K destKey);
-
-	void diffAndStore(Collection<K> keys, K destKey);
-
-	Set<V> intersect(K key);
-
-	Set<V> intersect(Collection<K> keys);
-
-	void intersectAndStore(K key, K destKey);
-
-	void intersectAndStore(Collection<K> keys, K destKey);
-
-	Set<V> union(K key);
-
-	Set<V> union(Collection<K> keys);
-
-	void unionAndStore(K key, K destKey);
-
-	void unionAndStore(Collection<K> keys, K destKey);
-
+	/**
+	 * Add given {@code values} to set at the bound key.
+	 *
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 */
 	Long add(V... values);
 
-	Boolean isMember(Object o);
-
-	Set<V> members();
-
-	Boolean move(K destKey, V value);
-
-	V randomMember();
-
-	Set<V> distinctRandomMembers(long count);
-
-	List<V> randomMembers(long count);
-
+	/**
+	 * Remove given {@code values} from set at the bound key and return the number of removed elements.
+	 *
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 */
 	Long remove(Object... values);
 
+	/**
+	 * Remove and return a random member from set at the bound key.
+	 *
+	 * @return
+	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 */
 	V pop();
 
+	/**
+	 * Move {@code value} from the bound key to {@code destKey}
+	 *
+	 * @param destKey must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 */
+	Boolean move(K destKey, V value);
+
+	/**
+	 * Get size of set at the bound key.
+	 *
+	 * @return
+	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 */
 	Long size();
+
+	/**
+	 * Check if set at the bound key contains {@code value}.
+	 *
+	 * @param o
+	 * @return
+	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 */
+	Boolean isMember(Object o);
+
+	/**
+	 * Returns the members intersecting all given sets at the bound key and {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 */
+	Set<V> intersect(K key);
+
+	/**
+	 * Returns the members intersecting all given sets at the bound key and {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 */
+	Set<V> intersect(Collection<K> keys);
+
+	/**
+	 * Intersect all given sets at the bound key and {@code key} and store result in {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 */
+	void intersectAndStore(K key, K destKey);
+
+	/**
+	 * Intersect all given sets at the bound key and {@code keys} and store result in {@code destKey}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 */
+	void intersectAndStore(Collection<K> keys, K destKey);
+
+	/**
+	 * Union all sets at given {@code key} and {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 */
+	Set<V> union(K key);
+
+	/**
+	 * Union all sets at given {@code keys} and {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 */
+	Set<V> union(Collection<K> keys);
+
+	/**
+	 * Union all sets at given the bound key and {@code key} and store result in {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 */
+	void unionAndStore(K key, K destKey);
+
+	/**
+	 * Union all sets at given the bound key and {@code keys} and store result in {@code destKey}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 */
+	void unionAndStore(Collection<K> keys, K destKey);
+
+	/**
+	 * Diff all sets for given the bound key and {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 */
+	Set<V> diff(K key);
+
+	/**
+	 * Diff all sets for given the bound key and {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 */
+	Set<V> diff(Collection<K> keys);
+
+	/**
+	 * Diff all sets for given the bound key and {@code keys} and store result in {@code destKey}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 */
+	void diffAndStore(K keys, K destKey);
+
+	/**
+	 * Diff all sets for given the bound key and {@code keys} and store result in {@code destKey}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 */
+	void diffAndStore(Collection<K> keys, K destKey);
+
+	/**
+	 * Get all elements of set at the bound key.
+	 *
+	 * @return
+	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 */
+	Set<V> members();
+
+	/**
+	 * Get random element from set at the bound key.
+	 *
+	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 */
+	V randomMember();
+
+	/**
+	 * Get {@code count} distinct random elements from set at the bound key.
+	 *
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 */
+	Set<V> distinctRandomMembers(long count);
+
+	/**
+	 * Get {@code count} random elements from set at the bound key.
+	 *
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 */
+	List<V> randomMembers(long count);
 
 	/**
 	 * @param options
@@ -79,4 +234,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @since 1.4
 	 */
 	Cursor<V> scan(ScanOptions options);
+	
+	RedisOperations<K, V> getOperations();
+
 }

--- a/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,30 +21,98 @@ import java.util.concurrent.TimeUnit;
  * Value (or String in Redis terminology) operations bound to a certain key.
  * 
  * @author Costin Leau
+ * @author Mark Paluch
  */
 public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 
-	RedisOperations<K, V> getOperations();
-
+	/**
+	 * Set {@code value} for the bound key.
+	 *
+	 * @param value
+	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 */
 	void set(V value);
 
-	void set(V value, long offset);
-
+	/**
+	 * Set the {@code value} and expiration {@code timeout} for the bound key.
+	 *
+	 * @param value
+	 * @param timeout
+	 * @param unit must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 */
 	void set(V value, long timeout, TimeUnit unit);
 
+	/**
+	 * Set the bound key to hold the string {@code value} if the bound key is absent.
+	 *
+	 * @param value
+	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 */
 	Boolean setIfAbsent(V value);
 
+	/**
+	 * Get the value of the bound key.
+	 *
+	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 */
 	V get();
 
-	String get(long start, long end);
-
+	/**
+	 * Set {@code value} of the bound key and return its old value.
+	 *
+	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 */
 	V getAndSet(V value);
 
+	/**
+	 * Increment an integer value stored as string value under the bound key by {@code delta}.
+	 *
+	 * @param delta
+	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 */
 	Long increment(long delta);
 
+	/**
+	 * Increment a floating point number value stored as string value under the bound key by {@code delta}.
+	 *
+	 * @param delta
+	 * @see <a href="http://redis.io/commands/incrbyfloar">Redis Documentation: INCRBYFLOAT</a>
+	 */
 	Double increment(double delta);
 
+	/**
+	 * Append a {@code value} to the bound key.
+	 *
+	 * @param value
+	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 */
 	Integer append(String value);
 
+	/**
+	 * Get a substring of value of the bound key between {@code begin} and {@code end}.
+	 *
+	 * @param start
+	 * @param end
+	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 */
+	String get(long start, long end);
+
+	/**
+	 * Overwrite parts of the bound key starting at the specified {@code offset} with given {@code value}.
+	 *
+	 * @param value
+	 * @param offset
+	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 */
+	void set(V value, long offset);
+
+	/**
+	 * Get the length of the value stored at the bound key.
+	 *
+	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 */
 	Long size();
+
+	RedisOperations<K, V> getOperations();
 }

--- a/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.core;
 
 import java.util.Collection;
@@ -21,6 +20,7 @@ import java.util.Set;
 
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
+import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
 /**
@@ -32,34 +32,257 @@ import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
  */
 public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 
-	RedisOperations<K, V> getOperations();
+	/**
+	 * Add {@code value} to a sorted set at the bound key, or update its {@code score} if it already exists.
+	 *
+	 * @param score the score.
+	 * @param value the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 */
+	Boolean add(V value, double score);
 
-	void intersectAndStore(K otherKey, K destKey);
+	/**
+	 * Add {@code tuples} to a sorted set at the bound key, or update its {@code score} if it already exists.
+	 *
+	 * @param tuples must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 */
+	Long add(Set<TypedTuple<V>> tuples);
 
-	void intersectAndStore(Collection<K> otherKeys, K destKey);
+	/**
+	 * Remove {@code values} from sorted set. Return number of removed elements.
+	 *
+	 * @param values must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 */
+	Long remove(Object... values);
 
+	/**
+	 * Increment the score of element with {@code value} in sorted set by {@code increment}.
+	 *
+	 * @param delta
+	 * @param value the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 */
+	Double incrementScore(V value, double delta);
+
+	/**
+	 * Determine the index of element with {@code value} in a sorted set.
+	 *
+	 * @param o the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 */
+	Long rank(Object o);
+
+	/**
+	 * Determine the index of element with {@code value} in a sorted set when scored high to low.
+	 *
+	 * @param o the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 */
+	Long reverseRank(Object o);
+
+	/**
+	 * Get elements between {@code start} and {@code end} from sorted set.
+	 *
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 */
 	Set<V> range(long start, long end);
 
-	Set<V> rangeByScore(double min, double max);
-
-	Set<V> reverseRange(long start, long end);
-
-	Set<V> reverseRangeByScore(double min, double max);
-
+	/**
+	 * Get set of {@link Tuple}s between {@code start} and {@code end} from sorted set.
+	 *
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 */
 	Set<TypedTuple<V>> rangeWithScores(long start, long end);
 
+	/**
+	 * Get elements where score is between {@code min} and {@code max} from sorted set.
+	 *
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 */
+	Set<V> rangeByScore(double min, double max);
+
+	/**
+	 * Get set of {@link Tuple}s where score is between {@code min} and {@code max} from sorted set.
+	 *
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 */
 	Set<TypedTuple<V>> rangeByScoreWithScores(double min, double max);
 
+	/**
+	 * Get elements in range from {@code start} to {@code end} from sorted set ordered from high to low.
+	 *
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 */
+	Set<V> reverseRange(long start, long end);
+
+	/**
+	 * Get set of {@link Tuple}s in range from {@code start} to {@code end} from sorted set ordered from high to low.
+	 *
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 */
 	Set<TypedTuple<V>> reverseRangeWithScores(long start, long end);
 
+	/**
+	 * Get elements where score is between {@code min} and {@code max} from sorted set ordered from high to low.
+	 *
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 */
+	Set<V> reverseRangeByScore(double min, double max);
+
+	/**
+	 * Get set of {@link Tuple} where score is between {@code min} and {@code max} from sorted set ordered from high to
+	 * low.
+	 *
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 */
 	Set<TypedTuple<V>> reverseRangeByScoreWithScores(double min, double max);
+
+	/**
+	 * Count number of elements within sorted set with scores between {@code min} and {@code max}.
+	 *
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 */
+	Long count(double min, double max);
+
+	/**
+	 * Returns the number of elements of the sorted set stored with given the bound key.
+	 *
+	 * @see #zCard()
+	 * @return
+	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 */
+	Long size();
+
+	/**
+	 * Get the size of sorted set with the bound key.
+	 *
+	 * @return
+	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 */
+	Long zCard();
+
+	/**
+	 * Get the score of element with {@code value} from sorted set with key the bound key.
+	 *
+	 * @param o the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 */
+	Double score(Object o);
+
+	/**
+	 * Remove elements in range between {@code start} and {@code end} from sorted set with the bound key.
+	 *
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 */
+	void removeRange(long start, long end);
+
+	/**
+	 * Remove elements with scores between {@code min} and {@code max} from sorted set with the bound key.
+	 *
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 */
+	void removeRangeByScore(double min, double max);
+
+	/**
+	 * Union sorted sets at the bound key and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param otherKey must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	void unionAndStore(K otherKey, K destKey);
+
+	/**
+	 * Union sorted sets at the bound key and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	void unionAndStore(Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Intersect sorted sets at the bound key and {@code otherKey} and store result in destination {@code destKey}.
+	 *
+	 * @param otherKey must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	void intersectAndStore(K otherKey, K destKey);
+
+	/**
+	 * Intersect sorted sets at the bound key and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	void intersectAndStore(Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Iterate over elements in zset at the bound key. <br />
+	 * <strong>Important:</strong> Call {@link Cursor#close()} when done to avoid resource leak.
+	 *
+	 * @param options
+	 * @return
+	 * @since 1.4
+	 */
+	Cursor<TypedTuple<V>> scan(ScanOptions options);
 
 	/**
 	 * Get all elements with lexicographical ordering with a value between {@link Range#getMin()} and
 	 * {@link Range#getMax()}.
-	 * 
+	 *
 	 * @param range must not be {@literal null}.
 	 * @since 1.7
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Set<V> rangeByLex(Range range);
 
@@ -67,58 +290,14 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * Get all elements {@literal n} elements, where {@literal n = } {@link Limit#getCount()}, starting at
 	 * {@link Limit#getOffset()} with lexicographical ordering having a value between {@link Range#getMin()} and
 	 * {@link Range#getMax()}.
-	 * 
+	 *
 	 * @param range must not be {@literal null}.
 	 * @param limit can be {@literal null}.
 	 * @return
 	 * @since 1.7
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Set<V> rangeByLex(Range range, Limit limit);
 
-	void removeRange(long start, long end);
-
-	void removeRangeByScore(double min, double max);
-
-	void unionAndStore(K otherKey, K destKey);
-
-	void unionAndStore(Collection<K> otherKeys, K destKey);
-
-	Boolean add(V value, double score);
-
-	Long add(Set<TypedTuple<V>> tuples);
-
-	Double incrementScore(V value, double delta);
-
-	Long rank(Object o);
-
-	Long reverseRank(Object o);
-
-	Long remove(Object... values);
-
-	Long count(double min, double max);
-
-	/**
-	 * Returns the number of elements of the sorted set.
-	 * 
-	 * @return
-	 * @see #zCard()
-	 */
-	Long size();
-
-	/**
-	 * Returns the number of elements of the sorted set.
-	 * 
-	 * @return
-	 * @since 1.3
-	 */
-	Long zCard();
-
-	Double score(Object o);
-
-	/**
-	 * @param options
-	 * @return
-	 * @since 1.4
-	 */
-	Cursor<TypedTuple<V>> scan(ScanOptions options);
+	RedisOperations<K, V> getOperations();
 }

--- a/src/main/java/org/springframework/data/redis/core/GeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/GeoOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@ import org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusComma
  *
  * @author Ninad Divadkar
  * @author Christoph Strobl
- * @see <a href="http://redis.io/commands#geo">http://redis.io/commands#geo</a>
+ * @author Mark Paluch
+ * @see <a href="http://redis.io/commands#geo">Redis Documentation: Geo Commands</a>
  * @since 1.8
  */
 public interface GeoOperations<K, M> {
@@ -43,7 +44,7 @@ public interface GeoOperations<K, M> {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(K key, Point point, M member);
 
@@ -53,7 +54,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(K key, GeoLocation<M> location);
 
@@ -63,7 +64,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(K key, Map<M, Point> memberCoordinateMap);
 
@@ -73,7 +74,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">http://redis.io/commands/geoadd</a>
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Long geoAdd(K key, Iterable<GeoLocation<M>> locations);
 
@@ -84,7 +85,7 @@ public interface GeoOperations<K, M> {
 	 * @param member1 must not be {@literal null}.
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">http://redis.io/commands/geodist</a>
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	Distance geoDist(K key, M member1, M member2);
 
@@ -96,7 +97,7 @@ public interface GeoOperations<K, M> {
 	 * @param member2 must not be {@literal null}.
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">http://redis.io/commands/geodist</a>
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	Distance geoDist(K key, M member1, M member2, Metric metric);
 
@@ -106,7 +107,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geohash">http://redis.io/commands/geohash</a>
+	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	List<String> geoHash(K key, M... members);
 
@@ -116,7 +117,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geopos">http://redis.io/commands/geopos</a>
+	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	List<Point> geoPos(K key, M... members);
 
@@ -126,7 +127,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadius(K key, Circle within);
 
@@ -137,7 +138,7 @@ public interface GeoOperations<K, M> {
 	 * @param within must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">http://redis.io/commands/georadius</a>
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadius(K key, Circle within, GeoRadiusCommandArgs args);
 
@@ -149,7 +150,7 @@ public interface GeoOperations<K, M> {
 	 * @param member must not be {@literal null}.
 	 * @param radius
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius);
 
@@ -161,7 +162,7 @@ public interface GeoOperations<K, M> {
 	 * @param member must not be {@literal null}.
 	 * @param distance must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance);
 
@@ -174,7 +175,7 @@ public interface GeoOperations<K, M> {
 	 * @param distance must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">http://redis.io/commands/georadiusbymember</a>
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance, GeoRadiusCommandArgs args);
 

--- a/src/main/java/org/springframework/data/redis/core/HashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/HashOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,18 +145,18 @@ public interface HashOperations<H, HK, HV> {
 	Map<HK, HV> entries(H key);
 
 	/**
-	 * @return
-	 */
-	RedisOperations<H, ?> getOperations();
-
-	/**
 	 * Use a {@link Cursor} to iterate over entries in hash at {@code key}. <br />
 	 * <strong>Important:</strong> Call {@link Cursor#close()} when done to avoid resource leak.
 	 *
-	 * @since 1.4
 	 * @param key must not be {@literal null}.
 	 * @param options
 	 * @return
+	 * @since 1.4
 	 */
 	Cursor<Map.Entry<HK, HV>> scan(H key, ScanOptions options);
+
+	/**
+	 * @return
+	 */
+	RedisOperations<H, ?> getOperations();
 }

--- a/src/main/java/org/springframework/data/redis/core/ListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ListOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,67 +26,236 @@ import java.util.concurrent.TimeUnit;
  * @author David Liu
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface ListOperations<K, V> {
 
+	/**
+	 * Get elements between {@code begin} and {@code end} from list at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 */
 	List<V> range(K key, long start, long end);
 
+	/**
+	 * Trim list at {@code key} to elements between {@code start} and {@code end}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 */
 	void trim(K key, long start, long end);
 
+	/**
+	 * Get the size of list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 */
 	Long size(K key);
 
+	/**
+	 * Prepend {@code value} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 */
 	Long leftPush(K key, V value);
 
+	/**
+	 * Prepend {@code values} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 */
 	Long leftPushAll(K key, V... values);
 
 	/**
-	 * Insert all {@literal values} at the head of the list stored at {@literal key}.
-	 * 
+	 * Prepend {@code values} to {@code key}.
+	 *
 	 * @param key must not be {@literal null}.
-	 * @param values must not be {@literal empty} nor contain {@literal null} values.
+	 * @param values must not be {@literal null}.
 	 * @return
 	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	Long leftPushAll(K key, Collection<V> values);
 
+	/**
+	 * Prepend {@code values} to {@code key} only if the list exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
+	 */
 	Long leftPushIfPresent(K key, V value);
 
+	/**
+	 * Prepend {@code values} to {@code key} before {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 */
 	Long leftPush(K key, V pivot, V value);
 
+	/**
+	 * Append {@code value} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 */
 	Long rightPush(K key, V value);
 
+	/**
+	 * Append {@code values} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 */
 	Long rightPushAll(K key, V... values);
 
 	/**
-	 * Insert all {@literal values} at the tail of the list stored at {@literal key}.
-	 * 
+	 * Append {@code values} to {@code key}.
+	 *
 	 * @param key must not be {@literal null}.
-	 * @param values must not be {@literal empty} nor contain {@literal null} values.
+	 * @param values
 	 * @return
 	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	Long rightPushAll(K key, Collection<V> values);
 
+	/**
+	 * Append {@code values} to {@code key} only if the list exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
+	 */
 	Long rightPushIfPresent(K key, V value);
 
+	/**
+	 * Append {@code values} to {@code key} before {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: RPUSH</a>
+	 */
 	Long rightPush(K key, V pivot, V value);
 
+	/**
+	 * Set the {@code value} list element at {@code index}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param index
+	 * @param value
+	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 */
 	void set(K key, long index, V value);
 
-	Long remove(K key, long i, Object value);
+	/**
+	 * Removes the first {@code count} occurrences of {@code value} from the list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param count
+	 * @param value
+	 * @return
+	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 */
+	Long remove(K key, long count, Object value);
 
+	/**
+	 * Get element at {@code index} form list at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param index
+	 * @return
+	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 */
 	V index(K key, long index);
 
+	/**
+	 * Removes and returns first element in list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 */
 	V leftPop(K key);
 
+	/**
+	 * Removes and returns first element from lists stored at {@code key} . <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param timeout
+	 * @param unit must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 */
 	V leftPop(K key, long timeout, TimeUnit unit);
 
+	/**
+	 * Removes and returns last element in list stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 */
 	V rightPop(K key);
 
+	/**
+	 * Removes and returns last element from lists stored at {@code key}. <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param timeout
+	 * @param unit must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 */
 	V rightPop(K key, long timeout, TimeUnit unit);
 
+	/**
+	 * Remove the last element from list at {@code sourceKey}, append it to {@code destinationKey} and return its value.
+	 *
+	 * @param sourceKey must not be {@literal null}.
+	 * @param destinationKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
+	 */
 	V rightPopAndLeftPush(K sourceKey, K destinationKey);
 
+	/**
+	 * Remove the last element from list at {@code srcKey}, append it to {@code dstKey} and return its value.<br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param sourceKey must not be {@literal null}.
+	 * @param destinationKey must not be {@literal null}.
+	 * @param timeout
+	 * @param unit must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 */
 	V rightPopAndLeftPush(K sourceKey, K destinationKey, long timeout, TimeUnit unit);
 
 	RedisOperations<K, V> getOperations();

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
@@ -48,12 +48,24 @@ public class RedisKeyExpiredEvent<T> extends RedisKeyspaceEvent {
 
 	/**
 	 * Creates new {@link RedisKeyExpiredEvent}
-	 * 
+	 *
 	 * @param key
 	 * @param value
 	 */
 	public RedisKeyExpiredEvent(byte[] key, Object value) {
-		super(key);
+		this(null, key, value);
+	}
+
+	/**
+	 * Creates new {@link RedisKeyExpiredEvent}
+	 *
+	 * @pamam channel
+	 * @param key
+	 * @param value
+	 * @since 1.8
+	 */
+	public RedisKeyExpiredEvent(String channel, byte[] key, Object value) {
+		super(channel, key);
 
 		args = ByteUtils.split(key, ':');
 		this.value = value;

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,8 +103,6 @@ import org.springframework.util.StringUtils;
 public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 		implements InitializingBean, ApplicationContextAware, ApplicationListener<RedisKeyspaceEvent> {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(RedisKeyValueAdapter.class);
-
 	private RedisOperations<?, ?> redisOps;
 	private RedisConverter converter;
 	private RedisMessageListenerContainer messageListenerContainer;
@@ -164,7 +162,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 	 * Creates new {@link RedisKeyValueAdapter} with specific {@link RedisConverter}.
 	 *
 	 * @param redisOps must not be {@literal null}.
-	 * @param mappingContext must not be {@literal null}.
+	 * @param redisConverter must not be {@literal null}.
 	 */
 	public RedisKeyValueAdapter(RedisOperations<?, ?> redisOps, RedisConverter redisConverter) {
 

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -64,6 +64,7 @@ import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.data.util.CloseableIterator;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Redis specific {@link KeyValueAdapter} implementation. Uses binary codec to read/write data from/to Redis. Objects
@@ -366,7 +367,6 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 		List<Object> result = new ArrayList<Object>();
 
 		List<byte[]> keys = new ArrayList<byte[]>(ids);
-
 
 		if (keys.isEmpty() || keys.size() < offset) {
 			return Collections.emptyList();
@@ -701,28 +701,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 	 */
 	@Override
 	public void onApplicationEvent(RedisKeyspaceEvent event) {
-
-		LOGGER.debug("Received %s .", event);
-
-		if (event instanceof RedisKeyExpiredEvent) {
-
-			final RedisKeyExpiredEvent expiredEvent = (RedisKeyExpiredEvent) event;
-
-			redisOps.execute(new RedisCallback<Void>() {
-
-				@Override
-				public Void doInRedis(RedisConnection connection) throws DataAccessException {
-
-					LOGGER.debug("Cleaning up expired key '%s' data structures in keyspace '%s'.", expiredEvent.getSource(),
-							expiredEvent.getKeyspace());
-
-					connection.sRem(toBytes(expiredEvent.getKeyspace()), expiredEvent.getId());
-					new IndexWriter(connection, converter).removeKeyFromIndexes(expiredEvent.getKeyspace(), expiredEvent.getId());
-					return null;
-				}
-			});
-
-		}
+		// just a customization hook
 	}
 
 	/*
@@ -814,12 +793,29 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 					if (!org.springframework.util.CollectionUtils.isEmpty(hash)) {
 						connection.del(phantomKey);
 					}
+
 					return hash;
 				}
 			});
 
 			Object value = converter.read(Object.class, new RedisData(hash));
-			publishEvent(new RedisKeyExpiredEvent(key, value));
+
+			String channel = !ObjectUtils.isEmpty(message.getChannel())
+					? converter.getConversionService().convert(message.getChannel(), String.class) : null;
+
+			final RedisKeyExpiredEvent event = new RedisKeyExpiredEvent(channel, key, value);
+
+			ops.execute(new RedisCallback<Void>() {
+				@Override
+				public Void doInRedis(RedisConnection connection) throws DataAccessException {
+
+					connection.sRem(converter.getConversionService().convert(event.getKeyspace(), byte[].class), event.getId());
+					new IndexWriter(connection, converter).removeKeyFromIndexes(event.getKeyspace(), event.getId());
+					return null;
+				}
+			});
+
+			publishEvent(event);
 		}
 
 		private boolean isKeyExpirationMessage(Message message) {

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyspaceEvent.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyspaceEvent.java
@@ -25,13 +25,28 @@ import org.springframework.context.ApplicationEvent;
  */
 public class RedisKeyspaceEvent extends ApplicationEvent {
 
+	private final String channel;
+
 	/**
 	 * Creates new {@link RedisKeyspaceEvent}.
-	 * 
+	 *
 	 * @param key The key that expired. Must not be {@literal null}.
 	 */
 	public RedisKeyspaceEvent(byte[] key) {
+		this(null, key);
+	}
+
+	/**
+	 * Creates new {@link RedisKeyspaceEvent}.
+	 *
+	 * @param channel The source channel aka subscription topic. Can be {@literal null}.
+	 * @param key The key that expired. Must not be {@literal null}.
+	 * @since 1.8
+	 */
+	public RedisKeyspaceEvent(String channel, byte[] key) {
+
 		super(key);
+		this.channel = channel;
 	}
 
 	/*
@@ -40,6 +55,15 @@ public class RedisKeyspaceEvent extends ApplicationEvent {
 	 */
 	public byte[] getSource() {
 		return (byte[]) super.getSource();
+	}
+
+	/**
+	 *
+	 * @return can be {@literal null}.
+	 * @since 1.8
+	 */
+	public String getChannel() {
+		return this.channel;
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/core/SetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/SetOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.core;
 
 import java.util.Collection;
@@ -25,63 +24,243 @@ import java.util.Set;
  * 
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface SetOperations<K, V> {
 
-	Set<V> difference(K key, K otherKey);
-
-	Set<V> difference(K key, Collection<K> otherKeys);
-
-	Long differenceAndStore(K key, K otherKey, K destKey);
-
-	Long differenceAndStore(K key, Collection<K> otherKeys, K destKey);
-
-	Set<V> intersect(K key, K otherKey);
-
-	Set<V> intersect(K key, Collection<K> otherKeys);
-
-	Long intersectAndStore(K key, K otherKey, K destKey);
-
-	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey);
-
-	Set<V> union(K key, K otherKey);
-
-	Set<V> union(K key, Collection<K> otherKeys);
-
-	Long unionAndStore(K key, K otherKey, K destKey);
-
-	Long unionAndStore(K key, Collection<K> otherKeys, K destKey);
-
+	/**
+	 * Add given {@code values} to set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 */
 	Long add(K key, V... values);
 
-	Boolean isMember(K key, Object o);
-
-	Set<V> members(K key);
-
-	Boolean move(K key, V value, K destKey);
-
-	V randomMember(K key);
-
-	Set<V> distinctRandomMembers(K key, long count);
-
-	List<V> randomMembers(K key, long count);
-
+	/**
+	 * Remove given {@code values} from set at {@code key} and return the number of removed elements.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values
+	 * @return
+	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 */
 	Long remove(K key, Object... values);
 
+	/**
+	 * Remove and return a random member from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 */
 	V pop(K key);
 
+	/**
+	 * Move {@code value} from {@code key} to {@code destKey}
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 */
+	Boolean move(K key, V value, K destKey);
+
+	/**
+	 * Get size of set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 */
 	Long size(K key);
 
-	RedisOperations<K, V> getOperations();
+	/**
+	 * Check if set at {@code key} contains {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param o
+	 * @return
+	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 */
+	Boolean isMember(K key, Object o);
+
+	/**
+	 * Returns the members intersecting all given sets at {@code key} and {@code otherKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 */
+	Set<V> intersect(K key, K otherKey);
+
+	/**
+	 * Returns the members intersecting all given sets at {@code key} and {@code otherKeys}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 */
+	Set<V> intersect(K key, Collection<K> otherKeys);
+
+	/**
+	 * Intersect all given sets at {@code key} and {@code otherKey} and store result in {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 */
+	Long intersectAndStore(K key, K otherKey, K destKey);
+
+	/**
+	 * Intersect all given sets at {@code key} and {@code otherKeys} and store result in {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 */
+	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Union all sets at given {@code keys} and {@code otherKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 */
+	Set<V> union(K key, K otherKey);
+
+	/**
+	 * Union all sets at given {@code keys} and {@code otherKeys}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 */
+	Set<V> union(K key, Collection<K> otherKeys);
+
+	/**
+	 * Union all sets at given {@code key} and {@code otherKey} and store result in {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 */
+	Long unionAndStore(K key, K otherKey, K destKey);
+
+	/**
+	 * Union all sets at given {@code key} and {@code otherKeys} and store result in {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 */
+	Long unionAndStore(K key, Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Diff all sets for given {@code key} and {@code otherKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 */
+	Set<V> difference(K key, K otherKey);
+
+	/**
+	 * Diff all sets for given {@code key} and {@code otherKeys}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 */
+	Set<V> difference(K key, Collection<K> otherKeys);
+
+	/**
+	 * Diff all sets for given {@code key} and {@code otherKey} and store result in {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 */
+	Long differenceAndStore(K key, K otherKey, K destKey);
+
+	/**
+	 * Diff all sets for given {@code key} and {@code otherKeys} and store result in {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 */
+	Long differenceAndStore(K key, Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Get all elements of set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 */
+	Set<V> members(K key);
+
+	/**
+	 * Get random element from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 */
+	V randomMember(K key);
+
+	/**
+	 * Get {@code count} distinct random elements from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 */
+	Set<V> distinctRandomMembers(K key, long count);
+
+	/**
+	 * Get {@code count} random elements from set at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 */
+	List<V> randomMembers(K key, long count);
 
 	/**
 	 * Iterate over elements in set at {@code key}. <br />
 	 * <strong>Important:</strong> Call {@link Cursor#close()} when done to avoid resource leak.
 	 *
-	 * @since 1.4
 	 * @param key
 	 * @param options
 	 * @return
+	 * @since 1.4
 	 */
 	Cursor<V> scan(K key, ScanOptions options);
+
+	RedisOperations<K, V> getOperations();
 }

--- a/src/main/java/org/springframework/data/redis/core/ValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ValueOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,63 +25,156 @@ import java.util.concurrent.TimeUnit;
  * 
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface ValueOperations<K, V> {
 
+	/**
+	 * Set {@code value} for {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 */
 	void set(K key, V value);
 
 	/**
-	 * Set {@code key} to hold the string {@code value} until {@code timeout}.
-	 * 
-	 * @param key
+	 * Set the {@code value} and expiration {@code timeout} for {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @param timeout
-	 * @param units
-	 * @see http://redis.io/commands/set
+	 * @param unit must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 */
 	void set(K key, V value, long timeout, TimeUnit unit);
 
+	/**
+	 * Set {@code key} to hold the string {@code value} if {@code key} is absent.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 */
 	Boolean setIfAbsent(K key, V value);
 
-	void multiSet(Map<? extends K, ? extends V> m);
+	/**
+	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple}.
+	 *
+	 * @param map must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 */
+	void multiSet(Map<? extends K, ? extends V> map);
 
-	Boolean multiSetIfAbsent(Map<? extends K, ? extends V> m);
+	/**
+	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple} only if the provided key does
+	 * not exist.
+	 *
+	 * @param map must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 */
+	Boolean multiSetIfAbsent(Map<? extends K, ? extends V> map);
 
+	/**
+	 * Get the value of {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 */
 	V get(Object key);
 
+	/**
+	 * Set {@code value} of {@code key} and return its old value.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 */
 	V getAndSet(K key, V value);
 
+	/**
+	 * Get multiple {@code keys}. Values are returned in the order of the requested keys.
+	 * 
+	 * @param keys must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/mget">Redis Documentation: MGET</a>
+	 */
 	List<V> multiGet(Collection<K> keys);
 
+	/**
+	 * Increment an integer value stored as string value under {@code key} by {@code delta}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param delta
+	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 */
 	Long increment(K key, long delta);
 
+	/**
+	 * Increment a floating point number value stored as string value under {@code key} by {@code delta}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param delta
+	 * @see <a href="http://redis.io/commands/incrbyfloar">Redis Documentation: INCRBYFLOAT</a>
+	 */
 	Double increment(K key, double delta);
 
+	/**
+	 * Append a {@code value} to {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 */
 	Integer append(K key, String value);
 
+	/**
+	 * Get a substring of value of {@code key} between {@code begin} and {@code end}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 */
 	String get(K key, long start, long end);
 
+	/**
+	 * Overwrite parts of {@code key} starting at the specified {@code offset} with given {@code value}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param value
+	 * @param offset
+	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 */
 	void set(K key, V value, long offset);
 
+	/**
+	 * Get the length of the value stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 */
 	Long size(K key);
 
-	RedisOperations<K, V> getOperations();
-	
 	/**
-	 * @since 1.5
-	 * @param key
+	 * Sets the bit at {@code offset} in value stored at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param offset
 	 * @param value
-	 * @return
+	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
 	 */
 	Boolean setBit(K key, long offset, boolean value);
-	
+
 	/**
-	 * @since 1.5
-	 * @param key
+	 * Get the bit value at {@code offset} of value at {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param offset
-	 * @return
+	 * @since 1.5
+	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: GETBIT</a>
 	 */
 	Boolean getBit(K key, long offset);
-	
+
+	RedisOperations<K, V> getOperations();
+
 }

--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.core;
 
 import java.util.Collection;
@@ -21,6 +20,7 @@ import java.util.Set;
 
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
+import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 
 /**
  * Redis ZSet/sorted set specific operations.
@@ -40,29 +40,339 @@ public interface ZSetOperations<K, V> {
 		Double getScore();
 	}
 
-	Long intersectAndStore(K key, K otherKey, K destKey);
+	/**
+	 * Add {@code value} to a sorted set at {@code key}, or update its {@code score} if it already exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param score the score.
+	 * @param value the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 */
+	Boolean add(K key, V value, double score);
 
-	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey);
+	/**
+	 * Add {@code tuples} to a sorted set at {@code key}, or update its {@code score} if it already exists.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param tuples must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 */
+	Long add(K key, Set<TypedTuple<V>> tuples);
 
-	Long unionAndStore(K key, K otherKey, K destKey);
+	/**
+	 * Remove {@code values} from sorted set. Return number of removed elements.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param values must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 */
+	Long remove(K key, Object... values);
 
-	Long unionAndStore(K key, Collection<K> otherKeys, K destKey);
+	/**
+	 * Increment the score of element with {@code value} in sorted set by {@code increment}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param delta
+	 * @param value the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 */
+	Double incrementScore(K key, V value, double delta);
 
+	/**
+	 * Determine the index of element with {@code value} in a sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param o the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 */
+	Long rank(K key, Object o);
+
+	/**
+	 * Determine the index of element with {@code value} in a sorted set when scored high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param o the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 */
+	Long reverseRank(K key, Object o);
+
+	/**
+	 * Get elements between {@code start} and {@code end} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 */
 	Set<V> range(K key, long start, long end);
 
-	Set<V> reverseRange(K key, long start, long end);
-
+	/**
+	 * Get set of {@link Tuple}s between {@code start} and {@code end} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 */
 	Set<TypedTuple<V>> rangeWithScores(K key, long start, long end);
 
+	/**
+	 * Get elements where score is between {@code min} and {@code max} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 */
+	Set<V> rangeByScore(K key, double min, double max);
+
+	/**
+	 * Get set of {@link Tuple}s where score is between {@code min} and {@code max} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 */
+	Set<TypedTuple<V>> rangeByScoreWithScores(K key, double min, double max);
+
+	/**
+	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
+	 * sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @param offset
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 */
+	Set<V> rangeByScore(K key, double min, double max, long offset, long count);
+
+	/**
+	 * Get set of {@link Tuple}s in range from {@code start} to {@code end} where score is between {@code min} and
+	 * {@code max} from sorted set.
+	 *
+	 * @param key
+	 * @param min
+	 * @param max
+	 * @param offset
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 */
+	Set<TypedTuple<V>> rangeByScoreWithScores(K key, double min, double max, long offset, long count);
+
+	/**
+	 * Get elements in range from {@code start} to {@code end} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 */
+	Set<V> reverseRange(K key, long start, long end);
+
+	/**
+	 * Get set of {@link Tuple}s in range from {@code start} to {@code end} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 */
 	Set<TypedTuple<V>> reverseRangeWithScores(K key, long start, long end);
+
+	/**
+	 * Get elements where score is between {@code min} and {@code max} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 */
+	Set<V> reverseRangeByScore(K key, double min, double max);
+
+	/**
+	 * Get set of {@link Tuple} where score is between {@code min} and {@code max} from sorted set ordered from high to
+	 * low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 */
+	Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, double min, double max);
+
+	/**
+	 * Get elements in range from {@code start} to {@code end} where score is between {@code min} and {@code max} from
+	 * sorted set ordered high -> low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @param offset
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 */
+	Set<V> reverseRangeByScore(K key, double min, double max, long offset, long count);
+
+	/**
+	 * Get set of {@link Tuple} in range from {@code start} to {@code end} where score is between {@code min} and
+	 * {@code max} from sorted set ordered high -> low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @param offset
+	 * @param count
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 */
+	Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, double min, double max, long offset, long count);
+
+	/**
+	 * Count number of elements within sorted set with scores between {@code min} and {@code max}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 */
+	Long count(K key, double min, double max);
+
+	/**
+	 * Returns the number of elements of the sorted set stored with given {@code key}.
+	 *
+	 * @see #zCard(Object)
+	 * @param key
+	 * @return
+	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 */
+	Long size(K key);
+
+	/**
+	 * Get the size of sorted set with {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @since 1.3
+	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 */
+	Long zCard(K key);
+
+	/**
+	 * Get the score of element with {@code value} from sorted set with key {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param o the value.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 */
+	Double score(K key, Object o);
+
+	/**
+	 * Remove elements in range between {@code start} and {@code end} from sorted set with {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param start
+	 * @param end
+	 * @return
+	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 */
+	Long removeRange(K key, long start, long end);
+
+	/**
+	 * Remove elements with scores between {@code min} and {@code max} from sorted set with {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param min
+	 * @param max
+	 * @return
+	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 */
+	Long removeRangeByScore(K key, double min, double max);
+
+	/**
+	 * Union sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	Long unionAndStore(K key, K otherKey, K destKey);
+
+	/**
+	 * Union sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	Long unionAndStore(K key, Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Intersect sorted sets at {@code key} and {@code otherKey} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	Long intersectAndStore(K key, K otherKey, K destKey);
+
+	/**
+	 * Intersect sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Iterate over elements in zset at {@code key}. <br />
+	 * <strong>Important:</strong> Call {@link Cursor#close()} when done to avoid resource leak.
+	 *
+	 * @param key
+	 * @param options
+	 * @return
+	 * @since 1.4
+	 */
+	Cursor<TypedTuple<V>> scan(K key, ScanOptions options);
 
 	/**
 	 * Get all elements with lexicographical ordering from {@literal ZSET} at {@code key} with a value between
 	 * {@link Range#getMin()} and {@link Range#getMax()}.
-	 * 
+	 *
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @since 1.7
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Set<V> rangeByLex(K key, Range range);
 
@@ -70,79 +380,15 @@ public interface ZSetOperations<K, V> {
 	 * Get all elements {@literal n} elements, where {@literal n = } {@link Limit#getCount()}, starting at
 	 * {@link Limit#getOffset()} with lexicographical ordering from {@literal ZSET} at {@code key} with a value between
 	 * {@link Range#getMin()} and {@link Range#getMax()}.
-	 * 
+	 *
 	 * @param key must not be {@literal null}
 	 * @param range must not be {@literal null}.
 	 * @param limit can be {@literal null}.
 	 * @return
 	 * @since 1.7
+	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Set<V> rangeByLex(K key, Range range, Limit limit);
 
-	Set<V> rangeByScore(K key, double min, double max);
-
-	Set<V> rangeByScore(K key, double min, double max, long offset, long count);
-
-	Set<V> reverseRangeByScore(K key, double min, double max);
-
-	Set<V> reverseRangeByScore(K key, double min, double max, long offset, long count);
-
-	Set<TypedTuple<V>> rangeByScoreWithScores(K key, double min, double max);
-
-	Set<TypedTuple<V>> rangeByScoreWithScores(K key, double min, double max, long offset, long count);
-
-	Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, double min, double max);
-
-	Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, double min, double max, long offset, long count);
-
-	Boolean add(K key, V value, double score);
-
-	Long add(K key, Set<TypedTuple<V>> tuples);
-
-	Double incrementScore(K key, V value, double delta);
-
-	Long rank(K key, Object o);
-
-	Long reverseRank(K key, Object o);
-
-	Double score(K key, Object o);
-
-	Long remove(K key, Object... values);
-
-	Long removeRange(K key, long start, long end);
-
-	Long removeRangeByScore(K key, double min, double max);
-
-	Long count(K key, double min, double max);
-
-	/**
-	 * Returns the number of elements of the sorted set stored with given {@code key}.
-	 * 
-	 * @see #zCard(Object)
-	 * @param key
-	 * @return
-	 */
-	Long size(K key);
-
-	/**
-	 * Returns the number of elements of the sorted set stored with given {@code key}.
-	 * 
-	 * @param key
-	 * @return
-	 * @since 1.3
-	 */
-	Long zCard(K key);
-
 	RedisOperations<K, V> getOperations();
-
-	/**
-	 * Iterate over elements in zset at {@code key}. <br />
-	 * <strong>Important:</strong> Call {@link Cursor#close()} when done to avoid resource leak.
-	 *
-	 * @since 1.4
-	 * @param key
-	 * @param options
-	 * @return
-	 */
-	Cursor<TypedTuple<V>> scan(K key, ScanOptions options);
 }

--- a/src/main/java/org/springframework/data/redis/core/convert/BinaryConverters.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/BinaryConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,9 @@ import org.springframework.util.NumberUtils;
 
 /**
  * Set of {@link ReadingConverter} and {@link WritingConverter} used to convert Objects into binary format.
- * 
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.7
  */
 final class BinaryConverters {
@@ -108,6 +109,7 @@ final class BinaryConverters {
 
 	/**
 	 * @author Christoph Strobl
+	 * @author Mark Paluch
 	 * @since 1.7
 	 */
 	@WritingConverter
@@ -120,9 +122,8 @@ final class BinaryConverters {
 				return new byte[] {};
 			}
 
-			return fromString(source.toString());
+			return fromString(source.name());
 		}
-
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/core/convert/CustomConversions.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/CustomConversions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ public class CustomConversions {
 	 */
 	public CustomConversions(List<?> converters) {
 
-		Assert.notNull(converters);
+		Assert.notNull(converters,"Converters must not be null!");
 
 		this.readingPairs = new LinkedHashSet<ConvertiblePair>();
 		this.writingPairs = new LinkedHashSet<ConvertiblePair>();
@@ -344,8 +344,8 @@ public class CustomConversions {
 	private static Class<?> getCustomTarget(Class<?> sourceType, Class<?> requestedTargetType,
 			Collection<ConvertiblePair> pairs) {
 
-		Assert.notNull(sourceType);
-		Assert.notNull(pairs);
+		Assert.notNull(sourceType, "SourceType must not be null!");
+		Assert.notNull(pairs, "Convertible pairs must not be null!");
 
 		if (requestedTargetType != null && pairs.contains(new ConvertiblePair(sourceType, requestedTargetType))) {
 			return requestedTargetType;
@@ -411,7 +411,7 @@ public class CustomConversions {
 		 */
 		public ConverterRegistration(ConvertiblePair convertiblePair, boolean isReading, boolean isWriting) {
 
-			Assert.notNull(convertiblePair);
+			Assert.notNull(convertiblePair, "Convertible pair must not be null!");
 
 			this.convertiblePair = convertiblePair;
 			this.reading = isReading;

--- a/src/main/java/org/springframework/data/redis/core/convert/KeyspaceConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/KeyspaceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public class KeyspaceConfiguration {
 	 */
 	public void addKeyspaceSettings(KeyspaceSettings keyspaceSettings) {
 
-		Assert.notNull(keyspaceSettings);
+		Assert.notNull(keyspaceSettings, "KeyspaceSettings must not be null!");
 		this.settingsMap.put(keyspaceSettings.getType(), keyspaceSettings);
 	}
 

--- a/src/main/java/org/springframework/data/redis/core/convert/ReferenceResolverImpl.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/ReferenceResolverImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public class ReferenceResolverImpl implements ReferenceResolver {
 	 */
 	public ReferenceResolverImpl(RedisOperations<?, ?> redisOperations) {
 
-		Assert.notNull(redisOperations);
+		Assert.notNull(redisOperations, "RedisOperations must not be null!");
 
 		this.redisOps = redisOperations;
 		this.converter = new StringToBytesConverter();

--- a/src/main/java/org/springframework/data/redis/core/mapping/BasicRedisPersistentEntity.java
+++ b/src/main/java/org/springframework/data/redis/core/mapping/BasicRedisPersistentEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public class BasicRedisPersistentEntity<T> extends BasicKeyValuePersistentEntity
 	protected KeyValuePersistentProperty returnPropertyIfBetterIdPropertyCandidateOrNull(
 			KeyValuePersistentProperty property) {
 
-		Assert.notNull(property);
+		Assert.notNull(property, "Property must not be null!");
 
 		if (!property.isIdProperty()) {
 			return null;

--- a/src/main/java/org/springframework/data/redis/repository/cdi/CdiBean.java
+++ b/src/main/java/org/springframework/data/redis/repository/cdi/CdiBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
  * Base class for {@link Bean} wrappers.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public abstract class CdiBean<T> implements Bean<T>, PassivationCapable {
 
@@ -76,10 +77,10 @@ public abstract class CdiBean<T> implements Bean<T>, PassivationCapable {
 	 */
 	public CdiBean(Set<Annotation> qualifiers, Set<Type> types, Class<T> beanClass, BeanManager beanManager) {
 
-		Assert.notNull(qualifiers);
-		Assert.notNull(beanManager);
-		Assert.notNull(types);
-		Assert.notNull(beanClass);
+		Assert.notNull(qualifiers, "Qualifier annotations must not be null!");
+		Assert.notNull(beanManager, "BeanManager must not be null!");
+		Assert.notNull(types, "Types must not be null!");
+		Assert.notNull(beanClass, "Bean class mast not be null!");
 
 		this.qualifiers = qualifiers;
 		this.types = types;

--- a/src/main/java/org/springframework/data/redis/repository/cdi/RedisKeyValueAdapterBean.java
+++ b/src/main/java/org/springframework/data/redis/repository/cdi/RedisKeyValueAdapterBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  * {@link CdiBean} to create {@link RedisKeyValueAdapter} instances.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class RedisKeyValueAdapterBean extends CdiBean<RedisKeyValueAdapter> {
 
@@ -45,14 +46,13 @@ public class RedisKeyValueAdapterBean extends CdiBean<RedisKeyValueAdapter> {
 	 *
 	 * @param redisOperations must not be {@literal null}.
 	 * @param qualifiers must not be {@literal null}.
-	 * @param repositoryType must not be {@literal null}.
 	 * @param beanManager must not be {@literal null}.
 	 */
 	public RedisKeyValueAdapterBean(Bean<RedisOperations<?, ?>> redisOperations, Set<Annotation> qualifiers,
 			BeanManager beanManager) {
 
 		super(qualifiers, RedisKeyValueAdapter.class, beanManager);
-		Assert.notNull(redisOperations);
+		Assert.notNull(redisOperations, "RedisOperations Bean must not be null!");
 		this.redisOperations = redisOperations;
 	}
 

--- a/src/main/java/org/springframework/data/redis/repository/cdi/RedisKeyValueTemplateBean.java
+++ b/src/main/java/org/springframework/data/redis/repository/cdi/RedisKeyValueTemplateBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * {@link CdiBean} to create {@link RedisKeyValueTemplate} instances.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class RedisKeyValueTemplateBean extends CdiBean<KeyValueOperations> {
 
@@ -50,7 +51,7 @@ public class RedisKeyValueTemplateBean extends CdiBean<KeyValueOperations> {
 			BeanManager beanManager) {
 
 		super(qualifiers, KeyValueOperations.class, beanManager);
-		Assert.notNull(keyValueAdapter);
+		Assert.notNull(keyValueAdapter, "KeyValueAdapter bean must not be null!");
 		this.keyValueAdapter = keyValueAdapter;
 	}
 

--- a/src/main/java/org/springframework/data/redis/repository/cdi/RedisRepositoryBean.java
+++ b/src/main/java/org/springframework/data/redis/repository/cdi/RedisRepositoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * {@link CdiRepositoryBean} to create Redis repository instances.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class RedisRepositoryBean<T> extends CdiRepositoryBean<T> {
 
@@ -53,7 +54,7 @@ public class RedisRepositoryBean<T> extends CdiRepositoryBean<T> {
 			Class<T> repositoryType, BeanManager beanManager, CustomRepositoryImplementationDetector detector) {
 
 		super(qualifiers, repositoryType, beanManager, detector);
-		Assert.notNull(keyValueTemplate);
+		Assert.notNull(keyValueTemplate, "Bean holding keyvalue template must not be null!");
 		this.keyValueTemplate = keyValueTemplate;
 	}
 

--- a/src/main/java/org/springframework/data/redis/repository/support/RedisRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/redis/repository/support/RedisRepositoryFactoryBean.java
@@ -29,6 +29,7 @@ import org.springframework.data.repository.query.parser.AbstractQueryCreator;
  * configuration.
  * 
  * @author Christoph Strobl
+ * @author Oliver Gierke
  * @param <T> The repository type.
  * @param <S> The repository domain type.
  * @param <ID> The repository id type.
@@ -36,6 +37,15 @@ import org.springframework.data.repository.query.parser.AbstractQueryCreator;
  */
 public class RedisRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
 		extends KeyValueRepositoryFactoryBean<T, S, ID> {
+
+	/**
+	 * Creates a new {@link RedisRepositoryFactoryBean} for the given repository interface.
+	 * 
+	 * @param repositoryInterface must not be {@literal null}.
+	 */
+	public RedisRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
+		super(repositoryInterface);
+	}
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/redis/serializer/GenericToStringSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericToStringSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * bean. <b>Note:</b> Does not handle nulls in any special way delegating everything to the container.
  * 
  * @author Costin Leau
+ * @author Christoph Strobl
  */
 public class GenericToStringSerializer<T> implements RedisSerializer<T>, BeanFactoryAware {
 
@@ -45,7 +46,7 @@ public class GenericToStringSerializer<T> implements RedisSerializer<T>, BeanFac
 	}
 
 	public GenericToStringSerializer(Class<T> type, Charset charset) {
-		Assert.notNull(type);
+		Assert.notNull(type, "tyoe must not be null!");
 		this.type = type;
 		this.charset = charset;
 	}

--- a/src/main/java/org/springframework/data/redis/serializer/JdkSerializationRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/JdkSerializationRedisSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
  * @author Mark Pollack
  * @author Costin Leau
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class JdkSerializationRedisSerializer implements RedisSerializer<Object> {
 
@@ -63,8 +64,8 @@ public class JdkSerializationRedisSerializer implements RedisSerializer<Object> 
 	 */
 	public JdkSerializationRedisSerializer(Converter<Object, byte[]> serializer, Converter<byte[], Object> deserializer) {
 
-		Assert.notNull("Serializer must not be null!");
-		Assert.notNull("Deserializer must not be null!");
+		Assert.notNull(serializer, "Serializer must not be null!");
+		Assert.notNull(deserializer, "Deserializer must not be null!");
 
 		this.serializer = serializer;
 		this.deserializer = deserializer;

--- a/src/main/java/org/springframework/data/redis/serializer/StringRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/StringRedisSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
  * Does not perform any null conversion since empty strings are valid keys/values.
  * 
  * @author Costin Leau
+ * @author Christoph Strobl
  */
 public class StringRedisSerializer implements RedisSerializer<String> {
 
@@ -38,7 +39,7 @@ public class StringRedisSerializer implements RedisSerializer<String> {
 	}
 
 	public StringRedisSerializer(Charset charset) {
-		Assert.notNull(charset);
+		Assert.notNull(charset, "Charset must not be null!");
 		this.charset = charset;
 	}
 

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.data.repository.core.support.RepositoryFactorySupport=org.springframework.data.redis.repository.support.RedisRepositoryFactory

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,13 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 1.7.7.RELEASE (2017-01-26)
+---------------------------------------------
+* DATAREDIS-593 - Enums with a customized toString method cannot be deserialized from byte[].
+* DATAREDIS-586 - Release 1.7.7 (Hopper SR7).
+* DATAREDIS-564 - Invoking JedisConnection.expire during transaction/pipelining can cause NPE.
+
+
 Changes in version 1.8.0.RELEASE (2017-01-26)
 ---------------------------------------------
 * DATAREDIS-594 - Update "what’s new" section in reference documentation.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,25 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 1.8.0.RC1 (2016-12-21)
+-----------------------------------------
+* DATAREDIS-584 - Upgrade to a newer JDK version on TravisCI.
+* DATAREDIS-583 - Adapt API in RepositoryFactoryBeanSupport implementation.
+* DATAREDIS-579 - Register repository factory in spring.factories for multi-store support.
+* DATAREDIS-558 - spring-data-redis - Cannot install in OSGi due import range of slf4j is locked down to 1.7.12 version.
+* DATAREDIS-553 - Support caching null values via RedisCache.
+* DATAREDIS-552 - Set client name on Jedis connection factory.
+* DATAREDIS-551 - NPE when counting keys while invoking findBy(Pageable).
+* DATAREDIS-548 - Connection should be released when used with read-only transactions.
+* DATAREDIS-547 - Getting NPE when writing valid Query Method without any criteria.
+* DATAREDIS-542 - RedisCache.putIfAbsent does not set the TTL on the element.
+* DATAREDIS-541 - Release 1.8 RC1 (Ingalls).
+* DATAREDIS-539 - replace call to deprecated addCache.
+* DATAREDIS-533 - Add support for geoindex query methods.
+* DATAREDIS-531 - ScanCursor holds reference to closed/released Jedis connection.
+* DATAREDIS-528 - Upgrade to Lettuce 4.2.
+
+
 Changes in version 2.0.0.M1 (2016-11-23)
 ----------------------------------------
 * DATAREDIS-569 - Set up 2.0 development.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,30 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 2.0.0.M2 (2017-04-04)
+----------------------------------------
+* DATAREDIS-618 - RedisServer.getNumberOtherSentinels() should read num-other-sentinels property.
+* DATAREDIS-617 - Drop support for Jackson 1.
+* DATAREDIS-606 - RedisCache Tests in Spring Data Redis 2.0.x builds fail testing null values.
+* DATAREDIS-602 - Provide reactive Redis Template.
+* DATAREDIS-599 - Remove references to single-argument assertion methods of Spring.
+* DATAREDIS-595 - Integrate Data Commons Java 8 upgrade branch.
+* DATAREDIS-594 - Update "what’s new" section in reference documentation.
+* DATAREDIS-593 - Enums with a customized toString method cannot be deserialized from byte[].
+* DATAREDIS-592 - RedisCache.get(Object, Callable) does not set the TTL on the element.
+* DATAREDIS-591 - Update project documentation with the CLA tool integration.
+* DATAREDIS-589 - Publishing RedisKeyExpiredEvent from other than Repository support causes NullPointerException in RedisKeyValueAdapter.
+* DATAREDIS-584 - Upgrade to a newer JDK version on TravisCI.
+* DATAREDIS-583 - Adapt API in RepositoryFactoryBeanSupport implementation.
+* DATAREDIS-579 - Register repository factory in spring.factories for multi-store support.
+* DATAREDIS-573 - Release 2.0 M2 (Kay).
+* DATAREDIS-564 - Invoking JedisConnection.expire during transaction/pipelining can cause NPE.
+* DATAREDIS-563 - Migrate Jira ticket reference format in tests.
+* DATAREDIS-559 - Reuse Surefire JVM forks during integration test.
+* DATAREDIS-552 - Set client name on Jedis connection factory.
+* DATAREDIS-532 - Convert all see http:// links to valid @see links.
+
+
 Changes in version 1.7.8.RELEASE (2017-03-02)
 ---------------------------------------------
 * DATAREDIS-599 - Remove references to single-argument assertion methods of Spring.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,12 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 1.7.9.RELEASE (2017-04-19)
+---------------------------------------------
+* DATAREDIS-618 - RedisServer.getNumberOtherSentinels() should read num-other-sentinels property.
+* DATAREDIS-608 - Release 1.7.9 (Hopper SR9).
+
+
 Changes in version 1.8.2.RELEASE (2017-04-19)
 ---------------------------------------------
 * DATAREDIS-618 - RedisServer.getNumberOtherSentinels() should read num-other-sentinels property.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,12 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 1.7.8.RELEASE (2017-03-02)
+---------------------------------------------
+* DATAREDIS-599 - Remove references to single-argument assertion methods of Spring.
+* DATAREDIS-597 - Release 1.7.8 (Hopper SR8).
+
+
 Changes in version 1.8.1.RELEASE (2017-03-02)
 ---------------------------------------------
 * DATAREDIS-599 - Remove references to single-argument assertion methods of Spring.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,11 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 1.8.3.RELEASE (2017-04-19)
+---------------------------------------------
+* DATAREDIS-627 - Release 1.8.3 (Ingalls SR3).
+
+
 Changes in version 1.7.9.RELEASE (2017-04-19)
 ---------------------------------------------
 * DATAREDIS-618 - RedisServer.getNumberOtherSentinels() should read num-other-sentinels property.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,11 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 1.7.6.RELEASE (2016-12-21)
+---------------------------------------------
+* DATAREDIS-566 - Release 1.7.6 (Hopper SR6).
+
+
 Changes in version 1.8.0.RC1 (2016-12-21)
 -----------------------------------------
 * DATAREDIS-584 - Upgrade to a newer JDK version on TravisCI.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,12 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 1.8.2.RELEASE (2017-04-19)
+---------------------------------------------
+* DATAREDIS-618 - RedisServer.getNumberOtherSentinels() should read num-other-sentinels property.
+* DATAREDIS-607 - Release 1.8.2 (Ingalls SR2).
+
+
 Changes in version 2.0.0.M2 (2017-04-04)
 ----------------------------------------
 * DATAREDIS-618 - RedisServer.getNumberOtherSentinels() should read num-other-sentinels property.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,12 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 1.8.1.RELEASE (2017-03-02)
+---------------------------------------------
+* DATAREDIS-599 - Remove references to single-argument assertion methods of Spring.
+* DATAREDIS-598 - Release 1.8.1 (Ingalls SR1).
+
+
 Changes in version 1.7.7.RELEASE (2017-01-26)
 ---------------------------------------------
 * DATAREDIS-593 - Enums with a customized toString method cannot be deserialized from byte[].

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,19 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 1.8.0.RELEASE (2017-01-26)
+---------------------------------------------
+* DATAREDIS-594 - Update "what’s new" section in reference documentation.
+* DATAREDIS-593 - Enums with a customized toString method cannot be deserialized from byte[].
+* DATAREDIS-592 - RedisCache.get(Object, Callable) does not set the TTL on the element.
+* DATAREDIS-591 - Update project documentation with the CLA tool integration.
+* DATAREDIS-589 - Publishing RedisKeyExpiredEvent from other than Repository support causes NullPointerException in RedisKeyValueAdapter.
+* DATAREDIS-587 - Release 1.8 GA (Ingalls).
+* DATAREDIS-564 - Invoking JedisConnection.expire during transaction/pipelining can cause NPE.
+* DATAREDIS-563 - Migrate Jira ticket reference format in tests.
+* DATAREDIS-532 - Convert all see http:// links to valid @see links.
+
+
 Changes in version 1.7.6.RELEASE (2016-12-21)
 ---------------------------------------------
 * DATAREDIS-566 - Release 1.7.6 (Hopper SR6).

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -6,6 +6,14 @@ Commit changelog: http://github.com/spring-projects/spring-data-redis/tree/v[ver
 Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10604
 ===========================
 
+Changes in version 2.0.0.M1 (2016-11-23)
+----------------------------------------
+* DATAREDIS-569 - Set up 2.0 development.
+* DATAREDIS-568 - Release 2.0 M1 (Kay).
+* DATAREDIS-567 - Remove Support for SRP and JRedis.
+* DATAREDIS-525 - Add support for reactive RedisConnection and RedisOperations.
+
+
 Changes in version 1.7.5.RELEASE (2016-11-03)
 ---------------------------------------------
 * DATAREDIS-558 - spring-data-redis - Cannot install in OSGi due import range of slf4j is locked down to 1.7.12 version.

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Redis 1.8 RC1
+Spring Data Redis 1.8 GA
    Copyright (c) [$copyright] Pivotal Software, Inc.
 
    ========================================================================

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Redis 1.8.1
+Spring Data Redis 1.8.2
    Copyright (c) [$copyright] Pivotal Software, Inc.
 
    ========================================================================

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Redis 1.8.2
+Spring Data Redis 1.8.3
    Copyright (c) [$copyright] Pivotal Software, Inc.
 
    ========================================================================

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Redis 1.8 GA
+Spring Data Redis 1.8.1
    Copyright (c) [$copyright] Pivotal Software, Inc.
 
    ========================================================================

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Redis 1.8 M1
+Spring Data Redis 1.8 RC1
    Copyright (c) [$copyright] Pivotal Software, Inc.
 
    ========================================================================

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerTransactionalUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerTransactionalUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,10 +103,7 @@ public class RedisCacheManagerTransactionalUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-375
-	 */
-	@Test
+	@Test // DATAREDIS-375
 	public void testCacheIsNotDecoratedTwiceWithTransactionAwareCacheDecorator() {
 
 		Cache cache = cacheManager.getCache(cacheName);

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,38 +68,26 @@ public class RedisCacheManagerUnitTests {
 		cacheManager.afterPropertiesSet();
 	}
 
-	/**
-	 * @see DATAREDIS-246
-	 */
-	@Test
+	@Test // DATAREDIS-246
 	public void testGetCacheReturnsNewCacheWhenRequestedCacheIsNotAvailable() {
 
 		Cache cache = cacheManager.getCache("not-available");
 		assertThat(cache, notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-246
-	 */
-	@Test
+	@Test // DATAREDIS-246
 	public void testGetCacheReturnsExistingCacheWhenRequested() {
 
 		Cache cache = cacheManager.getCache("cache");
 		assertThat(cacheManager.getCache("cache"), sameInstance(cache));
 	}
 
-	/**
-	 * @see DATAREDIS-246
-	 */
-	@Test
+	@Test // DATAREDIS-246
 	public void testCacheInitSouldNotRequestRemoteKeysByDefault() {
 		Mockito.verifyZeroInteractions(redisConnectionMock);
 	}
 
-	/**
-	 * @see DATAREDIS-246
-	 */
-	@Test
+	@Test // DATAREDIS-246
 	public void testCacheInitShouldFetchAllCacheKeysWhenLoadingRemoteCachesOnStartupIsEnabled() {
 
 		cacheManager = new RedisCacheManager(redisTemplate);
@@ -111,11 +99,8 @@ public class RedisCacheManagerUnitTests {
 		assertThat(redisTemplate.getKeySerializer().deserialize(captor.getValue()).toString(), is("*~keys"));
 	}
 
-	/**
-	 * @see DATAREDIS-246
-	 */
 	@SuppressWarnings("unchecked")
-	@Test
+	@Test // DATAREDIS-246
 	public void testCacheInitShouldInitializeRemoteCachesCorrectlyWhenLoadingRemoteCachesOnStartupIsEnabled() {
 
 		Set<byte[]> keys = new HashSet<byte[]>(Arrays.asList(redisTemplate.getKeySerializer()
@@ -129,10 +114,7 @@ public class RedisCacheManagerUnitTests {
 		assertThat(cacheManager.getCacheNames(), IsCollectionContaining.hasItem("remote-cache"));
 	}
 
-	/**
-	 * @see DATAREDIS-246
-	 */
-	@Test
+	@Test // DATAREDIS-246
 	public void testCacheInitShouldNotInitialzeCachesWhenLoadingRemoteCachesOnStartupIsEnabledAndNoCachesAvailableOnRemoteServer() {
 
 		when(redisConnectionMock.keys(any(byte[].class))).thenReturn(Collections.<byte[]> emptySet());
@@ -184,10 +166,7 @@ public class RedisCacheManagerUnitTests {
 		assertThat(cacheManager.getCache("redis"), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-283
-	 */
-	@Test
+	@Test // DATAREDIS-283
 	public void testRetainConfiguredCachesAfterBeanInitialization() {
 
 		cacheManager = new RedisCacheManager(redisTemplate);
@@ -198,10 +177,7 @@ public class RedisCacheManagerUnitTests {
 		assertThat(cacheManager.getCache("data"), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-283
-	 */
-	@Test
+	@Test // DATAREDIS-283
 	public void testRetainConfiguredCachesAfterBeanInitializationWithLoadingOfRemoteKeys() {
 
 		Set<byte[]> keys = new HashSet<byte[]>(Arrays.asList(redisTemplate.getKeySerializer()

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheTest.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,10 +228,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertFalse(monitorStateException.get());
 	}
 
-	/**
-	 * @see DATAREDIS-243
-	 */
-	@Test
+	@Test // DATAREDIS-243
 	public void testCacheGetShouldReturnCachedInstance() {
 		assumeThat(cache, instanceOf(RedisCache.class));
 
@@ -242,10 +239,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertThat(value, isEqual(((RedisCache) cache).get(key, Object.class)));
 	}
 
-	/**
-	 * @see DATAREDIS-243
-	 */
-	@Test
+	@Test // DATAREDIS-243
 	public void testCacheGetShouldRetunInstanceOfCorrectType() {
 		assumeThat(cache, instanceOf(RedisCache.class));
 
@@ -257,10 +251,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertThat(redisCache.get(key, value.getClass()), instanceOf(value.getClass()));
 	}
 
-	/**
-	 * @see DATAREDIS-243
-	 */
-	@Test(expected = ClassCastException.class)
+	@Test(expected = ClassCastException.class) // DATAREDIS-243
 	public void testCacheGetShouldThrowExceptionOnInvalidType() {
 		assumeThat(cache, instanceOf(RedisCache.class));
 
@@ -273,10 +264,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		Cache retrievedObject = redisCache.get(key, Cache.class);
 	}
 
-	/**
-	 * @see DATAREDIS-243
-	 */
-	@Test
+	@Test // DATAREDIS-243
 	public void testCacheGetShouldReturnNullIfNoCachedValueFound() {
 		assumeThat(cache, instanceOf(RedisCache.class));
 
@@ -290,11 +278,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertThat(redisCache.get(invalidKey, value.getClass()), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-344
-	 * @see DATAREDIS-416
-	 */
-	@Test
+	@Test // DATAREDIS-344, DATAREDIS-416
 	public void putIfAbsentShouldSetValueOnlyIfNotPresent() {
 
 		assumeThat(cache, instanceOf(RedisCache.class));
@@ -317,10 +301,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertThat(wrapper.get(), equalTo(value));
 	}
 
-	/**
-	 * @see DATAREDIS-510
-	 */
-	@Test
+	@Test // DATAREDIS-510
 	public void cachePutWithNullShouldNotAddStuffToRedis() {
 
 		assumeThat(getAllowCacheNullValues(), is(false));
@@ -333,10 +314,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertThat(cache.get(key), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-510
-	 */
-	@Test
+	@Test // DATAREDIS-510
 	public void cachePutWithNullShouldRemoveKeyIfExists() {
 
 		assumeThat(getAllowCacheNullValues(), is(false));
@@ -353,11 +331,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertThat(cache.get(key), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-443
-	 * @see DATAREDIS-452
-	 */
-	@Test
+	@Test // DATAREDIS-443, DATAREDIS-452
 	public void testCacheGetSynchronized() throws Throwable {
 
 		assumeThat(cache, instanceOf(RedisCache.class));
@@ -366,10 +340,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		runOnce(new CacheGetWithValueLoaderIsThreadSafe((RedisCache) cache));
 	}
 
-	/**
-	 * @see DATAREDIS-553
-	 */
-	@Test
+	@Test // DATAREDIS-553
 	public void cachePutWithNullShouldAddStuffToRedisWhenCachingNullIsEnabled() {
 
 		assumeThat(getAllowCacheNullValues(), is(true));
@@ -382,10 +353,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertThat(cache.get(key, String.class), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-553
-	 */
-	@Test
+	@Test // DATAREDIS-553
 	public void testCacheGetSynchronizedNullAllowingNull() {
 
 		assumeThat(getAllowCacheNullValues(), is(true));
@@ -403,10 +371,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertThat(cache.get(key).get(), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-553
-	 */
-	@Test
+	@Test // DATAREDIS-553
 	public void testCacheGetSynchronizedNullNotAllowingNull() {
 
 		assumeThat(getAllowCacheNullValues(), is(false));
@@ -425,10 +390,7 @@ public class RedisCacheTest extends AbstractNativeCacheTest<RedisTemplate> {
 		assertThat(cache.get(key), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-553
-	 */
-	@Test
+	@Test // DATAREDIS-553
 	public void testCacheGetSynchronizedNullWithStoredNull() {
 
 		assumeThat(getAllowCacheNullValues(), is(true));

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
@@ -101,8 +101,8 @@ public class RedisCacheUnitTests {
 		cache = new RedisCache(CACHE_NAME, PREFIX_BYTES, templateSpy, EXPIRATION);
 		cache.put(KEY, VALUE);
 
-		verify(connectionMock, times(1)).set(eq(KEY_WITH_PREFIX_BYTES), eq(VALUE_BYTES));
-		verify(connectionMock, times(1)).expire(eq(KEY_WITH_PREFIX_BYTES), eq(EXPIRATION));
+		verify(connectionMock).set(eq(KEY_WITH_PREFIX_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).expire(eq(KEY_WITH_PREFIX_BYTES), eq(EXPIRATION));
 		verify(connectionMock, never()).zAdd(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0D), any(byte[].class));
 	}
 
@@ -112,9 +112,9 @@ public class RedisCacheUnitTests {
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, EXPIRATION);
 		cache.put(KEY, VALUE);
 
-		verify(connectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
-		verify(connectionMock, times(1)).expire(eq(KEY_BYTES), eq(EXPIRATION));
-		verify(connectionMock, times(1)).zAdd(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0D), eq(KEY_BYTES));
+		verify(connectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).expire(eq(KEY_BYTES), eq(EXPIRATION));
+		verify(connectionMock).zAdd(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0D), eq(KEY_BYTES));
 	}
 
 	@Test // DATAREDIS-369
@@ -123,7 +123,7 @@ public class RedisCacheUnitTests {
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, EXPIRATION);
 		cache.clear();
 
-		verify(connectionMock, times(1)).zRange(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0L), eq(127L));
+		verify(connectionMock).zRange(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0L), eq(127L));
 	}
 
 	@Test // DATAREDIS-369
@@ -132,7 +132,7 @@ public class RedisCacheUnitTests {
 		cache = new RedisCache(CACHE_NAME, PREFIX_BYTES, templateSpy, EXPIRATION);
 		cache.clear();
 
-		verify(connectionMock, times(1)).eval(any(byte[].class), eq(ReturnType.INTEGER), eq(0),
+		verify(connectionMock).eval(any(byte[].class), eq(ReturnType.INTEGER), eq(0),
 				eq((PREFIX + "*").getBytes()));
 	}
 
@@ -222,10 +222,10 @@ public class RedisCacheUnitTests {
 			}
 		});
 
-		verify(connectionMock, times(1)).get(eq(KEY_BYTES));
-		verify(connectionMock, times(1)).multi();
-		verify(connectionMock, times(1)).del(eq(KEY_BYTES));
-		verify(connectionMock, times(1)).exec();
+		verify(connectionMock).get(eq(KEY_BYTES));
+		verify(connectionMock).multi();
+		verify(connectionMock).del(eq(KEY_BYTES));
+		verify(connectionMock).exec();
 	}
 
 	@Test // DATAREDIS-553
@@ -242,10 +242,10 @@ public class RedisCacheUnitTests {
 		});
 
 		verify(valueSerializerMock).serialize(isA(NullValue.class));
-		verify(connectionMock, times(1)).get(eq(KEY_BYTES));
-		verify(connectionMock, times(1)).multi();
-		verify(connectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
-		verify(connectionMock, times(1)).exec();
+		verify(connectionMock).get(eq(KEY_BYTES));
+		verify(connectionMock).multi();
+		verify(connectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).exec();
 	}
 
 	@Test // DATAREDIS-443, DATAREDIS-592
@@ -260,11 +260,11 @@ public class RedisCacheUnitTests {
 			}
 		});
 
-		verify(connectionMock, times(1)).get(eq(KEY_BYTES));
-		verify(connectionMock, times(1)).multi();
-		verify(connectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).get(eq(KEY_BYTES));
+		verify(connectionMock).multi();
+		verify(connectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
 		verify(connectionMock, never()).expire(any(byte[].class), anyLong());
-		verify(connectionMock, times(1)).exec();
+		verify(connectionMock).exec();
 	}
 
 	@Test // DATAREDIS-592
@@ -313,7 +313,7 @@ public class RedisCacheUnitTests {
 
 		cache.put(KEY, VALUE);
 
-		verify(clusterConnectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(clusterConnectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
 		verify(clusterConnectionMock, never()).multi();
 		verify(clusterConnectionMock, never()).exec();
 		verifyZeroInteractions(connectionMock);
@@ -334,8 +334,8 @@ public class RedisCacheUnitTests {
 			}
 		});
 
-		verify(clusterConnectionMock, times(1)).get(eq(KEY_BYTES));
-		verify(clusterConnectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(clusterConnectionMock).get(eq(KEY_BYTES));
+		verify(clusterConnectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
 
 		verify(clusterConnectionMock, never()).multi();
 		verify(clusterConnectionMock, never()).exec();

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,10 +95,7 @@ public class RedisCacheUnitTests {
 		when(valueSerializerMock.deserialize(eq(VALUE_BYTES))).thenReturn(VALUE);
 	}
 
-	/**
-	 * @see DATAREDIS-369
-	 */
-	@Test
+	@Test // DATAREDIS-369
 	public void putShouldNotKeepTrackOfKnownKeysWhenPrefixIsSet() {
 
 		cache = new RedisCache(CACHE_NAME, PREFIX_BYTES, templateSpy, EXPIRATION);
@@ -109,10 +106,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, never()).zAdd(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0D), any(byte[].class));
 	}
 
-	/**
-	 * @see DATAREDIS-369
-	 */
-	@Test
+	@Test // DATAREDIS-369
 	public void putShouldKeepTrackOfKnownKeysWhenNoPrefixIsSet() {
 
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, EXPIRATION);
@@ -123,10 +117,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, times(1)).zAdd(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0D), eq(KEY_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-369
-	 */
-	@Test
+	@Test // DATAREDIS-369
 	public void clearShouldRemoveKeysUsingKnownKeysWhenNoPrefixIsSet() {
 
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, EXPIRATION);
@@ -135,10 +126,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, times(1)).zRange(eq(KNOWN_KEYS_SET_NAME_BYTES), eq(0L), eq(127L));
 	}
 
-	/**
-	 * @see DATAREDIS-369
-	 */
-	@Test
+	@Test // DATAREDIS-369
 	public void clearShouldCallLuaScriptToRemoveKeysWhenPrefixIsSet() {
 
 		cache = new RedisCache(CACHE_NAME, PREFIX_BYTES, templateSpy, EXPIRATION);
@@ -148,10 +136,7 @@ public class RedisCacheUnitTests {
 				eq((PREFIX + "*").getBytes()));
 	}
 
-	/**
-	 * @see DATAREDIS-402
-	 */
-	@Test
+	@Test // DATAREDIS-402
 	public void putShouldNotExpireKnownKeysSetWhenTtlIsZero() {
 
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, 0L);
@@ -160,10 +145,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, never()).expire(eq(KNOWN_KEYS_SET_NAME_BYTES), anyLong());
 	}
 
-	/**
-	 * @see DATAREDIS-542
-	 */
-	@Test
+	@Test // DATAREDIS-542
 	public void putIfAbsentShouldExpireWhenValueWasSet() {
 
 		when(connectionMock.setNX(KEY_BYTES, VALUE_BYTES)).thenReturn(true);
@@ -176,10 +158,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock).expire(eq(KEY_BYTES), anyLong());
 	}
 
-	/**
-	 * @see DATAREDIS-542
-	 */
-	@Test
+	@Test // DATAREDIS-542
 	public void putIfAbsentShouldNotExpireWhenValueWasNotSetAndRedisContainsOtherData() {
 
 		String other = "other";
@@ -194,10 +173,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, never()).expire(eq(KEY_BYTES), anyLong());
 	}
 
-	/**
-	 * @see DATAREDIS-542
-	 */
-	@Test
+	@Test // DATAREDIS-542
 	public void putIfAbsentShouldNotSetExpireWhenValueWasNotSetAndRedisContainsSameData() {
 
 		when(connectionMock.setNX(KEY_BYTES, VALUE_BYTES)).thenReturn(false);
@@ -210,10 +186,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, never()).expire(eq(KEY_BYTES), anyLong());
 	}
 
-	/**
-	 * @see DATAREDIS-443
-	 */
-	@Test
+	@Test // DATAREDIS-443
 	@SuppressWarnings("unchecked")
 	public void getWithCallable() throws ClassNotFoundException {
 
@@ -236,10 +209,7 @@ public class RedisCacheUnitTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-553
-	 */
-	@Test
+	@Test // DATAREDIS-553
 	@SuppressWarnings("unchecked")
 	public void getWithCallableShouldStoreNullNotAllowingNull() throws ClassNotFoundException {
 
@@ -258,10 +228,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, times(1)).exec();
 	}
 
-	/**
-	 * @see DATAREDIS-553
-	 */
-	@Test
+	@Test // DATAREDIS-553
 	@SuppressWarnings("unchecked")
 	public void getWithCallableShouldStoreNullAllowingNull() throws ClassNotFoundException {
 
@@ -281,10 +248,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, times(1)).exec();
 	}
 
-	/**
-	 * @see DATAREDIS-443
-	 */
-	@Test
+	@Test // DATAREDIS-443
 	public void getWithCallableShouldReadValueFromCallableAddToCache() {
 
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, 0L);
@@ -302,10 +266,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, times(1)).exec();
 	}
 
-	/**
-	 * @see DATAREDIS-443
-	 */
-	@Test
+	@Test // DATAREDIS-443
 	@SuppressWarnings("unchecked")
 	public void getWithCallableShouldNotReadValueFromCallableWhenAlreadyPresent() {
 
@@ -319,10 +280,7 @@ public class RedisCacheUnitTests {
 		verifyZeroInteractions(callableMock);
 	}
 
-	/**
-	 * @see DATAREDIS-468
-	 */
-	@Test
+	@Test // DATAREDIS-468
 	public void noMultiExecForCluster() {
 
 		RedisClusterConnection clusterConnectionMock = mock(RedisClusterConnection.class);
@@ -341,10 +299,7 @@ public class RedisCacheUnitTests {
 		verifyZeroInteractions(connectionMock);
 	}
 
-	/**
-	 * @see DATAREDIS-468
-	 */
-	@Test
+	@Test // DATAREDIS-468
 	public void getWithCallableForCluster() {
 
 		RedisClusterConnection clusterConnectionMock = mock(RedisClusterConnection.class);

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheUnitTests.java
@@ -248,7 +248,7 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, times(1)).exec();
 	}
 
-	@Test // DATAREDIS-443
+	@Test // DATAREDIS-443, DATAREDIS-592
 	public void getWithCallableShouldReadValueFromCallableAddToCache() {
 
 		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, 0L);
@@ -263,7 +263,27 @@ public class RedisCacheUnitTests {
 		verify(connectionMock, times(1)).get(eq(KEY_BYTES));
 		verify(connectionMock, times(1)).multi();
 		verify(connectionMock, times(1)).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock, never()).expire(any(byte[].class), anyLong());
 		verify(connectionMock, times(1)).exec();
+	}
+
+	@Test // DATAREDIS-592
+	public void getWithCallableShouldReadValueFromCallableAddToCacheWithTtl() {
+
+		cache = new RedisCache(CACHE_NAME, NO_PREFIX_BYTES, templateSpy, 100L);
+
+		cache.get(KEY, new Callable<Object>() {
+			@Override
+			public Object call() throws Exception {
+				return VALUE;
+			}
+		});
+
+		verify(connectionMock).get(eq(KEY_BYTES));
+		verify(connectionMock).multi();
+		verify(connectionMock).set(eq(KEY_BYTES), eq(VALUE_BYTES));
+		verify(connectionMock).expire(eq(KEY_BYTES), eq(100L));
+		verify(connectionMock).exec();
 	}
 
 	@Test // DATAREDIS-443

--- a/src/test/java/org/springframework/data/redis/cache/TransactionalRedisCacheManagerWithCommitUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/TransactionalRedisCacheManagerWithCommitUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,11 +129,8 @@ public class TransactionalRedisCacheManagerWithCommitUnitTests {
 				IsEqual.equalTo("bar~keys"));
 	}
 
-	/**
-	 * @see DATAREDIS-246
-	 */
 	@Rollback(false)
-	@Test
+	@Test // DATAREDIS-246
 	public void testValuesAddedToCacheWhenTransactionIsCommited() {
 		transactionalService.foo();
 	}

--- a/src/test/java/org/springframework/data/redis/cache/TransactionalRedisCacheManagerWithRollbackUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/TransactionalRedisCacheManagerWithRollbackUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,11 +119,8 @@ public class TransactionalRedisCacheManagerWithRollbackUnitTests {
 				any(byte[].class));
 	}
 
-	/**
-	 * @see DATAREDIS-246
-	 */
 	@Rollback(true)
-	@Test
+	@Test // DATAREDIS-246
 	public void tesValuesNotAddedToCacheWhenTransactionIsRolledBack() {
 		transactionalService.foo();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -421,10 +421,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertTrue(waitFor(new KeyExpired("expy"), 2500l));
 	}
 
-	/**
-	 * @see DATAREDIS-271
-	 */
-	@Test
+	@Test // DATAREDIS-271
 	@IfProfileValue(name = "runLongTests", value = "true")
 	public void testPsetEx() throws Exception {
 
@@ -980,10 +977,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		verifyResults(Arrays.asList(new Object[] { -1L }));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void testTtlWithTimeUnit() {
 
 		connection.set("whatup", "yo");
@@ -1017,10 +1011,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertTrue((Long) results.get(1) > -1);
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	@IfProfileValue(name = "redisVersion", value = "2.6+")
 	public void testPTtlWithTimeUnit() {
 
@@ -1970,11 +1961,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertNotNull(results.get(0));
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 * @see DATAREDIS-513
-	 */
-	@Test
+	@Test // DATAREDIS-206, DATAREDIS-513
 	public void testGetTimeShouldRequestServerTime() {
 
 		actual.add(connection.time());
@@ -1985,18 +1972,12 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((Long) results.get(0) > 0, equalTo(true));
 	}
 
-	/**
-	 * @see DATAREDIS-269
-	 */
-	@Test
+	@Test // DATAREDIS-269
 	public void clientSetNameWorksCorrectly() {
 		connection.setClientName("foo".getBytes());
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void testListClientsContainsAtLeastOneElement() {
 
 		actual.add(connection.getClientList());
@@ -2012,10 +1993,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(info.getDatabaseId(), is(notNullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-290
-	 */
-	@Test
+	@Test // DATAREDIS-290
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	public void scanShouldReadEntireValueRange() {
 
@@ -2046,10 +2024,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(i, is(itemCount));
 	}
 
-	/**
-	 * @see DATAREDIS-417
-	 */
-	@Test
+	@Test // DATAREDIS-417
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection() {
@@ -2067,10 +2042,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(i, is(10));
 	}
 
-	/**
-	 * @see DATAREDIS-306
-	 */
-	@Test
+	@Test // DATAREDIS-306
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	public void zScanShouldReadEntireValueRange() {
 
@@ -2102,10 +2074,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(count, equalTo(3));
 	}
 
-	/**
-	 * @see DATAREDIS-304
-	 */
-	@Test
+	@Test // DATAREDIS-304
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	public void sScanShouldReadEntireValueRange() {
 
@@ -2131,10 +2100,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(i, is(6));
 	}
 
-	/**
-	 * @see DATAREDIS-305
-	 */
-	@Test
+	@Test // DATAREDIS-305
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	public void hScanShouldReadEntireValueRange() {
 
@@ -2169,10 +2135,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(i, is(3));
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	@IfProfileValue(name = "redisVersion", value = "2.8.9+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void pfAddShouldAddToNonExistingKeyCorrectly() {
@@ -2183,10 +2146,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((Long) results.get(0), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	@IfProfileValue(name = "redisVersion", value = "2.8.9+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void pfAddShouldReturnZeroWhenValueAlreadyExists() {
@@ -2201,10 +2161,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((Long) results.get(2), is(0L));
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	@IfProfileValue(name = "redisVersion", value = "2.8.9+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void pfCountShouldReturnCorrectly() {
@@ -2217,10 +2174,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((Long) results.get(1), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	@IfProfileValue(name = "redisVersion", value = "2.8.9+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void pfCountWithMultipleKeysShouldReturnCorrectly() {
@@ -2235,21 +2189,15 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((Long) results.get(2), is(6L));
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-308
 	@IfProfileValue(name = "redisVersion", value = "2.8.9+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void pfCountWithNullKeysShouldThrowIllegalArgumentException() {
 		actual.add(connection.pfCount((String[]) null));
 	}
 
-	/**
-	 * @see DATAREDIS-378
-	 */
 	@SuppressWarnings("unchecked")
-	@Test
+	@Test // DATAREDIS-378
 	@IfProfileValue(name = "redisVersion", value = "2.9.0+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void zRangeByLexTest() {
@@ -2287,10 +2235,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(values, not(hasItems("a", "b", "c", "d")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithExpirationAndNullOpionShouldSetTtlWhenKeyDoesNotExist() {
 
@@ -2305,10 +2250,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((Long) result.get(1)).doubleValue(), is(closeTo(500d, 499d)));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithExpirationAndUpsertOpionShouldSetTtlWhenKeyDoesNotExist() {
 
@@ -2323,10 +2265,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((Long) result.get(1)).doubleValue(), is(closeTo(500d, 499d)));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithExpirationAndUpsertOpionShouldSetTtlWhenKeyDoesExist() {
 
@@ -2344,10 +2283,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((String) result.get(2)), is(equalTo("data")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithExpirationAndAbsentOptionShouldSetTtlWhenKeyDoesExist() {
 
@@ -2365,10 +2301,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((String) result.get(2)), is(equalTo("spring")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithExpirationAndAbsentOptionShouldSetTtlWhenKeyDoesNotExist() {
 
@@ -2385,10 +2318,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((String) result.get(2)), is(equalTo("data")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithExpirationAndPresentOptionShouldSetTtlWhenKeyDoesExist() {
 
@@ -2406,10 +2336,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((String) result.get(2)), is(equalTo("data")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithExpirationAndPresentOptionShouldSetTtlWhenKeyDoesNotExist() {
 
@@ -2425,10 +2352,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((Long) result.get(1)).doubleValue(), is(closeTo(-2, 0)));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithNullExpirationAndUpsertOpionShouldSetTtlWhenKeyDoesNotExist() {
 
@@ -2443,10 +2367,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((Long) result.get(1)).doubleValue(), is(closeTo(-1, 0)));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithoutExpirationAndUpsertOpionShouldSetTtlWhenKeyDoesNotExist() {
 
@@ -2461,10 +2382,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((Long) result.get(1)).doubleValue(), is(closeTo(-1, 0)));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithoutExpirationAndUpsertOpionShouldSetTtlWhenKeyDoesExist() {
 
@@ -2482,10 +2400,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((String) result.get(2)), is(equalTo("data")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithoutExpirationAndAbsentOptionShouldSetTtlWhenKeyDoesExist() {
 
@@ -2503,10 +2418,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((String) result.get(2)), is(equalTo("spring")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithoutExpirationAndAbsentOptionShouldSetTtlWhenKeyDoesNotExist() {
 
@@ -2523,10 +2435,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((String) result.get(2)), is(equalTo("data")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithoutExpirationAndPresentOptionShouldSetTtlWhenKeyDoesExist() {
 
@@ -2544,10 +2453,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((String) result.get(2)), is(equalTo("data")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void setWithoutExpirationAndPresentOptionShouldSetTtlWhenKeyDoesNotExist() {
 
@@ -2563,10 +2469,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((Long) result.get(1)).doubleValue(), is(closeTo(-2, 0)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoAddSingleGeoLocation() {
@@ -2578,10 +2481,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((Long) result.get(0), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoAddMultipleGeoLocations() {
@@ -2593,10 +2493,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((Long) result.get(0), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoDist() {
@@ -2610,10 +2507,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((Distance) result.get(1)).getUnit(), is("m"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoDistWithMetric() {
@@ -2627,10 +2521,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((Distance) result.get(1)).getUnit(), is("km"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS })
 	public void geoHash() {
@@ -2644,10 +2535,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((List<String>) result.get(1)).get(1), is("sqdtr74hyu0"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS })
 	public void geoHashNonExisting() {
@@ -2662,10 +2550,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((List<String>) result.get(1)).get(2), is("sqdtr74hyu0"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoPosition() {
@@ -2683,10 +2568,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((List<Point>) result.get(1)).get(1).getY(), is(closeTo(POINT_CATANIA.getY(), 0.005)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoPositionNonExisting() {
@@ -2706,10 +2588,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((List<Point>) result.get(1)).get(2).getY(), is(closeTo(POINT_CATANIA.getY(), 0.005)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoRadiusShouldReturnMembersCorrectly() {
@@ -2725,10 +2604,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((GeoResults<GeoLocation<String>>) results.get(2)).getContent(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoRadiusShouldReturnDistanceCorrectly() {
@@ -2747,10 +2623,7 @@ public abstract class AbstractConnectionIntegrationTests {
 				is("km"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoRadiusShouldApplyLimit() {
@@ -2765,10 +2638,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((GeoResults<GeoLocation<String>>) results.get(1)).getContent(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoRadiusByMemberShouldReturnMembersCorrectly() {
@@ -2786,10 +2656,7 @@ public abstract class AbstractConnectionIntegrationTests {
 				is(ARIGENTO.getName()));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoRadiusByMemberShouldReturnDistanceCorrectly() {
@@ -2808,10 +2675,7 @@ public abstract class AbstractConnectionIntegrationTests {
 				is("km"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void geoRadiusByMemberShouldApplyLimit() {

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,10 +120,7 @@ abstract public class AbstractConnectionPipelineIntegrationTests extends Abstrac
 		assertTrue(results.isEmpty());
 	}
 
-	/**
-	 * @see DATAREDIS-417
-	 */
-	@Test
+	@Test // DATAREDIS-417
 	@Ignore
 	@Override
 	public void scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection() {

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionTransactionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionTransactionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,10 +107,7 @@ abstract public class AbstractConnectionTransactionIntegrationTests extends Abst
 		connection.scriptKill();
 	}
 
-	/**
-	 * @see DATAREDIS-417
-	 */
-	@Test
+	@Test // DATAREDIS-417
 	@Ignore
 	@Override
 	public void scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection() {

--- a/src/test/java/org/springframework/data/redis/connection/AbstractTransactionalTestBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractTransactionalTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,11 +111,8 @@ public abstract class AbstractTransactionalTestBase {
 		connection.close();
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
 	@Rollback(true)
-	@Test
+	@Test // DATAREDIS-73
 	public void valueOperationSetShouldBeRolledBackCorrectly() {
 
 		for (String key : KEYS) {
@@ -123,11 +120,8 @@ public abstract class AbstractTransactionalTestBase {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
 	@Rollback(false)
-	@Test
+	@Test // DATAREDIS-73
 	public void valueOperationSetShouldBeCommittedCorrectly() {
 
 		this.valuesShouldHaveBeenPersisted = true;
@@ -136,10 +130,7 @@ public abstract class AbstractTransactionalTestBase {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-548
-	 */
-	@Test
+	@Test // DATAREDIS-548
 	@Transactional(readOnly = true)
 	public void valueOperationShouldWorkWithReadOnlyTransactions() {
 
@@ -149,11 +140,8 @@ public abstract class AbstractTransactionalTestBase {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
 	@Rollback(true)
-	@Test
+	@Test // DATAREDIS-73
 	public void listOperationLPushShoudBeRolledBackCorrectly() {
 
 		for (String key : KEYS) {
@@ -161,11 +149,8 @@ public abstract class AbstractTransactionalTestBase {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
 	@Rollback(false)
-	@Test
+	@Test // DATAREDIS-73
 	public void listOperationLPushShouldBeCommittedCorrectly() {
 
 		this.valuesShouldHaveBeenPersisted = true;

--- a/src/test/java/org/springframework/data/redis/connection/ClusterCommandExecutorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterCommandExecutorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,10 +131,7 @@ public class ClusterCommandExecutorUnitTests {
 		this.executor.destroy();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandOnSingleNodeShouldBeExecutedCorrectly() {
 
 		executor.executeCommandOnSingleNode(COMMAND_CALLBACK, CLUSTER_NODE_2);
@@ -142,10 +139,7 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con2, times(1)).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandOnSingleNodeByHostAndPortShouldBeExecutedCorrectly() {
 
 		executor.executeCommandOnSingleNode(COMMAND_CALLBACK,
@@ -154,10 +148,7 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con2, times(1)).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandOnSingleNodeByNodeIdShouldBeExecutedCorrectly() {
 
 		executor.executeCommandOnSingleNode(COMMAND_CALLBACK, new RedisClusterNode(CLUSTER_NODE_2.id));
@@ -165,34 +156,22 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con2, times(1)).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void executeCommandOnSingleNodeShouldThrowExceptionWhenNodeIsNull() {
 		executor.executeCommandOnSingleNode(COMMAND_CALLBACK, null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void executeCommandOnSingleNodeShouldThrowExceptionWhenCommandCallbackIsNull() {
 		executor.executeCommandOnSingleNode(null, CLUSTER_NODE_1);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void executeCommandOnSingleNodeShouldThrowExceptionWhenNodeIsUnknown() {
 		executor.executeCommandOnSingleNode(COMMAND_CALLBACK, UNKNOWN_CLUSTER_NODE);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandAsyncOnNodesShouldExecuteCommandOnGivenNodes() {
 
 		ClusterCommandExecutor executor = new ClusterCommandExecutor(new MockClusterNodeProvider(),
@@ -206,10 +185,7 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con3, never()).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandAsyncOnNodesShouldExecuteCommandOnGivenNodesByHostAndPort() {
 
 		ClusterCommandExecutor executor = new ClusterCommandExecutor(new MockClusterNodeProvider(),
@@ -225,10 +201,7 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con3, never()).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandAsyncOnNodesShouldExecuteCommandOnGivenNodesByNodeId() {
 
 		ClusterCommandExecutor executor = new ClusterCommandExecutor(new MockClusterNodeProvider(),
@@ -243,10 +216,7 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con3, never()).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void executeCommandAsyncOnNodesShouldFailOnGivenUnknownNodes() {
 
 		ClusterCommandExecutor executor = new ClusterCommandExecutor(new MockClusterNodeProvider(),
@@ -257,10 +227,7 @@ public class ClusterCommandExecutorUnitTests {
 				Arrays.asList(new RedisClusterNode("unknown"), CLUSTER_NODE_2_LOOKUP));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandOnAllNodesShouldExecuteCommandOnEveryKnownClusterNode() {
 
 		ClusterCommandExecutor executor = new ClusterCommandExecutor(new MockClusterNodeProvider(),
@@ -274,10 +241,7 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con3, times(1)).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandAsyncOnNodesShouldCompleteAndCollectErrorsOfAllNodes() {
 
 		when(con1.theWheelWeavesAsTheWheelWills()).thenReturn("rand");
@@ -297,10 +261,7 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con3, times(1)).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandAsyncOnNodesShouldCollectResultsCorrectly() {
 
 		when(con1.theWheelWeavesAsTheWheelWills()).thenReturn("rand");
@@ -312,11 +273,7 @@ public class ClusterCommandExecutorUnitTests {
 		assertThat(result.resultsAsList(), hasItems("rand", "mat", "perrin"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 * @see DATAREDIS-467
-	 */
-	@Test
+	@Test // DATAREDIS-315, DATAREDIS-467
 	public void executeMultikeyCommandShouldRunCommandAcrossCluster() {
 
 		// key-1 and key-9 map both to node1
@@ -335,10 +292,7 @@ public class ClusterCommandExecutorUnitTests {
 		assertThat(captor.getAllValues().size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandOnSingleNodeAndFollowRedirect() {
 
 		when(con1.theWheelWeavesAsTheWheelWills()).thenThrow(new MovedException(CLUSTER_NODE_3_HOST, CLUSTER_NODE_3_PORT));
@@ -350,10 +304,7 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con2, never()).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandOnSingleNodeAndFollowRedirectButStopsAfterMaxRedirects() {
 
 		when(con1.theWheelWeavesAsTheWheelWills()).thenThrow(new MovedException(CLUSTER_NODE_3_HOST, CLUSTER_NODE_3_PORT));
@@ -372,10 +323,7 @@ public class ClusterCommandExecutorUnitTests {
 		verify(con2, times(1)).theWheelWeavesAsTheWheelWills();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeCommandOnArbitraryNodeShouldPickARandomNode() {
 
 		executor.executeCommandOnArbitraryNode(COMMAND_CALLBACK);

--- a/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,1014 +27,610 @@ public interface ClusterConnectionTests {
 	static final Point POINT_CATANIA = new Point(15.087269, 37.502669);
 	static final Point POINT_PALERMO = new Point(13.361389, 38.115556);
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void shouldAllowSettingAndGettingValues();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void delShouldRemoveSingleKeyCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void delShouldRemoveMultipleKeysCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void delShouldRemoveMultipleKeysOnSameSlotCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void typeShouldReadKeyTypeCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void keysShouldReturnAllKeys();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void keysShouldReturnAllKeysForSpecificNode();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void randomKeyShouldReturnCorrectlyWhenKeysAvailable();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void randomKeyShouldReturnNullWhenNoKeysAvailable();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void rename();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void renameSameKeysOnSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void renameNXWhenTargetKeyDoesNotExist();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void renameNXWhenTargetKeyDoesExist();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void renameNXWhenOnSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void expireShouldBeSetCorreclty();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pExpireShouldBeSetCorreclty();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void expireAtShouldBeSetCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pExpireAtShouldBeSetCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void persistShouldRemoveTTL();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void moveShouldNotBeSupported();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void dbSizeShouldReturnCummulatedDbSize();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void dbSizeForSpecificNodeShouldGetNodeDbSize();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void ttlShouldReturnMinusTwoWhenKeyDoesNotExist();
 
-	/**
-	 * @see DATAREDIS-526
-	 */
+	// DATAREDIS-526
 	void ttlWithTimeUnitShouldReturnMinusTwoWhenKeyDoesNotExist();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void ttlShouldReturnMinusOneWhenKeyDoesNotHaveExpirationSet();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void ttlShouldReturnValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pTtlShouldReturnMinusTwoWhenKeyDoesNotExist();
 
-	/**
-	 * @see DATAREDIS-526
-	 */
+	// DATAREDIS-526
 	void pTtlWithTimeUnitShouldReturnMinusTwoWhenKeyDoesNotExist();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pTtlShouldReturnMinusOneWhenKeyDoesNotHaveExpirationSet();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pTtlShouldReturValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sortShouldReturnValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sortAndStoreShouldAddSortedValuesValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sortAndStoreShouldReturnZeroWhenListDoesNotExist();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void dumpAndRestoreShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void getShouldReturnValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void getSetShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void mGetShouldReturnCorrectlyWhenKeysMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void mGetShouldReturnCorrectlyWhenKeysDoNotMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void setShouldSetValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void setNxShouldSetValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void setNxShouldNotSetValueWhenAlreadyExistsInDBCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void setExShouldSetValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pSetExShouldSetValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void mSetShouldWorkWhenKeysMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void mSetShouldWorkWhenKeysDoNotMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void mSetNXShouldReturnTrueIfAllKeysSet();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void mSetNXShouldReturnFalseIfNotAllKeysSet();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void mSetNXShouldWorkForOnSameSlotKeys();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void incrShouldIncreaseValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void incrByShouldIncreaseValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void incrByFloatShouldIncreaseValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void decrShouldDecreaseValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void decrByShouldDecreaseValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void appendShouldAddValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void getRangeShouldReturnValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void setRangeShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void getBitShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void setBitShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void bitCountShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void bitCountWithRangeShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void bitOpShouldThrowExceptionWhenKeysDoNotMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void strLenShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void rPushShoultAddValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lPushShoultAddValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void rPushNXShoultNotAddValuesWhenKeyDoesNotExist();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lPushNXShoultNotAddValuesWhenKeyDoesNotExist();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lLenShouldCountValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lRangeShouldGetValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lTrimShouldTrimListCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lIndexShouldGetElementAtIndexCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lInsertShouldAddElementAtPositionCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lSetShouldSetElementAtPositionCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lRemShouldRemoveElementAtPositionCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void lPopShouldReturnElementCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void rPopShouldReturnElementCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void blPopShouldPopElementCorectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void blPopShouldPopElementCorectlyWhenKeyOnSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void brPopShouldPopElementCorectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void brPopShouldPopElementCorectlyWhenKeyOnSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void rPopLPushShouldWorkWhenDoNotMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	public void rPopLPushShouldWorkWhenKeysOnSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void bRPopLPushShouldWork();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void bRPopLPushShouldWorkOnSameSlotKeys();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sAddShouldAddValueToSetCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sRemShouldRemoveValueFromSetCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sPopShouldPopValueFromSetCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sMoveShouldWorkWhenKeysMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sMoveShouldWorkWhenKeysDoNotMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sCardShouldCountValuesInSetCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sIsMemberShouldReturnTrueIfValueIsMemberOfSet();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sIsMemberShouldReturnFalseIfValueIsMemberOfSet();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sInterShouldWorkForKeysMappingToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sInterShouldWorkForKeysNotMappingToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sInterStoreShouldWorkForKeysMappingToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sInterStoreShouldWorkForKeysNotMappingToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sUnionShouldWorkForKeysMappingToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sUnionShouldWorkForKeysNotMappingToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sUnionStoreShouldWorkForKeysMappingToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sUnionStoreShouldWorkForKeysNotMappingToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sDiffShouldWorkWhenKeysMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sDiffShouldWorkWhenKeysNotMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sDiffStoreShouldWorkWhenKeysMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sDiffStoreShouldWorkWhenKeysNotMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sMembersShouldReturnValuesContainedInSetCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sRandMamberShouldReturnValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sRandMamberWithCountShouldReturnValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void sscanShouldRetrieveAllValuesInSetCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zAddShouldAddValueWithScoreCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRemShouldRemoveValueWithScoreCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zIncrByShouldIncScoreForValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRankShouldReturnPositionForValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRankShouldReturnReversePositionForValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRangeShouldReturnValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRangeWithScoresShouldReturnValuesAndScoreCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRangeByScoreShouldReturnValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRangeByScoreWithScoresShouldReturnValuesAndScoreCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRangeByScoreShouldReturnValuesCorrectlyWhenGivenOffsetAndScore();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRangeByScoreWithScoresShouldReturnValuesCorrectlyWhenGivenOffsetAndScore();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRevRangeShouldReturnValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRevRangeWithScoresShouldReturnValuesAndScoreCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRevRangeByScoreShouldReturnValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRevRangeByScoreWithScoresShouldReturnValuesAndScoreCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRevRangeByScoreShouldReturnValuesCorrectlyWhenGivenOffsetAndScore();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRevRangeByScoreWithScoresShouldReturnValuesCorrectlyWhenGivenOffsetAndScore();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zCountShouldCountValuesInRange();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zCardShouldReturnTotalNumberOfValues();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zScoreShouldRetrieveScoreForValue();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRemRangeShouldRemoveValues();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRemRangeByScoreShouldRemoveValues();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zUnionStoreShouldWorkForSameSlotKeys();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zUnionStoreShouldThrowExceptionWhenKeysDoNotMapToSameSlots();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zInterStoreShouldWorkForSameSlotKeys();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zInterStoreShouldThrowExceptionWhenKeysDoNotMapToSameSlots();
 
-	/**
-	 * @see DATAREDIS-479
-	 */
+	// DATAREDIS-479
 	void zScanShouldReadEntireValueRange();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hSetShouldSetValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hSetNXShouldSetValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hSetNXShouldNotSetValueWhenAlreadyExists();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hGetShouldRetrieveValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hMGetShouldRetrieveValueCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hMSetShouldAddValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hIncrByShouldIncreaseFieldCorretly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hIncrByFloatShouldIncreaseFieldCorretly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hExistsShouldReturnPresenceOfFieldCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hDelShouldRemoveFieldsCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hLenShouldRetrieveSizeCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hKeysShouldRetrieveKeysCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hValsShouldRetrieveValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void hGetAllShouldRetrieveEntriesCorrectly();
 
-	/**
-	 * @see DATAREDIS-479
-	 */
+	// DATAREDIS-479
 	public void hScanShouldReadEntireValueRange();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void multiShouldThrowException();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void execShouldThrowException();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void discardShouldThrowException();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void watchShouldThrowException();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void unwatchShouldThrowException();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void selectShouldAllowSelectionOfDBIndexZero();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void selectShouldThrowExceptionWhenSelectingNonZeroDbIndex();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void echoShouldReturnInputCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pingShouldRetrunPongForExistingNode();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pingShouldRetrunPong();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pingShouldThrowExceptionWhenNodeNotKnownToCluster();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void flushDbShouldFlushAllClusterNodes();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void flushDbOnSingleNodeShouldFlushOnlyGivenNodesDb();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void zRangeByLexShouldReturnResultCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void infoShouldCollectionInfoFromAllClusterNodes();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void clientListShouldGetInfosForAllClients();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void getClusterNodeForKeyShouldReturnNodeCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void countKeysShouldReturnNumberOfKeysInSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 
 	void pfAddShouldAddValuesCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pfCountShouldAllowCountingOnSingleKey();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pfCountShouldAllowCountingOnSameSlotKeys();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pfCountShouldThrowErrorCountingOnDifferentSlotKeys();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void pfMergeShouldWorkWhenAllKeysMapToSameSlot();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	public void pfMergeShouldThrowErrorOnDifferentSlotKeys();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void infoShouldCollectInfoForSpecificNode();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void infoShouldCollectInfoForSpecificNodeAndSection();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void getConfigShouldLoadCumulatedConfiguration();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void getConfigShouldLoadConfigurationOfSpecificNode();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void clusterGetSlavesShouldReturnSlaveCorrectly();
 
-	/**
-	 * @see DATAREDIS-315
-	 */
+	// DATAREDIS-315
 	void clusterGetMasterSlaveMapShouldListMastersAndSlavesCorrectly();
 
-	/**
-	 * @see DATAREDIS-316
-	 */
+	// DATAREDIS-316
 	void setWithExpirationInSecondsShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-316
-	 */
+	// DATAREDIS-316
 	void setWithExpirationInMillisecondsShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-316
-	 */
+	// DATAREDIS-316
 	void setWithOptionIfPresentShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-316
-	 */
+	// DATAREDIS-316
 	void setWithOptionIfAbsentShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-316
-	 */
+	// DATAREDIS-316
 	void setWithExpirationAndIfAbsentShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-316
-	 */
+	// DATAREDIS-316
 	void setWithExpirationAndIfAbsentShouldNotBeAppliedWhenKeyExists();
 
-	/**
-	 * @see DATAREDIS-316
-	 */
+	// DATAREDIS-316
 	void setWithExpirationAndIfPresentShouldWorkCorrectly();
 
-	/**
-	 * @see DATAREDIS-316
-	 */
+	// DATAREDIS-316
 	void setWithExpirationAndIfPresentShouldNotBeAppliedWhenKeyDoesNotExists();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoAddSingleGeoLocation();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoAddMultipleGeoLocations();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoDist();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoDistWithMetric();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoHash();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoHashNonExisting();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoPosition();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoPositionNonExisting();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoRadiusShouldReturnMembersCorrectly();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoRadiusShouldReturnDistanceCorrectly();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoRadiusShouldApplyLimit();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoRadiusByMemberShouldReturnMembersCorrectly();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoRadiusByMemberShouldReturnDistanceCorrectly();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoRadiusByMemberShouldApplyLimit();
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	void geoRemoveDeletesMembers();
 }

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionPipelineTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionPipelineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -974,9 +974,7 @@ public class DefaultStringRedisConnectionPipelineTests extends DefaultStringRedi
 		super.testTtl();
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
+	// DATAREDIS-526
 	@Override
 	public void testTtlWithTimeUnit() {
 		doReturn(Arrays.asList(new Object[] { 5L })).when(nativeConnection).closePipeline();
@@ -1322,29 +1320,21 @@ public class DefaultStringRedisConnectionPipelineTests extends DefaultStringRedi
 		super.testZUnionStore();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddBytes() {
 
 		doReturn(Collections.singletonList(1L)).when(nativeConnection).closePipeline();
 		super.testGeoAddBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAdd() {
 
 		doReturn(Collections.singletonList(1L)).when(nativeConnection).closePipeline();
 		super.testGeoAddBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	@Override
 	public void testGeoAddWithGeoLocationBytes() {
 
@@ -1352,9 +1342,7 @@ public class DefaultStringRedisConnectionPipelineTests extends DefaultStringRedi
 		super.testGeoAddWithGeoLocationBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	@Override
 	public void testGeoAddWithGeoLocation() {
 
@@ -1362,29 +1350,21 @@ public class DefaultStringRedisConnectionPipelineTests extends DefaultStringRedi
 		super.testGeoAddWithGeoLocation();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddCoordinateMapBytes() {
 
 		doReturn(Collections.singletonList(1L)).when(nativeConnection).closePipeline();
 		super.testGeoAddCoordinateMapBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddCoordinateMap() {
 
 		doReturn(Collections.singletonList(1L)).when(nativeConnection).closePipeline();
 		super.testGeoAddCoordinateMap();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	@Override
 	public void testGeoAddWithIterableOfGeoLocationBytes() {
 
@@ -1392,9 +1372,7 @@ public class DefaultStringRedisConnectionPipelineTests extends DefaultStringRedi
 		super.testGeoAddWithIterableOfGeoLocationBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	@Override
 	public void testGeoAddWithIterableOfGeoLocation() {
 
@@ -1402,180 +1380,126 @@ public class DefaultStringRedisConnectionPipelineTests extends DefaultStringRedi
 		super.testGeoAddWithIterableOfGeoLocation();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoDistBytes() {
 
 		doReturn(Arrays.asList(new Distance(102121.12d, DistanceUnit.METERS))).when(nativeConnection).closePipeline();
 		super.testGeoDistBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoDist() {
 		doReturn(Arrays.asList(new Distance(102121.12d, DistanceUnit.METERS))).when(nativeConnection).closePipeline();
 		super.testGeoDist();
 
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoHashBytes() {
 
 		doReturn(Arrays.asList(Collections.singletonList(bar))).when(nativeConnection).closePipeline();
 		super.testGeoHashBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoHash() {
 
 		doReturn(Arrays.asList(Collections.singletonList(bar))).when(nativeConnection).closePipeline();
 		super.testGeoHash();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoPosBytes() {
 
 		doReturn(Arrays.asList(points)).when(nativeConnection).closePipeline();
 		super.testGeoPosBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoPos() {
 
 		doReturn(Arrays.asList(points)).when(nativeConnection).closePipeline();
 		super.testGeoPos();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithoutParamBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithoutParamBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithoutParam() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithoutParam();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithDistBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithDistBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithDist() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithDist();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithCoordAndDescBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithCoordAndDescBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithCoordAndDesc() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithCoordAndDesc();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithoutParamBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithoutParamBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithoutParam() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithoutParam();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithDistAndAscBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithDistAndAscBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithDistAndAsc() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithDistAndAsc();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithCoordAndCountBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithCoordAndCountBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithCoordAndCount() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).closePipeline();
@@ -1705,10 +1629,7 @@ public class DefaultStringRedisConnectionPipelineTests extends DefaultStringRedi
 		verifyResults(Arrays.asList(new Object[] { barBytes, 3l }));
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test
+	@Test // DATAREDIS-206
 	@Override
 	public void testTimeIsDelegatedCorrectlyToNativeConnection() {
 

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionPipelineTxTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionPipelineTxTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1048,9 +1048,7 @@ public class DefaultStringRedisConnectionPipelineTxTests extends DefaultStringRe
 		super.testTtl();
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
+	// DATAREDIS-526
 	@Override
 	public void testTtlWithTimeUnit() {
 
@@ -1567,90 +1565,63 @@ public class DefaultStringRedisConnectionPipelineTxTests extends DefaultStringRe
 				results);
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddBytes() {
 
 		doReturn(Arrays.asList(Collections.singletonList(1L))).when(nativeConnection).closePipeline();
 		super.testGeoAddBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAdd() {
 
 		doReturn(Arrays.asList(Collections.singletonList(1L))).when(nativeConnection).closePipeline();
 		super.testGeoAddBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddWithGeoLocationBytes() {
 
 		doReturn(Arrays.asList(Collections.singletonList(1L))).when(nativeConnection).closePipeline();
 		super.testGeoAddWithGeoLocationBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddWithGeoLocation() {
 
 		doReturn(Arrays.asList(Collections.singletonList(1L))).when(nativeConnection).closePipeline();
 		super.testGeoAddWithGeoLocation();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddCoordinateMapBytes() {
 
 		doReturn(Arrays.asList(Collections.singletonList(1L))).when(nativeConnection).closePipeline();
 		super.testGeoAddCoordinateMapBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddCoordinateMap() {
 
 		doReturn(Arrays.asList(Collections.singletonList(1L))).when(nativeConnection).closePipeline();
 		super.testGeoAddCoordinateMap();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddWithIterableOfGeoLocationBytes() {
 
 		doReturn(Arrays.asList(Collections.singletonList(1L))).when(nativeConnection).closePipeline();
 		super.testGeoAddWithIterableOfGeoLocationBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddWithIterableOfGeoLocation() {
 
 		doReturn(Arrays.asList(Collections.singletonList(1L))).when(nativeConnection).closePipeline();
 		super.testGeoAddWithIterableOfGeoLocation();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoDistBytes() {
 
 		doReturn(Arrays.asList(Arrays.asList(new Distance(102121.12d, DistanceUnit.METERS)))).when(nativeConnection)
@@ -1658,10 +1629,7 @@ public class DefaultStringRedisConnectionPipelineTxTests extends DefaultStringRe
 		super.testGeoDistBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoDist() {
 
 		doReturn(Arrays.asList(Arrays.asList(new Distance(102121.12d, DistanceUnit.METERS)))).when(nativeConnection)
@@ -1669,160 +1637,112 @@ public class DefaultStringRedisConnectionPipelineTxTests extends DefaultStringRe
 		super.testGeoDist();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoHashBytes() {
 
 		doReturn(Arrays.asList(Arrays.asList(Collections.singletonList(bar)))).when(nativeConnection).closePipeline();
 		super.testGeoHashBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoHash() {
 
 		doReturn(Arrays.asList(Arrays.asList(Collections.singletonList(bar)))).when(nativeConnection).closePipeline();
 		super.testGeoHash();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoPosBytes() {
 
 		doReturn(Arrays.asList(Arrays.asList(points))).when(nativeConnection).closePipeline();
 		super.testGeoPosBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoPos() {
 
 		doReturn(Arrays.asList(Arrays.asList(points))).when(nativeConnection).closePipeline();
 		super.testGeoPos();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithoutParamBytes() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithoutParamBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithoutParam() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithoutParam();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithDistBytes() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithDistBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithDist() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithDist();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithCoordAndDescBytes() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithCoordAndDescBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithCoordAndDesc() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusWithCoordAndDesc();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithoutParamBytes() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithoutParamBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithoutParam() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithoutParam();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithDistAndAscBytes() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithDistAndAscBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithDistAndAsc() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithDistAndAsc();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithCoordAndCountBytes() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();
 		super.testGeoRadiusByMemberWithCoordAndCountBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithCoordAndCount() {
 
 		doReturn(Arrays.asList(Arrays.asList(geoResults))).when(nativeConnection).closePipeline();

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -932,10 +932,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(new Object[] { true }));
 	}
 
-	/**
-	 * @see DATAREDIS-271
-	 */
-	@Test
+	@Test // DATAREDIS-271
 	public void testPSetExShouldDelegateCallToNativeConnection() {
 
 		connection.pSetEx(fooBytes, 10L, barBytes);
@@ -1194,10 +1191,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(new Object[] { 5l }));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void testTtlWithTimeUnit() {
 
 		doReturn(5L).when(nativeConnection).ttl(fooBytes, TimeUnit.SECONDS);
@@ -1724,10 +1718,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(new Object[] { "foo" }));
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test
+	@Test // DATAREDIS-206
 	public void testTimeIsDelegatedCorrectlyToNativeConnection() {
 
 		doReturn(1L).when(nativeConnection).time();
@@ -1735,30 +1726,21 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-184
-	 */
-	@Test
+	@Test // DATAREDIS-184
 	public void testShutdownInDelegatedCorrectlyToNativeConnection() {
 
 		connection.shutdown(ShutdownOption.NOSAVE);
 		verify(nativeConnection, times(1)).shutdown(eq(ShutdownOption.NOSAVE));
 	}
 
-	/**
-	 * @see DATAREDIS-269
-	 */
-	@Test
+	@Test // DATAREDIS-269
 	public void settingClientNameShouldDelegateToNativeConnection() {
 
 		connection.setClientName("foo");
 		verify(nativeConnection, times(1)).setClientName(eq("foo".getBytes()));
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	public void pfAddShouldDelegateToNativeConnectionCorrectly() {
 
 		connection.pfAdd("hll", "spring", "data", "redis");
@@ -1766,20 +1748,14 @@ public class DefaultStringRedisConnectionTests {
 				"redis".getBytes());
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	public void pfCountShouldDelegateToNativeConnectionCorrectly() {
 
 		connection.pfCount("hll", "hyperLogLog");
 		verify(nativeConnection, times(1)).pfCount("hll".getBytes(), "hyperLogLog".getBytes());
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	public void pfMergeShouldDelegateToNativeConnectionCorrectly() {
 
 		connection.pfMerge("merged", "spring", "data", "redis");
@@ -1787,20 +1763,14 @@ public class DefaultStringRedisConnectionTests {
 				"redis".getBytes());
 	}
 
-	/**
-	 * @see DATAREDIS-270
-	 */
-	@Test
+	@Test // DATAREDIS-270
 	public void testGetClientNameIsDelegatedCorrectlyToNativeConnection() {
 
 		actual.add(connection.getClientName());
 		verify(nativeConnection, times(1)).getClientName();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddBytes() {
 
 		doReturn(1l).when(nativeConnection).geoAdd(fooBytes, new Point(1.23232, 34.2342434), barBytes);
@@ -1809,10 +1779,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAdd() {
 
 		doReturn(1l).when(nativeConnection).geoAdd(fooBytes, new Point(1.23232, 34.2342434), barBytes);
@@ -1821,10 +1788,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddWithGeoLocationBytes() {
 
 		doReturn(1l).when(nativeConnection).geoAdd(fooBytes,
@@ -1834,10 +1798,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddWithGeoLocation() {
 
 		doReturn(1l).when(nativeConnection).geoAdd(fooBytes, new Point(1.23232, 34.2342434), barBytes);
@@ -1846,10 +1807,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddCoordinateMapBytes() {
 
 		Map<byte[], Point> memberGeoCoordinateMap = Collections.singletonMap(barBytes, new Point(1.23232, 34.2342434));
@@ -1859,10 +1817,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddCoordinateMap() {
 
 		doReturn(1l).when(nativeConnection).geoAdd(any(byte[].class), anyMapOf(byte[].class, Point.class));
@@ -1871,10 +1826,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddWithIterableOfGeoLocationBytes() {
 
 		List<GeoLocation<byte[]>> values = Collections.singletonList(new GeoLocation<byte[]>(barBytes, new Point(1, 2)));
@@ -1884,10 +1836,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddWithIterableOfGeoLocation() {
 
 		doReturn(1l).when(nativeConnection).geoAdd(eq(fooBytes), anyMapOf(byte[].class, Point.class));
@@ -1896,10 +1845,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoDistBytes() {
 
 		doReturn(new Distance(102121.12d, DistanceUnit.METERS)).when(nativeConnection).geoDist(fooBytes, barBytes,
@@ -1909,10 +1855,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(new Distance(102121.12d, DistanceUnit.METERS)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoDist() {
 
 		doReturn(new Distance(102121.12d, DistanceUnit.METERS)).when(nativeConnection).geoDist(fooBytes, barBytes,
@@ -1922,10 +1865,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Collections.singletonList(new Distance(102121.12d, DistanceUnit.METERS)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoHashBytes() {
 
 		doReturn(stringList).when(nativeConnection).geoHash(fooBytes, barBytes);
@@ -1934,10 +1874,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(Collections.singletonList(bar)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoHash() {
 
 		doReturn(stringList).when(nativeConnection).geoHash(fooBytes, barBytes);
@@ -1946,10 +1883,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(Collections.singletonList(bar)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoPosBytes() {
 
 		doReturn(points).when(nativeConnection).geoPos(fooBytes, barBytes);
@@ -1958,10 +1892,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(points));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoPos() {
 
 		doReturn(points).when(nativeConnection).geoPos(fooBytes, barBytes);
@@ -1969,10 +1900,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(points));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithoutParamBytes() {
 
 		doReturn(geoResults).when(nativeConnection).geoRadius(eq(fooBytes), any(Circle.class));
@@ -1981,10 +1909,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(geoResults));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithoutParam() {
 
 		doReturn(geoResults).when(nativeConnection).geoRadius(eq(fooBytes), any(Circle.class));
@@ -1994,10 +1919,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithDistBytes() {
 
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeDistance();
@@ -2008,10 +1930,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(geoResults));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithDist() {
 
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeDistance();
@@ -2022,10 +1941,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithCoordAndDescBytes() {
 
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeCoordinates().sortDescending();
@@ -2036,10 +1952,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(geoResults));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithCoordAndDesc() {
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeCoordinates().sortDescending();
 		doReturn(geoResults).when(nativeConnection).geoRadius(eq(fooBytes), any(Circle.class), eq(geoRadiusParam));
@@ -2049,10 +1962,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithoutParamBytes() {
 
 		doReturn(geoResults).when(nativeConnection).geoRadiusByMember(fooBytes, barBytes,
@@ -2062,10 +1972,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(geoResults));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithoutParam() {
 
 		doReturn(geoResults).when(nativeConnection).geoRadiusByMember(fooBytes, barBytes,
@@ -2075,10 +1982,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithDistAndAscBytes() {
 
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeDistance().sortAscending();
@@ -2090,10 +1994,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(geoResults));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithDistAndAsc() {
 
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeDistance().sortAscending();
@@ -2104,10 +2005,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(Converters.deserializingGeoResultsConverter(serializer).convert(geoResults)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithCoordAndCountBytes() {
 
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeDistance().limit(23);
@@ -2119,10 +2017,7 @@ public class DefaultStringRedisConnectionTests {
 		verifyResults(Arrays.asList(geoResults));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithCoordAndCount() {
 
 		GeoRadiusCommandArgs geoRadiusParam = GeoRadiusCommandArgs.newGeoRadiusArgs().includeDistance().limit(23);

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTxTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTxTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -959,9 +959,7 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 		super.testTtl();
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
+	// DATAREDIS-526
 	@Override
 	public void testTtlWithTimeUnit() {
 
@@ -1444,10 +1442,7 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 		verifyResults(Arrays.asList(new Object[] { foo }));
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test
+	@Test // DATAREDIS-206
 	@Override
 	public void testTimeIsDelegatedCorrectlyToNativeConnection() {
 
@@ -1456,28 +1451,20 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 		super.testTimeIsDelegatedCorrectlyToNativeConnection();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddBytes() {
 
 		doReturn(Collections.singletonList(1L)).when(nativeConnection).exec();
 		super.testGeoAddBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAdd() {
 		doReturn(Collections.singletonList(1L)).when(nativeConnection).exec();
 		super.testGeoAddBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	@Override
 	public void testGeoAddWithGeoLocationBytes() {
 
@@ -1485,9 +1472,7 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 		super.testGeoAddWithGeoLocationBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	@Override
 	public void testGeoAddWithGeoLocation() {
 
@@ -1495,27 +1480,19 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 		super.testGeoAddWithGeoLocation();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddCoordinateMapBytes() {
 		doReturn(Collections.singletonList(1L)).when(nativeConnection).exec();
 		super.testGeoAddCoordinateMapBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddCoordinateMap() {
 		doReturn(Collections.singletonList(1L)).when(nativeConnection).exec();
 		super.testGeoAddCoordinateMap();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	@Override
 	public void testGeoAddWithIterableOfGeoLocationBytes() {
 
@@ -1523,9 +1500,7 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 		super.testGeoAddWithIterableOfGeoLocationBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
+	// DATAREDIS-438
 	@Override
 	public void testGeoAddWithIterableOfGeoLocation() {
 
@@ -1533,100 +1508,70 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 		super.testGeoAddWithIterableOfGeoLocation();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoDistBytes() {
 
 		doReturn(Arrays.asList(new Distance(102121.12d, DistanceUnit.METERS))).when(nativeConnection).exec();
 		super.testGeoDistBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoDist() {
 
 		doReturn(Arrays.asList(new Distance(102121.12d, DistanceUnit.METERS))).when(nativeConnection).exec();
 		super.testGeoDist();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoHashBytes() {
 
 		doReturn(Arrays.asList(Collections.singletonList(bar))).when(nativeConnection).exec();
 		super.testGeoHashBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoHash() {
 
 		doReturn(Arrays.asList(Collections.singletonList(bar))).when(nativeConnection).exec();
 		super.testGeoHash();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoPosBytes() {
 
 		doReturn(Arrays.asList(points)).when(nativeConnection).exec();
 		super.testGeoPosBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoPos() {
 
 		doReturn(Arrays.asList(points)).when(nativeConnection).exec();
 		super.testGeoPos();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithoutParamBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
 		super.testGeoRadiusWithoutParamBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithoutParam() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
 		super.testGeoRadiusWithoutParam();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithDistBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
 		super.testGeoRadiusWithDistBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithDist() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
@@ -1640,70 +1585,49 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 		super.testGeoRadiusWithCoordAndDescBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusWithCoordAndDesc() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
 		super.testGeoRadiusWithCoordAndDesc();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithoutParamBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
 		super.testGeoRadiusByMemberWithoutParamBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithoutParam() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
 		super.testGeoRadiusByMemberWithoutParam();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithDistAndAscBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
 		super.testGeoRadiusByMemberWithDistAndAscBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithDistAndAsc() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
 		super.testGeoRadiusByMemberWithDistAndAsc();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithCoordAndCountBytes() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();
 		super.testGeoRadiusByMemberWithCoordAndCountBytes();
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRadiusByMemberWithCoordAndCount() {
 
 		doReturn(Arrays.asList(geoResults)).when(nativeConnection).exec();

--- a/src/test/java/org/springframework/data/redis/connection/RedisClusterConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisClusterConfigurationUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,10 +40,7 @@ public class RedisClusterConfigurationUnitTests {
 	static final String HOST_AND_PORT_3 = "localhost:789";
 	static final String HOST_AND_NO_PORT = "localhost";
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldCreateRedisClusterConfigurationCorrectly() {
 
 		RedisClusterConfiguration config = new RedisClusterConfiguration(Collections.singleton(HOST_AND_PORT_1));
@@ -53,10 +50,7 @@ public class RedisClusterConfigurationUnitTests {
 		assertThat(config.getMaxRedirects(), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldCreateRedisClusterConfigurationCorrectlyGivenMultipleHostAndPortStrings() {
 
 		RedisClusterConfiguration config = new RedisClusterConfiguration(new HashSet<String>(Arrays.asList(HOST_AND_PORT_1,
@@ -67,26 +61,17 @@ public class RedisClusterConfigurationUnitTests {
 				hasItems(new RedisNode("127.0.0.1", 123), new RedisNode("localhost", 456), new RedisNode("localhost", 789)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void shouldThrowExecptionOnInvalidHostAndPortString() {
 		new RedisClusterConfiguration(Collections.singleton(HOST_AND_NO_PORT));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void shouldThrowExceptionWhenListOfHostAndPortIsNull() {
 		new RedisClusterConfiguration(Collections.<String> singleton(null));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldNotFailWhenListOfHostAndPortIsEmpty() {
 
 		RedisClusterConfiguration config = new RedisClusterConfiguration(Collections.<String> emptySet());
@@ -94,18 +79,12 @@ public class RedisClusterConfigurationUnitTests {
 		assertThat(config.getClusterNodes().size(), is(0));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void shouldThrowExceptionGivenNullPropertySource() {
 		new RedisClusterConfiguration((PropertySource<?>) null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldNotFailWhenGivenPropertySourceNotContainingRelevantProperties() {
 
 		RedisClusterConfiguration config = new RedisClusterConfiguration(new MockPropertySource());
@@ -114,10 +93,7 @@ public class RedisClusterConfigurationUnitTests {
 		assertThat(config.getClusterNodes().size(), is(0));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldBeCreatedCorrecltyGivenValidPropertySourceWithSingleHostPort() {
 
 		MockPropertySource propertySource = new MockPropertySource();
@@ -130,10 +106,7 @@ public class RedisClusterConfigurationUnitTests {
 		assertThat(config.getClusterNodes(), hasItems(new RedisNode("127.0.0.1", 123)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldBeCreatedCorrecltyGivenValidPropertySourceWithMultipleHostPort() {
 
 		MockPropertySource propertySource = new MockPropertySource();

--- a/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,10 +62,7 @@ public class RedisConnectionUnitTests {
 		connection.setSentinelConnection(sentinelConnectionMock);
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void shouldCloseSentinelConnectionAlongWithRedisConnection() throws IOException {
 
 		when(sentinelConnectionMock.isOpen()).thenReturn(true).thenReturn(false);
@@ -77,10 +74,7 @@ public class RedisConnectionUnitTests {
 		verify(sentinelConnectionMock, times(1)).close();
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void shouldNotTryToCloseSentinelConnectionsWhenAlreadyClosed() throws IOException {
 
 		when(sentinelConnectionMock.isOpen()).thenReturn(true);

--- a/src/test/java/org/springframework/data/redis/connection/RedisSentinelConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisSentinelConfigurationUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,7 @@ public class RedisSentinelConfigurationUnitTests {
 	static final String HOST_AND_PORT_3 = "localhost:789";
 	static final String HOST_AND_NO_PORT = "localhost";
 
-	/**
-	 * @see DATAREDIS-372
-	 */
-	@Test
+	@Test // DATAREDIS-372
 	public void shouldCreateRedisSentinelConfigurationCorrectlyGivenMasterAndSingleHostAndPortString() {
 
 		RedisSentinelConfiguration config = new RedisSentinelConfiguration("mymaster",
@@ -52,10 +49,7 @@ public class RedisSentinelConfigurationUnitTests {
 		assertThat(config.getSentinels(), hasItems(new RedisNode("127.0.0.1", 123)));
 	}
 
-	/**
-	 * @see DATAREDIS-372
-	 */
-	@Test
+	@Test // DATAREDIS-372
 	public void shouldCreateRedisSentinelConfigurationCorrectlyGivenMasterAndMultipleHostAndPortStrings() {
 
 		RedisSentinelConfiguration config = new RedisSentinelConfiguration("mymaster", new HashSet<String>(Arrays.asList(
@@ -66,26 +60,17 @@ public class RedisSentinelConfigurationUnitTests {
 				hasItems(new RedisNode("127.0.0.1", 123), new RedisNode("localhost", 456), new RedisNode("localhost", 789)));
 	}
 
-	/**
-	 * @see DATAREDIS-372
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-372
 	public void shouldThrowExecptionOnInvalidHostAndPortString() {
 		new RedisSentinelConfiguration("mymaster", Collections.singleton(HOST_AND_NO_PORT));
 	}
 
-	/**
-	 * @see DATAREDIS-372
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-372
 	public void shouldThrowExceptionWhenListOfHostAndPortIsNull() {
 		new RedisSentinelConfiguration("mymaster", Collections.<String> singleton(null));
 	}
 
-	/**
-	 * @see DATAREDIS-372
-	 */
-	@Test
+	@Test // DATAREDIS-372
 	public void shouldNotFailWhenListOfHostAndPortIsEmpty() {
 
 		RedisSentinelConfiguration config = new RedisSentinelConfiguration("mymaster", Collections.<String> emptySet());
@@ -93,18 +78,12 @@ public class RedisSentinelConfigurationUnitTests {
 		assertThat(config.getSentinels().size(), is(0));
 	}
 
-	/**
-	 * @see DATAREDIS-372
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-372
 	public void shouldThrowExceptionGivenNullPropertySource() {
 		new RedisSentinelConfiguration((PropertySource<?>) null);
 	}
 
-	/**
-	 * @see DATAREDIS-372
-	 */
-	@Test
+	@Test // DATAREDIS-372
 	public void shouldNotFailWhenGivenPropertySourceNotContainingRelevantProperties() {
 
 		RedisSentinelConfiguration config = new RedisSentinelConfiguration(new MockPropertySource());
@@ -113,10 +92,7 @@ public class RedisSentinelConfigurationUnitTests {
 		assertThat(config.getSentinels().size(), is(0));
 	}
 
-	/**
-	 * @see DATAREDIS-372
-	 */
-	@Test
+	@Test // DATAREDIS-372
 	public void shouldBeCreatedCorrecltyGivenValidPropertySourceWithMasterAndSingleHostPort() {
 
 		MockPropertySource propertySource = new MockPropertySource();
@@ -130,10 +106,7 @@ public class RedisSentinelConfigurationUnitTests {
 		assertThat(config.getSentinels(), hasItems(new RedisNode("127.0.0.1", 123)));
 	}
 
-	/**
-	 * @see DATAREDIS-372
-	 */
-	@Test
+	@Test // DATAREDIS-372
 	public void shouldBeCreatedCorrecltyGivenValidPropertySourceWithMasterAndMultipleHostPort() {
 
 		MockPropertySource propertySource = new MockPropertySource();

--- a/src/test/java/org/springframework/data/redis/connection/RedisServerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisServerUnitTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link RedisServer}.
+ *
+ * @author Mark Paluch
+ */
+public class RedisServerUnitTests {
+
+	@Test // DATAREDIS-618
+	public void shouldReadNumberOfOtherSentinelsCorrectly() {
+
+		RedisServer redisServer = RedisServer.newServerFrom(createProperties());
+
+		assertThat(redisServer.getNumberOtherSentinels(), is(2L));
+	}
+
+	private Properties createProperties() {
+
+		Properties map = new Properties();
+
+		map.put("num-other-sentinels", "2");
+
+		return map;
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/convert/ConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/convert/ConvertersUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,10 +58,7 @@ public class ConvertersUnitTests {
 
 	private static final String CLUSTER_NODE_IMPORTING_SLOT = "ef570f86c7b1a953846668debc177a3a16733420 127.0.0.1:6379 myself,master - 0 0 1 connected [5461-<-0f2ee5df45d18c50aca07228cc18b1da96fd5e84]";
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void toSetOfRedis30ClusterNodesShouldConvertSingleStringNodesResponseCorrectly() {
 
 		Iterator<RedisClusterNode> nodes = Converters.toSetOfRedisClusterNodes(REDIS_3_0_CLUSTER_NODES_RESPONSE).iterator();
@@ -111,10 +108,7 @@ public class ConvertersUnitTests {
 		assertThat(node.getLinkState(), is(LinkState.CONNECTED));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void toSetOfRedis32ClusterNodesShouldConvertSingleStringNodesResponseCorrectly() {
 
 		Iterator<RedisClusterNode> nodes = Converters.toSetOfRedisClusterNodes(REDIS_3_2_CLUSTER_NODES_RESPONSE).iterator();
@@ -164,10 +158,7 @@ public class ConvertersUnitTests {
 		assertThat(node.getLinkState(), is(LinkState.CONNECTED));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void toSetOfRedisClusterNodesShouldConvertNodesWithSingleSlotCorrectly() {
 
 		Iterator<RedisClusterNode> nodes = Converters.toSetOfRedisClusterNodes(CLUSTER_NODE_WITH_SINGLE_SLOT_RESPONSE)
@@ -181,10 +172,7 @@ public class ConvertersUnitTests {
 		assertThat(node.getSlotRange().contains(3456), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void toSetOfRedisClusterNodesShouldParseLinkStateAndDisconnectedCorrectly() {
 
 		Iterator<RedisClusterNode> nodes = Converters.toSetOfRedisClusterNodes(
@@ -200,10 +188,7 @@ public class ConvertersUnitTests {
 		assertThat(node.getSlotRange().getSlots().size(), is(0));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void toSetOfRedisClusterNodesShouldIgnoreImportingSlot() {
 
 		Iterator<RedisClusterNode> nodes = Converters.toSetOfRedisClusterNodes(CLUSTER_NODE_IMPORTING_SLOT).iterator();

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,20 +136,14 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		nativeConnection.close();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldAllowSettingAndGettingValues() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
 		assertThat(clusterConnection.get(KEY_1_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void delShouldRemoveSingleKeyCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -159,10 +153,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void delShouldRemoveMultipleKeysCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -174,10 +165,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void delShouldRemoveMultipleKeysOnSameSlotCorrectly() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1);
@@ -189,10 +177,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void typeShouldReadKeyTypeCorrectly() {
 
 		nativeConnection.sadd(KEY_1_BYTES, VALUE_1_BYTES);
@@ -204,10 +189,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.type(KEY_3_BYTES), is(DataType.HASH));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void keysShouldReturnAllKeys() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -216,10 +198,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.keys(JedisConverters.toBytes("*")), hasItems(KEY_1_BYTES, KEY_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void keysShouldReturnAllKeysForSpecificNode() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -232,10 +211,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(keysOnNode, not(hasItems(KEY_1_BYTES)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void randomKeyShouldReturnCorrectlyWhenKeysAvailable() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -244,18 +220,12 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.randomKey(), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void randomKeyShouldReturnNullWhenNoKeysAvailable() {
 		assertThat(clusterConnection.randomKey(), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rename() {
 
 		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
@@ -266,10 +236,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void renameSameKeysOnSameSlot() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES);
@@ -280,10 +247,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void renameNXWhenTargetKeyDoesNotExist() {
 
 		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
@@ -294,10 +258,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void renameNXWhenTargetKeyDoesExist() {
 
 		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
@@ -309,10 +270,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2_BYTES), is(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void renameNXWhenOnSameSlot() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES);
@@ -323,10 +281,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void expireShouldBeSetCorreclty() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -336,10 +291,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(JedisConverters.toString(KEY_1_BYTES)) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pExpireShouldBeSetCorreclty() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -349,10 +301,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(JedisConverters.toString(KEY_1_BYTES)) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void expireAtShouldBeSetCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -362,10 +311,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(JedisConverters.toString(KEY_1_BYTES)) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pExpireAtShouldBeSetCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -375,10 +321,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(JedisConverters.toString(KEY_1_BYTES)) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void persistShouldRemoveTTL() {
 
 		nativeConnection.setex(KEY_1_BYTES, 10, VALUE_1_BYTES);
@@ -387,18 +330,12 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1_BYTES), is(-1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-315
 	public void moveShouldNotBeSupported() {
 		clusterConnection.move(KEY_1_BYTES, 3);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void dbSizeShouldReturnCummulatedDbSize() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -407,10 +344,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.dbSize(), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void dbSizeForSpecificNodeShouldGetNodeDbSize() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -421,26 +355,17 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.dbSize(new RedisClusterNode("127.0.0.1", 7381, null)), is(0L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void ttlShouldReturnMinusTwoWhenKeyDoesNotExist() {
 		assertThat(clusterConnection.ttl(KEY_1_BYTES), is(-2L));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void ttlWithTimeUnitShouldReturnMinusTwoWhenKeyDoesNotExist() {
 		assertThat(clusterConnection.ttl(KEY_1_BYTES, TimeUnit.HOURS), is(-2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void ttlShouldReturnMinusOneWhenKeyDoesNotHaveExpirationSet() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -448,10 +373,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.ttl(KEY_1_BYTES), is(-1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void ttlShouldReturnValueCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -460,26 +382,17 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.ttl(KEY_1_BYTES) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pTtlShouldReturnMinusTwoWhenKeyDoesNotExist() {
 		assertThat(clusterConnection.pTtl(KEY_1_BYTES), is(-2L));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void pTtlWithTimeUnitShouldReturnMinusTwoWhenKeyDoesNotExist() {
 		assertThat(clusterConnection.pTtl(KEY_1_BYTES, TimeUnit.HOURS), is(-2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pTtlShouldReturnMinusOneWhenKeyDoesNotHaveExpirationSet() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -487,10 +400,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.pTtl(KEY_1_BYTES), is(-1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pTtlShouldReturValueCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -499,10 +409,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.pTtl(KEY_1_BYTES) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sortShouldReturnValuesCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_2, VALUE_1);
@@ -511,10 +418,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sortAndStoreShouldAddSortedValuesValuesCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_2, VALUE_1);
@@ -523,18 +427,12 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_2_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sortAndStoreShouldReturnZeroWhenListDoesNotExist() {
 		assertThat(clusterConnection.sort(KEY_1_BYTES, new DefaultSortParameters().alpha(), KEY_2_BYTES), is(0L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void dumpAndRestoreShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -545,10 +443,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getShouldReturnValueCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -556,10 +451,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.get(KEY_1_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getSetShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -570,10 +462,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mGetShouldReturnCorrectlyWhenKeysMapToSameSlot() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES);
@@ -583,10 +472,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				contains(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mGetShouldReturnCorrectlyWhenKeysDoNotMapToSameSlot() {
 
 		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
@@ -595,10 +481,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.mGet(KEY_1_BYTES, KEY_2_BYTES), contains(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setShouldSetValueCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
@@ -606,10 +489,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setNxShouldSetValueCorrectly() {
 
 		clusterConnection.setNX(KEY_1_BYTES, VALUE_1_BYTES);
@@ -617,10 +497,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setNxShouldNotSetValueWhenAlreadyExistsInDBCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -630,10 +507,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setExShouldSetValueCorrectly() {
 
 		clusterConnection.setEx(KEY_1_BYTES, 5, VALUE_1_BYTES);
@@ -642,10 +516,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pSetExShouldSetValueCorrectly() {
 
 		clusterConnection.pSetEx(KEY_1_BYTES, 5000, VALUE_1_BYTES);
@@ -654,10 +525,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetShouldWorkWhenKeysMapToSameSlot() {
 
 		Map<byte[], byte[]> map = new LinkedHashMap<byte[], byte[]>();
@@ -670,10 +538,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetShouldWorkWhenKeysDoNotMapToSameSlot() {
 
 		Map<byte[], byte[]> map = new LinkedHashMap<byte[], byte[]>();
@@ -686,10 +551,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetNXShouldReturnTrueIfAllKeysSet() {
 
 		Map<byte[], byte[]> map = new LinkedHashMap<byte[], byte[]>();
@@ -702,10 +564,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetNXShouldReturnFalseIfNotAllKeysSet() {
 
 		nativeConnection.set(KEY_2_BYTES, VALUE_3_BYTES);
@@ -719,10 +578,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_3));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetNXShouldWorkForOnSameSlotKeys() {
 
 		Map<byte[], byte[]> map = new LinkedHashMap<byte[], byte[]>();
@@ -735,10 +591,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void incrShouldIncreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "1");
@@ -746,10 +599,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.incr(KEY_1_BYTES), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void incrByShouldIncreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "1");
@@ -757,10 +607,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.incrBy(KEY_1_BYTES, 5), is(6L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void incrByFloatShouldIncreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "1");
@@ -768,10 +615,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.incrBy(KEY_1_BYTES, 5.5D), is(6.5D));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void decrShouldDecreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "5");
@@ -779,10 +623,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.decr(KEY_1_BYTES), is(4L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void decrByShouldDecreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "5");
@@ -790,10 +631,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.decrBy(KEY_1_BYTES, 4), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void appendShouldAddValueCorrectly() {
 
 		clusterConnection.append(KEY_1_BYTES, VALUE_1_BYTES);
@@ -802,10 +640,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_1.concat(VALUE_2)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getRangeShouldReturnValueCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -813,10 +648,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.getRange(KEY_1_BYTES, 0, 2), is(JedisConverters.toBytes("val")));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setRangeShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -826,10 +658,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is("valUE1"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getBitShouldWorkCorrectly() {
 
 		nativeConnection.setbit(KEY_1, 0, true);
@@ -839,10 +668,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.getBit(KEY_1_BYTES, 1), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setBitShouldWorkCorrectly() {
 
 		clusterConnection.setBit(KEY_1_BYTES, 0, true);
@@ -852,10 +678,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.getbit(KEY_1, 1), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bitCountShouldWorkCorrectly() {
 
 		nativeConnection.setbit(KEY_1, 0, true);
@@ -864,10 +687,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bitCount(KEY_1_BYTES), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bitCountWithRangeShouldWorkCorrectly() {
 
 		nativeConnection.setbit(KEY_1, 0, true);
@@ -879,10 +699,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bitCount(KEY_1_BYTES, 0, 3), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bitOpShouldWorkCorrectly() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
@@ -893,18 +710,12 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_3), is("bab"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void bitOpShouldThrowExceptionWhenKeysDoNotMapToSameSlot() {
 		clusterConnection.bitOp(BitOperation.AND, KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void strLenShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -912,10 +723,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.strLen(KEY_1_BYTES), is(6L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPushShoultAddValuesCorrectly() {
 
 		clusterConnection.rPush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -923,10 +731,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1), hasItems(VALUE_1, VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lPushShoultAddValuesCorrectly() {
 
 		clusterConnection.lPush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -934,10 +739,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1), hasItems(VALUE_1, VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPushNXShoultNotAddValuesWhenKeyDoesNotExist() {
 
 		clusterConnection.rPushX(KEY_1_BYTES, VALUE_1_BYTES);
@@ -945,10 +747,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_1), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lPushNXShoultNotAddValuesWhenKeyDoesNotExist() {
 
 		clusterConnection.lPushX(KEY_1_BYTES, VALUE_1_BYTES);
@@ -956,10 +755,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_1), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lLenShouldCountValuesCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2);
@@ -967,10 +763,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.lLen(KEY_1_BYTES), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lRangeShouldGetValuesCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2);
@@ -978,10 +771,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.lRange(KEY_1_BYTES, 0L, -1L), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lTrimShouldTrimListCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -991,10 +781,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1), hasItems(VALUE_1, VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lIndexShouldGetElementAtIndexCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -1002,10 +789,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.lIndex(KEY_1_BYTES, 1), is(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lInsertShouldAddElementAtPositionCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -1015,10 +799,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1).get(2), is("booh!"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lSetShouldSetElementAtPositionCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -1028,10 +809,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1).get(1), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lRemShouldRemoveElementAtPositionCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -1041,10 +819,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.llen(KEY_1), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lPopShouldReturnElementCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2);
@@ -1052,10 +827,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.lPop(KEY_1_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPopShouldReturnElementCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2);
@@ -1063,10 +835,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.rPop(KEY_1_BYTES), is(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void blPopShouldPopElementCorectly() {
 
 		nativeConnection.lpush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1075,10 +844,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bLPop(100, KEY_1_BYTES, KEY_2_BYTES).size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void blPopShouldPopElementCorectlyWhenKeyOnSameSlot() {
 
 		nativeConnection.lpush(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1087,10 +853,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bLPop(100, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES).size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void brPopShouldPopElementCorectly() {
 
 		nativeConnection.lpush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1099,10 +862,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bRPop(100, KEY_1_BYTES, KEY_2_BYTES).size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void brPopShouldPopElementCorectlyWhenKeyOnSameSlot() {
 
 		nativeConnection.lpush(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1111,10 +871,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bRPop(100, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES).size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPopLPushShouldWorkWhenDoNotMapToSameSlot() {
 
 		nativeConnection.lpush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1123,10 +880,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_2_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPopLPushShouldWorkWhenKeysOnSameSlot() {
 
 		nativeConnection.lpush(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1135,10 +889,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(SAME_SLOT_KEY_2_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bRPopLPushShouldWork() {
 
 		nativeConnection.lpush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1147,10 +898,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_2_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bRPopLPushShouldWorkOnSameSlotKeys() {
 
 		nativeConnection.lpush(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1159,10 +907,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(SAME_SLOT_KEY_2_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sAddShouldAddValueToSetCorrectly() {
 
 		clusterConnection.sAdd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1170,10 +915,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_1), hasItems(VALUE_1, VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sRemShouldRemoveValueFromSetCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1183,10 +925,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_1), hasItems(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sPopShouldPopValueFromSetCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1194,10 +933,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sPop(KEY_1_BYTES), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sMoveShouldWorkWhenKeysMapToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1209,10 +945,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.sismember(SAME_SLOT_KEY_2_BYTES, VALUE_2_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sMoveShouldWorkWhenKeysDoNotMapToSameSlot() {
 
 		nativeConnection.sadd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1224,10 +957,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.sismember(KEY_2_BYTES, VALUE_2_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sCardShouldCountValuesInSetCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1235,10 +965,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sCard(KEY_1_BYTES), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sIsMemberShouldReturnTrueIfValueIsMemberOfSet() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1246,10 +973,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sIsMember(KEY_1_BYTES, VALUE_1_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sIsMemberShouldReturnFalseIfValueIsMemberOfSet() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1257,10 +981,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sIsMember(KEY_1_BYTES, JedisConverters.toBytes("foo")), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sInterShouldWorkForKeysMappingToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1269,10 +990,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sInter(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES), hasItem(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sInterShouldWorkForKeysNotMappingToSameSlot() {
 
 		nativeConnection.sadd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1281,10 +999,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sInter(KEY_1_BYTES, KEY_2_BYTES), hasItem(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sInterStoreShouldWorkForKeysMappingToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1295,10 +1010,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(SAME_SLOT_KEY_3_BYTES), hasItem(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sInterStoreShouldWorkForKeysNotMappingToSameSlot() {
 
 		nativeConnection.sadd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1309,10 +1021,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_3_BYTES), hasItem(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sUnionShouldWorkForKeysMappingToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1322,10 +1031,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sUnionShouldWorkForKeysNotMappingToSameSlot() {
 
 		nativeConnection.sadd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1335,10 +1041,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sUnionStoreShouldWorkForKeysMappingToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1349,10 +1052,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(SAME_SLOT_KEY_3_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sUnionStoreShouldWorkForKeysNotMappingToSameSlot() {
 
 		nativeConnection.sadd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1363,10 +1063,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_3_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sDiffShouldWorkWhenKeysMapToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1375,10 +1072,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sDiff(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES), hasItems(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sDiffShouldWorkWhenKeysNotMapToSameSlot() {
 
 		nativeConnection.sadd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1387,10 +1081,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sDiff(KEY_1_BYTES, KEY_2_BYTES), hasItems(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sDiffStoreShouldWorkWhenKeysMapToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1401,10 +1092,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(SAME_SLOT_KEY_3_BYTES), hasItems(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sDiffStoreShouldWorkWhenKeysNotMapToSameSlot() {
 
 		nativeConnection.sadd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1415,10 +1103,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_3_BYTES), hasItems(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sMembersShouldReturnValuesContainedInSetCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1426,10 +1111,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sMembers(KEY_1_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sRandMamberShouldReturnValueCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1437,10 +1119,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sRandMember(KEY_1_BYTES), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sRandMamberWithCountShouldReturnValueCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1448,10 +1127,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sRandMember(KEY_1_BYTES, 3), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sscanShouldRetrieveAllValuesInSetCorrectly() {
 
 		for (int i = 0; i < 30; i++) {
@@ -1468,10 +1144,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(count, is(30));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zAddShouldAddValueWithScoreCorrectly() {
 
 		clusterConnection.zAdd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1480,10 +1153,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zcard(KEY_1_BYTES), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRemShouldRemoveValueWithScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1494,10 +1164,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zcard(KEY_1_BYTES), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zIncrByShouldIncScoreForValueCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1508,10 +1175,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrank(KEY_1_BYTES, VALUE_1_BYTES), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRankShouldReturnPositionForValueCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1520,10 +1184,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRank(KEY_1_BYTES, VALUE_2_BYTES), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRankShouldReturnReversePositionForValueCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1532,10 +1193,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRevRank(KEY_1_BYTES, VALUE_2_BYTES), is(0L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeShouldReturnValuesCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1545,10 +1203,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRange(KEY_1_BYTES, 1, 2), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeWithScoresShouldReturnValuesAndScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1559,10 +1214,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D), (Tuple) new DefaultTuple(VALUE_2_BYTES, 20D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByScoreShouldReturnValuesCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1572,10 +1224,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRangeByScore(KEY_1_BYTES, 10, 20), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByScoreWithScoresShouldReturnValuesAndScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1586,10 +1235,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D), (Tuple) new DefaultTuple(VALUE_2_BYTES, 20D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByScoreShouldReturnValuesCorrectlyWhenGivenOffsetAndScore() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1599,10 +1245,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRangeByScore(KEY_1_BYTES, 10D, 20D, 0L, 1L), hasItems(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByScoreWithScoresShouldReturnValuesCorrectlyWhenGivenOffsetAndScore() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1613,10 +1256,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeShouldReturnValuesCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1626,10 +1266,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRevRange(KEY_1_BYTES, 1, 2), hasItems(VALUE_3_BYTES, VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeWithScoresShouldReturnValuesAndScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1640,10 +1277,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_3_BYTES, 5D), (Tuple) new DefaultTuple(VALUE_1_BYTES, 10D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeByScoreShouldReturnValuesCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1653,10 +1287,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRevRangeByScore(KEY_1_BYTES, 10D, 20D), hasItems(VALUE_2_BYTES, VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeByScoreWithScoresShouldReturnValuesAndScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1667,10 +1298,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_2_BYTES, 20D), (Tuple) new DefaultTuple(VALUE_1_BYTES, 10D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeByScoreShouldReturnValuesCorrectlyWhenGivenOffsetAndScore() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1680,10 +1308,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRevRangeByScore(KEY_1_BYTES, 10D, 20D, 0L, 1L), hasItems(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeByScoreWithScoresShouldReturnValuesCorrectlyWhenGivenOffsetAndScore() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1694,10 +1319,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_2_BYTES, 20D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zCountShouldCountValuesInRange() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1707,10 +1329,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zCount(KEY_1_BYTES, 10, 20), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zCardShouldReturnTotalNumberOfValues() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1720,10 +1339,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zCard(KEY_1_BYTES), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zScoreShouldRetrieveScoreForValue() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1732,10 +1348,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zScore(KEY_1_BYTES, VALUE_2_BYTES), is(20D));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRemRangeShouldRemoveValues() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1748,10 +1361,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrange(KEY_1_BYTES, 0, -1), hasItem(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRemRangeByScoreShouldRemoveValues() {
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1764,10 +1374,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrange(KEY_1_BYTES, 0, -1), hasItems(VALUE_1_BYTES, VALUE_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zUnionStoreShouldWorkForSameSlotKeys() {
 
 		nativeConnection.zadd(SAME_SLOT_KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1780,18 +1387,12 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				hasItems(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void zUnionStoreShouldThrowExceptionWhenKeysDoNotMapToSameSlots() {
 		clusterConnection.zUnionStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zInterStoreShouldWorkForSameSlotKeys() {
 
 		nativeConnection.zadd(SAME_SLOT_KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1805,18 +1406,12 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrange(SAME_SLOT_KEY_3_BYTES, 0, -1), hasItems(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void zInterStoreShouldThrowExceptionWhenKeysDoNotMapToSameSlots() {
 		clusterConnection.zInterStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES);
 	}
 
-	/**
-	 * @see DATAREDIS-479
-	 */
-	@Test
+	@Test // DATAREDIS-479
 	public void zScanShouldReadEntireValueRange() {
 
 		int nrOfValues = 321;
@@ -1836,10 +1431,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(count, equalTo(nrOfValues));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hSetShouldSetValueCorrectly() {
 
 		clusterConnection.hSet(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1847,10 +1439,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1_BYTES, KEY_2_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hSetNXShouldSetValueCorrectly() {
 
 		clusterConnection.hSetNX(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1858,10 +1447,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1_BYTES, KEY_2_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hSetNXShouldNotSetValueWhenAlreadyExists() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1871,10 +1457,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1_BYTES, KEY_2_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hGetShouldRetrieveValueCorrectly() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1882,10 +1465,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_2_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hMGetShouldRetrieveValueCorrectly() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1894,10 +1474,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hMGet(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hMSetShouldAddValuesCorrectly() {
 
 		Map<byte[], byte[]> hashes = new HashMap<byte[], byte[]>();
@@ -1909,10 +1486,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hmget(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hIncrByShouldIncreaseFieldCorretly() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, JedisConverters.toBytes(1L));
@@ -1923,10 +1497,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1_BYTES, KEY_3_BYTES), is(JedisConverters.toBytes(5L)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hIncrByFloatShouldIncreaseFieldCorretly() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, JedisConverters.toBytes(1L));
@@ -1937,10 +1508,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1_BYTES, KEY_3_BYTES), is(JedisConverters.toBytes(5.5D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hExistsShouldReturnPresenceOfFieldCorrectly() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1950,10 +1518,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hExists(JedisConverters.toBytes("foo"), KEY_2_BYTES), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hDelShouldRemoveFieldsCorrectly() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1965,10 +1530,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hexists(KEY_1_BYTES, KEY_3_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hLenShouldRetrieveSizeCorrectly() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1977,10 +1539,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hLen(KEY_1_BYTES), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hKeysShouldRetrieveKeysCorrectly() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1989,10 +1548,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hKeys(KEY_1_BYTES), hasItems(KEY_2_BYTES, KEY_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hValsShouldRetrieveValuesCorrectly() {
 
 		nativeConnection.hset(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -2001,10 +1557,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hVals(KEY_1_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hGetAllShouldRetrieveEntriesCorrectly() {
 
 		Map<byte[], byte[]> hashes = new HashMap<byte[], byte[]>();
@@ -2019,10 +1572,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(hGetAll.containsKey(KEY_3_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-479
-	 */
-	@Test
+	@Test // DATAREDIS-479
 	public void hScanShouldReadEntireValueRange() {
 
 		int nrOfValues = 321;
@@ -2043,98 +1593,62 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(i, is(nrOfValues));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void multiShouldThrowException() {
 		clusterConnection.multi();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void execShouldThrowException() {
 		clusterConnection.exec();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void discardShouldThrowException() {
 		clusterConnection.discard();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void watchShouldThrowException() {
 		clusterConnection.watch();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void unwatchShouldThrowException() {
 		clusterConnection.unwatch();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void selectShouldAllowSelectionOfDBIndexZero() {
 		clusterConnection.select(0);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void selectShouldThrowExceptionWhenSelectingNonZeroDbIndex() {
 		clusterConnection.select(1);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void echoShouldReturnInputCorrectly() {
 		assertThat(clusterConnection.echo(VALUE_1_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pingShouldRetrunPongForExistingNode() {
 		assertThat(clusterConnection.ping(new RedisClusterNode("127.0.0.1", 7379, null)), is("PONG"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pingShouldRetrunPong() {
 		assertThat(clusterConnection.ping(), is("PONG"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void pingShouldThrowExceptionWhenNodeNotKnownToCluster() {
 		clusterConnection.ping(new RedisClusterNode("127.0.0.1", 1234, null));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void flushDbShouldFlushAllClusterNodes() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -2146,10 +1660,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void flushDbOnSingleNodeShouldFlushOnlyGivenNodesDb() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -2161,10 +1672,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByLexShouldReturnResultCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 0, "a");
@@ -2198,34 +1706,22 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 				JedisConverters.toBytes("c"), JedisConverters.toBytes("d"))));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void infoShouldCollectionInfoFromAllClusterNodes() {
 		assertThat(Double.valueOf(clusterConnection.info().size()), closeTo(245d, 35d));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clientListShouldGetInfosForAllClients() {
 		assertThat(clusterConnection.getClientList().isEmpty(), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getClusterNodeForKeyShouldReturnNodeCorrectly() {
 		assertThat((RedisNode) clusterConnection.clusterGetNodeForKey(KEY_1_BYTES), is(new RedisNode("127.0.0.1", 7380)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void countKeysShouldReturnNumberOfKeysInSlot() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1);
@@ -2234,10 +1730,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.clusterCountKeysInSlot(ClusterSlotHashUtil.calculateSlot(SAME_SLOT_KEY_1)), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pfAddShouldAddValuesCorrectly() {
 
 		clusterConnection.pfAdd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES);
@@ -2245,10 +1738,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.pfcount(KEY_1_BYTES), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pfCountShouldAllowCountingOnSingleKey() {
 
 		nativeConnection.pfadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
@@ -2256,10 +1746,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.pfCount(KEY_1_BYTES), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pfCountShouldAllowCountingOnSameSlotKeys() {
 
 		nativeConnection.pfadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -2268,10 +1755,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.pfCount(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void pfCountShouldThrowErrorCountingOnDifferentSlotKeys() {
 
 		nativeConnection.pfadd(KEY_1, VALUE_1, VALUE_2);
@@ -2280,10 +1764,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		clusterConnection.pfCount(KEY_1_BYTES, KEY_2_BYTES);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pfMergeShouldWorkWhenAllKeysMapToSameSlot() {
 
 		nativeConnection.pfadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -2294,18 +1775,12 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.pfcount(SAME_SLOT_KEY_3), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void pfMergeShouldThrowErrorOnDifferentSlotKeys() {
 		clusterConnection.pfMerge(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void infoShouldCollectInfoForSpecificNode() {
 
 		Properties properties = clusterConnection.info(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT));
@@ -2313,10 +1788,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(properties.getProperty("tcp_port"), is(Integer.toString(MASTER_NODE_2_PORT)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void infoShouldCollectInfoForSpecificNodeAndSection() {
 
 		Properties properties = clusterConnection.info(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT), "server");
@@ -2325,10 +1797,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(properties.getProperty("used_memory"), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getConfigShouldLoadCumulatedConfiguration() {
 
 		List<String> result = clusterConnection.getConfig("*max-*-entries*");
@@ -2346,10 +1815,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getConfigShouldLoadConfigurationOfSpecificNode() {
 
 		List<String> result = clusterConnection.getConfig(new RedisClusterNode(CLUSTER_HOST, SLAVEOF_NODE_1_PORT), "*");
@@ -2369,10 +1835,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.get(valueIndex), endsWith("7379"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterGetSlavesShouldReturnSlaveCorrectly() {
 
 		Set<RedisClusterNode> slaves = clusterConnection
@@ -2382,10 +1845,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(slaves, hasItem(new RedisClusterNode(CLUSTER_HOST, SLAVEOF_NODE_1_PORT)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterGetMasterSlaveMapShouldListMastersAndSlavesCorrectly() {
 
 		Map<RedisClusterNode, Collection<RedisClusterNode>> masterSlaveMap = clusterConnection.clusterGetMasterSlaveMap();
@@ -2398,10 +1858,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(masterSlaveMap.get(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_3_PORT)).isEmpty(), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationInSecondsShouldWorkCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.upsert());
@@ -2410,10 +1867,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1_BYTES), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationInMillisecondsShouldWorkCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.milliseconds(500), SetOption.upsert());
@@ -2422,20 +1876,14 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.pttl(KEY_1).doubleValue(), is(closeTo(500d, 499d)));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-316
 	public void setWithOptionIfPresentShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
 		clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.persistent(), SetOption.ifPresent());
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithOptionIfAbsentShouldWorkCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.persistent(), SetOption.ifAbsent());
@@ -2444,10 +1892,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1_BYTES), is(-1L));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationAndIfAbsentShouldWorkCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifAbsent());
@@ -2456,10 +1901,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1_BYTES), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationAndIfAbsentShouldNotBeAppliedWhenKeyExists() {
 
 		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
@@ -2471,10 +1913,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1_BYTES), is(equalTo(VALUE_1_BYTES)));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationAndIfPresentShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
@@ -2486,10 +1925,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1_BYTES), is(equalTo(VALUE_2_BYTES)));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationAndIfPresentShouldNotBeAppliedWhenKeyDoesNotExists() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifPresent());
@@ -2497,28 +1933,19 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_1_BYTES), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoAddSingleGeoLocation() {
 		assertThat(clusterConnection.geoAdd(KEY_1_BYTES, PALERMO), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoAddMultipleGeoLocations() {
 		assertThat(clusterConnection.geoAdd(KEY_1_BYTES, Arrays.asList(PALERMO, ARIGENTO, CATANIA, PALERMO)), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoDist() {
 
@@ -2531,10 +1958,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(distance.getUnit(), is("m"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoDistWithMetric() {
 
@@ -2548,10 +1972,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoHash() {
 
@@ -2562,10 +1983,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result, contains("sqc8b49rny0", "sqdtr74hyu0"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoHashNonExisting() {
 
@@ -2577,10 +1995,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result, contains("sqc8b49rny0", (String) null, "sqdtr74hyu0"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoPosition() {
 
@@ -2596,10 +2011,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(positions.get(1).getY(), is(closeTo(POINT_CATANIA.getY(), 0.005)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoPositionNonExisting() {
 
@@ -2618,10 +2030,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(positions.get(2).getY(), is(closeTo(POINT_CATANIA.getY(), 0.005)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusShouldReturnMembersCorrectly() {
 
@@ -2634,10 +2043,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusShouldReturnDistanceCorrectly() {
 
@@ -2653,10 +2059,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent().get(0).getDistance().getUnit(), is("km"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusShouldApplyLimit() {
 
@@ -2670,10 +2073,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusByMemberShouldReturnMembersCorrectly() {
 
@@ -2688,10 +2088,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent().get(1).getContent().getName(), is(ARIGENTO.getName()));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusByMemberShouldReturnDistanceCorrectly() {
 
@@ -2707,10 +2104,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent().get(0).getDistance().getUnit(), is("km"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusByMemberShouldApplyLimit() {
 
@@ -2724,10 +2118,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRemoveDeletesMembers() {
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,10 +103,7 @@ public class JedisClusterConnectionUnitTests {
 		connection = new JedisClusterConnection(clusterMock);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void thowsExceptionWhenClusterCommandExecturorIsNull() {
 
 		expectedException.expect(IllegalArgumentException.class);
@@ -114,10 +111,7 @@ public class JedisClusterConnectionUnitTests {
 		new JedisClusterConnection(clusterMock, null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterMeetShouldSendCommandsToExistingNodesCorrectly() {
 
 		connection.clusterMeet(UNKNOWN_CLUSTER_NODE);
@@ -127,10 +121,7 @@ public class JedisClusterConnectionUnitTests {
 		verify(con2Mock, times(1)).clusterMeet(UNKNOWN_CLUSTER_NODE.getHost(), UNKNOWN_CLUSTER_NODE.getPort());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterMeetShouldThrowExceptionWhenNodeIsNull() {
 
 		expectedException.expect(IllegalArgumentException.class);
@@ -138,10 +129,7 @@ public class JedisClusterConnectionUnitTests {
 		connection.clusterMeet(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterForgetShouldSendCommandsToRemainingNodesCorrectly() {
 
 		connection.clusterForget(CLUSTER_NODE_2);
@@ -151,10 +139,7 @@ public class JedisClusterConnectionUnitTests {
 		verify(con3Mock, times(1)).clusterForget(CLUSTER_NODE_2.getId());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterReplicateShouldSendCommandsCorrectly() {
 
 		connection.clusterReplicate(CLUSTER_NODE_1, CLUSTER_NODE_2);
@@ -164,10 +149,7 @@ public class JedisClusterConnectionUnitTests {
 		verifyZeroInteractions(con1Mock);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void closeShouldNotCloseUnderlyingClusterPool() throws IOException {
 
 		connection.close();
@@ -175,10 +157,7 @@ public class JedisClusterConnectionUnitTests {
 		verify(clusterMock, never()).close();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void isClosedShouldReturnConnectionStateCorrectly() {
 
 		assertThat(connection.isClosed(), is(false));
@@ -188,10 +167,7 @@ public class JedisClusterConnectionUnitTests {
 		assertThat(connection.isClosed(), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterInfoShouldBeReturnedCorrectly() {
 
 		when(con1Mock.clusterInfo()).thenReturn(CLUSTER_INFO_RESPONSE);
@@ -204,10 +180,7 @@ public class JedisClusterConnectionUnitTests {
 		verifyInvocationsAcross("clusterInfo", times(1), con1Mock, con2Mock, con3Mock);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotImportingShouldBeExecutedCorrectly() {
 
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, AddSlots.IMPORTING);
@@ -215,10 +188,7 @@ public class JedisClusterConnectionUnitTests {
 		verify(con1Mock, times(1)).clusterSetSlotImporting(eq(100), eq(CLUSTER_NODE_1.getId()));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotMigratingShouldBeExecutedCorrectly() {
 
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, AddSlots.MIGRATING);
@@ -226,10 +196,7 @@ public class JedisClusterConnectionUnitTests {
 		verify(con1Mock, times(1)).clusterSetSlotMigrating(eq(100), eq(CLUSTER_NODE_1.getId()));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotStableShouldBeExecutedCorrectly() {
 
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, AddSlots.STABLE);
@@ -237,10 +204,7 @@ public class JedisClusterConnectionUnitTests {
 		verify(con1Mock, times(1)).clusterSetSlotStable(eq(100));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotNodeShouldBeExecutedCorrectly() {
 
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, AddSlots.NODE);
@@ -248,10 +212,7 @@ public class JedisClusterConnectionUnitTests {
 		verify(con1Mock, times(1)).clusterSetSlotNode(eq(100), eq(CLUSTER_NODE_1.getId()));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotShouldBeExecutedOnTargetNodeWhenNodeIdNotSet() {
 
 		connection.clusterSetSlot(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT), 100, AddSlots.IMPORTING);
@@ -259,18 +220,12 @@ public class JedisClusterConnectionUnitTests {
 		verify(con2Mock, times(1)).clusterSetSlotImporting(eq(100), eq(CLUSTER_NODE_2.getId()));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void clusterSetSlotShouldThrowExceptionWhenModeIsNull() {
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterDeleteSlotsShouldBeExecutedCorrectly() {
 
 		int[] slots = new int[] { 9000, 10000 };
@@ -279,18 +234,12 @@ public class JedisClusterConnectionUnitTests {
 		verify(con2Mock, times(1)).clusterDelSlots((int[]) anyVararg());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void clusterDeleteSlotShouldThrowExceptionWhenNodeIsNull() {
 		connection.clusterDeleteSlots(null, new int[] { 1 });
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void timeShouldBeExecutedOnArbitraryNode() {
 
 		List<String> values = Arrays.asList("1449655759", "92217");
@@ -303,10 +252,7 @@ public class JedisClusterConnectionUnitTests {
 		verifyInvocationsAcross("time", times(1), con1Mock, con2Mock, con3Mock);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void timeShouldBeExecutedOnSingleNode() {
 
 		when(con2Mock.time()).thenReturn(Arrays.asList("1449655759", "92217"));
@@ -318,10 +264,7 @@ public class JedisClusterConnectionUnitTests {
 		verifyZeroInteractions(con1Mock, con3Mock);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void resetConfigStatsShouldBeExecutedOnAllNodes() {
 
 		connection.resetConfigStats();
@@ -331,10 +274,7 @@ public class JedisClusterConnectionUnitTests {
 		verify(con3Mock, times(1)).configResetStat();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void resetConfigStatsShouldBeExecutedOnSingleNodeCorrectly() {
 
 		connection.resetConfigStats(CLUSTER_NODE_2);
@@ -344,10 +284,7 @@ public class JedisClusterConnectionUnitTests {
 		verify(con3Mock, never()).configResetStat();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterTopologyProviderShouldCollectErrorsWhenLoadingNodes() {
 
 		expectedException.expect(ClusterStateFailureException.class);

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,18 +49,12 @@ public class JedisConnectionFactoryTests {
 		factory.destroy();
 	}
 
-	/**
-	 * @see DATAREDIS-324
-	 */
-	@Test
+	@Test // DATAREDIS-324
 	public void shouldSendCommandCorrectlyViaConnectionFactoryUsingSentinel() {
 		assertThat(factory.getConnection().ping(), equalTo("PONG"));
 	}
 
-	/**
-	 * @see DATAREDIS-552
-	 */
-	@Test
+	@Test // DATAREDIS-552
 	public void getClientNameShouldEqualWithFactorySetting() {
 		assertThat(factory.getConnection().getClientName(), equalTo("clientName"));
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryTests.java
@@ -39,6 +39,7 @@ public class JedisConnectionFactoryTests {
 	@Before
 	public void setUp() {
 		factory = new JedisConnectionFactory(SENTINEL_CONFIG);
+		factory.setClientName("clientName");
 		factory.afterPropertiesSet();
 	}
 
@@ -53,5 +54,10 @@ public class JedisConnectionFactoryTests {
 	@Test
 	public void shouldSendCommandCorrectlyViaConnectionFactoryUsingSentinel() {
 		assertThat(factory.getConnection().ping(), equalTo("PONG"));
+	}
+	
+	@Test
+	public void getClientNameShouldEqualWithFactorySetting() {
+		assertThat(factory.getConnection().getClientName(), equalTo("clientName"));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.data.redis.test.util.RedisSentinelRule;
 
 /**
  * @author Christoph Strobl
+ * @author Fu Jian
  */
 public class JedisConnectionFactoryTests {
 
@@ -55,7 +56,10 @@ public class JedisConnectionFactoryTests {
 	public void shouldSendCommandCorrectlyViaConnectionFactoryUsingSentinel() {
 		assertThat(factory.getConnection().ping(), equalTo("PONG"));
 	}
-	
+
+	/**
+	 * @see DATAREDIS-552
+	 */
 	@Test
 	public void getClientNameShouldEqualWithFactorySetting() {
 		assertThat(factory.getConnection().getClientName(), equalTo("clientName"));

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,10 +42,7 @@ public class JedisConnectionFactoryUnitTests {
 	private static final RedisClusterConfiguration CLUSTER_CONFIG = new RedisClusterConfiguration().clusterNode(
 			"127.0.0.1", 6379).clusterNode("127.0.0.1", 6380);
 
-	/**
-	 * @see DATAREDIS-324
-	 */
-	@Test
+	@Test // DATAREDIS-324
 	public void shouldInitSentinelPoolWhenSentinelConfigPresent() {
 
 		connectionFactory = initSpyedConnectionFactory(SINGLE_SENTINEL_CONFIG, new JedisPoolConfig());
@@ -55,10 +52,7 @@ public class JedisConnectionFactoryUnitTests {
 		verify(connectionFactory, never()).createRedisPool();
 	}
 
-	/**
-	 * @see DATAREDIS-324
-	 */
-	@Test
+	@Test // DATAREDIS-324
 	public void shouldInitJedisPoolWhenNoSentinelConfigPresent() {
 
 		connectionFactory = initSpyedConnectionFactory((RedisSentinelConfiguration) null, new JedisPoolConfig());
@@ -68,10 +62,7 @@ public class JedisConnectionFactoryUnitTests {
 		verify(connectionFactory, never()).createRedisSentinelPool(Matchers.any(RedisSentinelConfiguration.class));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldInitConnectionCorrectlyWhenClusterConfigPresent() {
 
 		connectionFactory = initSpyedConnectionFactory(CLUSTER_CONFIG, new JedisPoolConfig());
@@ -82,11 +73,7 @@ public class JedisConnectionFactoryUnitTests {
 		verify(connectionFactory, never()).createRedisPool();
 	}
 
-	/**
-	 * @throws IOException
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldClostClusterCorrectlyOnFactoryDestruction() throws IOException {
 
 		JedisCluster clusterMock = mock(JedisCluster.class);

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.jedis;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -62,6 +61,7 @@ import redis.clients.jedis.JedisPoolConfig;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author David Liu
+ * @author Mark Paluch
  */
 @RunWith(RelaxedJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -400,6 +400,14 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 		((JedisConnection) byteConnection).setSentinelConfiguration(new RedisSentinelConfiguration().master("mymaster")
 				.sentinel("127.0.0.1", 26379).sentinel("127.0.0.1", 26380));
 		assertThat(connection.getSentinelConnection(), notNullValue());
+	}
+
+	/**
+	 * @see DATAREDIS-552
+	 */
+	@Test
+	public void shouldSetClientName() {
+		assertThat(connection.getClientName(), is(equalTo("jedis-client")));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -343,11 +343,8 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 		factory2.destroy();
 	}
 
-	/**
-	 * @see DATAREDIS-285
-	 */
 	@SuppressWarnings("unchecked")
-	@Test
+	@Test // DATAREDIS-285
 	public void testExecuteShouldConvertArrayReplyCorrectly() {
 		connection.set("spring", "awesome");
 		connection.set("data", "cool");
@@ -359,10 +356,7 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 						"cool".getBytes(), "supercalifragilisticexpialidocious".getBytes())));
 	}
 
-	/**
-	 * @see DATAREDIS-286
-	 */
-	@Test
+	@Test // DATAREDIS-286
 	public void expireShouldSupportExiprationForValuesLargerThanInteger() {
 
 		connection.set("expireKey", "foo");
@@ -374,10 +368,7 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 		assertThat(ttl, is(seconds));
 	}
 
-	/**
-	 * @see DATAREDIS-286
-	 */
-	@Test
+	@Test // DATAREDIS-286
 	public void pExpireShouldSupportExiprationForValuesLargerThanInteger() {
 
 		connection.set("pexpireKey", "foo");
@@ -390,10 +381,7 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 				millis, ttl, millis - ttl), millis - ttl < 20L);
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	@RequiresRedisSentinel(SentinelsAvailable.ONE_ACTIVE)
 	public void shouldReturnSentinelCommandsWhenWhenActiveSentinelFound() {
 
@@ -402,18 +390,12 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 		assertThat(connection.getSentinelConnection(), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-552
-	 */
-	@Test
+	@Test // DATAREDIS-552
 	public void shouldSetClientName() {
 		assertThat(connection.getClientName(), is(equalTo("jedis-client")));
 	}
 
-	/**
-	 * @see DATAREDIS-106
-	 */
-	@Test
+	@Test // DATAREDIS-106
 	public void zRangeByScoreTest() {
 
 		connection.zAdd("myzset", 1, "one");

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
@@ -356,7 +356,7 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 						"cool".getBytes(), "supercalifragilisticexpialidocious".getBytes())));
 	}
 
-	@Test // DATAREDIS-286
+	@Test // DATAREDIS-286, DATAREDIS-564
 	public void expireShouldSupportExiprationForValuesLargerThanInteger() {
 
 		connection.set("expireKey", "foo");

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,27 +255,18 @@ public class JedisConnectionPipelineIntegrationTests extends AbstractConnectionP
 		super.testZAddMultiple();
 	}
 
-	/**
-	 * @see DATAREDIS-269
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-269
 	public void clientSetNameWorksCorrectly() {
 		super.clientSetNameWorksCorrectly();
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
 	@Override
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-268
 	public void testListClientsContainsAtLeastOneElement() {
 		super.testListClientsContainsAtLeastOneElement();
 	}
 
-	/**
-	 * @see DATAREDIS-296
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAREDIS-296
 	public void testExecWithoutMulti() {
 		super.testExecWithoutMulti();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineTxIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineTxIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,11 +69,8 @@ public class JedisConnectionPipelineTxIntegrationTests extends JedisConnectionTr
 		return txResults;
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
 	@Override
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-268
 	public void testListClientsContainsAtLeastOneElement() {
 		super.testListClientsContainsAtLeastOneElement();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionTransactionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionTransactionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,19 +198,13 @@ public class JedisConnectionTransactionIntegrationTests extends AbstractConnecti
 		super.testRestoreExistingKey();
 	}
 
-	/**
-	 * @see DATAREDIS-269
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-269
 	public void clientSetNameWorksCorrectly() {
 		super.clientSetNameWorksCorrectly();
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
 	@Override
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-268
 	public void testListClientsContainsAtLeastOneElement() {
 		super.testListClientsContainsAtLeastOneElement();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTestSuite.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,10 +63,7 @@ public class JedisConnectionUnitTestSuite {
 			connection = new JedisConnection(jedisSpy);
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithNullShouldDelegateCommandCorrectly() {
 
 			connection.shutdown(null);
@@ -74,10 +71,7 @@ public class JedisConnectionUnitTestSuite {
 			verifyNativeConnectionInvocation().shutdown();
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownNosaveShouldBeSentCorrectlyUsingLuaScript() {
 
 			connection.shutdown(ShutdownOption.NOSAVE);
@@ -88,10 +82,7 @@ public class JedisConnectionUnitTestSuite {
 			assertThat(captor.getValue(), equalTo("return redis.call('SHUTDOWN','NOSAVE')".getBytes()));
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownSaveShouldBeSentCorrectlyUsingLuaScript() {
 
 			connection.shutdown(ShutdownOption.SAVE);
@@ -102,122 +93,80 @@ public class JedisConnectionUnitTestSuite {
 			assertThat(captor.getValue(), equalTo("return redis.call('SHUTDOWN','SAVE')".getBytes()));
 		}
 
-		/**
-		 * @see DATAREDIS-267
-		 */
-		@Test
+		@Test // DATAREDIS-267
 		public void killClientShouldDelegateCallCorrectly() {
 
 			connection.killClient("127.0.0.1", 1001);
 			verifyNativeConnectionInvocation().clientKill(eq("127.0.0.1:1001"));
 		}
 
-		/**
-		 * @see DATAREDIS-270
-		 */
-		@Test
+		@Test // DATAREDIS-270
 		public void getClientNameShouldSendRequestCorrectly() {
 
 			connection.getClientName();
 			verifyNativeConnectionInvocation().clientGetname();
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-277
 		public void slaveOfShouldThrowExectpionWhenCalledForNullHost() {
 			connection.slaveOf(null, 0);
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test
+		@Test // DATAREDIS-277
 		public void slaveOfShouldBeSentCorrectly() {
 
 			connection.slaveOf("127.0.0.1", 1001);
 			verifyNativeConnectionInvocation().slaveof(eq("127.0.0.1"), eq(1001));
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test
+		@Test // DATAREDIS-277
 		public void slaveOfNoOneShouldBeSentCorrectly() {
 
 			connection.slaveOfNoOne();
 			verifyNativeConnectionInvocation().slaveofNoOne();
 		}
 
-		/**
-		 * @see DATAREDIS-330
-		 */
-		@Test(expected = InvalidDataAccessResourceUsageException.class)
+		@Test(expected = InvalidDataAccessResourceUsageException.class) // DATAREDIS-330
 		public void shouldThrowExceptionWhenAccessingRedisSentinelsCommandsWhenNoSentinelsConfigured() {
 			connection.getSentinelConnection();
 		}
 
-		/**
-		 * @see DATAREDIS-472
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-472
 		public void restoreShouldThrowExceptionWhenTtlInMillisExceedsIntegerRange() {
 			connection.restore("foo".getBytes(), new Long(Integer.MAX_VALUE) + 1L, "bar".getBytes());
 		}
 
-		/**
-		 * @see DATAREDIS-472
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-472
 		public void setExShouldThrowExceptionWhenTimeExceedsIntegerRange() {
 			connection.setEx("foo".getBytes(), new Long(Integer.MAX_VALUE) + 1L, "bar".getBytes());
 		}
 
-		/**
-		 * @see DATAREDIS-472
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-472
 		public void getRangeShouldThrowExceptionWhenStartExceedsIntegerRange() {
 			connection.getRange("foo".getBytes(), new Long(Integer.MAX_VALUE) + 1L, Integer.MAX_VALUE);
 		}
 
-		/**
-		 * @see DATAREDIS-472
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-472
 		public void getRangeShouldThrowExceptionWhenEndExceedsIntegerRange() {
 			connection.getRange("foo".getBytes(), Integer.MAX_VALUE, new Long(Integer.MAX_VALUE) + 1L);
 		}
 
-		/**
-		 * @see DATAREDIS-472
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-472
 		public void sRandMemberShouldThrowExceptionWhenCountExceedsIntegerRange() {
 			connection.sRandMember("foo".getBytes(), new Long(Integer.MAX_VALUE) + 1L);
 		}
 
-		/**
-		 * @see DATAREDIS-472
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-472
 		public void zRangeByScoreShouldThrowExceptionWhenOffsetExceedsIntegerRange() {
 			connection.zRangeByScore("foo".getBytes(), "foo", "bar", new Long(Integer.MAX_VALUE) + 1L, Integer.MAX_VALUE);
 		}
 
-		/**
-		 * @see DATAREDIS-472
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-472
 		public void zRangeByScoreShouldThrowExceptionWhenCountExceedsIntegerRange() {
 			connection.zRangeByScore("foo".getBytes(), "foo", "bar", Integer.MAX_VALUE, new Long(Integer.MAX_VALUE) + 1L);
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test
+		@Test // DATAREDIS-531
 		public void scanShouldKeepTheConnectionOpen() {
 
 			doReturn(new ScanResult<String>("0", Collections.<String> emptyList())).when(jedisSpy).scan(anyString(),
@@ -228,10 +177,7 @@ public class JedisConnectionUnitTestSuite {
 			verify(jedisSpy, never()).quit();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test
+		@Test // DATAREDIS-531
 		public void scanShouldCloseTheConnectionWhenCursorIsClosed() throws IOException {
 
 			doReturn(new ScanResult<String>("0", Collections.<String> emptyList())).when(jedisSpy).scan(anyString(),
@@ -243,10 +189,7 @@ public class JedisConnectionUnitTestSuite {
 			verify(jedisSpy, times(1)).quit();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test
+		@Test // DATAREDIS-531
 		public void sScanShouldKeepTheConnectionOpen() {
 
 			doReturn(new ScanResult<String>("0", Collections.<String> emptyList())).when(jedisSpy).sscan(any(byte[].class),
@@ -257,10 +200,7 @@ public class JedisConnectionUnitTestSuite {
 			verify(jedisSpy, never()).quit();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test
+		@Test // DATAREDIS-531
 		public void sScanShouldCloseTheConnectionWhenCursorIsClosed() throws IOException {
 
 			doReturn(new ScanResult<String>("0", Collections.<String> emptyList())).when(jedisSpy).sscan(any(byte[].class),
@@ -272,10 +212,7 @@ public class JedisConnectionUnitTestSuite {
 			verify(jedisSpy, times(1)).quit();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test
+		@Test // DATAREDIS-531
 		public void zScanShouldKeepTheConnectionOpen() {
 
 			doReturn(new ScanResult<String>("0", Collections.<String> emptyList())).when(jedisSpy).zscan(any(byte[].class),
@@ -286,10 +223,7 @@ public class JedisConnectionUnitTestSuite {
 			verify(jedisSpy, never()).quit();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test
+		@Test // DATAREDIS-531
 		public void zScanShouldCloseTheConnectionWhenCursorIsClosed() throws IOException {
 
 			doReturn(new ScanResult<String>("0", Collections.<String> emptyList())).when(jedisSpy).zscan(any(byte[].class),
@@ -301,10 +235,7 @@ public class JedisConnectionUnitTestSuite {
 			verify(jedisSpy, times(1)).quit();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test
+		@Test // DATAREDIS-531
 		public void hScanShouldKeepTheConnectionOpen() {
 
 			doReturn(new ScanResult<String>("0", Collections.<String> emptyList())).when(jedisSpy).hscan(any(byte[].class),
@@ -315,10 +246,7 @@ public class JedisConnectionUnitTestSuite {
 			verify(jedisSpy, never()).quit();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test
+		@Test // DATAREDIS-531
 		public void hScanShouldCloseTheConnectionWhenCursorIsClosed() throws IOException {
 
 			doReturn(new ScanResult<String>("0", Collections.<String> emptyList())).when(jedisSpy).hscan(any(byte[].class),
@@ -340,118 +268,76 @@ public class JedisConnectionUnitTestSuite {
 			connection.openPipeline();
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
 		@Override
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-184
 		public void shutdownNosaveShouldBeSentCorrectlyUsingLuaScript() {
 			super.shutdownNosaveShouldBeSentCorrectlyUsingLuaScript();
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
 		@Override
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-184
 		public void shutdownSaveShouldBeSentCorrectlyUsingLuaScript() {
 			super.shutdownSaveShouldBeSentCorrectlyUsingLuaScript();
 		}
 
-		/**
-		 * @see DATAREDIS-267
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-267
 		public void killClientShouldDelegateCallCorrectly() {
 			super.killClientShouldDelegateCallCorrectly();
 		}
 
-		/**
-		 * @see DATAREDIS-270
-		 */
 		@Override
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-270
 		public void getClientNameShouldSendRequestCorrectly() {
 			super.getClientNameShouldSendRequestCorrectly();
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
 		@Override
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-277
 		public void slaveOfShouldBeSentCorrectly() {
 			super.slaveOfShouldBeSentCorrectly();
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-277
 		public void slaveOfNoOneShouldBeSentCorrectly() {
 			super.slaveOfNoOneShouldBeSentCorrectly();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-531
 		public void scanShouldKeepTheConnectionOpen() {
 			super.scanShouldKeepTheConnectionOpen();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-531
 		public void scanShouldCloseTheConnectionWhenCursorIsClosed() throws IOException {
 			super.scanShouldCloseTheConnectionWhenCursorIsClosed();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-531
 		public void sScanShouldKeepTheConnectionOpen() {
 			super.sScanShouldKeepTheConnectionOpen();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-531
 		public void sScanShouldCloseTheConnectionWhenCursorIsClosed() throws IOException {
 			super.sScanShouldCloseTheConnectionWhenCursorIsClosed();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-531
 		public void zScanShouldKeepTheConnectionOpen() {
 			super.zScanShouldKeepTheConnectionOpen();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-531
 		public void zScanShouldCloseTheConnectionWhenCursorIsClosed() throws IOException {
 			super.zScanShouldCloseTheConnectionWhenCursorIsClosed();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-531
 		public void hScanShouldKeepTheConnectionOpen() {
 			super.hScanShouldKeepTheConnectionOpen();
 		}
 
-		/**
-		 * @see DATAREDIS-531
-		 */
-		@Test(expected = UnsupportedOperationException.class)
+		@Test(expected = UnsupportedOperationException.class) // DATAREDIS-531
 		public void hScanShouldCloseTheConnectionWhenCursorIsClosed() throws IOException {
 			super.hScanShouldCloseTheConnectionWhenCursorIsClosed();
 		}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,26 +41,17 @@ public class JedisConvertersUnitTests {
 
 	private static final String CLIENT_ALL_SINGLE_LINE_RESPONSE = "addr=127.0.0.1:60311 fd=6 name= age=4059 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=client";
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingEmptyStringToListOfRedisClientInfoShouldReturnEmptyList() {
 		assertThat(JedisConverters.toListOfRedisClientInformation(""), equalTo(Collections.<RedisClientInfo> emptyList()));
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingNullToListOfRedisClientInfoShouldReturnEmptyList() {
 		assertThat(JedisConverters.toListOfRedisClientInformation(null), equalTo(Collections.<RedisClientInfo> emptyList()));
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingMultipleLiesToListOfRedisClientInfoReturnsListCorrectly() {
 
 		StringBuilder sb = new StringBuilder();
@@ -71,10 +62,7 @@ public class JedisConvertersUnitTests {
 		assertThat(JedisConverters.toListOfRedisClientInformation(sb.toString()).size(), equalTo(2));
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void convertsSingleMapToRedisServerReturnsCollectionCorrectly() {
 
 		Map<String, String> values = getRedisServerInfoMap("mymaster", 23697);
@@ -84,10 +72,7 @@ public class JedisConvertersUnitTests {
 		verifyRedisServerInfo(servers.get(0), values);
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void convertsMultipleMapsToRedisServerReturnsCollectionCorrectly() {
 
 		List<Map<String, String>> vals = Arrays.asList(getRedisServerInfoMap("mymaster", 23697),
@@ -100,18 +85,12 @@ public class JedisConvertersUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void convertsRedisServersCorrectlyWhenGivenAnEmptyList() {
 		assertThat(JedisConverters.toListOfRedisServer(Collections.<Map<String, String>> emptyList()), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void convertsRedisServersCorrectlyWhenGivenNull() {
 		assertThat(JedisConverters.toListOfRedisServer(null), notNullValue());
 	}
@@ -126,10 +105,7 @@ public class JedisConvertersUnitTests {
 		assertThat(JedisConverters.boundaryToBytesForZRangeByLex(null, defaultValue), is(defaultValue));
 	}
 
-	/**
-	 * @see DATAREDIS-378
-	 */
-	@Test
+	@Test // DATAREDIS-378
 	public void boundaryToBytesForZRangeByLexShouldReturnDefaultValueWhenBoundaryValueIsNull() {
 
 		byte[] defaultValue = "tyrion".getBytes();
@@ -138,10 +114,7 @@ public class JedisConvertersUnitTests {
 				is(defaultValue));
 	}
 
-	/**
-	 * @see DATAREDIS-378
-	 */
-	@Test
+	@Test // DATAREDIS-378
 	public void boundaryToBytesForZRangeByLexShouldReturnValueCorrectlyWhenBoundaryIsIncluing() {
 
 		assertThat(
@@ -149,10 +122,7 @@ public class JedisConvertersUnitTests {
 				is(JedisConverters.toBytes("[a")));
 	}
 
-	/**
-	 * @see DATAREDIS-378
-	 */
-	@Test
+	@Test // DATAREDIS-378
 	public void boundaryToBytesForZRangeByLexShouldReturnValueCorrectlyWhenBoundaryIsExcluding() {
 
 		assertThat(
@@ -160,38 +130,26 @@ public class JedisConvertersUnitTests {
 				is(JedisConverters.toBytes("(a")));
 	}
 
-	/**
-	 * @see DATAREDIS-378
-	 */
-	@Test
+	@Test // DATAREDIS-378
 	public void boundaryToBytesForZRangeByLexShouldReturnValueCorrectlyWhenBoundaryIsAString() {
 
 		assertThat(JedisConverters.boundaryToBytesForZRangeByLex(Range.range().gt("a").getMin(), null),
 				is(JedisConverters.toBytes("(a")));
 	}
 
-	/**
-	 * @see DATAREDIS-378
-	 */
-	@Test
+	@Test // DATAREDIS-378
 	public void boundaryToBytesForZRangeByLexShouldReturnValueCorrectlyWhenBoundaryIsANumber() {
 
 		assertThat(JedisConverters.boundaryToBytesForZRangeByLex(Range.range().gt(1L).getMin(), null),
 				is(JedisConverters.toBytes("(1")));
 	}
 
-	/**
-	 * @see DATAREDIS-378
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-378
 	public void boundaryToBytesForZRangeByLexShouldThrowExceptionWhenBoundaryHoldsUnknownType() {
 		JedisConverters.boundaryToBytesForZRangeByLex(Range.range().gt(new Date()).getMin(), null);
 	}
 
-	/**
-	 * @see DATAREDIS-352
-	 */
-	@Test
+	@Test // DATAREDIS-352
 	public void boundaryToBytesForZRangeByShouldReturnDefaultValueWhenBoundaryIsNull() {
 
 		byte[] defaultValue = "tyrion".getBytes();
@@ -199,10 +157,7 @@ public class JedisConvertersUnitTests {
 		assertThat(JedisConverters.boundaryToBytesForZRange(null, defaultValue), is(defaultValue));
 	}
 
-	/**
-	 * @see DATAREDIS-352
-	 */
-	@Test
+	@Test // DATAREDIS-352
 	public void boundaryToBytesForZRangeByShouldReturnDefaultValueWhenBoundaryValueIsNull() {
 
 		byte[] defaultValue = "tyrion".getBytes();
@@ -210,10 +165,7 @@ public class JedisConvertersUnitTests {
 		assertThat(JedisConverters.boundaryToBytesForZRange(Range.unbounded().getMax(), defaultValue), is(defaultValue));
 	}
 
-	/**
-	 * @see DATAREDIS-352
-	 */
-	@Test
+	@Test // DATAREDIS-352
 	public void boundaryToBytesForZRangeByShouldReturnValueCorrectlyWhenBoundaryIsIncluing() {
 
 		assertThat(
@@ -221,90 +173,60 @@ public class JedisConvertersUnitTests {
 				is(JedisConverters.toBytes("a")));
 	}
 
-	/**
-	 * @see DATAREDIS-352
-	 */
-	@Test
+	@Test // DATAREDIS-352
 	public void boundaryToBytesForZRangeByShouldReturnValueCorrectlyWhenBoundaryIsExcluding() {
 
 		assertThat(JedisConverters.boundaryToBytesForZRange(Range.range().gt(JedisConverters.toBytes("a")).getMin(), null),
 				is(JedisConverters.toBytes("(a")));
 	}
 
-	/**
-	 * @see DATAREDIS-352
-	 */
-	@Test
+	@Test // DATAREDIS-352
 	public void boundaryToBytesForZRangeByShouldReturnValueCorrectlyWhenBoundaryIsAString() {
 
 		assertThat(JedisConverters.boundaryToBytesForZRange(Range.range().gt("a").getMin(), null),
 				is(JedisConverters.toBytes("(a")));
 	}
 
-	/**
-	 * @see DATAREDIS-352
-	 */
-	@Test
+	@Test // DATAREDIS-352
 	public void boundaryToBytesForZRangeByShouldReturnValueCorrectlyWhenBoundaryIsANumber() {
 
 		assertThat(JedisConverters.boundaryToBytesForZRange(Range.range().gt(1L).getMin(), null),
 				is(JedisConverters.toBytes("(1")));
 	}
 
-	/**
-	 * @see DATAREDIS-352
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-352
 	public void boundaryToBytesForZRangeByShouldThrowExceptionWhenBoundaryHoldsUnknownType() {
 		JedisConverters.boundaryToBytesForZRange(Range.range().gt(new Date()).getMin(), null);
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetCommandExPxOptionShouldReturnEXforSeconds() {
 		assertThat(JedisConverters.toSetCommandExPxArgument(Expiration.seconds(100)), equalTo(JedisConverters.toBytes("EX")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetCommandExPxOptionShouldReturnEXforMilliseconds() {
 
 		assertThat(JedisConverters.toSetCommandExPxArgument(Expiration.milliseconds(100)),
 				equalTo(JedisConverters.toBytes("PX")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetCommandExPxOptionShouldReturnEmptyArrayForNull() {
 		assertThat(JedisConverters.toSetCommandExPxArgument(null), equalTo(new byte[] {}));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetCommandNxXxOptionShouldReturnNXforAbsent() {
 		assertThat(JedisConverters.toSetCommandNxXxArgument(SetOption.ifAbsent()), equalTo(JedisConverters.toBytes("NX")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetCommandNxXxOptionShouldReturnXXforAbsent() {
 		assertThat(JedisConverters.toSetCommandNxXxArgument(SetOption.ifPresent()), equalTo(JedisConverters.toBytes("XX")));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetCommandNxXxOptionShouldReturnEmptyArrayforUpsert() {
 		assertThat(JedisConverters.toSetCommandNxXxArgument(SetOption.upsert()), equalTo(new byte[] {}));
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisExceptionConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisExceptionConverterUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,10 +42,7 @@ public class JedisExceptionConverterUnitTests {
 		converter = new JedisExceptionConverter();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldConvertMovedDataException() {
 
 		DataAccessException converted = converter.convert(new JedisMovedDataException("MOVED 3999 127.0.0.1:6381",
@@ -57,10 +54,7 @@ public class JedisExceptionConverterUnitTests {
 		assertThat(((ClusterRedirectException) converted).getTargetPort(), is(6381));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldConvertAskDataException() {
 
 		DataAccessException converted = converter.convert(new JedisAskDataException("ASK 3999 127.0.0.1:6381",
@@ -72,10 +66,7 @@ public class JedisExceptionConverterUnitTests {
 		assertThat(((ClusterRedirectException) converted).getTargetPort(), is(6381));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldConvertMaxRedirectException() {
 
 		DataAccessException converted = converter

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisSentinelConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisSentinelConnectionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,19 +44,13 @@ public class JedisSentinelConnectionUnitTests {
 		this.connection = new JedisSentinelConnection(jedisMock);
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void shouldConnectAfterCreation() {
 		verify(jedisMock, times(1)).connect();
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
 	@SuppressWarnings("resource")
-	@Test
+	@Test // DATAREDIS-330
 	public void shouldNotConnectIfAlreadyConnected() {
 
 		Jedis yetAnotherJedisMock = mock(Jedis.class);
@@ -67,124 +61,82 @@ public class JedisSentinelConnectionUnitTests {
 		verify(yetAnotherJedisMock, never()).connect();
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void failoverShouldBeSentCorrectly() {
 
 		connection.failover(new RedisNodeBuilder().withName("mymaster").build());
 		verify(jedisMock, times(1)).sentinelFailover(eq("mymaster"));
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-330
 	public void failoverShouldThrowExceptionIfMasterNodeIsNull() {
 		connection.failover(null);
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-330
 	public void failoverShouldThrowExceptionIfMasterNodeNameIsEmpty() {
 		connection.failover(new RedisNodeBuilder().build());
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void mastersShouldReadMastersCorrectly() {
 
 		connection.masters();
 		verify(jedisMock, times(1)).sentinelMasters();
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void shouldReadSlavesCorrectly() {
 
 		connection.slaves("mymaster");
 		verify(jedisMock, times(1)).sentinelSlaves(eq("mymaster"));
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void shouldReadSlavesCorrectlyWhenGivenNamedNode() {
 
 		connection.slaves(new RedisNodeBuilder().withName("mymaster").build());
 		verify(jedisMock, times(1)).sentinelSlaves(eq("mymaster"));
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-330
 	public void readSlavesShouldThrowExceptionWhenGivenEmptyMasterName() {
 		connection.slaves("");
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-330
 	public void readSlavesShouldThrowExceptionWhenGivenNull() {
 		connection.slaves((RedisNode) null);
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-330
 	public void readSlavesShouldThrowExceptionWhenNodeWithoutName() {
 		connection.slaves(new RedisNodeBuilder().build());
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void shouldRemoveMasterCorrectlyWhenGivenNamedNode() {
 
 		connection.remove(new RedisNodeBuilder().withName("mymaster").build());
 		verify(jedisMock, times(1)).sentinelRemove(eq("mymaster"));
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-330
 	public void removeShouldThrowExceptionWhenGivenEmptyMasterName() {
 		connection.remove("");
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-330
 	public void removeShouldThrowExceptionWhenGivenNull() {
 		connection.remove((RedisNode) null);
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-330
 	public void removeShouldThrowExceptionWhenNodeWithoutName() {
 		connection.remove(new RedisNodeBuilder().build());
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void monitorShouldBeSentCorrectly() {
 
 		RedisServer server = new RedisServer("127.0.0.1", 6382);

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisSentinelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisSentinelIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,10 +127,7 @@ public class JedisSentinelIntegrationTests extends AbstractConnectionIntegration
 		super.testErrorInTx();
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void shouldReadMastersCorrectly() {
 
 		List<RedisServer> servers = (List<RedisServer>) connectionFactory.getSentinelConnection().masters();
@@ -138,10 +135,7 @@ public class JedisSentinelIntegrationTests extends AbstractConnectionIntegration
 		assertThat(servers.get(0).getName(), is(MASTER_NAME));
 	}
 
-	/**
-	 * @see DATAREDIS-330
-	 */
-	@Test
+	@Test // DATAREDIS-330
 	public void shouldReadSlavesOfMastersCorrectly() {
 
 		RedisSentinelConnection sentinelConnection = connectionFactory.getSentinelConnection();
@@ -154,10 +148,7 @@ public class JedisSentinelIntegrationTests extends AbstractConnectionIntegration
 		assertThat(slaves, hasItems(SLAVE_0, SLAVE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-552
-	 */
-	@Test
+	@Test // DATAREDIS-552
 	public void shouldSetClientName() {
 
 		RedisSentinelConnection sentinelConnection = connectionFactory.getSentinelConnection();

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisTransactionalConnectionStarvationTest.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisTransactionalConnectionStarvationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,37 +50,25 @@ public class JedisTransactionalConnectionStarvationTest extends AbstractTransact
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-332
-	 */
-	@Test
+	@Test // DATAREDIS-332
 	@Rollback
 	public void testNumberOfOperationsIsOne() {
 		tryOperations(1);
 	}
 
-	/**
-	 * @see DATAREDIS-332
-	 */
-	@Test
+	@Test // DATAREDIS-332
 	@Rollback
 	public void testNumberOfOperationsEqualToNumberOfConnections() {
 		tryOperations(MAX_CONNECTIONS);
 	}
 
-	/**
-	 * @see DATAREDIS-332
-	 */
-	@Test
+	@Test // DATAREDIS-332
 	@Rollback
 	public void testNumberOfOperationsGreaterThanNumberOfConnections() {
 		tryOperations(MAX_CONNECTIONS + 1);
 	}
 
-	/**
-	 * @see DATAREDIS-548
-	 */
-	@Test
+	@Test // DATAREDIS-548
 	@Transactional(readOnly = true)
 	public void readonlyTransactionSyncShouldNotExcceedMaxConnections() {
 		tryOperations(MAX_CONNECTIONS + 1);

--- a/src/test/java/org/springframework/data/redis/connection/jredis/JRedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jredis/JRedisConnectionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -349,10 +349,7 @@ public class JRedisConnectionIntegrationTests extends AbstractConnectionIntegrat
 		super.testPTtlNoExpire();
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-526
 	public void testPTtlWithTimeUnit() {
 		super.testPTtlWithTimeUnit();
 	}
@@ -788,18 +785,12 @@ public class JRedisConnectionIntegrationTests extends AbstractConnectionIntegrat
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-206
 	public void testGetTimeShouldRequestServerTime() {
 		super.testGetTimeShouldRequestServerTime();
 	}
 
-	/**
-	 * @see DATAREDIS-285
-	 */
-	@Test
+	@Test // DATAREDIS-285
 	public void testExecuteShouldConvertArrayReplyCorrectly() {
 		connection.set("spring", "awesome");
 		connection.set("data", "cool");
@@ -816,28 +807,19 @@ public class JRedisConnectionIntegrationTests extends AbstractConnectionIntegrat
 						"supercalifragilisticexpialidocious".getBytes()));
 	}
 
-	/**
-	 * @see DATAREDIS-271
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-271
 	public void testPsetEx() throws Exception {
 		super.testPsetEx();
 	}
 
-	/**
-	 * @see DATAREDIS-269
-	 */
 	@Override
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-269
 	public void clientSetNameWorksCorrectly() {
 		super.clientSetNameWorksCorrectly();
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
 	@Override
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-268
 	public void testListClientsContainsAtLeastOneElement() {
 		super.testListClientsContainsAtLeastOneElement();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jredis/JRedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jredis/JRedisConnectionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,34 +33,22 @@ public class JRedisConnectionUnitTests extends AbstractConnectionUnitTestBase<JR
 		connection = new JredisConnection(getNativeRedisConnectionMock());
 	}
 
-	/**
-	 * @see DATAREDIS-184
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-184
 	public void shutdownSaveShouldThrowUnsupportedOperationException() {
 		connection.shutdown(ShutdownOption.SAVE);
 	}
 
-	/**
-	 * @see DATAREDIS-184
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-184
 	public void shutdownNosaveShouldThrowUnsupportedOperationException() {
 		connection.shutdown(ShutdownOption.NOSAVE);
 	}
 
-	/**
-	 * @see DATAREDIS-184
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-184
 	public void shutdownWithNullShouldThrowUnsupportedOperationException() {
 		connection.shutdown(null);
 	}
 
-	/**
-	 * @see DATAREDIS-270
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-270
 	public void getClientNameShouldSendRequestCorrectly() {
 		connection.getClientName();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,10 +205,7 @@ public class DefaultLettucePoolTests {
 		pool.getResource();
 	}
 
-	/**
-	 * @see DATAREDIS-524
-	 */
-	@Test
+	@Test // DATAREDIS-524
 	public void testCreateSentinelWithPassword() {
 
 		pool = new DefaultLettucePool(new RedisSentinelConfiguration("mymaster", Collections.singleton("host:1234")));
@@ -221,10 +218,7 @@ public class DefaultLettucePoolTests {
 		assertThat(redisUri.getPassword(), is(equalTo(pool.getPassword().toCharArray())));
 	}
 
-	/**
-	 * @see DATAREDIS-462
-	 */
-	@Test
+	@Test // DATAREDIS-462
 	public void poolWorksWithoutClientResources() {
 
 		pool = new DefaultLettucePool(SettingsUtils.getHost(), SettingsUtils.getPort());

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,20 +133,14 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		client.shutdown(0, 0, TimeUnit.MILLISECONDS);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldAllowSettingAndGettingValues() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
 		assertThat(clusterConnection.get(KEY_1_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void delShouldRemoveSingleKeyCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -156,10 +150,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void delShouldRemoveMultipleKeysCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -172,10 +163,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void delShouldRemoveMultipleKeysOnSameSlotCorrectly() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1);
@@ -187,10 +175,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void typeShouldReadKeyTypeCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1);
@@ -202,10 +187,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.type(KEY_3_BYTES), is(DataType.HASH));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void keysShouldReturnAllKeys() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -214,10 +196,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.keys(LettuceConverters.toBytes("*")), hasItems(KEY_1_BYTES, KEY_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void keysShouldReturnAllKeysForSpecificNode() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -230,10 +209,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(keysOnNode, not(hasItems(KEY_1_BYTES)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void randomKeyShouldReturnCorrectlyWhenKeysAvailable() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -242,18 +218,12 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.randomKey(), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void randomKeyShouldReturnNullWhenNoKeysAvailable() {
 		assertThat(clusterConnection.randomKey(), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rename() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -264,10 +234,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void renameSameKeysOnSameSlot() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1);
@@ -278,10 +245,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void renameNXWhenTargetKeyDoesNotExist() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -292,10 +256,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void renameNXWhenTargetKeyDoesExist() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -307,10 +268,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void renameNXWhenOnSameSlot() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1);
@@ -321,10 +279,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void expireShouldBeSetCorreclty() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -334,10 +289,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(LettuceConverters.toString(KEY_1_BYTES)) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pExpireShouldBeSetCorreclty() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -347,10 +299,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(LettuceConverters.toString(KEY_1_BYTES)) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void expireAtShouldBeSetCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -360,10 +309,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(LettuceConverters.toString(KEY_1_BYTES)) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pExpireAtShouldBeSetCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -373,10 +319,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(LettuceConverters.toString(KEY_1_BYTES)) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void persistShouldRemoveTTL() {
 
 		nativeConnection.setex(KEY_1, 10, VALUE_1);
@@ -385,18 +328,12 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1), is(-1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-315
 	public void moveShouldNotBeSupported() {
 		clusterConnection.move(KEY_1_BYTES, 3);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void dbSizeShouldReturnCummulatedDbSize() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -405,10 +342,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.dbSize(), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void dbSizeForSpecificNodeShouldGetNodeDbSize() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -419,26 +353,17 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.dbSize(new RedisClusterNode("127.0.0.1", 7381, null)), is(0L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void ttlShouldReturnMinusTwoWhenKeyDoesNotExist() {
 		assertThat(clusterConnection.ttl(KEY_1_BYTES), is(-2L));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void ttlWithTimeUnitShouldReturnMinusTwoWhenKeyDoesNotExist() {
 		assertThat(clusterConnection.ttl(KEY_1_BYTES, TimeUnit.HOURS), is(-2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void ttlShouldReturnMinusOneWhenKeyDoesNotHaveExpirationSet() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -446,10 +371,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.ttl(KEY_1_BYTES), is(-1L));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void ttlWithTimeUnitShouldReturnMinusOneWhenKeyDoesNotHaveExpirationSet() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -457,10 +379,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.ttl(KEY_1_BYTES, TimeUnit.SECONDS), is(-1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void ttlShouldReturnValueCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -469,26 +388,17 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.ttl(KEY_1_BYTES) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pTtlShouldReturnMinusTwoWhenKeyDoesNotExist() {
 		assertThat(clusterConnection.pTtl(KEY_1_BYTES), is(-2L));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void pTtlWithTimeUnitShouldReturnMinusTwoWhenKeyDoesNotExist() {
 		assertThat(clusterConnection.pTtl(KEY_1_BYTES, TimeUnit.SECONDS), is(-2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pTtlShouldReturnMinusOneWhenKeyDoesNotHaveExpirationSet() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -496,10 +406,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.pTtl(KEY_1_BYTES), is(-1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pTtlShouldReturValueCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -508,10 +415,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.pTtl(KEY_1_BYTES) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sortShouldReturnValuesCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_2, VALUE_1);
@@ -520,10 +424,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sortAndStoreShouldAddSortedValuesValuesCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_2, VALUE_1);
@@ -532,18 +433,12 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_2), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sortAndStoreShouldReturnZeroWhenListDoesNotExist() {
 		assertThat(clusterConnection.sort(KEY_1_BYTES, new DefaultSortParameters().alpha(), KEY_2_BYTES), is(0L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void dumpAndRestoreShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -554,10 +449,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getShouldReturnValueCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -565,10 +457,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.get(KEY_1_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getSetShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -579,10 +468,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mGetShouldReturnCorrectlyWhenKeysMapToSameSlot() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1);
@@ -592,10 +478,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				contains(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mGetShouldReturnCorrectlyWhenKeysDoNotMapToSameSlot() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -604,10 +487,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.mGet(KEY_1_BYTES, KEY_2_BYTES), contains(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setShouldSetValueCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
@@ -615,10 +495,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setNxShouldSetValueCorrectly() {
 
 		clusterConnection.setNX(KEY_1_BYTES, VALUE_1_BYTES);
@@ -626,10 +503,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setNxShouldNotSetValueWhenAlreadyExistsInDBCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -639,10 +513,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setExShouldSetValueCorrectly() {
 
 		clusterConnection.setEx(KEY_1_BYTES, 5, VALUE_1_BYTES);
@@ -651,10 +522,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pSetExShouldSetValueCorrectly() {
 
 		clusterConnection.pSetEx(KEY_1_BYTES, 5000, VALUE_1_BYTES);
@@ -663,10 +531,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1) > 1, is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetShouldWorkWhenKeysMapToSameSlot() {
 
 		Map<byte[], byte[]> map = new LinkedHashMap<byte[], byte[]>();
@@ -679,10 +544,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetShouldWorkWhenKeysDoNotMapToSameSlot() {
 
 		Map<byte[], byte[]> map = new LinkedHashMap<byte[], byte[]>();
@@ -695,10 +557,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetNXShouldReturnTrueIfAllKeysSet() {
 
 		Map<byte[], byte[]> map = new LinkedHashMap<byte[], byte[]>();
@@ -711,10 +570,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetNXShouldReturnFalseIfNotAllKeysSet() {
 
 		nativeConnection.set(KEY_2, VALUE_3);
@@ -728,10 +584,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), is(VALUE_3));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void mSetNXShouldWorkForOnSameSlotKeys() {
 
 		Map<byte[], byte[]> map = new LinkedHashMap<byte[], byte[]>();
@@ -744,10 +597,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_2), is(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void incrShouldIncreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "1");
@@ -755,10 +605,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.incr(KEY_1_BYTES), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void incrByFloatShouldIncreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "1");
@@ -766,10 +613,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.incrBy(KEY_1_BYTES, 5.5D), is(6.5D));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void incrByShouldIncreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "1");
@@ -777,10 +621,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.incrBy(KEY_1_BYTES, 5), is(6L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void decrShouldDecreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "5");
@@ -788,10 +629,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.decr(KEY_1_BYTES), is(4L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void decrByShouldDecreaseValueCorrectly() {
 
 		nativeConnection.set(KEY_1, "5");
@@ -799,10 +637,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.decrBy(KEY_1_BYTES, 4), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void appendShouldAddValueCorrectly() {
 
 		clusterConnection.append(KEY_1_BYTES, VALUE_1_BYTES);
@@ -811,10 +646,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is(VALUE_1.concat(VALUE_2)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getRangeShouldReturnValueCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -822,10 +654,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.getRange(KEY_1_BYTES, 0, 2), is(LettuceConverters.toBytes("val")));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setRangeShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -835,10 +664,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_1), is("valUE1"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getBitShouldWorkCorrectly() {
 
 		nativeConnection.setbit(KEY_1, 0, 1);
@@ -848,10 +674,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.getBit(KEY_1_BYTES, 1), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void setBitShouldWorkCorrectly() {
 
 		clusterConnection.setBit(KEY_1_BYTES, 0, true);
@@ -861,10 +684,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.getbit(KEY_1, 1), is(0L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bitCountShouldWorkCorrectly() {
 
 		nativeConnection.setbit(KEY_1, 0, 1);
@@ -873,10 +693,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bitCount(KEY_1_BYTES), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bitCountWithRangeShouldWorkCorrectly() {
 
 		nativeConnection.setbit(KEY_1, 0, 1);
@@ -888,10 +705,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bitCount(KEY_1_BYTES, 0, 3), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bitOpShouldWorkCorrectly() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
@@ -902,18 +716,12 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_3), is("bab"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void bitOpShouldThrowExceptionWhenKeysDoNotMapToSameSlot() {
 		clusterConnection.bitOp(BitOperation.AND, KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void strLenShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -921,10 +729,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.strLen(KEY_1_BYTES), is(6L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPushShoultAddValuesCorrectly() {
 
 		clusterConnection.rPush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -932,10 +737,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1), hasItems(VALUE_1, VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lPushShoultAddValuesCorrectly() {
 
 		clusterConnection.lPush(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -943,10 +745,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1), hasItems(VALUE_1, VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPushNXShoultNotAddValuesWhenKeyDoesNotExist() {
 
 		clusterConnection.rPushX(KEY_1_BYTES, VALUE_1_BYTES);
@@ -954,10 +753,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_1), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lPushNXShoultNotAddValuesWhenKeyDoesNotExist() {
 
 		clusterConnection.lPushX(KEY_1_BYTES, VALUE_1_BYTES);
@@ -965,10 +761,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_1), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lLenShouldCountValuesCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2);
@@ -976,10 +769,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.lLen(KEY_1_BYTES), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lRangeShouldGetValuesCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2);
@@ -987,10 +777,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.lRange(KEY_1_BYTES, 0L, -1L), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lTrimShouldTrimListCorrectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -1000,10 +787,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1), hasItems(VALUE_1, VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lIndexShouldGetElementAtIndexCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -1011,10 +795,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.lIndex(KEY_1_BYTES, 1), is(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lInsertShouldAddElementAtPositionCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -1024,10 +805,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1).get(2), is("booh!"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lSetShouldSetElementAtPositionCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -1037,10 +815,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.lrange(KEY_1, 0, -1).get(1), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lRemShouldRemoveElementAtPositionCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2, "foo", "bar");
@@ -1050,10 +825,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.llen(KEY_1), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void lPopShouldReturnElementCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2);
@@ -1061,10 +833,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.lPop(KEY_1_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPopShouldReturnElementCorrectly() {
 
 		nativeConnection.rpush(KEY_1, VALUE_1, VALUE_2);
@@ -1072,10 +841,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.rPop(KEY_1_BYTES), is(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void blPopShouldPopElementCorectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2);
@@ -1084,10 +850,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bLPop(100, KEY_1_BYTES, KEY_2_BYTES).size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void blPopShouldPopElementCorectlyWhenKeyOnSameSlot() {
 
 		nativeConnection.lpush(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1096,10 +859,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bLPop(100, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES).size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void brPopShouldPopElementCorectly() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2);
@@ -1108,10 +868,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bRPop(100, KEY_1_BYTES, KEY_2_BYTES).size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void brPopShouldPopElementCorectlyWhenKeyOnSameSlot() {
 
 		nativeConnection.lpush(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1120,10 +877,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bRPop(100, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES).size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPopLPushShouldWorkWhenDoNotMapToSameSlot() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2);
@@ -1132,10 +886,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.bLPop(100, KEY_1_BYTES, KEY_2_BYTES).size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bRPopLPushShouldWork() {
 
 		nativeConnection.lpush(KEY_1, VALUE_1, VALUE_2);
@@ -1144,10 +895,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_2), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bRPopLPushShouldWorkOnSameSlotKeys() {
 
 		nativeConnection.lpush(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1156,10 +904,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(SAME_SLOT_KEY_2), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void rPopLPushShouldWorkWhenKeysOnSameSlot() {
 
 		nativeConnection.lpush(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1168,10 +913,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(SAME_SLOT_KEY_2), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sAddShouldAddValueToSetCorrectly() {
 
 		clusterConnection.sAdd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES);
@@ -1179,10 +921,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_1), hasItems(VALUE_1, VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sRemShouldRemoveValueFromSetCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1192,10 +931,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_1), hasItems(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sPopShouldPopValueFromSetCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1203,10 +939,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sPop(KEY_1_BYTES), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sMoveShouldWorkWhenKeysMapToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1218,10 +951,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.sismember(SAME_SLOT_KEY_2, VALUE_2), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sMoveShouldWorkWhenKeysDoNotMapToSameSlot() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1233,10 +963,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.sismember(KEY_2, VALUE_2), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sCardShouldCountValuesInSetCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1244,10 +971,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sCard(KEY_1_BYTES), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sIsMemberShouldReturnTrueIfValueIsMemberOfSet() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1255,10 +979,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sIsMember(KEY_1_BYTES, VALUE_1_BYTES), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sIsMemberShouldReturnFalseIfValueIsMemberOfSet() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1266,10 +987,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sIsMember(KEY_1_BYTES, LettuceConverters.toBytes("foo")), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sInterShouldWorkForKeysMappingToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1278,10 +996,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sInter(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES), hasItem(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sInterShouldWorkForKeysNotMappingToSameSlot() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1290,10 +1005,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sInter(KEY_1_BYTES, KEY_2_BYTES), hasItem(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sInterStoreShouldWorkForKeysMappingToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1304,10 +1016,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(SAME_SLOT_KEY_3), hasItem(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sInterStoreShouldWorkForKeysNotMappingToSameSlot() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1318,10 +1027,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_3), hasItem(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sUnionShouldWorkForKeysMappingToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1331,10 +1037,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItems(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sUnionShouldWorkForKeysNotMappingToSameSlot() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1344,10 +1047,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItems(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sUnionStoreShouldWorkForKeysMappingToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1358,10 +1058,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(SAME_SLOT_KEY_3), hasItems(VALUE_1, VALUE_2, VALUE_3));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sUnionStoreShouldWorkForKeysNotMappingToSameSlot() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1372,10 +1069,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_3), hasItems(VALUE_1, VALUE_2, VALUE_3));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sDiffShouldWorkWhenKeysMapToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1384,10 +1078,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sDiff(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES), hasItems(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sDiffShouldWorkWhenKeysNotMapToSameSlot() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1396,10 +1087,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sDiff(KEY_1_BYTES, KEY_2_BYTES), hasItems(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sDiffStoreShouldWorkWhenKeysMapToSameSlot() {
 
 		nativeConnection.sadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -1410,10 +1098,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(SAME_SLOT_KEY_3), hasItems(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sDiffStoreShouldWorkWhenKeysNotMapToSameSlot() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1424,10 +1109,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.smembers(KEY_3), hasItems(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sMembersShouldReturnValuesContainedInSetCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1435,10 +1117,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sMembers(KEY_1_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sRandMamberShouldReturnValueCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1446,10 +1125,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sRandMember(KEY_1_BYTES), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sRandMamberWithCountShouldReturnValueCorrectly() {
 
 		nativeConnection.sadd(KEY_1, VALUE_1, VALUE_2);
@@ -1457,10 +1133,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.sRandMember(KEY_1_BYTES, 3), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void sscanShouldRetrieveAllValuesInSetCorrectly() {
 
 		for (int i = 0; i < 30; i++) {
@@ -1477,10 +1150,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(count, is(30));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zAddShouldAddValueWithScoreCorrectly() {
 
 		clusterConnection.zAdd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
@@ -1489,10 +1159,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zcard(KEY_1), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRemShouldRemoveValueWithScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1503,10 +1170,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zcard(KEY_1), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zIncrByShouldIncScoreForValueCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1517,10 +1181,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrank(KEY_1, VALUE_1), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRankShouldReturnPositionForValueCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1529,10 +1190,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRank(KEY_1_BYTES, VALUE_2_BYTES), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRankShouldReturnReversePositionForValueCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1541,10 +1199,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRevRank(KEY_1_BYTES, VALUE_2_BYTES), is(0L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeShouldReturnValuesCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1554,10 +1209,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRange(KEY_1_BYTES, 1, 2), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeWithScoresShouldReturnValuesAndScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1568,10 +1220,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D), (Tuple) new DefaultTuple(VALUE_2_BYTES, 20D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByScoreShouldReturnValuesCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1581,10 +1230,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRangeByScore(KEY_1_BYTES, 10, 20), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByScoreWithScoresShouldReturnValuesAndScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1595,10 +1241,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D), (Tuple) new DefaultTuple(VALUE_2_BYTES, 20D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByScoreShouldReturnValuesCorrectlyWhenGivenOffsetAndScore() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1608,10 +1251,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRangeByScore(KEY_1_BYTES, 10D, 20D, 0L, 1L), hasItems(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByScoreWithScoresShouldReturnValuesCorrectlyWhenGivenOffsetAndScore() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1622,10 +1262,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_1_BYTES, 10D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeShouldReturnValuesCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1635,10 +1272,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRevRange(KEY_1_BYTES, 1, 2), hasItems(VALUE_3_BYTES, VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeWithScoresShouldReturnValuesAndScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1649,10 +1283,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_3_BYTES, 5D), (Tuple) new DefaultTuple(VALUE_1_BYTES, 10D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeByScoreShouldReturnValuesCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1662,10 +1293,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRevRangeByScore(KEY_1_BYTES, 10D, 20D), hasItems(VALUE_2_BYTES, VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeByScoreWithScoresShouldReturnValuesAndScoreCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1676,10 +1304,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_2_BYTES, 20D), (Tuple) new DefaultTuple(VALUE_1_BYTES, 10D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeByScoreShouldReturnValuesCorrectlyWhenGivenOffsetAndScore() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1689,10 +1314,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zRevRangeByScore(KEY_1_BYTES, 10D, 20D, 0L, 1L), hasItems(VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRevRangeByScoreWithScoresShouldReturnValuesCorrectlyWhenGivenOffsetAndScore() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1703,10 +1325,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				hasItems((Tuple) new DefaultTuple(VALUE_2_BYTES, 20D)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zCountShouldCountValuesInRange() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1716,10 +1335,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zCount(KEY_1_BYTES, 10, 20), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zCardShouldReturnTotalNumberOfValues() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1729,10 +1345,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zCard(KEY_1_BYTES), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zScoreShouldRetrieveScoreForValue() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1741,10 +1354,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.zScore(KEY_1_BYTES, VALUE_2_BYTES), is(20D));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRemRangeShouldRemoveValues() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1757,10 +1367,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrange(KEY_1, 0, -1), hasItem(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRemRangeByScoreShouldRemoveValues() {
 
 		nativeConnection.zadd(KEY_1, 10D, VALUE_1);
@@ -1773,10 +1380,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrange(KEY_1, 0, -1), hasItems(VALUE_1, VALUE_3));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zUnionStoreShouldWorkForSameSlotKeys() {
 
 		nativeConnection.zadd(SAME_SLOT_KEY_1, 10D, VALUE_1);
@@ -1788,18 +1392,12 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrange(SAME_SLOT_KEY_3, 0, -1), hasItems(VALUE_1, VALUE_2, VALUE_3));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void zUnionStoreShouldThrowExceptionWhenKeysDoNotMapToSameSlots() {
 		clusterConnection.zUnionStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zInterStoreShouldWorkForSameSlotKeys() {
 
 		nativeConnection.zadd(SAME_SLOT_KEY_1, 10D, VALUE_1);
@@ -1813,10 +1411,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrange(SAME_SLOT_KEY_3, 0, -1), hasItems(VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void zInterStoreShouldThrowExceptionWhenKeysDoNotMapToSameSlots() {
 		clusterConnection.zInterStore(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES);
 	}
@@ -1841,10 +1436,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(count, equalTo(nrOfValues));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hSetShouldSetValueCorrectly() {
 
 		clusterConnection.hSet(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1852,10 +1444,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1, KEY_2), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hSetNXShouldSetValueCorrectly() {
 
 		clusterConnection.hSetNX(KEY_1_BYTES, KEY_2_BYTES, VALUE_1_BYTES);
@@ -1863,10 +1452,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1, KEY_2), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hSetNXShouldNotSetValueWhenAlreadyExists() {
 
 		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
@@ -1876,10 +1462,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1, KEY_2), is(VALUE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hGetShouldRetrieveValueCorrectly() {
 
 		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
@@ -1887,10 +1470,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_2_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hMGetShouldRetrieveValueCorrectly() {
 
 		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
@@ -1899,10 +1479,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hMGet(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hMSetShouldAddValuesCorrectly() {
 
 		Map<byte[], byte[]> hashes = new HashMap<byte[], byte[]>();
@@ -1914,10 +1491,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hmget(KEY_1, KEY_2, KEY_3), hasItems(VALUE_1, VALUE_2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hIncrByShouldIncreaseFieldCorretly() {
 
 		nativeConnection.hset(KEY_1, KEY_2, "1");
@@ -1928,10 +1502,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1, KEY_3), is("5"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hIncrByFloatShouldIncreaseFieldCorretly() {
 
 		nativeConnection.hset(KEY_1, KEY_2, "1");
@@ -1942,10 +1513,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hget(KEY_1, KEY_3), is("5.5"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hExistsShouldReturnPresenceOfFieldCorrectly() {
 
 		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
@@ -1955,10 +1523,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hExists(LettuceConverters.toBytes("foo"), KEY_2_BYTES), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hDelShouldRemoveFieldsCorrectly() {
 
 		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
@@ -1970,10 +1535,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.hexists(KEY_1, KEY_3), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hLenShouldRetrieveSizeCorrectly() {
 
 		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
@@ -1982,10 +1544,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hLen(KEY_1_BYTES), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hKeysShouldRetrieveKeysCorrectly() {
 
 		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
@@ -1994,10 +1553,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hKeys(KEY_1_BYTES), hasItems(KEY_2_BYTES, KEY_3_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hValsShouldRetrieveValuesCorrectly() {
 
 		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
@@ -2006,10 +1562,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hVals(KEY_1_BYTES), hasItems(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void hGetAllShouldRetrieveEntriesCorrectly() {
 
 		Map<String, String> hashes = new HashMap<String, String>();
@@ -2044,98 +1597,62 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(i, is(nrOfValues));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void multiShouldThrowException() {
 		clusterConnection.multi();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void execShouldThrowException() {
 		clusterConnection.exec();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void discardShouldThrowException() {
 		clusterConnection.discard();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void watchShouldThrowException() {
 		clusterConnection.watch();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void unwatchShouldThrowException() {
 		clusterConnection.unwatch();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void selectShouldAllowSelectionOfDBIndexZero() {
 		clusterConnection.select(0);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void selectShouldThrowExceptionWhenSelectingNonZeroDbIndex() {
 		clusterConnection.select(1);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void echoShouldReturnInputCorrectly() {
 		assertThat(clusterConnection.echo(VALUE_1_BYTES), is(VALUE_1_BYTES));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pingShouldRetrunPongForExistingNode() {
 		assertThat(clusterConnection.ping(new RedisClusterNode("127.0.0.1", 7379, null)), is("PONG"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pingShouldRetrunPong() {
 		assertThat(clusterConnection.ping(), is("PONG"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void pingShouldThrowExceptionWhenNodeNotKnownToCluster() {
 		clusterConnection.ping(new RedisClusterNode("127.0.0.1", 1234, null));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void flushDbShouldFlushAllClusterNodes() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -2147,10 +1664,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void flushDbOnSingleNodeShouldFlushOnlyGivenNodesDb() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -2162,10 +1676,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void zRangeByLexShouldReturnResultCorrectly() {
 
 		nativeConnection.zadd(KEY_1, 0, "a");
@@ -2199,34 +1710,22 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 				LettuceConverters.toBytes("c"), LettuceConverters.toBytes("d"))));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void infoShouldCollectionInfoFromAllClusterNodes() {
 		assertThat(Double.valueOf(clusterConnection.info().size()), closeTo(245d, 35d));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clientListShouldGetInfosForAllClients() {
 		assertThat(clusterConnection.getClientList().isEmpty(), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getClusterNodeForKeyShouldReturnNodeCorrectly() {
 		assertThat((RedisNode) clusterConnection.clusterGetNodeForKey(KEY_1_BYTES), is(new RedisNode("127.0.0.1", 7380)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void countKeysShouldReturnNumberOfKeysInSlot() {
 
 		nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1);
@@ -2235,10 +1734,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.clusterCountKeysInSlot(ClusterSlotHashUtil.calculateSlot(SAME_SLOT_KEY_1)), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pfAddShouldAddValuesCorrectly() {
 
 		clusterConnection.pfAdd(KEY_1_BYTES, VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES);
@@ -2246,10 +1742,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(((RedisHLLCommands<String, String>) nativeConnection).pfcount(KEY_1), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pfCountShouldAllowCountingOnSingleKey() {
 
 		((RedisHLLCommands<String, String>) nativeConnection).pfadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
@@ -2257,10 +1750,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.pfCount(KEY_1_BYTES), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pfCountShouldAllowCountingOnSameSlotKeys() {
 
 		((RedisHLLCommands<String, String>) nativeConnection).pfadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -2269,10 +1759,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.pfCount(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void pfCountShouldThrowErrorCountingOnDifferentSlotKeys() {
 
 		((RedisHLLCommands<String, String>) nativeConnection).pfadd(KEY_1, VALUE_1, VALUE_2);
@@ -2281,10 +1768,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		clusterConnection.pfCount(KEY_1_BYTES, KEY_2_BYTES);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pfMergeShouldWorkWhenAllKeysMapToSameSlot() {
 
 		((RedisHLLCommands<String, String>) nativeConnection).pfadd(SAME_SLOT_KEY_1, VALUE_1, VALUE_2);
@@ -2295,18 +1779,12 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(((RedisHLLCommands<String, String>) nativeConnection).pfcount(SAME_SLOT_KEY_3), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = DataAccessException.class)
+	@Test(expected = DataAccessException.class) // DATAREDIS-315
 	public void pfMergeShouldThrowErrorOnDifferentSlotKeys() {
 		clusterConnection.pfMerge(KEY_3_BYTES, KEY_1_BYTES, KEY_2_BYTES);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void infoShouldCollectInfoForSpecificNode() {
 
 		Properties properties = clusterConnection.info(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT));
@@ -2314,10 +1792,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(properties.getProperty("tcp_port"), is(Integer.toString(MASTER_NODE_2_PORT)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void infoShouldCollectInfoForSpecificNodeAndSection() {
 
 		Properties properties = clusterConnection.info(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT), "server");
@@ -2326,10 +1801,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(properties.getProperty("used_memory"), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getConfigShouldLoadCumulatedConfiguration() {
 
 		List<String> result = clusterConnection.getConfig("*max-*-entries*");
@@ -2347,10 +1819,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getConfigShouldLoadConfigurationOfSpecificNode() {
 
 		List<String> result = clusterConnection.getConfig(new RedisClusterNode(CLUSTER_HOST, SLAVEOF_NODE_1_PORT), "*");
@@ -2370,10 +1839,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.get(valueIndex), endsWith("7379"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterGetSlavesShouldReturnSlaveCorrectly() {
 
 		Set<RedisClusterNode> slaves = clusterConnection
@@ -2383,10 +1849,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(slaves, hasItem(new RedisClusterNode(CLUSTER_HOST, SLAVEOF_NODE_1_PORT)));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterGetMasterSlaveMapShouldListMastersAndSlavesCorrectly() {
 
 		Map<RedisClusterNode, Collection<RedisClusterNode>> masterSlaveMap = clusterConnection.clusterGetMasterSlaveMap();
@@ -2399,10 +1862,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(masterSlaveMap.get(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_3_PORT)).isEmpty(), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationInSecondsShouldWorkCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.upsert());
@@ -2411,10 +1871,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationInMillisecondsShouldWorkCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.milliseconds(500), SetOption.upsert());
@@ -2423,20 +1880,14 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.pttl(KEY_1).doubleValue(), is(closeTo(500d, 499d)));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithOptionIfPresentShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
 		clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.persistent(), SetOption.ifPresent());
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithOptionIfAbsentShouldWorkCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.persistent(), SetOption.ifAbsent());
@@ -2445,10 +1896,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1), is(-1L));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationAndIfAbsentShouldWorkCorrectly() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifAbsent());
@@ -2457,10 +1905,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationAndIfAbsentShouldNotBeAppliedWhenKeyExists() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -2473,10 +1918,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationAndIfPresentShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1, VALUE_1);
@@ -2489,10 +1931,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void setWithExpirationAndIfPresentShouldNotBeAppliedWhenKeyDoesNotExists() {
 
 		clusterConnection.set(KEY_1_BYTES, VALUE_1_BYTES, Expiration.seconds(1), SetOption.ifPresent());
@@ -2500,29 +1939,20 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.exists(KEY_1), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoAddSingleGeoLocation() {
 		assertThat(clusterConnection.geoAdd(KEY_1_BYTES, PALERMO_BYTES), is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoAddMultipleGeoLocations() {
 		assertThat(clusterConnection.geoAdd(KEY_1_BYTES,
 				Arrays.asList(PALERMO_BYTES, ARIGENTO_BYTES, CATANIA_BYTES, PALERMO_BYTES)), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoDist() {
 
@@ -2535,10 +1965,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(distance.getUnit(), is("m"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoDistWithMetric() {
 
@@ -2553,10 +1980,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoHash() {
 
@@ -2567,10 +1991,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result, contains("sqc8b49rny0", "sqdtr74hyu0"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoHashNonExisting() {
 
@@ -2582,10 +2003,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result, contains("sqc8b49rny0", (String) null, "sqdtr74hyu0"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoPosition() {
 
@@ -2601,10 +2019,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(positions.get(1).getY(), is(closeTo(POINT_CATANIA.getY(), 0.005)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoPositionNonExisting() {
 
@@ -2623,10 +2038,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(positions.get(2).getY(), is(closeTo(POINT_CATANIA.getY(), 0.005)));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusShouldReturnMembersCorrectly() {
 
@@ -2639,10 +2051,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusShouldReturnDistanceCorrectly() {
 
@@ -2658,10 +2067,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent().get(0).getDistance().getUnit(), is("km"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusShouldApplyLimit() {
 
@@ -2675,10 +2081,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusByMemberShouldReturnMembersCorrectly() {
 
@@ -2693,10 +2096,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent().get(1).getContent().getName(), is(ARIGENTO_BYTES.getName()));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusByMemberShouldReturnDistanceCorrectly() {
 
@@ -2712,10 +2112,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent().get(0).getDistance().getUnit(), is("km"));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRadiusByMemberShouldApplyLimit() {
 
@@ -2729,10 +2126,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(result.getContent(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	@IfProfileValue(name = "redisVersion", value = "3.2+")
 	public void geoRemoveDeletesMembers() {
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,18 +122,12 @@ public class LettuceClusterConnectionUnitTests {
 		};
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void thowsExceptionWhenClusterCommandExecturorIsNull() {
 		new LettuceClusterConnection(clusterMock, null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterMeetShouldSendCommandsToExistingNodesCorrectly() {
 
 		connection.clusterMeet(UNKNOWN_CLUSTER_NODE);
@@ -146,18 +140,12 @@ public class LettuceClusterConnectionUnitTests {
 				UNKNOWN_CLUSTER_NODE.getPort());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void clusterMeetShouldThrowExceptionWhenNodeIsNull() {
 		connection.clusterMeet(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterForgetShouldSendCommandsToRemainingNodesCorrectly() {
 
 		connection.clusterForget(CLUSTER_NODE_2);
@@ -167,10 +155,7 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection3Mock, times(1)).clusterForget(CLUSTER_NODE_2.getId());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterReplicateShouldSendCommandsCorrectly() {
 
 		connection.clusterReplicate(CLUSTER_NODE_1, CLUSTER_NODE_2);
@@ -179,10 +164,7 @@ public class LettuceClusterConnectionUnitTests {
 		verifyZeroInteractions(clusterConnection1Mock);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void closeShouldNotCloseUnderlyingClusterPool() throws IOException {
 
 		connection.close();
@@ -190,10 +172,7 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterMock, never()).shutdown();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void isClosedShouldReturnConnectionStateCorrectly() {
 
 		assertThat(connection.isClosed(), is(false));
@@ -203,10 +182,7 @@ public class LettuceClusterConnectionUnitTests {
 		assertThat(connection.isClosed(), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void keysShouldBeRunOnAllClusterNodes() {
 
 		when(clusterConnection1Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]>emptyList());
@@ -222,10 +198,7 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection3Mock, times(1)).keys(pattern);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void keysShouldOnlyBeRunOnDedicatedNodeWhenPinned() {
 
 		when(clusterConnection2Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]>emptyList());
@@ -239,10 +212,7 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection3Mock, never()).keys(pattern);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void randomKeyShouldReturnAnyKeyFromRandomNode() {
 
 		when(clusterConnection1Mock.randomkey()).thenReturn(KEY_1_BYTES);
@@ -254,10 +224,7 @@ public class LettuceClusterConnectionUnitTests {
 				clusterConnection3Mock);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void randomKeyShouldReturnKeyWhenAvailableOnAnyNode() {
 
 		when(clusterConnection3Mock.randomkey()).thenReturn(KEY_3_BYTES);
@@ -267,10 +234,7 @@ public class LettuceClusterConnectionUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void randomKeyShouldReturnNullWhenNoKeysPresentOnAllNodes() {
 
 		when(clusterConnection1Mock.randomkey()).thenReturn(null);
@@ -280,10 +244,7 @@ public class LettuceClusterConnectionUnitTests {
 		assertThat(connection.randomKey(), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotImportingShouldBeExecutedCorrectly() {
 
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, AddSlots.IMPORTING);
@@ -291,10 +252,7 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection1Mock, times(1)).clusterSetSlotImporting(eq(100), eq(CLUSTER_NODE_1.getId()));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotMigratingShouldBeExecutedCorrectly() {
 
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, AddSlots.MIGRATING);
@@ -302,10 +260,7 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection1Mock, times(1)).clusterSetSlotMigrating(eq(100), eq(CLUSTER_NODE_1.getId()));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotStableShouldBeExecutedCorrectly() {
 
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, AddSlots.STABLE);
@@ -313,10 +268,7 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection1Mock, times(1)).clusterSetSlotStable(eq(100));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotNodeShouldBeExecutedCorrectly() {
 
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, AddSlots.NODE);
@@ -324,10 +276,7 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection1Mock, times(1)).clusterSetSlotNode(eq(100), eq(CLUSTER_NODE_1.getId()));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterSetSlotShouldBeExecutedOnTargetNodeWhenNodeIdNotSet() {
 
 		connection.clusterSetSlot(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_2_PORT), 100, AddSlots.IMPORTING);
@@ -335,18 +284,12 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection2Mock, times(1)).clusterSetSlotImporting(eq(100), eq(CLUSTER_NODE_2.getId()));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void clusterSetSlotShouldThrowExceptionWhenModeIsNull() {
 		connection.clusterSetSlot(CLUSTER_NODE_1, 100, null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void clusterDeleteSlotsShouldBeExecutedCorrectly() {
 
 		int[] slots = new int[] { 9000, 10000 };
@@ -355,18 +298,12 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection2Mock, times(1)).clusterDelSlots((int[]) anyVararg());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void clusterDeleteSlotShouldThrowExceptionWhenNodeIsNull() {
 		connection.clusterDeleteSlots(null, new int[] { 1 });
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void timeShouldBeExecutedOnArbitraryNode() {
 
 		List<byte[]> values = Arrays.asList("1449655759".getBytes(), "92217".getBytes());
@@ -379,10 +316,7 @@ public class LettuceClusterConnectionUnitTests {
 		verifyInvocationsAcross("time", times(1), clusterConnection1Mock, clusterConnection2Mock, clusterConnection3Mock);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void timeShouldBeExecutedOnSingleNode() {
 
 		when(clusterConnection2Mock.time()).thenReturn(Arrays.asList("1449655759".getBytes(), "92217".getBytes()));
@@ -393,10 +327,7 @@ public class LettuceClusterConnectionUnitTests {
 		verifyZeroInteractions(clusterConnection1Mock, clusterConnection3Mock);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void resetConfigStatsShouldBeExecutedOnAllNodes() {
 
 		connection.resetConfigStats();
@@ -406,10 +337,7 @@ public class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection3Mock, times(1)).configResetstat();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void resetConfigStatsShouldBeExecutedOnSingleNodeCorrectly() {
 
 		connection.resetConfigStats(CLUSTER_NODE_2);

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,10 +278,7 @@ public class LettuceConnectionFactoryTests {
 		conn.close();
 	}
 
-	/**
-	 * @see DATAREDIS-431
-	 */
-	@Test
+	@Test // DATAREDIS-431
 	public void dbIndexShouldBePropagatedCorrectly() {
 
 		LettuceConnectionFactory factory = new LettuceConnectionFactory();
@@ -305,10 +302,7 @@ public class LettuceConnectionFactoryTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-462
-	 */
-	@Test
+	@Test // DATAREDIS-462
 	public void factoryWorksWithoutClientResources() {
 
 		LettuceConnectionFactory factory = new LettuceConnectionFactory();

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,10 +57,7 @@ public class LettuceConnectionFactoryUnitTests {
 		ConnectionFactoryTracker.cleanUp();
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shouldInitClientCorrectlyWhenClusterConfigPresent() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(clusterConfig);
@@ -71,10 +68,7 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(getField(connectionFactory, "client"), instanceOf(RedisClusterClient.class));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	@SuppressWarnings("unchecked")
 	public void timeoutShouldBeSetCorrectlyOnClusterClient() {
 
@@ -95,10 +89,7 @@ public class LettuceConnectionFactoryUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	@SuppressWarnings("unchecked")
 	public void passwordShouldBeSetCorrectlyOnClusterClient() {
 
@@ -118,10 +109,7 @@ public class LettuceConnectionFactoryUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-524
-	 */
-	@Test
+	@Test // DATAREDIS-524
 	public void passwordShouldBeSetCorrectlyOnSentinelClient() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(
@@ -139,10 +127,7 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(redisUri.getPassword(), is(equalTo(connectionFactory.getPassword().toCharArray())));
 	}
 
-	/**
-	 * @see DATAREDIS-462
-	 */
-	@Test
+	@Test // DATAREDIS-462
 	public void clusterClientShouldInitializeWithoutClientResources() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(clusterConfig);
@@ -154,10 +139,7 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(client, instanceOf(RedisClusterClient.class));
 	}
 
-	/**
-	 * @see DATAREDIS-480
-	 */
-	@Test
+	@Test // DATAREDIS-480
 	public void sslOptionsShouldBeDisabledByDefaultOnClient() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory();
@@ -178,10 +160,7 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(connectionFactory.isVerifyPeer(), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-476
-	 */
-	@Test
+	@Test // DATAREDIS-476
 	public void sslShouldBeSetCorrectlyOnClient() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory();
@@ -201,10 +180,7 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(connectionFactory.isVerifyPeer(), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-480
-	 */
-	@Test
+	@Test // DATAREDIS-480
 	public void verifyPeerOptionShouldBeSetCorrectlyOnClient() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory();
@@ -222,10 +198,7 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(connectionFactory.isVerifyPeer(), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-480
-	 */
-	@Test
+	@Test // DATAREDIS-480
 	public void startTLSOptionShouldBeSetCorrectlyOnClient() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory();
@@ -243,10 +216,7 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(connectionFactory.isStartTls(), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-537
-	 */
-	@Test
+	@Test // DATAREDIS-537
 	public void sslShouldBeSetCorrectlyOnClusterClient() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(
@@ -266,10 +236,7 @@ public class LettuceConnectionFactoryUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-537
-	 */
-	@Test
+	@Test // DATAREDIS-537
 	public void startTLSOptionShouldBeSetCorrectlyOnClusterClient() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(
@@ -289,10 +256,7 @@ public class LettuceConnectionFactoryUnitTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-537
-	 */
-	@Test
+	@Test // DATAREDIS-537
 	public void verifyPeerTLSOptionShouldBeSetCorrectlyOnClusterClient() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -298,11 +298,8 @@ public class LettuceConnectionIntegrationTests extends AbstractConnectionIntegra
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-285
-	 */
 	@SuppressWarnings("unchecked")
-	@Test
+	@Test // DATAREDIS-285
 	public void testExecuteShouldConvertArrayReplyCorrectly() {
 
 		connection.set("spring", "awesome");
@@ -329,10 +326,7 @@ public class LettuceConnectionIntegrationTests extends AbstractConnectionIntegra
 				Arrays.asList(new Object[] { new String(scriptResults.get(0)), new String(scriptResults.get(1)) }));
 	}
 
-	/**
-	 * @see DATAREDIS-106
-	 */
-	@Test
+	@Test // DATAREDIS-106
 	public void zRangeByScoreTest() {
 
 		connection.zAdd("myzset", 1, "one");
@@ -344,10 +338,7 @@ public class LettuceConnectionIntegrationTests extends AbstractConnectionIntegra
 		assertEquals("two", new String(zRangeByScore.iterator().next()));
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	@RequiresRedisSentinel(RedisSentinelRule.SentinelsAvailable.ONE_ACTIVE)
 	public void shouldReturnSentinelCommandsWhenWhenActiveSentinelFound() {
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionPipelineIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,11 +110,8 @@ public class LettuceConnectionPipelineIntegrationTests extends AbstractConnectio
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
 	@Override
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-268
 	public void testListClientsContainsAtLeastOneElement() {
 		super.testListClientsContainsAtLeastOneElement();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionPipelineTxIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionPipelineTxIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,11 +83,8 @@ public class LettuceConnectionPipelineTxIntegrationTests extends LettuceConnecti
 		return txResults;
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
 	@Override
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-268
 	public void testListClientsContainsAtLeastOneElement() {
 		super.testListClientsContainsAtLeastOneElement();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionUnitTestSuite.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionUnitTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,40 +70,28 @@ public class LettuceConnectionUnitTestSuite {
 			connection = new LettuceConnection(0, clientMock);
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithNullOptionsIsCalledCorrectly() {
 
 			connection.shutdown(null);
 			verify(syncCommandsMock, times(1)).shutdown(true);
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithNosaveOptionIsCalledCorrectly() {
 
 			connection.shutdown(ShutdownOption.NOSAVE);
 			verify(syncCommandsMock, times(1)).shutdown(false);
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithSaveOptionIsCalledCorrectly() {
 
 			connection.shutdown(ShutdownOption.SAVE);
 			verify(syncCommandsMock, times(1)).shutdown(true);
 		}
 
-		/**
-		 * @see DATAREDIS-267
-		 */
-		@Test
+		@Test // DATAREDIS-267
 		public void killClientShouldDelegateCallCorrectly() {
 
 			String ipPort = "127.0.0.1:1001";
@@ -111,56 +99,38 @@ public class LettuceConnectionUnitTestSuite {
 			verify(syncCommandsMock, times(1)).clientKill(eq(ipPort));
 		}
 
-		/**
-		 * @see DATAREDIS-270
-		 */
-		@Test
+		@Test // DATAREDIS-270
 		public void getClientNameShouldSendRequestCorrectly() {
 
 			connection.getClientName();
 			verify(syncCommandsMock, times(1)).clientGetname();
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-277
 		public void slaveOfShouldThrowExectpionWhenCalledForNullHost() {
 			connection.slaveOf(null, 0);
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test
+		@Test // DATAREDIS-277
 		public void slaveOfShouldBeSentCorrectly() {
 
 			connection.slaveOf("127.0.0.1", 1001);
 			verify(syncCommandsMock, times(1)).slaveof(eq("127.0.0.1"), eq(1001));
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test
+		@Test // DATAREDIS-277
 		public void slaveOfNoOneShouldBeSentCorrectly() {
 
 			connection.slaveOfNoOne();
 			verify(syncCommandsMock, times(1)).slaveofNoOne();
 		}
 
-		/**
-		 * @see DATAREDIS-348
-		 */
-		@Test(expected = InvalidDataAccessResourceUsageException.class)
+		@Test(expected = InvalidDataAccessResourceUsageException.class) // DATAREDIS-348
 		public void shouldThrowExceptionWhenAccessingRedisSentinelsCommandsWhenNoSentinelsConfigured() {
 			connection.getSentinelConnection();
 		}
 
-		/**
-		 * @see DATAREDIS-431
-		 */
-		@Test
+		@Test // DATAREDIS-431
 		public void dbIndexShouldBeSetWhenObtainingConnection() {
 
 			connection = new LettuceConnection(null, 0, clientMock, null, 1);
@@ -179,50 +149,35 @@ public class LettuceConnectionUnitTestSuite {
 			this.connection.openPipeline();
 		}
 
-		/**
-		 * @see DATAREDIS-528
-		 */
-		@Test
+		@Test // DATAREDIS-528
 		public void shutdownWithSaveOptionIsCalledCorrectly() {
 
 			connection.shutdown(ShutdownOption.SAVE);
 			verify(asyncCommandsMock, times(1)).shutdown(true);
 		}
 
-		/**
-		 * @see DATAREDIS-528
-		 */
-		@Test
+		@Test // DATAREDIS-528
 		public void shutdownWithNosaveOptionIsCalledCorrectly() {
 
 			connection.shutdown(ShutdownOption.NOSAVE);
 			verify(asyncCommandsMock, times(1)).shutdown(false);
 		}
 
-		/**
-		 * @see DATAREDIS-528
-		 */
-		@Test
+		@Test // DATAREDIS-528
 		public void slaveOfShouldBeSentCorrectly() {
 
 			connection.slaveOf("127.0.0.1", 1001);
 			verify(asyncCommandsMock, times(1)).slaveof(eq("127.0.0.1"), eq(1001));
 		}
 
-		/**
-		 * @see DATAREDIS-528
-		 */
-		@Test
+		@Test // DATAREDIS-528
 		public void shutdownWithNullOptionsIsCalledCorrectly() {
 
 			connection.shutdown(null);
 			verify(asyncCommandsMock, times(1)).shutdown(true);
 		}
 
-		/**
-		 * @see DATAREDIS-528
-		 */
-		@Test
+		@Test // DATAREDIS-528
 		public void killClientShouldDelegateCallCorrectly() {
 
 			String ipPort = "127.0.0.1:1001";
@@ -230,20 +185,14 @@ public class LettuceConnectionUnitTestSuite {
 			verify(asyncCommandsMock, times(1)).clientKill(eq(ipPort));
 		}
 
-		/**
-		 * @see DATAREDIS-528
-		 */
-		@Test
+		@Test // DATAREDIS-528
 		public void slaveOfNoOneShouldBeSentCorrectly() {
 
 			connection.slaveOfNoOne();
 			verify(asyncCommandsMock, times(1)).slaveofNoOne();
 		}
 
-		/**
-		 * @see DATAREDIS-528
-		 */
-		@Test
+		@Test // DATAREDIS-528
 		public void getClientNameShouldSendRequestCorrectly() {
 
 			connection.getClientName();

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,27 +48,18 @@ public class LettuceConvertersUnitTests {
 
 	private static final String CLIENT_ALL_SINGLE_LINE_RESPONSE = "addr=127.0.0.1:60311 fd=6 name= age=4059 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=client";
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingEmptyStringToListOfRedisClientInfoShouldReturnEmptyList() {
 		assertThat(LettuceConverters.toListOfRedisClientInformation(""), equalTo(Collections.<RedisClientInfo>emptyList()));
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingNullToListOfRedisClientInfoShouldReturnEmptyList() {
 		assertThat(LettuceConverters.toListOfRedisClientInformation(null),
 				equalTo(Collections.<RedisClientInfo>emptyList()));
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingMultipleLiesToListOfRedisClientInfoReturnsListCorrectly() {
 
 		StringBuilder sb = new StringBuilder();
@@ -79,18 +70,12 @@ public class LettuceConvertersUnitTests {
 		assertThat(LettuceConverters.toListOfRedisClientInformation(sb.toString()).size(), equalTo(2));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void partitionsToClusterNodesShouldReturnEmptyCollectionWhenPartionsDoesNotContainElements() {
 		assertThat(LettuceConverters.partitionsToClusterNodes(new Partitions()), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void partitionsToClusterNodesShouldConvertPartitionCorrctly() {
 
 		Partitions partitions = new Partitions();
@@ -116,10 +101,7 @@ public class LettuceConvertersUnitTests {
 		assertThat(node.getSlotRange().getSlots(), hasItems(1, 2, 3, 4, 5));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetArgsShouldReturnEmptyArgsForNullValues() {
 
 		SetArgs args = LettuceConverters.toSetArgs(null, null);
@@ -130,10 +112,7 @@ public class LettuceConvertersUnitTests {
 		assertThat((Boolean) getField(args, "xx"), is(Boolean.FALSE));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetArgsShouldNotSetExOrPxForPersistent() {
 
 		SetArgs args = LettuceConverters.toSetArgs(Expiration.persistent(), null);
@@ -144,10 +123,7 @@ public class LettuceConvertersUnitTests {
 		assertThat((Boolean) getField(args, "xx"), is(Boolean.FALSE));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetArgsShouldSetExForSeconds() {
 
 		SetArgs args = LettuceConverters.toSetArgs(Expiration.seconds(10), null);
@@ -158,10 +134,7 @@ public class LettuceConvertersUnitTests {
 		assertThat((Boolean) getField(args, "xx"), is(Boolean.FALSE));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetArgsShouldSetPxForMilliseconds() {
 
 		SetArgs args = LettuceConverters.toSetArgs(Expiration.milliseconds(100), null);
@@ -172,10 +145,7 @@ public class LettuceConvertersUnitTests {
 		assertThat((Boolean) getField(args, "xx"), is(Boolean.FALSE));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetArgsShouldSetNxForAbsent() {
 
 		SetArgs args = LettuceConverters.toSetArgs(null, SetOption.ifAbsent());
@@ -186,10 +156,7 @@ public class LettuceConvertersUnitTests {
 		assertThat((Boolean) getField(args, "xx"), is(Boolean.FALSE));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetArgsShouldSetXxForPresent() {
 
 		SetArgs args = LettuceConverters.toSetArgs(null, SetOption.ifPresent());
@@ -200,10 +167,7 @@ public class LettuceConvertersUnitTests {
 		assertThat((Boolean) getField(args, "xx"), is(Boolean.TRUE));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void toSetArgsShouldNotSetNxOrXxForUpsert() {
 
 		SetArgs args = LettuceConverters.toSetArgs(null, SetOption.upsert());

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnectionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,44 +62,29 @@ public class LettuceSentinelConnectionUnitTests {
 		this.connection = new LettuceSentinelConnection(redisClientMock);
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	public void shouldConnectAfterCreation() {
 		verify(redisClientMock, times(1)).connectSentinel();
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	public void failoverShouldBeSentCorrectly() {
 
 		connection.failover(new RedisNodeBuilder().withName(MASTER_ID).build());
 		verify(sentinelCommandsMock, times(1)).failover(eq(MASTER_ID));
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-348
 	public void failoverShouldThrowExceptionIfMasterNodeIsNull() {
 		connection.failover(null);
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-348
 	public void failoverShouldThrowExceptionIfMasterNodeNameIsEmpty() {
 		connection.failover(new RedisNodeBuilder().build());
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	public void mastersShouldReadMastersCorrectly() {
 
 		when(sentinelCommandsMock.masters()).thenReturn(Collections.<Map<String, String>>emptyList());
@@ -107,10 +92,7 @@ public class LettuceSentinelConnectionUnitTests {
 		verify(sentinelCommandsMock, times(1)).masters();
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	public void shouldReadSlavesCorrectly() {
 
 		when(sentinelCommandsMock.slaves(MASTER_ID)).thenReturn(Collections.<Map<String, String>>emptyList());
@@ -118,10 +100,7 @@ public class LettuceSentinelConnectionUnitTests {
 		verify(sentinelCommandsMock, times(1)).slaves(eq(MASTER_ID));
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	public void shouldReadSlavesCorrectlyWhenGivenNamedNode() {
 
 		when(sentinelCommandsMock.slaves(MASTER_ID)).thenReturn(Collections.<Map<String, String>>emptyList());
@@ -129,68 +108,44 @@ public class LettuceSentinelConnectionUnitTests {
 		verify(sentinelCommandsMock, times(1)).slaves(eq(MASTER_ID));
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-348
 	public void readSlavesShouldThrowExceptionWhenGivenEmptyMasterName() {
 		connection.slaves("");
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-348
 	public void readSlavesShouldThrowExceptionWhenGivenNull() {
 		connection.slaves((RedisNode) null);
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-348
 	public void readSlavesShouldThrowExceptionWhenNodeWithoutName() {
 		connection.slaves(new RedisNodeBuilder().build());
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	public void shouldRemoveMasterCorrectlyWhenGivenNamedNode() {
 
 		connection.remove(new RedisNodeBuilder().withName(MASTER_ID).build());
 		verify(sentinelCommandsMock, times(1)).remove(eq(MASTER_ID));
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-348
 	public void removeShouldThrowExceptionWhenGivenEmptyMasterName() {
 		connection.remove("");
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-348
 	public void removeShouldThrowExceptionWhenGivenNull() {
 		connection.remove((RedisNode) null);
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-348
 	public void removeShouldThrowExceptionWhenNodeWithoutName() {
 		connection.remove(new RedisNodeBuilder().build());
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	public void monitorShouldBeSentCorrectly() {
 
 		RedisServer server = new RedisServer("127.0.0.1", 6382);

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,10 +77,7 @@ public class LettuceSentinelIntegrationTests extends AbstractConnectionIntegrati
 		((LettuceConnectionFactory) connectionFactory).destroy();
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	public void shouldReadMastersCorrectly() {
 
 		List<RedisServer> servers = (List<RedisServer>) connectionFactory.getSentinelConnection().masters();
@@ -88,10 +85,7 @@ public class LettuceSentinelIntegrationTests extends AbstractConnectionIntegrati
 		assertThat(servers.get(0).getName(), is(MASTER_NAME));
 	}
 
-	/**
-	 * @see DATAREDIS-348
-	 */
-	@Test
+	@Test // DATAREDIS-348
 	public void shouldReadSlavesOfMastersCorrectly() {
 
 		RedisSentinelConnection sentinelConnection = connectionFactory.getSentinelConnection();
@@ -104,10 +98,7 @@ public class LettuceSentinelIntegrationTests extends AbstractConnectionIntegrati
 		assertThat(slaves, hasItems(SLAVE_0, SLAVE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-462
-	 */
-	@Test
+	@Test // DATAREDIS-462
 	public void factoryWorksWithoutClientResources() {
 
 		LettuceConnectionFactory factory = new LettuceConnectionFactory(SENTINEL_CONFIG);

--- a/src/test/java/org/springframework/data/redis/connection/srp/SrpConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/srp/SrpConnectionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,10 +87,7 @@ public class SrpConnectionIntegrationTests extends AbstractConnectionIntegration
 		verifyResults(Arrays.asList(new Object[] { Arrays.asList(new Object[] { "OK", "OK" }) }));
 	}
 
-	/**
-	 * @see DATAREDIS-285
-	 */
-	@Test
+	@Test // DATAREDIS-285
 	public void testExecuteShouldConvertArrayReplyCorrectly() {
 		connection.set("spring", "awesome");
 		connection.set("data", "cool");
@@ -120,10 +117,7 @@ public class SrpConnectionIntegrationTests extends AbstractConnectionIntegration
 				Arrays.asList(new Object[] { new String(scriptResults.get(0)), new String(scriptResults.get(1)) }));
 	}
 
-	/**
-	 * @see DATAREDIS-106
-	 */
-	@Test
+	@Test // DATAREDIS-106
 	public void zRangeByScoreTest() {
 
 		connection.zAdd("myzset", 1, "one");

--- a/src/test/java/org/springframework/data/redis/connection/srp/SrpConnectionTransactionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/srp/SrpConnectionTransactionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,10 +60,7 @@ public class SrpConnectionTransactionIntegrationTests extends AbstractConnection
 		super.testZUnionStoreAggWeights();
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-268
 	public void testListClientsContainsAtLeastOneElement() {
 		super.testListClientsContainsAtLeastOneElement();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/srp/SrpConnectionUnitTestSuite.java
+++ b/src/test/java/org/springframework/data/redis/connection/srp/SrpConnectionUnitTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,42 +48,28 @@ public class SrpConnectionUnitTestSuite {
 			connection = new SrpConnection(getNativeRedisConnectionMock());
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithNullOpionsIsCalledCorrectly() {
 
 			connection.shutdown(null);
 			verifyNativeConnectionInvocation().shutdown("SAVE".getBytes(Charsets.UTF_8), null);
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithSaveIsCalledCorrectly() {
 
 			connection.shutdown(ShutdownOption.SAVE);
 			verifyNativeConnectionInvocation().shutdown("SAVE".getBytes(Charsets.UTF_8), null);
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithNosaveIsCalledCorrectly() {
 
 			connection.shutdown(ShutdownOption.NOSAVE);
 			verifyNativeConnectionInvocation().shutdown("NOSAVE".getBytes(Charsets.UTF_8), null);
 		}
 
-		/**
-		 * <<<<<<< HEAD
-		 * 
-		 * @see DATAREDIS-267
-		 */
-		@Test
+		@Test // DATAREDIS-267
 		public void killClientShouldDelegateCallCorrectly() {
 
 			String ipPort = "127.0.0.1:1001";
@@ -91,38 +77,26 @@ public class SrpConnectionUnitTestSuite {
 			verifyNativeConnectionInvocation().client_kill(eq(ipPort));
 		}
 
-		/**
-		 * @see DATAREDIS-270
-		 */
-		@Test
+		@Test // DATAREDIS-270
 		public void getClientNameShouldSendRequestCorrectly() {
 
 			connection.getClientName();
 			verifyNativeConnectionInvocation().client_getname();
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test(expected = IllegalArgumentException.class)
+		@Test(expected = IllegalArgumentException.class) // DATAREDIS-277
 		public void slaveOfShouldThrowExectpionWhenCalledForNullHost() {
 			connection.slaveOf(null, 0);
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test
+		@Test // DATAREDIS-277
 		public void slaveOfShouldBeSentCorrectly() {
 
 			connection.slaveOf("127.0.0.1", 1001);
 			verifyNativeConnectionInvocation().slaveof(eq("127.0.0.1"), eq(1001));
 		}
 
-		/**
-		 * @see DATAREDIS-277
-		 */
-		@Test
+		@Test // DATAREDIS-277
 		public void slaveOfNoOneShouldBeSentCorrectly() {
 
 			connection.slaveOfNoOne();
@@ -144,40 +118,28 @@ public class SrpConnectionUnitTestSuite {
 			connection.openPipeline();
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithNullOpionsIsCalledCorrectly() {
 
 			connection.shutdown(null);
 			verifyNativeConnectionInvocation().shutdown("SAVE".getBytes(Charsets.UTF_8), null);
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithSaveIsCalledCorrectly() {
 
 			connection.shutdown(ShutdownOption.SAVE);
 			verifyNativeConnectionInvocation().shutdown("SAVE".getBytes(Charsets.UTF_8), null);
 		}
 
-		/**
-		 * @see DATAREDIS-184
-		 */
-		@Test
+		@Test // DATAREDIS-184
 		public void shutdownWithNosaveIsCalledCorrectly() {
 
 			connection.shutdown(ShutdownOption.NOSAVE);
 			verifyNativeConnectionInvocation().shutdown("NOSAVE".getBytes(Charsets.UTF_8), null);
 		}
 
-		/**
-		 * @see DATAREDIS-270
-		 */
-		@Test
+		@Test // DATAREDIS-270
 		public void getClientNameShouldSendRequestCorrectly() {
 
 			connection.getClientName();

--- a/src/test/java/org/springframework/data/redis/connection/srp/SrpConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/srp/SrpConvertersUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,36 +35,24 @@ public class SrpConvertersUnitTests {
 
 	private static final String CLIENT_ALL_SINGLE_LINE_RESPONSE = "addr=127.0.0.1:60311 fd=6 name= age=4059 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=client";
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingNullReplyToListOfRedisClientInfoShouldReturnEmptyList() {
 		assertThat(SrpConverters.toListOfRedisClientInformation(new BulkReply(null)),
 				equalTo(Collections.<RedisClientInfo> emptyList()));
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingEmptyReplyToListOfRedisClientInfoShouldReturnEmptyList() {
 		assertThat(SrpConverters.toListOfRedisClientInformation(new BulkReply(new byte[0])),
 				equalTo(Collections.<RedisClientInfo> emptyList()));
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingNullToListOfRedisClientInfoShouldReturnEmptyList() {
 		assertThat(SrpConverters.toListOfRedisClientInformation(null), equalTo(Collections.<RedisClientInfo> emptyList()));
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test
+	@Test // DATAREDIS-268
 	public void convertingMultipleLiesToListOfRedisClientInfoReturnsListCorrectly() {
 
 		StringBuilder sb = new StringBuilder();
@@ -75,10 +63,7 @@ public class SrpConvertersUnitTests {
 		assertThat(SrpConverters.toListOfRedisClientInformation(new BulkReply(sb.toString().getBytes())).size(), equalTo(2));
 	}
 
-	/**
-	 * @see DATAREDIS-268
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-268
 	public void expectExcptionWhenProvidingInvalidDataInReply() {
 		SrpConverters.toListOfRedisClientInformation(new Reply<String>() {
 

--- a/src/test/java/org/springframework/data/redis/connection/srp/SrpReplyToTimeAsLongConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/srp/SrpReplyToTimeAsLongConverterUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,7 @@ public class SrpReplyToTimeAsLongConverterUnitTests {
 		this.converter = SrpConverters.repliesToTimeAsLong();
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test
+	@Test // DATAREDIS-206
 	public void testConverterShouldCreateMillisecondsCorrectlyWhenGivenValidReplyArray() {
 
 		Reply<?> seconds = new BulkReply("1392183718".getBytes(Charset.forName("UTF-8")));
@@ -51,46 +48,31 @@ public class SrpReplyToTimeAsLongConverterUnitTests {
 		Assert.assertThat(converter.convert(new Reply[] { seconds, microseconds }), IsEqual.equalTo(1392183718555L));
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-206
 	public void testConverterShouldThrowExceptionWhenGivenReplyArrayIsNull() {
 
 		converter.convert(null);
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-206
 	public void testConverterShouldThrowExceptionWhenGivenReplyArrayIsEmpty() {
 
 		converter.convert(new Reply[] {});
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-206
 	public void testConverterShouldThrowExceptionWhenGivenReplyArrayHasOnlyOneItem() {
 
 		converter.convert(new Reply[] { new BulkReply(null) });
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-206
 	public void testConverterShouldThrowExceptionWhenGivenReplyArrayMoreThanTwoItems() {
 
 		converter.convert(new Reply[] { new BulkReply(null), new BulkReply(null), new BulkReply(null) });
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test(expected = NumberFormatException.class)
+	@Test(expected = NumberFormatException.class) // DATAREDIS-206
 	public void testConverterShouldThrowExecptionForNonParsableReply() {
 
 		Reply<?> invalidDataBlock = new BulkReply("123-not-a-number".getBytes(Charset.forName("UTF-8")));
@@ -99,10 +81,7 @@ public class SrpReplyToTimeAsLongConverterUnitTests {
 		converter.convert(new Reply[] { invalidDataBlock, microseconds });
 	}
 
-	/**
-	 * @see DATAREDIS-206
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-206
 	public void testConverterShouldThrowExecptionForEmptyDataBlocks() {
 
 		Reply<?> invalidDataBlock = new BulkReply(null);

--- a/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 - 2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,9 +44,7 @@ import org.springframework.oxm.xstream.XStreamMarshaller;
  */
 abstract public class AbstractOperationsTestParams {
 
-	/**
-	 * @see DATAREDIS-241
-	 */
+	// DATAREDIS-241
 	public static Collection<Object[]> testParams() {
 
 		ObjectFactory<String> stringFactory = new StringObjectFactory();

--- a/src/test/java/org/springframework/data/redis/core/ConnectionSplittingInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ConnectionSplittingInterceptorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,10 +61,7 @@ public class ConnectionSplittingInterceptorUnitTests {
 		Mockito.when(connectionFactoryMock.getConnection()).thenReturn(freshConnectionMock);
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void interceptorShouldRequestFreshConnectionForReadonlyCommand() throws Throwable {
 
 		interceptor.intercept(boundConnectionMock, READONLY_METHOD, new Object[] { new byte[] {} }, null);
@@ -72,10 +69,7 @@ public class ConnectionSplittingInterceptorUnitTests {
 		Mockito.verifyZeroInteractions(boundConnectionMock);
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void interceptorShouldUseBoundConnectionForWriteOperations() throws Throwable {
 
 		interceptor.intercept(boundConnectionMock, WRITE_METHOD, new Object[] { new byte[] {}, 0L }, null);
@@ -83,11 +77,8 @@ public class ConnectionSplittingInterceptorUnitTests {
 		Mockito.verifyZeroInteractions(connectionFactoryMock);
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
 	@SuppressWarnings("unchecked")
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAREDIS-73
 	public void interceptorShouldNotWrapException() throws Throwable {
 
 		Mockito.when(freshConnectionMock.keys(Mockito.any(byte[].class))).thenThrow(

--- a/src/test/java/org/springframework/data/redis/core/DefaultClusterOperationsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultClusterOperationsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,10 +79,7 @@ public class DefaultClusterOperationsUnitTests {
 		this.clusterOps = new DefaultClusterOperations<String, String>(template);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void keysShouldDelegateToConnectionCorrectly() {
 
 		Set<byte[]> keys = new HashSet<byte[]>(Arrays.asList(serializer.serialize("key-1"), serializer.serialize("key-2")));
@@ -91,18 +88,12 @@ public class DefaultClusterOperationsUnitTests {
 		assertThat(clusterOps.keys(NODE_1, "*"), hasItems("key-1", "key-2"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void keysShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.keys(null, "*");
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void keysShouldReturnEmptySetWhenNoKeysAvailable() {
 
 		when(connection.keys(any(RedisClusterNode.class), any(byte[].class))).thenReturn(null);
@@ -110,10 +101,7 @@ public class DefaultClusterOperationsUnitTests {
 		assertThat(clusterOps.keys(NODE_1, "*"), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void randomKeyShouldDelegateToConnection() {
 
 		when(connection.randomKey(any(RedisClusterNode.class))).thenReturn(serializer.serialize("key-1"));
@@ -121,18 +109,12 @@ public class DefaultClusterOperationsUnitTests {
 		assertThat(clusterOps.randomKey(NODE_1), is("key-1"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void randomKeyShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.randomKey(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void randomKeyShouldReturnNullWhenNoKeyAvailable() {
 
 		when(connection.randomKey(any(RedisClusterNode.class))).thenReturn(null);
@@ -140,10 +122,7 @@ public class DefaultClusterOperationsUnitTests {
 		assertThat(clusterOps.randomKey(NODE_1), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void pingShouldDelegateToConnection() {
 
 		when(connection.ping(any(RedisClusterNode.class))).thenReturn("PONG");
@@ -151,18 +130,12 @@ public class DefaultClusterOperationsUnitTests {
 		assertThat(clusterOps.ping(NODE_1), is("PONG"));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void pingShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.ping(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void addSlotsShouldDelegateToConnection() {
 
 		clusterOps.addSlots(NODE_1, 1, 2, 3);
@@ -170,18 +143,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).clusterAddSlots(eq(NODE_1), Mockito.<int[]> anyVararg());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void addSlotsShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.addSlots(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void addSlotsWithRangeShouldDelegateToConnection() {
 
 		clusterOps.addSlots(NODE_1, new SlotRange(1, 3));
@@ -189,18 +156,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).clusterAddSlots(eq(NODE_1), Mockito.<int[]> anyVararg());
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void addSlotsWithRangeShouldThrowExceptionWhenRangeIsNull() {
 		clusterOps.addSlots(NODE_1, (SlotRange) null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void bgSaveShouldDelegateToConnection() {
 
 		clusterOps.bgSave(NODE_1);
@@ -208,18 +169,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).bgSave(eq(NODE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void bgSaveShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.bgSave(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void meetShouldDelegateToConnection() {
 
 		clusterOps.meet(NODE_1);
@@ -227,18 +182,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).clusterMeet(eq(NODE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void meetShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.meet(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void forgetShouldDelegateToConnection() {
 
 		clusterOps.forget(NODE_1);
@@ -246,18 +195,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).clusterForget(eq(NODE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void forgetShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.forget(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void flushDbShouldDelegateToConnection() {
 
 		clusterOps.flushDb(NODE_1);
@@ -265,18 +208,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).flushDb(eq(NODE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void flushDbShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.flushDb(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void getSlavesShouldDelegateToConnection() {
 
 		clusterOps.getSlaves(NODE_1);
@@ -284,18 +221,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).clusterGetSlaves(eq(NODE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void getSlavesShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.getSlaves(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void saveShouldDelegateToConnection() {
 
 		clusterOps.save(NODE_1);
@@ -303,18 +234,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).save(eq(NODE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void saveShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.save(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void shutdownShouldDelegateToConnection() {
 
 		clusterOps.shutdown(NODE_1);
@@ -322,18 +247,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).shutdown(eq(NODE_1));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void shutdownShouldThrowExceptionWhenNodeIsNull() {
 		clusterOps.shutdown(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void executeShouldDelegateToConnection() {
 
 		final byte[] key = serializer.serialize("foo");
@@ -348,18 +267,12 @@ public class DefaultClusterOperationsUnitTests {
 		verify(connection, times(1)).get(eq(key));
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-315
 	public void executeShouldThrowExceptionWhenCallbackIsNull() {
 		clusterOps.execute(null);
 	}
 
-	/**
-	 * @see DATAREDIS-315
-	 */
-	@Test
+	@Test // DATAREDIS-315
 	public void reshardShouldExecuteCommandsCorrectly() {
 
 		byte[] key = "foo".getBytes();

--- a/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,10 +113,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAdd() {
 
 		Long numAdded = geoOperations.geoAdd(keyFactory.instance(), POINT_PALERMO, valueFactory.instance());
@@ -124,10 +121,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(numAdded, is(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoAddWithLocationMap() {
 
 		Map<M, Point> memberCoordinateMap = new HashMap<M, Point>();
@@ -139,10 +133,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(numAdded, is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoDistShouldReturnDistanceInMetersByDefault() {
 
 		K key = keyFactory.instance();
@@ -157,10 +148,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(dist.getUnit(), is(equalTo("m")));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoDistShouldReturnDistanceInKilometersCorrectly() {
 
 		K key = keyFactory.instance();
@@ -175,10 +163,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(dist.getUnit(), is(equalTo("km")));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoDistShouldReturnDistanceInMilesCorrectly() {
 
 		K key = keyFactory.instance();
@@ -193,10 +178,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(dist.getUnit(), is(equalTo("mi")));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoDistShouldReturnDistanceInFeeCorrectly() {
 
 		K key = keyFactory.instance();
@@ -211,10 +193,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(dist.getUnit(), is(equalTo("ft")));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoHash() {
 
 		K key = keyFactory.instance();
@@ -233,10 +212,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.get(1), is(equalTo("sqdtr74hyu0")));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoPos() {
 
 		K key = keyFactory.instance();
@@ -259,10 +235,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.get(2), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoRadiusShouldReturnMembersCorrectly() {
 
 		K key = keyFactory.instance();
@@ -278,10 +251,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.getContent(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoRadiusShouldReturnLocationsWithDistance() {
 
 		K key = keyFactory.instance();
@@ -305,10 +275,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.getContent().get(1).getContent().getName(), is(member2));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoRadiusShouldReturnLocationsWithCoordinates() {
 
 		K key = keyFactory.instance();
@@ -332,10 +299,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.getContent().get(1).getContent().getName(), is(member1));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoRadiusShouldReturnLocationsWithCoordinatesAndDistance() {
 
 		K key = keyFactory.instance();
@@ -363,10 +327,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.getContent().get(1).getContent().getName(), is(member1));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoRadiusByMemberShouldReturnMembersCorrectly() {
 
 		K key = keyFactory.instance();
@@ -382,10 +343,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.getContent(), hasSize(3));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoRadiusByMemberShouldReturnDistanceCorrectly() {
 
 		K key = keyFactory.instance();
@@ -407,10 +365,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.getContent().get(1).getContent().getName(), is(member3));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoRadiusByMemberShouldReturnCoordinates() {
 
 		K key = keyFactory.instance();
@@ -435,10 +390,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.getContent().get(1).getContent().getName(), is(member1));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void geoRadiusByMemberShouldReturnCoordinatesAndDistance() {
 
 		K key = keyFactory.instance();
@@ -466,10 +418,7 @@ public class DefaultGeoOperationsTests<K, M> {
 		assertThat(result.getContent().get(1).getContent().getName(), is(member3));
 	}
 
-	/**
-	 * @see DATAREDIS-438
-	 */
-	@Test
+	@Test // DATAREDIS-438
 	public void testGeoRemove() {
 
 		K key = keyFactory.instance();

--- a/src/test/java/org/springframework/data/redis/core/DefaultHashOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultHashOperationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,10 +149,7 @@ public class DefaultHashOperationsTests<K, HK, HV> {
 		assertEquals(2L, numDeleted.longValue());
 	}
 
-	/**
-	 * @see DATAREDIS-305
-	 */
-	@Test
+	@Test // DATAREDIS-305
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	public void testHScanReadsValuesFully() throws IOException {
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultHyperLogLogOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultHyperLogLogOperationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,10 +86,7 @@ public class DefaultHyperLogLogOperationsTests<K, V> {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	@SuppressWarnings("unchecked")
 	public void addShouldAddDistinctValuesCorrectly() {
 
@@ -101,10 +98,7 @@ public class DefaultHyperLogLogOperationsTests<K, V> {
 		assertThat(hyperLogLogOps.add(key, v1, v2, v3), equalTo(1L));
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	@SuppressWarnings("unchecked")
 	public void addShouldNotAddExistingValuesCorrectly() {
 
@@ -117,10 +111,7 @@ public class DefaultHyperLogLogOperationsTests<K, V> {
 		assertThat(hyperLogLogOps.add(key, v2), equalTo(0L));
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	@SuppressWarnings("unchecked")
 	public void sizeShouldCountValuesCorrectly() {
 
@@ -133,10 +124,7 @@ public class DefaultHyperLogLogOperationsTests<K, V> {
 		assertThat(hyperLogLogOps.size(key), equalTo(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	@SuppressWarnings("unchecked")
 	public void sizeShouldCountValuesOfMultipleKeysCorrectly() {
 
@@ -153,11 +141,7 @@ public class DefaultHyperLogLogOperationsTests<K, V> {
 		assertThat(hyperLogLogOps.size(key, key2), equalTo(4L));
 	}
 
-	/**
-	 * @throws InterruptedException
-	 * @see DATAREDIS-308
-	 */
-	@Test
+	@Test // DATAREDIS-308
 	@SuppressWarnings("unchecked")
 	public void unionShouldMergeValuesOfMultipleKeysCorrectly() throws InterruptedException {
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultListOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultListOperationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,10 +186,7 @@ public class DefaultListOperationsTests<K, V> {
 		assertThat(listOps.range(key, 0, -1), isEqual(Arrays.asList(new Object[] { v1, v2, v3 })));
 	}
 
-	/**
-	 * @see DATAREDIS-288
-	 */
-	@Test
+	@Test // DATAREDIS-288
 	@SuppressWarnings("unchecked")
 	public void testRightPushAllCollection() {
 
@@ -203,35 +200,23 @@ public class DefaultListOperationsTests<K, V> {
 		assertThat(listOps.range(key, 0, -1), isEqual(Arrays.asList(new Object[] { v1, v2, v3 })));
 	}
 
-	/**
-	 * @see DATAREDIS-288
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-288
 	public void rightPushAllShouldThrowExceptionWhenCalledWithEmptyCollection() {
 		listOps.rightPushAll(keyFactory.instance(), Collections.<V> emptyList());
 	}
 
-	/**
-	 * @see DATAREDIS-288
-	 */
 	@SuppressWarnings("unchecked")
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-288
 	public void rightPushAllShouldThrowExceptionWhenCollectionContainsNullValue() {
 		listOps.rightPushAll(keyFactory.instance(), Arrays.asList(valueFactory.instance(), null));
 	}
 
-	/**
-	 * @see DATAREDIS-288
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-288
 	public void rightPushAllShouldThrowExceptionWhenCalledWithNull() {
 		listOps.rightPushAll(keyFactory.instance(), (Collection<V>) null);
 	}
 
-	/**
-	 * @see DATAREDIS-288
-	 */
-	@Test
+	@Test // DATAREDIS-288
 	@SuppressWarnings("unchecked")
 	public void testLeftPushAllCollection() {
 
@@ -245,27 +230,18 @@ public class DefaultListOperationsTests<K, V> {
 		assertThat(listOps.range(key, 0, -1), isEqual(Arrays.asList(new Object[] { v3, v2, v1 })));
 	}
 
-	/**
-	 * @see DATAREDIS-288
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-288
 	public void leftPushAllShouldThrowExceptionWhenCalledWithEmptyCollection() {
 		listOps.leftPushAll(keyFactory.instance(), Collections.<V> emptyList());
 	}
 
-	/**
-	 * @see DATAREDIS-288
-	 */
 	@SuppressWarnings("unchecked")
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-288
 	public void leftPushAllShouldThrowExceptionWhenCollectionContainsNullValue() {
 		listOps.leftPushAll(keyFactory.instance(), Arrays.asList(valueFactory.instance(), null));
 	}
 
-	/**
-	 * @see DATAREDIS-288
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-288
 	public void leftPushAllShouldThrowExceptionWhenCalledWithNull() {
 		listOps.leftPushAll(keyFactory.instance(), (Collection<V>) null);
 	}

--- a/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 - 2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -210,10 +210,7 @@ public class DefaultSetOperationsTests<K, V> {
 		assertThat(setOps.members(key), isEqual(Collections.singleton(v3)));
 	}
 
-	/**
-	 * @see DATAREDIS-304
-	 */
-	@Test
+	@Test // DATAREDIS-304
 	@SuppressWarnings("unchecked")
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	public void testSSCanReadsValuesFully() throws IOException {
@@ -234,10 +231,7 @@ public class DefaultSetOperationsTests<K, V> {
 		assertThat(count, is(setOps.size(key)));
 	}
 
-	/**
-	 * @see DATAREDIS-448
-	 */
-	@Test
+	@Test // DATAREDIS-448
 	public void intersectAndStoreShouldReturnNumberOfElementsInDestination() {
 
 		K sourceKey1 = keyFactory.instance();

--- a/src/test/java/org/springframework/data/redis/core/DefaultTypedTupleUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultTypedTupleUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,10 +31,7 @@ public class DefaultTypedTupleUnitTests {
 	private static final TypedTuple<String> WITH_SCORE_2 = new DefaultTypedTuple<String>("bar", 2D);
 	private static final TypedTuple<String> WITH_SCORE_NULL = new DefaultTypedTuple<String>("foo", null);
 
-	/**
-	 * @see DATAREDIS-294
-	 */
-	@Test
+	@Test // DATAREDIS-294
 	public void compareToShouldUseScore() {
 
 		assertThat(WITH_SCORE_1.compareTo(WITH_SCORE_2), equalTo(-1));
@@ -42,20 +39,14 @@ public class DefaultTypedTupleUnitTests {
 		assertThat(WITH_SCORE_1.compareTo(ANOTHER_ONE_WITH_SCORE_1), equalTo(0));
 	}
 
-	/**
-	 * @see DATAREDIS-294
-	 */
-	@Test
+	@Test // DATAREDIS-294
 	public void compareToShouldConsiderGivenNullAsZeroScore() {
 
 		assertThat(WITH_SCORE_1.compareTo(null), equalTo(1));
 		assertThat(WITH_SCORE_NULL.compareTo(null), equalTo(0));
 	}
 
-	/**
-	 * @see DATAREDIS-294
-	 */
-	@Test
+	@Test // DATAREDIS-294
 	public void compareToShouldConsiderNullScoreAsZeroScore() {
 
 		assertThat(WITH_SCORE_1.compareTo(WITH_SCORE_NULL), equalTo(1));

--- a/src/test/java/org/springframework/data/redis/core/DefaultValueOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultValueOperationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,10 +108,7 @@ public class DefaultValueOperationsTests<K, V> {
 		assertEquals(Long.valueOf((Long) v1 - 20), (Long) valueOps.get(key));
 	}
 
-	/**
-	 * @see DATAREDIS-247
-	 */
-	@Test
+	@Test // DATAREDIS-247
 	public void testIncrementDouble() {
 
 		assumeTrue(RedisTestProfileValueSource.matches("redisVersion", "2.6"));
@@ -197,10 +194,7 @@ public class DefaultValueOperationsTests<K, V> {
 		}, 1000);
 	}
 
-	/**
-	 * @see DATAREDIS-271
-	 */
-	@Test
+	@Test // DATAREDIS-271
 	public void testSetWithExpirationWithTimeUnitMilliseconds() {
 
 		assumeTrue(RedisTestProfileValueSource.matches("runLongTests", "true"));
@@ -287,10 +281,7 @@ public class DefaultValueOperationsTests<K, V> {
 		assertNotNull(((DefaultValueOperations) valueOps).deserializeKey((byte[]) key1));
 	}
 
-	/**
-	 * @see DATAREDIS-197
-	 */
-	@Test
+	@Test // DATAREDIS-197
 	public void testSetAndGetBit() {
 
 		assumeTrue(redisTemplate instanceof StringRedisTemplate);

--- a/src/test/java/org/springframework/data/redis/core/DefaultZSetOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultZSetOperationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,10 +183,7 @@ public class DefaultZSetOperationsTests<K, V> {
 		assertThat(tuple, isEqual(new DefaultTypedTuple<V>(value2, 3.7)));
 	}
 
-	/**
-	 * @see DATAREDIS-407
-	 */
-	@Test
+	@Test // DATAREDIS-407
 	public void testRangeByLexUnbounded() {
 
 		assumeThat(valueFactory, anyOf(instanceOf(DoubleObjectFactory.class), instanceOf(DoubleAsStringObjectFactory.class),
@@ -207,10 +204,7 @@ public class DefaultZSetOperationsTests<K, V> {
 		assertThat(tuple, isEqual(value1));
 	}
 
-	/**
-	 * @see DATAREDIS-407
-	 */
-	@Test
+	@Test // DATAREDIS-407
 	public void testRangeByLexBounded() {
 
 		assumeThat(valueFactory, anyOf(instanceOf(DoubleObjectFactory.class), instanceOf(DoubleAsStringObjectFactory.class),
@@ -231,10 +225,7 @@ public class DefaultZSetOperationsTests<K, V> {
 		assertThat(tuple, isEqual(value2));
 	}
 
-	/**
-	 * @see DATAREDIS-407
-	 */
-	@Test
+	@Test // DATAREDIS-407
 	public void testRangeByLexUnboundedWithLimit() {
 
 		assumeThat(valueFactory, anyOf(instanceOf(DoubleObjectFactory.class), instanceOf(DoubleAsStringObjectFactory.class),
@@ -256,10 +247,7 @@ public class DefaultZSetOperationsTests<K, V> {
 		assertThat(tuple, isEqual(value2));
 	}
 
-	/**
-	 * @see DATAREDIS-407
-	 */
-	@Test
+	@Test // DATAREDIS-407
 	public void testRangeByLexBoundedWithLimit() {
 
 		assumeThat(valueFactory, anyOf(instanceOf(DoubleObjectFactory.class), instanceOf(DoubleAsStringObjectFactory.class),
@@ -350,10 +338,7 @@ public class DefaultZSetOperationsTests<K, V> {
 		assertThat(zSetOps.size(key), equalTo(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-306
-	 */
-	@Test
+	@Test // DATAREDIS-306
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	public void testZScanShouldReadEntireValueRange() throws IOException {
 

--- a/src/test/java/org/springframework/data/redis/core/IndexWriterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/IndexWriterUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,10 +70,7 @@ public class IndexWriterUnitTests {
 		writer = new IndexWriter(connectionMock, converter);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void addKeyToIndexShouldInvokeSaddCorrectly() {
 
 		writer.addKeyToIndex(KEY_BIN, new SimpleIndexedPropertyValue(KEYSPACE, "firstname", "Rand"));
@@ -83,18 +80,12 @@ public class IndexWriterUnitTests {
 				eq("persons:firstname:Rand".getBytes(CHARSET)));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-425
 	public void addKeyToIndexShouldThrowErrorWhenIndexedDataIsNull() {
 		writer.addKeyToIndex(KEY_BIN, null);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void removeKeyFromExistingIndexesShouldCheckForExistingIndexesForPath() {
 
 		writer.removeKeyFromExistingIndexes(KEY_BIN, new StubIndxedData());
@@ -103,10 +94,7 @@ public class IndexWriterUnitTests {
 		verifyNoMoreInteractions(connectionMock);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void removeKeyFromExistingIndexesShouldRemoveKeyFromAllExistingIndexesForPath() {
 
 		byte[] indexKey1 = "persons:firstname:rand".getBytes(CHARSET);
@@ -121,18 +109,12 @@ public class IndexWriterUnitTests {
 		verify(connectionMock).sRem(indexKey2, KEY_BIN);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-425
 	public void removeKeyFromExistingIndexesShouldThrowExecptionForNullIndexedData() {
 		writer.removeKeyFromExistingIndexes(KEY_BIN, null);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void removeAllIndexesShouldDeleteAllIndexKeys() {
 
 		byte[] indexKey1 = "persons:firstname:rand".getBytes(CHARSET);
@@ -149,19 +131,13 @@ public class IndexWriterUnitTests {
 		assertThat(captor.getAllValues(), hasItems(indexKey1, indexKey2));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAREDIS-425
 	public void addToIndexShouldThrowDataAccessExceptionWhenAddingDataThatConnotBeConverted() {
 		writer.addKeyToIndex(KEY_BIN, new SimpleIndexedPropertyValue(KEYSPACE, "firstname", new DummyObject()));
 
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void addToIndexShouldUseRegisteredConverterWhenAddingData() {
 
 		DummyObject value = new DummyObject();
@@ -180,10 +156,7 @@ public class IndexWriterUnitTests {
 		verify(connectionMock).sAdd(eq(("persons:firstname:" + identityHexString).getBytes(CHARSET)), eq(KEY_BIN));
 	}
 
-	/**
-	 * @see DATAREDIS-512
-	 */
-	@Test
+	@Test // DATAREDIS-512
 	public void createIndexShouldNotTryToRemoveExistingValues() {
 
 		when(connectionMock.keys(any(byte[].class)))
@@ -198,10 +171,7 @@ public class IndexWriterUnitTests {
 		verify(connectionMock, never()).sRem(any(byte[].class), eq(KEY_BIN));
 	}
 
-	/**
-	 * @see DATAREDIS-512
-	 */
-	@Test
+	@Test // DATAREDIS-512
 	public void updateIndexShouldRemoveExistingValues() {
 
 		when(connectionMock.keys(any(byte[].class)))
@@ -216,10 +186,7 @@ public class IndexWriterUnitTests {
 		verify(connectionMock, times(1)).sRem(any(byte[].class), eq(KEY_BIN));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void removeGeoIndexShouldCallGeoRemove() {
 
 		byte[] indexKey1 = "persons:location".getBytes(CHARSET);

--- a/src/test/java/org/springframework/data/redis/core/MultithreadedRedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/MultithreadedRedisTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,10 +74,7 @@ public class MultithreadedRedisTemplateTests {
 		return Arrays.asList(new Object[][] { { jedis }, { lettuce }, { srp } });
 	}
 
-	/**
-	 * @see DATAREDIS-300
-	 */
-	@Test
+	@Test // DATAREDIS-300
 	public void assertResouresAreReleasedProperlyWhenSharingRedisTemplate() throws InterruptedException {
 
 		final RedisTemplate<Object, Object> template = new RedisTemplate<Object, Object>();

--- a/src/test/java/org/springframework/data/redis/core/RedisCommandUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisCommandUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,66 +30,42 @@ public class RedisCommandUnitTests {
 
 	public @Rule ExpectedException expectedException = ExpectedException.none();
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void shouldIdentifyAliasCorrectly() {
 		assertThat(RedisCommand.CONFIG_SET.isRepresentedBy("setconfig"), equalTo(true));
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void shouldIdentifyAliasCorrectlyWhenNamePassedInMixedCase() {
 		assertThat(RedisCommand.CONFIG_SET.isRepresentedBy("SetConfig"), equalTo(true));
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void shouldNotThrowExceptionWhenUsingNullKeyForRepresentationCheck() {
 		assertThat(RedisCommand.CONFIG_SET.isRepresentedBy(null), equalTo(false));
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void shouldIdentifyAliasCorrectlyViaLookup() {
 		assertThat(RedisCommand.failsafeCommandLookup("setconfig"), is(RedisCommand.CONFIG_SET));
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void shouldIdentifyAliasCorrectlyWhenNamePassedInMixedCaseViaLookup() {
 		assertThat(RedisCommand.failsafeCommandLookup("SetConfig"), is(RedisCommand.CONFIG_SET));
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void shouldReturnUnknownCommandForUnknownCommandString() {
 		assertThat(RedisCommand.failsafeCommandLookup("strangecommand"), is(RedisCommand.UNKNOWN));
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void shouldNotThrowExceptionOnValidArgumentCount() {
 		RedisCommand.AUTH.validateArgumentCount(1);
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void shouldThrowExceptionOnInvalidArgumentCountWhenExpectedExcatMatch() {
 
 		expectedException.expect(IllegalArgumentException.class);
@@ -97,10 +73,7 @@ public class RedisCommandUnitTests {
 		RedisCommand.AUTH.validateArgumentCount(2);
 	}
 
-	/**
-	 * @see DATAREDIS-73
-	 */
-	@Test
+	@Test // DATAREDIS-73
 	public void shouldThrowExceptionOnInvalidArgumentCountWhenExpectedMinimalMatch() {
 
 		expectedException.expect(IllegalArgumentException.class);

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -43,6 +44,7 @@ import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
 import org.springframework.data.redis.core.convert.Bucket;
 import org.springframework.data.redis.core.convert.KeyspaceConfiguration;
 import org.springframework.data.redis.core.convert.MappingConfiguration;
@@ -92,6 +94,7 @@ public class RedisKeyValueAdapterTests {
 		mappingContext.afterPropertiesSet();
 
 		adapter = new RedisKeyValueAdapter(template, mappingContext);
+		adapter.setEnableKeyspaceEvents(EnableKeyspaceEvents.ON_STARTUP);
 		adapter.afterPropertiesSet();
 
 		template.execute(new RedisCallback<Void>() {
@@ -239,26 +242,67 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForSet().members("persons:firstname:rand"), not(hasItem("1")));
 	}
 
-	@Test // DATAREDIS-425
-	public void keyExpiredEventShouldRemoveHelperStructures() {
+	/**
+	 * @see DATAREDIS-425
+	 */
+	@Test
+	public void keyExpiredEventShouldRemoveHelperStructures() throws InterruptedException {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
 		map.put("_class", Person.class.getName());
 		map.put("firstname", "rand");
 		map.put("address.country", "Andor");
 
+		template.opsForHash().putAll("persons:1", map);
+		template.expire("persons:1", 1, TimeUnit.SECONDS);
+
 		template.opsForSet().add("persons", "1");
 		template.opsForSet().add("persons:firstname:rand", "1");
 		template.opsForSet().add("persons:1:idx", "persons:firstname:rand");
 
-		adapter.onApplicationEvent(new RedisKeyExpiredEvent("persons:1".getBytes(Bucket.CHARSET)));
+		int iterationCount = 0;
+		while (template.hasKey("persons:1") && iterationCount++ < 3) { // ci might be a little slow
+			Thread.sleep(2000);
+		}
 
+		assertThat(template.hasKey("persons:1"), is(false));
 		assertThat(template.hasKey("persons:firstname:rand"), is(false));
 		assertThat(template.hasKey("persons:1:idx"), is(false));
 		assertThat(template.opsForSet().members("persons"), not(hasItem("1")));
 	}
 
-	@Test // DATAREDIS-512
+	/**
+	 * @see DATAREDIS-589
+	 */
+	@Test
+	public void keyExpiredEventWithoutKeyspaceShouldBeIgnored() throws InterruptedException {
+
+		Map<String, String> map = new LinkedHashMap<String, String>();
+		map.put("_class", Person.class.getName());
+		map.put("firstname", "rand");
+		map.put("address.country", "Andor");
+
+		template.opsForHash().putAll("persons:1", map);
+		template.opsForHash().putAll("1", map);
+
+		template.expire("1", 1, TimeUnit.SECONDS);
+
+		template.opsForSet().add("persons", "1");
+		template.opsForSet().add("persons:firstname:rand", "1");
+		template.opsForSet().add("persons:1:idx", "persons:firstname:rand");
+
+		Thread.sleep(2000);
+
+		assertThat(template.hasKey("persons:1"), is(true));
+		assertThat(template.hasKey("persons:firstname:rand"), is(true));
+		assertThat(template.hasKey("persons:1:idx"), is(true));
+		assertThat(template.opsForSet().members("persons"), hasItem("1"));
+	}
+
+	/**
+	 * @see DATAREDIS-512
+	 */
+	@Test
 	public void putWritesIndexDataCorrectly() {
 
 		Person rand = new Person();

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,10 +114,7 @@ public class RedisKeyValueAdapterTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void putWritesDataCorrectly() {
 
 		Person rand = new Person();
@@ -131,10 +128,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForHash().entries("persons:1").size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void putWritesSimpleIndexDataCorrectly() {
 
 		Person rand = new Person();
@@ -146,10 +140,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForSet().members("persons:firstname:rand"), hasItems("1"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void putWritesNestedDataCorrectly() {
 
 		Person rand = new Person();
@@ -162,10 +153,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForHash().entries("persons:1").size(), is(2));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void putWritesSimpleNestedIndexValuesCorrectly() {
 
 		Person rand = new Person();
@@ -178,10 +166,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForSet().members("persons:address.country:Andor"), hasItems("1"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getShouldReadSimpleObjectCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -195,10 +180,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(((Person) loaded).age, is(24));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getShouldReadNestedObjectCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -212,10 +194,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(((Person) loaded).address.country, is("Andor"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void couldReadsKeyspaceSizeCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -228,10 +207,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(adapter.count("persons"), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void deleteRemovesEntriesCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -246,10 +222,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.hasKey("persons:1"), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void deleteCleansIndexedDataCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -266,10 +239,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForSet().members("persons:firstname:rand"), not(hasItem("1")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void keyExpiredEventShouldRemoveHelperStructures() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -288,10 +258,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForSet().members("persons"), not(hasItem("1")));
 	}
 
-	/**
-	 * @see DATAREDIS-512
-	 */
-	@Test
+	@Test // DATAREDIS-512
 	public void putWritesIndexDataCorrectly() {
 
 		Person rand = new Person();
@@ -327,10 +294,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForSet().isMember("persons:mat:idx", "persons:firstname:mat"), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void updateShouldAlterIndexDataCorrectly() {
 
 		Person rand = new Person();
@@ -349,10 +313,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.hasKey("persons:firstname:mat"), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void updateShouldAlterIndexDataOnNestedObjectCorrectly() {
 
 		Person rand = new Person();
@@ -375,10 +336,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.hasKey("persons:address.country:tear"), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void updateShouldAlterIndexDataOnNestedObjectPathCorrectly() {
 
 		Person rand = new Person();
@@ -398,10 +356,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.hasKey("persons:address.country:tear"), is(true));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void updateShouldRemoveComplexObjectCorrectly() {
 
 		Person rand = new Person();
@@ -421,10 +376,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForSet().isMember("persons:address.country:andor", "1"), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void updateShouldRemoveSimpleListValuesCorrectly() {
 
 		Person rand = new Person();
@@ -441,10 +393,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForHash().hasKey("persons:1", "nicknames.[1]"), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void updateShouldRemoveComplexListValuesCorrectly() {
 
 		Person mat = new Person();
@@ -471,10 +420,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForHash().hasKey("persons:1", "coworkers.[1].nicknames.[0]"), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void updateShouldRemoveSimpleMapValuesCorrectly() {
 
 		Person rand = new Person();
@@ -490,10 +436,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForHash().hasKey("persons:1", "physicalAttributes.[eye-color]"), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void updateShouldRemoveComplexMapValuesCorrectly() {
 
 		Person tam = new Person();
@@ -512,10 +455,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForHash().hasKey("persons:1", "relatives.[stepfather].firstname"), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void putShouldCreateGeoIndexCorrectly() {
 
 		Person tam = new Person();
@@ -529,10 +469,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForZSet().score("persons:address:location", "1"), is(notNullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void deleteShouldRemoveGeoIndexCorrectly() {
 
 		Person tam = new Person();
@@ -548,10 +485,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForZSet().score("persons:address:location", "1"), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void updateShouldAlterGeoIndexCorrectlyOnDelete() {
 
 		Person tam = new Person();
@@ -570,10 +504,7 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.opsForZSet().score("persons:address:location", "1"), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void updateShouldAlterGeoIndexCorrectlyOnUpdate() {
 
 		Person tam = new Person();

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,10 +84,7 @@ public class RedisKeyValueAdapterUnitTests {
 		adapter.destroy();
 	}
 
-	/**
-	 * @see DATAREDIS-507
-	 */
-	@Test
+	@Test // DATAREDIS-507
 	public void destroyShouldNotDestroyConnectionFactory() throws Exception {
 
 		adapter.destroy();
@@ -95,11 +92,7 @@ public class RedisKeyValueAdapterUnitTests {
 		verify(jedisConnectionFactoryMock, never()).destroy();
 	}
 
-	/**
-	 * @see DATAREDIS-512
-	 * @see DATAREDIS-530
-	 */
-	@Test
+	@Test // DATAREDIS-512, DATAREDIS-530
 	public void putShouldRemoveExistingIndexValuesWhenUpdating() {
 
 		RedisData rd = new RedisData(Bucket.newBucketFromStringMap(Collections.singletonMap("_id", "1")));
@@ -115,10 +108,7 @@ public class RedisKeyValueAdapterUnitTests {
 				org.mockito.Matchers.any(byte[].class));
 	}
 
-	/**
-	 * @see DATAREDIS-512
-	 */
-	@Test
+	@Test // DATAREDIS-512
 	public void putShouldNotTryToRemoveExistingIndexValuesWhenInsertingNew() {
 
 		RedisData rd = new RedisData(Bucket.newBucketFromStringMap(Collections.singletonMap("_id", "1")));
@@ -133,10 +123,7 @@ public class RedisKeyValueAdapterUnitTests {
 		verify(redisConnectionMock, never()).sRem(org.mockito.Matchers.any(byte[].class), (byte[][]) anyVararg());
 	}
 
-	/**
-	 * @see DATAREDIS-491
-	 */
-	@Test
+	@Test // DATAREDIS-491
 	public void shouldInitKeyExpirationListenerOnStartup() throws Exception {
 
 		adapter.destroy();
@@ -150,10 +137,7 @@ public class RedisKeyValueAdapterUnitTests {
 		assertThat(listener, notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-491
-	 */
-	@Test
+	@Test // DATAREDIS-491
 	public void shouldInitKeyExpirationListenerOnFirstPutWithTtl() throws Exception {
 
 		adapter.destroy();
@@ -177,10 +161,7 @@ public class RedisKeyValueAdapterUnitTests {
 		assertThat(listener, notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-491
-	 */
-	@Test
+	@Test // DATAREDIS-491
 	public void shouldNeverInitKeyExpirationListener() throws Exception {
 
 		adapter.destroy();

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,10 +115,7 @@ public class RedisKeyValueTemplateTests {
 		adapter.destroy();
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void savesObjectCorrectly() {
 
 		final Person rand = new Person();
@@ -137,10 +134,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void findProcessesCallbackReturningSingleIdCorrectly() {
 
 		Person rand = new Person();
@@ -164,10 +158,7 @@ public class RedisKeyValueTemplateTests {
 		assertThat(result, hasItems(mat));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void findProcessesCallbackReturningMultipleIdsCorrectly() {
 
 		final Person rand = new Person();
@@ -191,10 +182,7 @@ public class RedisKeyValueTemplateTests {
 		assertThat(result, hasItems(rand, mat));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void findProcessesCallbackReturningNullCorrectly() {
 
 		Person rand = new Person();
@@ -217,10 +205,7 @@ public class RedisKeyValueTemplateTests {
 		assertThat(result.size(), is(0));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdate() {
 
 		final Person rand = new Person();
@@ -313,10 +298,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdateSimpleType() {
 
 		final VariousTypes source = new VariousTypes();
@@ -343,10 +325,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdateComplexType() {
 
 		Item callandor = new Item();
@@ -390,10 +369,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdateObjectType() {
 
 		Item callandor = new Item();
@@ -440,10 +416,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdateSimpleTypedMap() {
 
 		final VariousTypes source = new VariousTypes();
@@ -477,10 +450,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdateComplexTypedMap() {
 
 		final VariousTypes source = new VariousTypes();
@@ -543,10 +513,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdateObjectTypedMap() {
 
 		final VariousTypes source = new VariousTypes();
@@ -626,10 +593,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdateSimpleTypedList() {
 
 		final VariousTypes source = new VariousTypes();
@@ -664,10 +628,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdateComplexTypedList() {
 
 		final VariousTypes source = new VariousTypes();
@@ -723,10 +684,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void partialUpdateObjectTypedList() {
 
 		final VariousTypes source = new VariousTypes();
@@ -795,10 +753,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-530
-	 */
-	@Test
+	@Test // DATAREDIS-530
 	public void partialUpdateShouldLeaveIndexesNotInvolvedInUpdateUntouched() {
 
 		final Person rand = new Person();
@@ -830,10 +785,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-530
-	 */
-	@Test
+	@Test // DATAREDIS-530
 	public void updateShouldAlterIndexesCorrectlyWhenValuesGetRemovedFromHash() {
 
 		final Person rand = new Person();
@@ -870,10 +822,7 @@ public class RedisKeyValueTemplateTests {
 		});
 	}
 
-	/**
-	 * @see DATAREDIS-523
-	 */
-	@Test
+	@Test // DATAREDIS-523
 	public void shouldReadBackExplicitTimeToLive() throws InterruptedException {
 
 		WithTtl source = new WithTtl();
@@ -890,10 +839,7 @@ public class RedisKeyValueTemplateTests {
 		assertThat(target.ttl.doubleValue(), is(closeTo(3D, 1D)));
 	}
 
-	/**
-	 * @see DATAREDIS-523
-	 */
-	@Test
+	@Test // DATAREDIS-523
 	public void shouldReadBackExplicitTimeToLiveToPrimitiveField() throws InterruptedException {
 
 		WithPrimitiveTtl source = new WithPrimitiveTtl();
@@ -909,10 +855,7 @@ public class RedisKeyValueTemplateTests {
 		assertThat((double) target.ttl, is(closeTo(3D, 1D)));
 	}
 
-	/**
-	 * @see DATAREDIS-523
-	 */
-	@Test
+	@Test // DATAREDIS-523
 	public void shouldReadBackExplicitTimeToLiveWhenFetchingList() throws InterruptedException {
 
 		WithTtl source = new WithTtl();
@@ -930,10 +873,7 @@ public class RedisKeyValueTemplateTests {
 		assertThat(target.ttl.doubleValue(), is(closeTo(3D, 1D)));
 	}
 
-	/**
-	 * @see DATAREDIS-523
-	 */
-	@Test
+	@Test // DATAREDIS-523
 	public void shouldReadBackExplicitTimeToLiveAndSetItToMinusOnelIfPersisted() throws InterruptedException {
 
 		WithTtl source = new WithTtl();

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -324,10 +324,7 @@ public class RedisTemplateTests<K, V> {
 		assertEquals(Arrays.asList(new Object[] { 5l, 1l, 2l, Arrays.asList(new Long[] { 10l, 11l }) }), results);
 	}
 
-	/**
-	 * @see DATAREDIS-500
-	 */
-	@Test
+	@Test // DATAREDIS-500
 	public void testExecutePipelinedWidthDifferentHashKeySerializerAndHashValueSerializer() {
 
 		assumeTrue(redisTemplate instanceof StringRedisTemplate);
@@ -534,20 +531,14 @@ public class RedisTemplateTests<K, V> {
 		assertEquals(Long.valueOf(1), redisTemplate.getExpire(key1, TimeUnit.SECONDS));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void testGetExpireSecondsForKeyDoesNotExist() {
 
 		Long expire = redisTemplate.getExpire(keyFactory.instance(), TimeUnit.SECONDS);
 		assertTrue(expire < 0L);
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void testGetExpireSecondsForKeyExistButHasNoAssociatedExpire() {
 
 		K key = keyFactory.instance();
@@ -556,10 +547,7 @@ public class RedisTemplateTests<K, V> {
 		assertTrue(expire < 0L);
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void testGetExpireMillisForKeyDoesNotExist() {
 
 		Long expire = redisTemplate.getExpire(keyFactory.instance(), TimeUnit.MILLISECONDS);
@@ -567,10 +555,7 @@ public class RedisTemplateTests<K, V> {
 		assertTrue(expire < 0L);
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void testGetExpireMillisForKeyExistButHasNoAssociatedExpire() {
 
 		K key = keyFactory.instance();
@@ -581,10 +566,7 @@ public class RedisTemplateTests<K, V> {
 		assertTrue(expire < 0L);
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	public void testGetExpireMillis() {
 
 		assumeTrue(redisTemplate.getConnectionFactory() instanceof JedisConnectionFactory
@@ -600,10 +582,7 @@ public class RedisTemplateTests<K, V> {
 		assertThat(ttl, lessThan(25L));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void testGetExpireMillisUsingTransactions() {
 
@@ -630,10 +609,7 @@ public class RedisTemplateTests<K, V> {
 		assertThat(((Long) result.get(1)), lessThan(25L));
 	}
 
-	/**
-	 * @see DATAREDIS-526
-	 */
-	@Test
+	@Test // DATAREDIS-526
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void testGetExpireMillisUsingPipelining() {
 
@@ -761,10 +737,7 @@ public class RedisTemplateTests<K, V> {
 		assertEquals(DataType.STRING, redisTemplate.type(key1));
 	}
 
-	/**
-	 * @see DATAREDIS-506
-	 */
-	@Test
+	@Test // DATAREDIS-506
 	public void testWatch() {
 		final K key1 = keyFactory.instance();
 		V value1 = valueFactory.instance();
@@ -840,10 +813,7 @@ public class RedisTemplateTests<K, V> {
 		assertThat(redisTemplate.opsForValue().get(key1), isEqual(value3));
 	}
 
-	/**
-	 * @see DATAREDIS-506
-	 */
-	@Test
+	@Test // DATAREDIS-506
 	public void testWatchMultipleKeys() {
 
 		final K key1 = keyFactory.instance();

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,30 +55,21 @@ public class RedisTemplateUnitTests {
 		template.afterPropertiesSet();
 	}
 
-	/**
-	 * @see DATAREDIS-277
-	 */
-	@Test
+	@Test // DATAREDIS-277
 	public void slaveOfIsDelegatedToConnectionCorrectly() {
 
 		template.slaveOf("127.0.0.1", 1001);
 		verify(redisConnectionMock, times(1)).slaveOf(eq("127.0.0.1"), eq(1001));
 	}
 
-	/**
-	 * @see DATAREDIS-277
-	 */
-	@Test
+	@Test // DATAREDIS-277
 	public void slaveOfNoOneIsDelegatedToConnectionCorrectly() {
 
 		template.slaveOfNoOne();
 		verify(redisConnectionMock, times(1)).slaveOfNoOne();
 	}
 
-	/**
-	 * @see DATAREDIS-501
-	 */
-	@Test
+	@Test // DATAREDIS-501
 	public void templateShouldPassOnAndUseResoureLoaderClassLoaderToDefaultJdkSerializerWhenNotAlreadySet() {
 
 		ShadowingClassLoader scl = new ShadowingClassLoader(ClassLoader.getSystemClassLoader());
@@ -96,10 +87,7 @@ public class RedisTemplateUnitTests {
 		assertThat(deserialized.getClass().getClassLoader(), is((ClassLoader) scl));
 	}
 
-	/**
-	 * @see DATAREDIS-531
-	 */
-	@Test
+	@Test // DATAREDIS-531
 	public void executeWithStickyConnectionShouldNotCloseConnectionWhenDone() {
 
 		CapturingCallback callback = new CapturingCallback();

--- a/src/test/java/org/springframework/data/redis/core/ScanCursorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ScanCursorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,28 +41,19 @@ public class ScanCursorUnitTests {
 
 	public @Rule ExpectedException exception = ExpectedException.none();
 
-	/**
-	 * @see DATAREDIS-290
-	 */
-	@Test
+	@Test // DATAREDIS-290
 	public void cursorShouldNotLoopWhenNoValuesFound() {
 
 		CapturingCursorDummy cursor = initCursor(new LinkedList<ScanIteration<String>>());
 		assertThat(cursor.hasNext(), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-290
-	 */
-	@Test(expected = NoSuchElementException.class)
+	@Test(expected = NoSuchElementException.class) // DATAREDIS-290
 	public void cursorShouldReturnNullWhenNoNextElementAvailable() {
 		initCursor(new LinkedList<ScanIteration<String>>()).next();
 	}
 
-	/**
-	 * @see DATAREDIS-290
-	 */
-	@Test
+	@Test // DATAREDIS-290
 	public void cursorShouldNotLoopWhenReachingStartingPointInFistLoop() {
 
 		LinkedList<ScanIteration<String>> values = new LinkedList<ScanIteration<String>>();
@@ -82,10 +73,7 @@ public class ScanCursorUnitTests {
 		assertThat(cursor.hasNext(), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-290
-	 */
-	@Test
+	@Test // DATAREDIS-290
 	public void cursorShouldStopLoopWhenReachingStartingPoint() {
 
 		LinkedList<ScanIteration<String>> values = new LinkedList<ScanIteration<String>>();
@@ -107,10 +95,7 @@ public class ScanCursorUnitTests {
 		assertThat(cursor.hasNext(), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-290
-	 */
-	@Test
+	@Test // DATAREDIS-290
 	public void shouldThrowExceptionWhenAccessingClosedCursor() {
 
 		CapturingCursorDummy cursor = new CapturingCursorDummy(null);
@@ -123,10 +108,7 @@ public class ScanCursorUnitTests {
 		cursor.next();
 	}
 
-	/**
-	 * @see DATAREDIS-290
-	 */
-	@Test(expected = InvalidDataAccessApiUsageException.class)
+	@Test(expected = InvalidDataAccessApiUsageException.class) // DATAREDIS-290
 	public void repoeningCursorShouldHappenAtLastPosition() throws IOException {
 
 		LinkedList<ScanIteration<String>> values = new LinkedList<ScanIteration<String>>();
@@ -146,10 +128,7 @@ public class ScanCursorUnitTests {
 		cursor.open();
 	}
 
-	/**
-	 * @see DATAREDIS-290
-	 */
-	@Test
+	@Test // DATAREDIS-290
 	public void positionShouldBeIncrementedCorrectly() throws IOException {
 
 		LinkedList<ScanIteration<String>> values = new LinkedList<ScanIteration<String>>();
@@ -167,10 +146,7 @@ public class ScanCursorUnitTests {
 		assertThat(cursor.getPosition(), is(2L));
 	}
 
-	/**
-	 * @see DATAREDIS-417
-	 */
-	@Test
+	@Test // DATAREDIS-417
 	public void hasNextShouldCallScanUntilFinishedWhenScanResultIsAnEmptyCollection() {
 
 		LinkedList<ScanIteration<String>> values = new LinkedList<ScanIteration<String>>();
@@ -191,10 +167,7 @@ public class ScanCursorUnitTests {
 		assertThat(result, hasItems("spring", "redis"));
 	}
 
-	/**
-	 * @see DATAREDIS-417
-	 */
-	@Test
+	@Test // DATAREDIS-417
 	public void hasNextShouldStopWhenScanResultIsAnEmptyCollectionAndStateIsFinished() {
 
 		LinkedList<ScanIteration<String>> values = new LinkedList<ScanIteration<String>>();
@@ -217,10 +190,7 @@ public class ScanCursorUnitTests {
 		assertThat(result, hasItems("spring", "data"));
 	}
 
-	/**
-	 * @see DATAREDIS-417
-	 */
-	@Test
+	@Test // DATAREDIS-417
 	public void hasNextShouldStopCorrectlyWhenWholeScanIterationDoesNotReturnResultsAndStateIsFinished() {
 
 		LinkedList<ScanIteration<String>> values = new LinkedList<ScanIteration<String>>();

--- a/src/test/java/org/springframework/data/redis/core/convert/CompositeIndexResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/CompositeIndexResolverUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,26 +39,17 @@ public class CompositeIndexResolverUnitTests {
 	@Mock IndexResolver resolver2;
 	@Mock TypeInformation<?> typeInfoMock;
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-425
 	public void shouldRejectNull() {
 		new CompositeIndexResolver(null);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-425
 	public void shouldRejectCollectionWithNullValues() {
 		new CompositeIndexResolver(Arrays.asList(resolver1, null, resolver2));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void shouldCollectionIndexesFromResolvers() {
 
 		when(resolver1.resolveIndexesFor(any(TypeInformation.class), anyObject())).thenReturn(

--- a/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.springframework.data.redis.core.convert;
+
+import lombok.EqualsAndHashCode;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -36,10 +38,9 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
-import lombok.EqualsAndHashCode;
-
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class ConversionTestEntities {
 
@@ -97,7 +98,13 @@ public class ConversionTestEntities {
 	}
 
 	public static enum Gender {
-		MALE, FEMALE
+		MALE, FEMALE {
+
+			@Override
+			public String toString() {
+				return "Superwoman";
+			}
+		}
 	}
 
 	public static class AddressWithPostcode extends Address {

--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,18 +98,12 @@ public class MappingRedisConverterUnitTests {
 		rand = new Person();
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsTypeHintForRootCorrectly() {
 		assertThat(write(rand).getBucket(), isBucket().containingTypeHint("_class", Person.class));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsKeyCorrectly() {
 
 		rand.id = "1";
@@ -117,10 +111,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getId(), is((Serializable) "1"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsKeyCorrectlyWhenThereIsAnAdditionalIdFieldInNestedElement() {
 
 		AddressWithId address = new AddressWithId();
@@ -136,10 +127,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(data.getBucket(), isBucket().containingUtf8String("address.id", "tear"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeDoesNotAppendPropertiesWithNullValues() {
 
 		rand.firstname = "rand";
@@ -147,10 +135,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().without("lastname"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeDoesNotAppendPropertiesWithEmptyCollections() {
 
 		rand.firstname = "rand";
@@ -158,10 +143,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().without("nicknames"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsSimpleRootPropertyCorrectly() {
 
 		rand.firstname = "nynaeve";
@@ -169,10 +151,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("firstname", "nynaeve"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsListOfSimplePropertiesCorrectly() {
 
 		rand.nicknames = Arrays.asList("dragon reborn", "lews therin");
@@ -183,10 +162,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("nicknames.[1]", "lews therin"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsComplexObjectCorrectly() {
 
 		Address address = new Address();
@@ -200,10 +176,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("address.country", "andora"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsListOfComplexObjectsCorrectly() {
 
 		Person mat = new Person();
@@ -228,10 +201,7 @@ public class MappingRedisConverterUnitTests {
 						.containingUtf8String("coworkers.[1].address.city", "two rivers"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeDoesNotAddClassTypeInformationCorrectlyForMatchingTypes() {
 
 		Address address = new Address();
@@ -244,10 +214,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.getBucket(), isBucket().without("address._class"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAddsClassTypeInformationCorrectlyForNonMatchingTypes() {
 
 		AddressWithPostcode address = new AddressWithPostcode();
@@ -261,10 +228,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.getBucket(), isBucket().containingTypeHint("address._class", AddressWithPostcode.class));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readConsidersClassTypeInformationCorrectlyForNonMatchingTypes() {
 
 		Map<String, String> map = new HashMap<String, String>();
@@ -276,10 +240,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.address, instanceOf(AddressWithPostcode.class));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAddsClassTypeInformationCorrectlyForNonMatchingTypesInCollections() {
 
 		Person mat = new TaVeren();
@@ -292,10 +253,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.getBucket(), isBucket().containingTypeHint("coworkers.[0]._class", TaVeren.class));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readConvertsSimplePropertiesCorrectly() {
 
 		RedisData rdo = new RedisData(Bucket.newBucketFromStringMap(Collections.singletonMap("firstname", "rand")));
@@ -303,10 +261,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(converter.read(Person.class, rdo).firstname, is("rand"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readConvertsListOfSimplePropertiesCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -317,10 +272,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(converter.read(Person.class, rdo).nicknames, contains("dragon reborn", "lews therin"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readConvertsUnorderedListOfSimplePropertiesCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -332,10 +284,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(converter.read(Person.class, rdo).nicknames, contains("dragon reborn", "car'a'carn", "lews therin"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readComplexPropertyCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -350,10 +299,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.address.country, is("andor"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readListComplexPropertyCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -376,10 +322,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.coworkers.get(1).address.city, is("two rivers"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readUnorderedListOfComplexPropertyCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -403,10 +346,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.coworkers.get(1).address.city, is("two rivers"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readListComplexPropertyCorrectlyAndConsidersClassTypeInformation() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -422,10 +362,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.coworkers.get(0).firstname, is("mat"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsMapWithSimpleKeyCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -440,10 +377,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("physicalAttributes.[eye-color]", "grey"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsMapWithSimpleKeyOnNestedObjectCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -461,10 +395,7 @@ public class MappingRedisConverterUnitTests {
 						.containingUtf8String("coworkers.[0].physicalAttributes.[eye-color]", "grey"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readSimpleMapValuesCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -480,10 +411,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.physicalAttributes.get("eye-color"), is("grey"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsMapWithComplexObjectsCorrectly() {
 
 		Map<String, Person> map = new LinkedHashMap<String, Person>();
@@ -502,10 +430,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("relatives.[step-father].firstname", "tam"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readMapWithComplexObjectsCorrectly() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -521,10 +446,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.relatives.get("step-father").firstname, is("tam"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeAppendsClassTypeInformationCorrectlyForMapWithComplexObjects() {
 
 		Map<String, Person> map = new LinkedHashMap<String, Person>();
@@ -540,10 +462,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingTypeHint("relatives.[previous-incarnation]._class", TaVeren.class));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readConsidersClassTypeInformationCorrectlyForMapWithComplexObjects() {
 
 		Map<String, String> map = new LinkedHashMap<String, String>();
@@ -557,10 +476,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.relatives.get("previous-incarnation").firstname, is("lews"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesIntegerValuesCorrectly() {
 
 		rand.age = 20;
@@ -568,10 +484,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("age", "20"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesLocalDateTimeValuesCorrectly() {
 
 		rand.localDateTime = LocalDateTime.parse("2016-02-19T10:18:01");
@@ -579,10 +492,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("localDateTime", "2016-02-19T10:18:01"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsLocalDateTimeValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -591,10 +501,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.localDateTime, is(LocalDateTime.parse("2016-02-19T10:18:01")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesLocalDateValuesCorrectly() {
 
 		rand.localDate = LocalDate.parse("2016-02-19");
@@ -602,10 +509,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("localDate", "2016-02-19"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsLocalDateValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -614,10 +518,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.localDate, is(LocalDate.parse("2016-02-19")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesLocalTimeValuesCorrectly() {
 
 		rand.localTime = LocalTime.parse("11:12:13");
@@ -625,10 +526,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("localTime", "11:12:13"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsLocalTimeValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -637,10 +535,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.localTime, is(LocalTime.parse("11:12:00")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesZonedDateTimeValuesCorrectly() {
 
 		rand.zonedDateTime = ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]");
@@ -649,10 +544,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingUtf8String("zonedDateTime", "2007-12-03T10:15:30+01:00[Europe/Paris]"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsZonedDateTimeValuesCorrectly() {
 
 		Person target = converter.read(Person.class, new RedisData(Bucket
@@ -661,10 +553,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.zonedDateTime, is(ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesInstantValuesCorrectly() {
 
 		rand.instant = Instant.parse("2007-12-03T10:15:30.01Z");
@@ -672,10 +561,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("instant", "2007-12-03T10:15:30.010Z"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsInstantValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -684,10 +570,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.instant, is(Instant.parse("2007-12-03T10:15:30.01Z")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesZoneIdValuesCorrectly() {
 
 		rand.zoneId = ZoneId.of("Europe/Paris");
@@ -695,10 +578,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("zoneId", "Europe/Paris"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsZoneIdValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -707,10 +587,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.zoneId, is(ZoneId.of("Europe/Paris")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesDurationValuesCorrectly() {
 
 		rand.duration = Duration.parse("P2DT3H4M");
@@ -718,10 +595,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("duration", "PT51H4M"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsDurationValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -730,10 +604,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.duration, is(Duration.parse("P2DT3H4M")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesPeriodValuesCorrectly() {
 
 		rand.period = Period.parse("P1Y2M25D");
@@ -741,10 +612,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("period", "P1Y2M25D"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsPeriodValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -753,10 +621,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.period, is(Period.parse("P1Y2M25D")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesEnumValuesCorrectly() {
 
 		rand.gender = Gender.MALE;
@@ -764,10 +629,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("gender", "MALE"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsEnumValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -776,10 +638,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.gender, is(Gender.MALE));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesBooleanValuesCorrectly() {
 
 		rand.alive = Boolean.TRUE;
@@ -787,10 +646,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("alive", "1"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsBooleanValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -799,10 +655,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.alive, is(Boolean.TRUE));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsStringBooleanValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
@@ -811,10 +664,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.alive, is(Boolean.TRUE));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writesDateValuesCorrectly() {
 
 		Calendar cal = Calendar.getInstance();
@@ -825,10 +675,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingDateAsMsec("birthdate", rand.birthdate));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readsDateValuesCorrectly() {
 
 		Calendar cal = Calendar.getInstance();
@@ -842,10 +689,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.birthdate, is(date));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeSingleReferenceOnRootCorrectly() {
 
 		Location location = new Location();
@@ -862,10 +706,7 @@ public class MappingRedisConverterUnitTests {
 						.without("location.name"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readLoadsReferenceDataOnRootCorrectly() {
 
 		Location location = new Location();
@@ -887,10 +728,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.location, is(location));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeSingleReferenceOnNestedElementCorrectly() {
 
 		Location location = new Location();
@@ -910,10 +748,7 @@ public class MappingRedisConverterUnitTests {
 						.without("coworkers.[0].location.name"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readLoadsReferenceDataOnNestedElementCorrectly() {
 
 		Location location = new Location();
@@ -935,10 +770,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.coworkers.get(0).location, is(location));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeListOfReferencesOnRootCorrectly() {
 
 		Location tarValon = new Location();
@@ -963,10 +795,7 @@ public class MappingRedisConverterUnitTests {
 						.containingUtf8String("visited.[2]", "locations:3"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readLoadsListOfReferencesOnRootCorrectly() {
 
 		Location tarValon = new Location();
@@ -1014,10 +843,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.visited.get(2), is(tear));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeSetsAnnotatedTimeToLiveCorrectly() {
 
 		ExpiringPerson birgitte = new ExpiringPerson();
@@ -1027,10 +853,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(birgitte).getTimeToLive(), is(5L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeDoesNotTTLWhenNotPresent() {
 
 		Location tear = new Location();
@@ -1040,10 +863,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(tear).getTimeToLive(), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldConsiderKeyspaceConfiguration() {
 
 		this.converter.getMappingContext().getMappingConfiguration().getKeyspaceConfiguration()
@@ -1055,10 +875,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(address).getKeyspace(), is("o_O"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldConsiderTimeToLiveConfiguration() {
 
 		KeyspaceSettings assignment = new KeyspaceSettings(Address.class, "o_O");
@@ -1073,10 +890,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(address).getTimeToLive(), is(5L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldHonorCustomConversionOnRootType() {
 
 		this.converter = new MappingRedisConverter(null, null, resolverMock);
@@ -1092,10 +906,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingUtf8String("_raw", "{\"city\":\"unknown\",\"country\":\"Tel'aran'rhiod\"}"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldHonorCustomConversionOnNestedType() {
 
 		this.converter = new MappingRedisConverter(null, null, resolverMock);
@@ -1112,10 +923,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingUtf8String("address", "{\"city\":\"unknown\",\"country\":\"Tel'aran'rhiod\"}"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldHonorIndexOnCustomConversionForNestedType() {
 
 		this.converter = new MappingRedisConverter(null, null, resolverMock);
@@ -1131,10 +939,7 @@ public class MappingRedisConverterUnitTests {
 				hasItem(new SimpleIndexedPropertyValue(KEYSPACE_PERSON, "address.country", "andor")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldHonorIndexAnnotationsOnWhenCustomConversionOnNestedype() {
 
 		this.converter = new MappingRedisConverter(new RedisMappingContext(), null, resolverMock);
@@ -1150,10 +955,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getIndexedData().isEmpty(), is(false));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readShouldHonorCustomConversionOnRootType() {
 
 		this.converter = new MappingRedisConverter(null, null, resolverMock);
@@ -1170,10 +972,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.country, is("Tel'aran'rhiod"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readShouldHonorCustomConversionOnNestedType() {
 
 		this.converter = new MappingRedisConverter(new RedisMappingContext(), null, resolverMock);
@@ -1191,10 +990,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.address.country, is("Tel'aran'rhiod"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldPickUpTimeToLiveFromPropertyIfPresent() {
 
 		ExipringPersonWithExplicitProperty aviendha = new ExipringPersonWithExplicitProperty();
@@ -1204,10 +1000,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(aviendha).getTimeToLive(), is(120L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldUseDefaultTimeToLiveIfPropertyIsPresentButNull() {
 
 		ExipringPersonWithExplicitProperty aviendha = new ExipringPersonWithExplicitProperty();
@@ -1216,10 +1009,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(aviendha).getTimeToLive(), is(5L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldConsiderMapConvertersForRootType() {
 
 		this.converter = new MappingRedisConverter(new RedisMappingContext(), null, resolverMock);
@@ -1234,10 +1024,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("species-nicknames", "halfmen,fades,neverborn"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldConsiderMapConvertersForNestedType() {
 
 		this.converter = new MappingRedisConverter(null, null, resolverMock);
@@ -1250,10 +1037,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("species.species-name", "human"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readShouldConsiderMapConvertersForRootType() {
 
 		this.converter = new MappingRedisConverter(new RedisMappingContext(), null, resolverMock);
@@ -1268,10 +1052,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.name, is("trolloc"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readShouldConsiderMapConvertersForNestedType() {
 
 		this.converter = new MappingRedisConverter(null, null, resolverMock);
@@ -1287,10 +1068,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.species.name, is("trolloc"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void writeShouldConsiderMapConvertersInsideLists() {
 
 		this.converter = new MappingRedisConverter(new RedisMappingContext(), null, resolverMock);
@@ -1309,10 +1087,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("species.[0].species-nicknames", "halfmen,fades,neverborn"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void readShouldConsiderMapConvertersForValuesInList() {
 
 		this.converter = new MappingRedisConverter(null, null, resolverMock);
@@ -1330,10 +1105,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.species.get(0).name, is("trolloc"));
 	}
 
-	/**
-	 * @see DATAREDIS-492
-	 */
-	@Test
+	@Test // DATAREDIS-492
 	public void writeHandlesArraysProperly() {
 
 		this.converter = new MappingRedisConverter(null, null, resolverMock);
@@ -1350,10 +1122,7 @@ public class MappingRedisConverterUnitTests {
 		RedisData target = write(map);
 	}
 
-	/**
-	 * @see DATAREDIS-492
-	 */
-	@Test
+	@Test // DATAREDIS-492
 	public void writeHandlesArraysOfSimpleTypeProperly() {
 
 		WithArrays source = new WithArrays();
@@ -1365,10 +1134,7 @@ public class MappingRedisConverterUnitTests {
 						.containingUtf8String("arrayOfSimpleTypes.[2]", "perrin"));
 	}
 
-	/**
-	 * @see DATAREDIS-492
-	 */
-	@Test
+	@Test // DATAREDIS-492
 	public void readHandlesArraysOfSimpleTypeProperly() {
 
 		Map<String, String> source = new LinkedHashMap<String, String>();
@@ -1381,10 +1147,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.arrayOfSimpleTypes, IsEqual.equalTo(new String[] { "rand", "mat", "perrin" }));
 	}
 
-	/**
-	 * @see DATAREDIS-492
-	 */
-	@Test
+	@Test // DATAREDIS-492
 	public void writeHandlesArraysOfComplexTypeProperly() {
 
 		WithArrays source = new WithArrays();
@@ -1406,10 +1169,7 @@ public class MappingRedisConverterUnitTests {
 						.containingUtf8String("arrayOfCompexTypes.[1].alsoKnownAs.[2]", "neverborn"));
 	}
 
-	/**
-	 * @see DATAREDIS-492
-	 */
-	@Test
+	@Test // DATAREDIS-492
 	public void readHandlesArraysOfComplexTypeProperly() {
 
 		Map<String, String> source = new LinkedHashMap<String, String>();
@@ -1428,10 +1188,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.arrayOfCompexTypes[1].alsoKnownAs, contains("halfmen", "fades", "neverborn"));
 	}
 
-	/**
-	 * @see DATAREDIS-489
-	 */
-	@Test
+	@Test // DATAREDIS-489
 	public void writeHandlesArraysOfObjectTypeProperly() {
 
 		Species trolloc = new Species();
@@ -1449,10 +1206,7 @@ public class MappingRedisConverterUnitTests {
 						.containingUtf8String("arrayOfObject.[2]", "100"));
 	}
 
-	/**
-	 * @see DATAREDIS-489
-	 */
-	@Test
+	@Test // DATAREDIS-489
 	public void readHandlesArraysOfObjectTypeProperly() {
 
 		Map<String, String> source = new LinkedHashMap<String, String>();
@@ -1473,10 +1227,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.arrayOfObject[2], instanceOf(Long.class));
 	}
 
-	/**
-	 * @see DATAREDIS-489
-	 */
-	@Test
+	@Test // DATAREDIS-489
 	public void writeShouldAppendTyeHintToObjectPropertyValueTypesCorrectly() {
 
 		TypeWithObjectValueTypes sample = new TypeWithObjectValueTypes();
@@ -1488,10 +1239,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingUtf8String("object", "bar").containingUtf8String("object._class", "java.lang.String"));
 	}
 
-	/**
-	 * @see DATAREDIS-489
-	 */
-	@Test
+	@Test // DATAREDIS-489
 	public void shouldWriteReadObjectPropertyValueTypeCorrectly() {
 
 		TypeWithObjectValueTypes di = new TypeWithObjectValueTypes();
@@ -1503,10 +1251,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(result.object, instanceOf(String.class));
 	}
 
-	/**
-	 * @see DATAREDIS-489
-	 */
-	@Test
+	@Test // DATAREDIS-489
 	public void writeShouldAppendTyeHintToObjectMapValueTypesCorrectly() {
 
 		TypeWithObjectValueTypes sample = new TypeWithObjectValueTypes();
@@ -1523,10 +1268,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(bucket, isBucket().containingUtf8String("map.[date]._class", "java.util.Date"));
 	}
 
-	/**
-	 * @see DATAREDIS-489
-	 */
-	@Test
+	@Test // DATAREDIS-489
 	public void shouldWriteReadObjectMapValueTypeCorrectly() {
 
 		TypeWithObjectValueTypes sample = new TypeWithObjectValueTypes();
@@ -1542,10 +1284,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(result.map.get("date"), instanceOf(Date.class));
 	}
 
-	/**
-	 * @see DATAREDIS-489
-	 */
-	@Test
+	@Test // DATAREDIS-489
 	public void writeShouldAppendTyeHintToObjectListValueTypesCorrectly() {
 
 		TypeWithObjectValueTypes sample = new TypeWithObjectValueTypes();
@@ -1562,10 +1301,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(bucket, isBucket().containingUtf8String("list.[2]._class", "java.util.Date"));
 	}
 
-	/**
-	 * @see DATAREDIS-489
-	 */
-	@Test
+	@Test // DATAREDIS-489
 	public void shouldWriteReadObjectListValueTypeCorrectly() {
 
 		TypeWithObjectValueTypes sample = new TypeWithObjectValueTypes();
@@ -1581,11 +1317,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(result.list.get(2), instanceOf(Date.class));
 	}
 
-	/**
-	 *
-	 * @see DATAREDIS-509
-	 */
-	@Test
+	@Test // DATAREDIS-509
 	public void writeHandlesArraysOfPrimitivesProperly() {
 
 		Map<String, String> source = new LinkedHashMap<String, String>();
@@ -1600,10 +1332,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.arrayOfPrimitives[2], is(3));
 	}
 
-	/**
-	 * @see DATAREDIS-509
-	 */
-	@Test
+	@Test // DATAREDIS-509
 	public void readHandlesArraysOfPrimitivesProperly() {
 
 		WithArrays source = new WithArrays();
@@ -1612,10 +1341,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("arrayOfPrimitives.[1]", "2").containingUtf8String("arrayOfPrimitives.[2]", "3"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldNotAppendClassTypeHint() {
 
 		Person value = new Person();
@@ -1627,10 +1353,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket().get("_class"), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdateSimpleValueCorrectly() {
 
 		Person value = new Person();
@@ -1643,10 +1366,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingUtf8String("firstname", "rand").containingUtf8String("age", "24"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithSimpleValueCorrectly() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("firstname", "rand").set("age",
@@ -1656,10 +1376,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingUtf8String("firstname", "rand").containingUtf8String("age", "24"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdateNestedPathWithSimpleValueCorrectly() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("address.city", "two rivers");
@@ -1667,10 +1384,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket(), isBucket().containingUtf8String("address.city", "two rivers"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithComplexValueCorrectly() {
 
 		Address address = new Address();
@@ -1683,10 +1397,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingUtf8String("address.city", "two rivers").containingUtf8String("address.country", "andor"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithSimpleListValueCorrectly() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("nicknames",
@@ -1696,10 +1407,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingUtf8String("nicknames.[0]", "dragon").containingUtf8String("nicknames.[1]", "lews"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithComplexListValueCorrectly() {
 
 		Person mat = new Person();
@@ -1716,10 +1424,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("coworkers.[0].age", "24").containingUtf8String("coworkers.[1].firstname", "perrin"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithSimpleListValueWhenNotPassedInAsCollectionCorrectly() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("nicknames", "dragon");
@@ -1727,10 +1432,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket(), isBucket().containingUtf8String("nicknames.[0]", "dragon"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithComplexListValueWhenNotPassedInAsCollectionCorrectly() {
 
 		Person mat = new Person();
@@ -1743,10 +1445,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("coworkers.[0].age", "24"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithSimpleListValueWhenNotPassedInAsCollectionWithPositionalParameterCorrectly() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("nicknames.[5]", "dragon");
@@ -1754,10 +1453,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket(), isBucket().containingUtf8String("nicknames.[5]", "dragon"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithComplexListValueWhenNotPassedInAsCollectionWithPositionalParameterCorrectly() {
 
 		Person mat = new Person();
@@ -1770,10 +1466,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("coworkers.[5].age", "24"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithSimpleMapValueCorrectly() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("physicalAttributes",
@@ -1782,10 +1475,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket(), isBucket().containingUtf8String("physicalAttributes.[eye-color]", "grey"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithComplexMapValueCorrectly() {
 
 		Person tam = new Person();
@@ -1799,10 +1489,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("relatives.[father].alive", "0"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithSimpleMapValueWhenNotPassedInAsCollectionCorrectly() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("physicalAttributes",
@@ -1811,10 +1498,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket(), isBucket().containingUtf8String("physicalAttributes.[eye-color]", "grey"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithComplexMapValueWhenNotPassedInAsCollectionCorrectly() {
 
 		Person tam = new Person();
@@ -1828,10 +1512,7 @@ public class MappingRedisConverterUnitTests {
 				.containingUtf8String("relatives.[father].alive", "0"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithSimpleMapValueWhenNotPassedInAsCollectionWithPositionalParameterCorrectly() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("physicalAttributes.[eye-color]",
@@ -1840,10 +1521,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket(), isBucket().containingUtf8String("physicalAttributes.[eye-color]", "grey"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithSimpleMapValueOnNestedElementCorrectly() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("relatives.[father].firstname",
@@ -1852,10 +1530,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket(), isBucket().containingUtf8String("relatives.[father].firstname", "tam"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test(expected = MappingException.class)
+	@Test(expected = MappingException.class) // DATAREDIS-471
 	public void writeShouldThrowExceptionOnPartialUpdatePathWithSimpleMapValueWhenItsASingleValueWithoutPath() {
 
 		PartialUpdate<Person> update = new PartialUpdate<Person>("123", Person.class).set("physicalAttributes", "grey");
@@ -1863,10 +1538,7 @@ public class MappingRedisConverterUnitTests {
 		write(update);
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithRegisteredCustomConversionCorrectly() {
 
 		this.converter = new MappingRedisConverter(null, null, resolverMock);
@@ -1884,10 +1556,7 @@ public class MappingRedisConverterUnitTests {
 				isBucket().containingUtf8String("address", "{\"city\":\"unknown\",\"country\":\"Tel'aran'rhiod\"}"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithReferenceCorrectly() {
 
 		Location tar = new Location();
@@ -1907,10 +1576,7 @@ public class MappingRedisConverterUnitTests {
 						.without("visited.name"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldWritePartialUpdatePathWithListOfReferencesCorrectly() {
 
 		Location location = new Location();
@@ -1926,10 +1592,7 @@ public class MappingRedisConverterUnitTests {
 						.without("location.name"));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldThrowExceptionForUpdateValueNotAssignableToDomainTypeProperty() {
 
 		exception.expect(MappingException.class);
@@ -1943,10 +1606,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket().get("_class"), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldThrowExceptionForUpdateCollectionValueNotAssignableToDomainTypeProperty() {
 
 		exception.expect(MappingException.class);
@@ -1960,10 +1620,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket().get("_class"), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldThrowExceptionForUpdateValueInCollectionNotAssignableToDomainTypeProperty() {
 
 		exception.expect(MappingException.class);
@@ -1977,10 +1634,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket().get("_class"), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldThrowExceptionForUpdateMapValueNotAssignableToDomainTypeProperty() {
 
 		exception.expect(MappingException.class);
@@ -1994,10 +1648,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket().get("_class"), is(nullValue()));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void writeShouldThrowExceptionForUpdateValueInMapNotAssignableToDomainTypeProperty() {
 
 		exception.expect(MappingException.class);

--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -17,7 +17,7 @@ package org.springframework.data.redis.core.convert;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.redis.core.convert.ConversionTestEntities.*;
 import static org.springframework.data.redis.test.util.IsBucketMatcher.*;
@@ -56,20 +56,8 @@ import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.mapping.model.MappingException;
 import org.springframework.data.redis.core.PartialUpdate;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Address;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.AddressWithId;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.AddressWithPostcode;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.ExipringPersonWithExplicitProperty;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.ExpiringPerson;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Gender;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Location;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Person;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.Species;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.TaVeren;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.TheWheelOfTime;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.TypeWithObjectValueTypes;
-import org.springframework.data.redis.core.convert.ConversionTestEntities.WithArrays;
 import org.springframework.data.redis.core.convert.KeyspaceConfiguration.KeyspaceSettings;
+import org.springframework.data.redis.core.convert.ConversionTestEntities.*;
 import org.springframework.data.redis.core.mapping.RedisMappingContext;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.util.StringUtils;
@@ -78,8 +66,11 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
+ * Unit tests for {@link MappingRedisConverter}.
+ *
  * @author Christoph Strobl
  * @author Greg Turnquist
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class MappingRedisConverterUnitTests {
@@ -621,21 +612,21 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.period, is(Period.parse("P1Y2M25D")));
 	}
 
-	@Test // DATAREDIS-425
+	@Test // DATAREDIS-425, DATAREDIS-593
 	public void writesEnumValuesCorrectly() {
 
-		rand.gender = Gender.MALE;
+		rand.gender = Gender.FEMALE;
 
-		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("gender", "MALE"));
+		assertThat(write(rand).getBucket(), isBucket().containingUtf8String("gender", "FEMALE"));
 	}
 
-	@Test // DATAREDIS-425
+	@Test // DATAREDIS-425, DATAREDIS-593
 	public void readsEnumValuesCorrectly() {
 
 		Person target = converter.read(Person.class,
-				new RedisData(Bucket.newBucketFromStringMap(Collections.singletonMap("gender", "MALE"))));
+				new RedisData(Bucket.newBucketFromStringMap(Collections.singletonMap("gender", "FEMALE"))));
 
-		assertThat(target.gender, is(Gender.MALE));
+		assertThat(target.gender, is(Gender.FEMALE));
 	}
 
 	@Test // DATAREDIS-425

--- a/src/test/java/org/springframework/data/redis/core/convert/PathIndexResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/PathIndexResolverUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,18 +80,12 @@ public class PathIndexResolverUnitTests {
 				new RedisMappingContext(new MappingConfiguration(indexConfig, new KeyspaceConfiguration())));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-425
 	public void shouldThrowExceptionOnNullMappingContext() {
 		new PathIndexResolver(null);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void shouldResolveAnnotatedIndexOnRootWhenValueIsNotNull() {
 
 		Address address = new Address();
@@ -103,10 +97,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes, hasItem(new SimpleIndexedPropertyValue(Address.class.getName(), "country", "andor")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void shouldNotResolveAnnotatedIndexOnRootWhenValueIsNull() {
 
 		Address address = new Address();
@@ -117,10 +108,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes.size(), is(0));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void shouldResolveAnnotatedIndexOnNestedObjectWhenValueIsNotNull() {
 
 		Person person = new Person();
@@ -133,10 +121,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes, hasItem(new SimpleIndexedPropertyValue(KEYSPACE_PERSON, "address.country", "andor")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void shouldResolveMultipleAnnotatedIndexesInLists() {
 
 		TheWheelOfTime twot = new TheWheelOfTime();
@@ -162,10 +147,7 @@ public class PathIndexResolverUnitTests {
 						new SimpleIndexedPropertyValue(KEYSPACE_TWOT, "mainCharacters.address.country", "saldaea")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void shouldResolveAnnotatedIndexesInMap() {
 
 		TheWheelOfTime twot = new TheWheelOfTime();
@@ -186,10 +168,7 @@ public class PathIndexResolverUnitTests {
 				hasItem(new SimpleIndexedPropertyValue(KEYSPACE_TWOT, "places.stone-of-tear.address.country", "illian")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void shouldResolveConfiguredIndexesInMapOfSimpleTypes() {
 
 		indexConfig.addIndexDefinition(new SimpleIndexDefinition(KEYSPACE_PERSON, "physicalAttributes.eye-color"));
@@ -205,10 +184,7 @@ public class PathIndexResolverUnitTests {
 				hasItem(new SimpleIndexedPropertyValue(KEYSPACE_PERSON, "physicalAttributes.eye-color", "grey")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void shouldResolveConfiguredIndexesInMapOfComplexTypes() {
 
 		indexConfig.addIndexDefinition(new SimpleIndexDefinition(KEYSPACE_PERSON, "relatives.father.firstname"));
@@ -228,11 +204,7 @@ public class PathIndexResolverUnitTests {
 				hasItem(new SimpleIndexedPropertyValue(KEYSPACE_PERSON, "relatives.father.firstname", "janduin")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-425, DATAREDIS-471
 	public void shouldIgnoreConfiguredIndexesInMapWhenValueIsNull() {
 
 		indexConfig.addIndexDefinition(new SimpleIndexDefinition(KEYSPACE_PERSON, "physicalAttributes.eye-color"));
@@ -247,10 +219,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes.iterator().next(), IsInstanceOf.instanceOf(RemoveIndexedData.class));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void shouldNotResolveIndexOnReferencedEntity() {
 
 		PersonWithAddressReference rand = new PersonWithAddressReference();
@@ -264,20 +233,14 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes.size(), is(0));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldReturnNullWhenNoIndexConfigured() {
 
 		when(propertyMock.isAnnotationPresent(eq(Indexed.class))).thenReturn(false);
 		assertThat(resolve("foo", "rand"), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldReturnDataWhenIndexConfigured() {
 
 		when(propertyMock.isAnnotationPresent(eq(Indexed.class))).thenReturn(false);
@@ -286,10 +249,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(resolve("foo", "rand"), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldReturnDataWhenNoIndexConfiguredButPropertyAnnotated() {
 
 		when(propertyMock.isAnnotationPresent(eq(Indexed.class))).thenReturn(true);
@@ -298,10 +258,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(resolve("foo", "rand"), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldRemovePositionIndicatorForValuesInLists() {
 
 		when(propertyMock.isCollectionLike()).thenReturn(true);
@@ -313,10 +270,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(index.getIndexName(), is("list.name"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldRemoveKeyIndicatorForValuesInMap() {
 
 		when(propertyMock.isMap()).thenReturn(true);
@@ -328,10 +282,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(index.getIndexName(), is("map.foo.name"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldKeepNumericalKeyForValuesInMap() {
 
 		when(propertyMock.isMap()).thenReturn(true);
@@ -343,10 +294,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(index.getIndexName(), is("map.0.name"));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldInspectObjectTypeProperties() {
 
 		Item hat = new Item();
@@ -361,10 +309,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes, hasItem(new SimpleIndexedPropertyValue(KEYSPACE_PERSON, "feature.type", "hat")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldInspectObjectTypePropertiesButIgnoreNullValues() {
 
 		Item hat = new Item();
@@ -378,10 +323,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes.size(), is(0));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldInspectObjectTypeValuesInMapProperties() {
 
 		Item hat = new Item();
@@ -399,10 +341,7 @@ public class PathIndexResolverUnitTests {
 				hasItem(new SimpleIndexedPropertyValue(KEYSPACE_PERSON, "characteristics.clothing.type", "hat")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexShouldInspectObjectTypeValuesInListProperties() {
 
 		Item hat = new Item();
@@ -419,10 +358,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes, hasItem(new SimpleIndexedPropertyValue(KEYSPACE_PERSON, "items.type", "hat")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexAllowCustomIndexName() {
 
 		indexConfig.addIndexDefinition(new SimpleIndexDefinition(KEYSPACE_PERSON, "items.type", "itemsType"));
@@ -441,10 +377,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes, hasItem(new SimpleIndexedPropertyValue(KEYSPACE_PERSON, "itemsType", "hat")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexForTypeThatHasNoIndexDefined() {
 
 		Size size = new Size();
@@ -456,10 +389,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(indexes, is(empty()));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexOnMapField() {
 
 		IndexedOnMapField source = new IndexedOnMapField();
@@ -478,10 +408,7 @@ public class PathIndexResolverUnitTests {
 						new SimpleIndexedPropertyValue(IndexedOnMapField.class.getName(), "values.arya", "stark")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveIndexOnListField() {
 
 		IndexedOnListField source = new IndexedOnListField();
@@ -500,10 +427,7 @@ public class PathIndexResolverUnitTests {
 						new SimpleIndexedPropertyValue(IndexedOnListField.class.getName(), "values", "arya")));
 	}
 
-	/**
-	 * @see DATAREDIS-509
-	 */
-	@Test
+	@Test // DATAREDIS-509
 	public void resolveIndexOnPrimitiveArrayField() {
 
 		IndexedOnPrimitiveArrayField source = new IndexedOnPrimitiveArrayField();
@@ -520,10 +444,7 @@ public class PathIndexResolverUnitTests {
 						new SimpleIndexedPropertyValue(IndexedOnPrimitiveArrayField.class.getName(), "values", 3)));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void resolveGeoIndexShouldMapNameCorrectly() {
 
 		when(propertyMock.isMap()).thenReturn(true);
@@ -535,10 +456,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(index.getIndexName(), is("location"));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void resolveGeoIndexShouldMapNameForNestedPropertyCorrectly() {
 
 		when(propertyMock.isMap()).thenReturn(true);
@@ -550,10 +468,7 @@ public class PathIndexResolverUnitTests {
 		assertThat(index.getIndexName(), is("property:location"));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void resolveGeoIndexOnPointField() {
 
 		GeoIndexedOnPoint source = new GeoIndexedOnPoint();
@@ -567,10 +482,7 @@ public class PathIndexResolverUnitTests {
 				new GeoIndexedPropertyValue(GeoIndexedOnPoint.class.getName(), "location", source.location)));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void resolveGeoIndexOnArrayFieldThrowsError() {
 
 		exception.expect(IllegalArgumentException.class);

--- a/src/test/java/org/springframework/data/redis/core/convert/SpelIndexResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/SpelIndexResolverUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,28 +73,19 @@ public class SpelIndexResolverUnitTests {
 		resolver = createWithExpression("getAttribute('" + securityContextAttrName + "')?.authentication?.name");
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-425
 	public void constructorNullRedisMappingContext() {
 
 		mappingContext = null;
 		new SpelIndexResolver(mappingContext);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-425
 	public void constructorNullSpelExpressionParser() {
 		new SpelIndexResolver(mappingContext, null);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void nullValue() {
 
 		Set<IndexedData> indexes = resolver.resolveIndexesFor(typeInformation, null);
@@ -102,10 +93,7 @@ public class SpelIndexResolverUnitTests {
 		assertThat(indexes.size(), equalTo(0));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void wrongKeyspace() {
 
 		typeInformation = ClassTypeInformation.from(String.class);
@@ -114,10 +102,7 @@ public class SpelIndexResolverUnitTests {
 		assertThat(indexes.size(), equalTo(0));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void sessionAttributeNull() {
 
 		session = new Session();
@@ -126,10 +111,7 @@ public class SpelIndexResolverUnitTests {
 		assertThat(indexes.size(), equalTo(0));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolvePrincipalName() {
 
 		Set<IndexedData> indexes = resolver.resolveIndexesFor(typeInformation, session);
@@ -137,10 +119,7 @@ public class SpelIndexResolverUnitTests {
 		assertThat(indexes, hasItem(new SimpleIndexedPropertyValue(keyspace, indexName, username)));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = SpelEvaluationException.class)
+	@Test(expected = SpelEvaluationException.class) // DATAREDIS-425
 	public void spelError() {
 
 		session.setAttribute(securityContextAttrName, "");
@@ -148,10 +127,7 @@ public class SpelIndexResolverUnitTests {
 		resolver.resolveIndexesFor(typeInformation, session);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void withBeanAndThis() {
 
 		this.resolver = createWithExpression("@bean.run(#this)");

--- a/src/test/java/org/springframework/data/redis/core/index/IndexConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/index/IndexConfigurationUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,7 @@ import org.junit.Test;
  */
 public class IndexConfigurationUnitTests {
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void redisIndexSettingIndexNameDefaulted() {
 
 		String path = "path";
@@ -37,10 +34,7 @@ public class IndexConfigurationUnitTests {
 		assertThat(setting.getIndexName(), equalTo(path));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void redisIndexSettingIndexNameExplicit() {
 
 		String indexName = "indexName";
@@ -48,10 +42,7 @@ public class IndexConfigurationUnitTests {
 		assertThat(setting.getIndexName(), equalTo(indexName));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void redisIndexSettingIndexNameUsedInEquals() {
 
 		SimpleIndexDefinition setting1 = new SimpleIndexDefinition("keyspace", "path", "indexName1");
@@ -61,10 +52,7 @@ public class IndexConfigurationUnitTests {
 		assertThat(setting1, not(equalTo(setting2)));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void redisIndexSettingIndexNameUsedInHashCode() {
 
 		SimpleIndexDefinition setting1 = new SimpleIndexDefinition("keyspace", "path", "indexName1");

--- a/src/test/java/org/springframework/data/redis/core/mapping/BasicRedisPersistentEntityUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/mapping/BasicRedisPersistentEntityUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,10 +61,7 @@ public class BasicRedisPersistentEntityUnitTests<T, ID extends Serializable> {
 		entity = new BasicRedisPersistentEntity<T>(entityInformation, keySpaceResolver, ttlAccessor);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void addingMultipleIdPropertiesWithoutAnExplicitOneThrowsException() {
 
 		expectedException.expect(MappingException.class);
@@ -81,10 +78,7 @@ public class BasicRedisPersistentEntityUnitTests<T, ID extends Serializable> {
 		entity.addPersistentProperty(property2);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	@SuppressWarnings("unchecked")
 	public void addingMultipleExplicitIdPropertiesThrowsException() {
 
@@ -104,10 +98,7 @@ public class BasicRedisPersistentEntityUnitTests<T, ID extends Serializable> {
 		entity.addPersistentProperty(property2);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	@SuppressWarnings("unchecked")
 	public void explicitIdPropertiyShouldBeFavoredOverNonExplicit() {
 

--- a/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareKeySpaceResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareKeySpaceResolverUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,26 +38,17 @@ public class ConfigAwareKeySpaceResolverUnitTests {
 		this.resolver = new ConfigAwareKeySpaceResolver(config);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-425
 	public void resolveShouldThrowExceptionWhenTypeIsNull() {
 		resolver.resolveKeySpace(null);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveShouldUseClassNameAsDefaultKeyspace() {
 		assertThat(resolver.resolveKeySpace(TypeWithoutAnySettings.class), is(TypeWithoutAnySettings.class.getName()));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void resolveShouldFavorConfiguredNameOverClassName() {
 
 		config.addKeyspaceSettings(new KeyspaceSettings(TypeWithoutAnySettings.class, "ji'e'toh"));

--- a/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareTimeToLiveAccessorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/mapping/ConfigAwareTimeToLiveAccessorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,26 +42,17 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		accessor = new ConfigAwareTimeToLiveAccessor(config, new RedisMappingContext());
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-425
 	public void getTimeToLiveShouldThrowExceptionWhenSourceObjectIsNull() {
 		accessor.getTimeToLive(null);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnNullIfNothingConfiguredOrAnnotated() {
 		assertThat(accessor.getTimeToLive(new SimpleType()), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnConfiguredValueForSimpleType() {
 
 		KeyspaceSettings setting = new KeyspaceSettings(SimpleType.class, null);
@@ -71,18 +62,12 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(accessor.getTimeToLive(new SimpleType()), is(10L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnValueWhenTypeIsAnnotated() {
 		assertThat(accessor.getTimeToLive(new TypeWithRedisHashAnnotation()), is(5L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveConsidersAnnotationOverConfig() {
 
 		KeyspaceSettings setting = new KeyspaceSettings(TypeWithRedisHashAnnotation.class, null);
@@ -92,34 +77,22 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(accessor.getTimeToLive(new TypeWithRedisHashAnnotation()), is(5L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnValueWhenPropertyIsAnnotatedAndHasValue() {
 		assertThat(accessor.getTimeToLive(new TypeWithRedisHashAnnotationAndTTLProperty(20L)), is(20L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnValueFromTypeAnnotationWhenPropertyIsAnnotatedAndHasNullValue() {
 		assertThat(accessor.getTimeToLive(new TypeWithRedisHashAnnotationAndTTLProperty()), is(10L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnNullWhenPropertyIsAnnotatedAndHasNullValue() {
 		assertThat(accessor.getTimeToLive(new SimpleTypeWithTTLProperty()), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnConfiguredValueWhenPropertyIsAnnotatedAndHasNullValue() {
 
 		KeyspaceSettings setting = new KeyspaceSettings(SimpleTypeWithTTLProperty.class, null);
@@ -129,10 +102,7 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(accessor.getTimeToLive(new SimpleTypeWithTTLProperty()), is(10L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldFavorAnnotatedNotNullPropertyValueOverConfiguredOne() {
 
 		KeyspaceSettings setting = new KeyspaceSettings(SimpleTypeWithTTLProperty.class, null);
@@ -142,18 +112,12 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(accessor.getTimeToLive(new SimpleTypeWithTTLProperty(25L)), is(25L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnMethodLevelTimeToLiveIfPresent() {
 		assertThat(accessor.getTimeToLive(new TypeWithTtlOnMethod(10L)), is(10L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnConfiguredValueWhenMethodLevelTimeToLiveIfPresentButHasNullValue() {
 
 		KeyspaceSettings setting = new KeyspaceSettings(TypeWithTtlOnMethod.class, null);
@@ -163,10 +127,7 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(accessor.getTimeToLive(new TypeWithTtlOnMethod(null)), is(10L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void getTimeToLiveShouldReturnValueWhenMethodLevelTimeToLiveIfPresentAlthoughConfiguredValuePresent() {
 
 		KeyspaceSettings setting = new KeyspaceSettings(TypeWithTtlOnMethod.class, null);
@@ -176,10 +137,7 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(accessor.getTimeToLive(new TypeWithTtlOnMethod(100L)), is(100L));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void getTimeToLiveShouldReturnDefaultValue() {
 
 		Long ttl = accessor
@@ -188,10 +146,7 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(ttl, is(5L));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void getTimeToLiveShouldReturnValueWhenUpdateModifiesTtlProperty() {
 
 		Long ttl = accessor
@@ -201,10 +156,7 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(ttl, is(100L));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void getTimeToLiveShouldReturnPropertyValueWhenUpdateModifiesTtlProperty() {
 
 		Long ttl = accessor.getTimeToLive(new PartialUpdate<TypeWithRedisHashAnnotationAndTTLProperty>("123",
@@ -213,10 +165,7 @@ public class ConfigAwareTimeToLiveAccessorUnitTests {
 		assertThat(ttl, is(100L));
 	}
 
-	/**
-	 * @see DATAREDIS-471
-	 */
-	@Test
+	@Test // DATAREDIS-471
 	public void getTimeToLiveShouldReturnDefaultValueWhenUpdateDoesNotModifyTtlProperty() {
 
 		Long ttl = accessor.getTimeToLive(new PartialUpdate<TypeWithRedisHashAnnotationAndTTLProperty>("123",

--- a/src/test/java/org/springframework/data/redis/core/script/AbstractDefaultScriptExecutorTests.java
+++ b/src/test/java/org/springframework/data/redis/core/script/AbstractDefaultScriptExecutorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,10 +246,7 @@ public abstract class AbstractDefaultScriptExecutorTests {
 		assertEquals("HELLO", scriptExecutor.execute(script, null));
 	}
 
-	/**
-	 * @see DATAREDIS-356
-	 */
-	@Test
+	@Test // DATAREDIS-356
 	public void shouldTransparentlyReEvaluateScriptIfNotPresent() throws Exception {
 
 		this.template = new StringRedisTemplate();

--- a/src/test/java/org/springframework/data/redis/core/script/DefaultScriptExecutorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/script/DefaultScriptExecutorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,10 +53,7 @@ public class DefaultScriptExecutorUnitTests {
 		executor = new DefaultScriptExecutor<String>(template);
 	}
 
-	/**
-	 * @see DATAREDIS-347
-	 */
-	@Test
+	@Test // DATAREDIS-347
 	public void excuteCheckForPresenceOfScriptViaEvalSha1() {
 
 		when(redisConnectionMock.evalSha(anyString(), any(ReturnType.class), anyInt())).thenReturn("FOO".getBytes());
@@ -66,10 +63,7 @@ public class DefaultScriptExecutorUnitTests {
 		verify(redisConnectionMock, times(1)).evalSha(anyString(), any(ReturnType.class), anyInt());
 	}
 
-	/**
-	 * @see DATAREDIS-347
-	 */
-	@Test
+	@Test // DATAREDIS-347
 	public void excuteShouldNotCallEvalWhenSha1Exists() {
 
 		when(redisConnectionMock.evalSha(anyString(), any(ReturnType.class), anyInt())).thenReturn("FOO".getBytes());
@@ -79,10 +73,7 @@ public class DefaultScriptExecutorUnitTests {
 		verify(redisConnectionMock, never()).eval(any(byte[].class), any(ReturnType.class), anyInt());
 	}
 
-	/**
-	 * @see DATAREDIS-347
-	 */
-	@Test
+	@Test // DATAREDIS-347
 	public void excuteShouldUseEvalInCaseNoSha1PresentForGivenScript() {
 
 		when(redisConnectionMock.evalSha(anyString(), any(ReturnType.class), anyInt())).thenThrow(
@@ -93,10 +84,7 @@ public class DefaultScriptExecutorUnitTests {
 		verify(redisConnectionMock, times(1)).eval(any(byte[].class), any(ReturnType.class), anyInt());
 	}
 
-	/**
-	 * @see DATAREDIS-347
-	 */
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-347
 	public void excuteShouldThrowExceptionInCaseEvalShaFailsWithOtherThanRedisSystemException() {
 
 		when(redisConnectionMock.evalSha(anyString(), any(ReturnType.class), anyInt())).thenThrow(
@@ -105,10 +93,7 @@ public class DefaultScriptExecutorUnitTests {
 		executor.execute(SCRIPT, null);
 	}
 
-	/**
-	 * @see DATAREDIS-347
-	 */
-	@Test(expected = RedisSystemException.class)
+	@Test(expected = RedisSystemException.class) // DATAREDIS-347
 	public void excuteShouldThrowExceptionInCaseEvalShaFailsWithAlthoughTheScriptExists() {
 
 		when(redisConnectionMock.evalSha(anyString(), any(ReturnType.class), anyInt())).thenThrow(

--- a/src/test/java/org/springframework/data/redis/core/types/ExpirationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/types/ExpirationUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,7 @@ import org.junit.Test;
  */
 public class ExpirationUnitTests {
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void fromDefault() throws Exception {
 
 		Expiration expiration = Expiration.from(5, null);
@@ -40,10 +37,7 @@ public class ExpirationUnitTests {
 		assertThat(expiration.getTimeUnit(), is(TimeUnit.SECONDS));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void fromNanos() throws Exception {
 
 		Expiration expiration = Expiration.from(5L * 1000 * 1000, TimeUnit.NANOSECONDS);
@@ -52,10 +46,7 @@ public class ExpirationUnitTests {
 		assertThat(expiration.getTimeUnit(), is(TimeUnit.MILLISECONDS));
 	}
 
-	/**
-	 * @see DATAREDIS-316
-	 */
-	@Test
+	@Test // DATAREDIS-316
 	public void fromMinutes() throws Exception {
 
 		Expiration expiration = Expiration.from(5, TimeUnit.MINUTES);

--- a/src/test/java/org/springframework/data/redis/listener/KeyExpirationEventMessageListenerTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/KeyExpirationEventMessageListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,10 +81,7 @@ public class KeyExpirationEventMessageListenerTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void listenerShouldPublishEventCorrectly() throws InterruptedException {
 
 		byte[] key = ("to-expire:" + UUID.randomUUID().toString()).getBytes();
@@ -110,10 +107,7 @@ public class KeyExpirationEventMessageListenerTests {
 		assertThat((byte[]) captor.getValue().getSource(), is(key));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void listenerShouldNotReactToDeleteEvents() throws InterruptedException {
 
 		byte[] key = ("to-delete:" + UUID.randomUUID().toString()).getBytes();

--- a/src/test/java/org/springframework/data/redis/listener/KeyExpirationEventMessageListenerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/KeyExpirationEventMessageListenerUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,10 +53,7 @@ public class KeyExpirationEventMessageListenerUnitTests {
 		listener.setApplicationEventPublisher(publisherMock);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void handleMessageShouldPublishKeyExpiredEvent() {
 
 		listener.onMessage(MESSAGE, "*".getBytes());
@@ -68,10 +65,7 @@ public class KeyExpirationEventMessageListenerUnitTests {
 		assertThat((byte[]) captor.getValue().getSource(), is(MESSAGE_BODY.getBytes()));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void handleMessageShouldNotRespondToNullMessage() {
 
 		listener.onMessage(null, "*".getBytes());
@@ -79,10 +73,7 @@ public class KeyExpirationEventMessageListenerUnitTests {
 		verifyZeroInteractions(publisherMock);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void handleMessageShouldNotRespondToEmptyMessage() {
 
 		listener.onMessage(new DefaultMessage(null, null), "*".getBytes());

--- a/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,11 +175,8 @@ public class PubSubTests<T> {
 		container.start();
 	}
 
-	/**
-	 * @see DATAREDIS-251
-	 */
 	@SuppressWarnings("unchecked")
-	@Test
+	@Test // DATAREDIS-251
 	public void testStartListenersToNoSpecificChannelTest() throws InterruptedException {
 		container.removeMessageListener(adapter, new ChannelTopic(CHANNEL));
 		container.addMessageListener(adapter, Arrays.asList(new PatternTopic("*")));

--- a/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,10 +79,7 @@ public class RedisMessageListenerContainerTests {
 		connectionFactory.destroy();
 	}
 
-	/*
-	 * @see DATAREDIS-415
-	 */
-	@Test
+	@Test // DATAREDIS-415
 	public void interruptAtStart() throws Exception {
 
 		final Thread main = Thread.currentThread();

--- a/src/test/java/org/springframework/data/redis/listener/SubscriptionConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/SubscriptionConnectionTests.java
@@ -140,7 +140,7 @@ public class SubscriptionConnectionTests {
 
 			if (connectionFactory instanceof JedisConnectionFactory) {
 				// Need to sleep shortly as jedis cannot deal propery with multiple repsonses within one connection
-				// @see https://github.com/xetorthio/jedis/issues/186
+				// see https://github.com/xetorthio/jedis/issues/186
 				Thread.sleep(100);
 			}
 

--- a/src/test/java/org/springframework/data/redis/listener/adapter/MessageListenerTest.java
+++ b/src/test/java/org/springframework/data/redis/listener/adapter/MessageListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,10 +139,7 @@ public class MessageListenerTest {
 		verify(target).customMethodWithChannel(PAYLOAD, CHANNEL);
 	}
 
-	/**
-	 * @see DATAREDIS-92
-	 */
-	@Test
+	@Test // DATAREDIS-92
 	public void triggersListenerImplementingInterfaceCorrectly() {
 
 		SampleListener listener = new SampleListener();
@@ -158,10 +155,7 @@ public class MessageListenerTest {
 		assertEquals(1, listener.count);
 	}
 
-	/**
-	 * @see DATAREDIS-337
-	 */
-	@Test
+	@Test // DATAREDIS-337
 	public void defaultConcreteHandlerMethodShouldOnlyBeInvokedOnce() {
 
 		ConcreteMessageHandler listener = spy(new ConcreteMessageHandler());
@@ -174,10 +168,7 @@ public class MessageListenerTest {
 		verify(listener, times(1)).handleMessage(anyString(), anyString());
 	}
 
-	/**
-	 * @see DATAREDIS-337
-	 */
-	@Test
+	@Test // DATAREDIS-337
 	public void defaultConcreteHandlerMethodWithoutSerializerShouldOnlyBeInvokedOnce() {
 
 		ConcreteMessageHandler listener = spy(new ConcreteMessageHandler());
@@ -191,10 +182,7 @@ public class MessageListenerTest {
 		verify(listener, times(1)).handleMessage(any(byte[].class), anyString());
 	}
 
-	/**
-	 * @see DATAREDIS-337
-	 */
-	@Test
+	@Test // DATAREDIS-337
 	public void defaultConcreteHandlerMethodWithCustomSerializerShouldOnlyBeInvokedOnce() {
 
 		ConcreteMessageHandler listener = spy(new ConcreteMessageHandler());
@@ -208,10 +196,7 @@ public class MessageListenerTest {
 		verify(listener, times(1)).handleMessage(any(Pojo.class), anyString());
 	}
 
-	/**
-	 * @see DATAREDIS-337
-	 */
-	@Test
+	@Test // DATAREDIS-337
 	public void customConcreteHandlerMethodShouldOnlyBeInvokedOnce() {
 
 		ConcreteMessageHandler listener = spy(new ConcreteMessageHandler());
@@ -225,10 +210,7 @@ public class MessageListenerTest {
 		verify(listener, times(1)).handle(anyString(), anyString());
 	}
 
-	/**
-	 * @see DATAREDIS-337
-	 */
-	@Test
+	@Test // DATAREDIS-337
 	public void customConcreteMessageOnlyHandlerMethodShouldOnlyBeInvokedOnce() {
 
 		ConcreteMessageHandler listener = spy(new ConcreteMessageHandler());
@@ -242,10 +224,7 @@ public class MessageListenerTest {
 		verify(listener, times(1)).handleMessageOnly(anyString());
 	}
 
-	/**
-	 * @see DATAREDIS-337
-	 */
-	@Test
+	@Test // DATAREDIS-337
 	public void customConcreteHandlerMethodWithoutSerializerShouldOnlyBeInvokedOnce() {
 
 		ConcreteMessageHandler listener = spy(new ConcreteMessageHandler());
@@ -260,10 +239,7 @@ public class MessageListenerTest {
 		verify(listener, times(1)).handle(any(byte[].class), anyString());
 	}
 
-	/**
-	 * @see DATAREDIS-337
-	 */
-	@Test
+	@Test // DATAREDIS-337
 	public void customConcreteHandlerMethodWithCustomSerializerShouldOnlyBeInvokedOnce() {
 
 		ConcreteMessageHandler listener = spy(new ConcreteMessageHandler());
@@ -289,7 +265,6 @@ public class MessageListenerTest {
 
 	/**
 	 * @author Thomas Darimont
-	 * @see DATAREDIS-337
 	 */
 	static class AbstractMessageHandler {
 
@@ -310,7 +285,6 @@ public class MessageListenerTest {
 
 	/**
 	 * @author Thomas Darimont
-	 * @see DATAREDIS-337
 	 */
 	static class ConcreteMessageHandler extends AbstractMessageHandler {
 

--- a/src/test/java/org/springframework/data/redis/mapping/AbstractHashMapperTest.java
+++ b/src/test/java/org/springframework/data/redis/mapping/AbstractHashMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,10 +55,7 @@ public abstract class AbstractHashMapperTest {
 		assertBackAndForwardMapping(new Person("George", "Enescu", 74, new Address("liveni", 19)));
 	}
 
-	/**
-	 * @see DATAREDIS-421
-	 */
-	@Test
+	@Test // DATAREDIS-421
 	public void toHashShouldTreatNullValuesCorrectly() {
 
 		Person source = new Person("rand", null, 19);

--- a/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,10 +78,7 @@ public class Jackson2HashMapperTests {
 		this.mapper = new Jackson2HashMapper(true);
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void shouldWriteReadHashCorrectly() {
 
 		Person jon = new Person("jon", "snow", 19);

--- a/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,10 +58,7 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		return this.mapper;
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void shouldMapTypedListOfSimpleType() {
 
 		WithList source = new WithList();
@@ -69,10 +66,7 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		assertBackAndForwardMapping(source);
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void shouldMapTypedListOfComplexType() {
 
 		WithList source = new WithList();
@@ -81,10 +75,7 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		assertBackAndForwardMapping(source);
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void shouldMapTypedListOfComplexObjectWihtNestedElements() {
 
 		WithList source = new WithList();
@@ -99,10 +90,7 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		assertBackAndForwardMapping(source);
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void shouldMapNestedObject() {
 
 		Person jon = new Person("jon", "snow", 19);
@@ -114,10 +102,7 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		assertBackAndForwardMapping(jon);
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void shouldMapUntypedList() {
 
 		WithList source = new WithList();
@@ -125,10 +110,7 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		assertBackAndForwardMapping(source);
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void shouldMapTypedMapOfSimpleTypes() {
 
 		WithMap source = new WithMap();
@@ -139,10 +121,7 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		assertBackAndForwardMapping(source);
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void shouldMapTypedMapOfComplexTypes() {
 
 		WithMap source = new WithMap();
@@ -152,10 +131,7 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		assertBackAndForwardMapping(source);
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void shouldMapUntypedMap() {
 
 		WithMap source = new WithMap();
@@ -166,10 +142,7 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		assertBackAndForwardMapping(source);
 	}
 
-	/**
-	 * @see DATAREDIS-423
-	 */
-	@Test
+	@Test // DATAREDIS-423
 	public void nestedStuff() {
 
 		WithList nestedList = new WithList();

--- a/src/test/java/org/springframework/data/redis/mapping/ObjectHashMapperTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/ObjectHashMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,18 +33,12 @@ public class ObjectHashMapperTests extends AbstractHashMapperTest {
 		return new ObjectHashMapper();
 	}
 
-	/**
-	 * @see DATAREDIS-503
-	 */
-	@Test
+	@Test // DATAREDIS-503
 	public void testSimpleType() {
 		assertBackAndForwardMapping(new Integer(100));
 	}
 
-	/**
-	 * @see DATAREDIS-503
-	 */
-	@Test
+	@Test // DATAREDIS-503
 	public void fromHashShouldCastToType() {
 
 		ObjectHashMapper objectHashMapper = new ObjectHashMapper();
@@ -55,10 +49,7 @@ public class ObjectHashMapperTests extends AbstractHashMapperTest {
 		assertThat(result, is(equalTo(new Integer(100))));
 	}
 
-	/**
-	 * @see DATAREDIS-503
-	 */
-	@Test(expected = ClassCastException.class)
+	@Test(expected = ClassCastException.class) // DATAREDIS-503
 	public void fromHashShouldFailIfTypeDoesNotMatch() {
 
 		ObjectHashMapper objectHashMapper = new ObjectHashMapper();

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,10 +66,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		kvTemplate.delete(City.class);
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void simpleFindShouldReturnEntitiesCorrectly() {
 
 		Person rand = new Person();
@@ -95,10 +92,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(repo.findByLastname("al'thor"), hasItem(rand));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void simpleFindByMultipleProperties() {
 
 		Person egwene = new Person();
@@ -117,10 +111,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(repo.findByFirstnameAndLastname("egwene", "al'vere").get(0), is(egwene));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void findReturnsReferenceDataCorrectly() {
 
 		// Prepare referenced data entry
@@ -150,10 +141,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(reLoaded.city, IsNull.nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void findReturnsPageCorrectly() {
 
 		Person eddard = new Person("eddard", "stark");
@@ -176,10 +164,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(page2.getTotalElements(), is(6L));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void findUsingOrReturnsResultCorrectly() {
 
 		Person eddard = new Person("eddard", "stark");
@@ -194,10 +179,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(eddardAndJon, containsInAnyOrder(eddard, jon));
 	}
 
-	/**
-	 * @see DATAREDIS-547
-	 */
-	@Test
+	@Test // DATAREDIS-547
 	public void shouldApplyFirstKeywordCorrectly() {
 
 		Person eddard = new Person("eddard", "stark");
@@ -209,10 +191,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(repo.findFirstBy(), hasSize(1));
 	}
 
-	/**
-	 * @see DATAREDIS-547
-	 */
-	@Test
+	@Test // DATAREDIS-547
 	public void shouldApplyPageableCorrectlyWhenUsingFindAll() {
 
 		Person eddard = new Person("eddard", "stark");
@@ -226,10 +205,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(repo.findAll(firstPage.nextPageable()).getContent(), hasSize(1));
 	}
 
-	/**
-	 * @see DATAREDIS-551
-	 */
-	@Test
+	@Test // DATAREDIS-551
 	public void shouldApplyPageableCorrectlyWhenUsingFindByWithoutCriteria() {
 
 		Person eddard = new Person("eddard", "stark");
@@ -244,10 +220,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(repo.findBy(firstPage.nextPageable()).getContent(), hasSize(1));
 	}
 
-	/**
-	 * @see DATAREDIS-547
-	 */
-	@Test
+	@Test // DATAREDIS-547
 	public void shouldReturnEmptyListWhenPageableOutOfBoundsUsingFindAll() {
 
 		Person eddard = new Person("eddard", "stark");
@@ -260,10 +233,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(firstPage.getContent(), hasSize(0));
 	}
 
-	/**
-	 * @see DATAREDIS-547
-	 */
-	@Test
+	@Test // DATAREDIS-547
 	public void shouldReturnEmptyListWhenPageableOutOfBoundsUsingQueryMethod() {
 
 		Person eddard = new Person("eddard", "stark");
@@ -285,10 +255,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(page2.getTotalElements(), is(3L));
 	}
 
-	/**
-	 * @see DATAREDIS-547
-	 */
-	@Test
+	@Test // DATAREDIS-547
 	public void shouldApplyTopKeywordCorrectly() {
 
 		Person eddard = new Person("eddard", "stark");
@@ -300,10 +267,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(repo.findTop2By(), hasSize(2));
 	}
 
-	/**
-	 * @see DATAREDIS-547
-	 */
-	@Test
+	@Test // DATAREDIS-547
 	public void shouldApplyTopKeywordCorrectlyWhenCriteriaPresent() {
 
 		Person eddard = new Person("eddard", "stark");
@@ -322,10 +286,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void nearQueryShouldReturnResultsCorrectly() {
 
 		City palermo = new City();
@@ -344,10 +305,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(result, not(hasItems(palermo)));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void nearQueryShouldFindNothingIfOutOfRange() {
 
 		City palermo = new City();
@@ -362,10 +320,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(result, is(empty()));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void nearQueryShouldReturnResultsCorrectlyOnNestedProperty() {
 
 		City palermo = new City();

--- a/src/test/java/org/springframework/data/redis/repository/cdi/CdiExtensionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/cdi/CdiExtensionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,10 +51,7 @@ public class CdiExtensionIntegrationTests {
 		LOGGER.debug("CDI container bootstrapped!");
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	@SuppressWarnings("rawtypes")
 	public void beanShouldBeRegistered() {
 
@@ -64,10 +61,7 @@ public class CdiExtensionIntegrationTests {
 		assertThat(beans.iterator().next().getScope(), is(equalTo((Class) ApplicationScoped.class)));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void saveAndFindUnqualified() {
 
 		RepositoryConsumer repositoryConsumer = container.getInstance(RepositoryConsumer.class);
@@ -81,10 +75,7 @@ public class CdiExtensionIntegrationTests {
 		assertThat(result, contains(person));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void saveAndFindQualified() {
 
 		RepositoryConsumer repositoryConsumer = container.getInstance(RepositoryConsumer.class);
@@ -99,10 +90,7 @@ public class CdiExtensionIntegrationTests {
 	}
 	
 	
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void callMethodOnCustomRepositoryShouldSuceed() {
 
 		RepositoryConsumer repositoryConsumer = container.getInstance(RepositoryConsumer.class);

--- a/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtensionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,36 +58,24 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 		extension = new RedisRepositoryConfigurationExtension();
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void isStrictMatchIfDomainTypeIsAnnotatedWithDocument() {
 		assertHasRepo(SampleRepository.class, extension.getRepositoryConfigurations(configurationSource, loader, true));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void isStrictMatchIfRepositoryExtendsStoreSpecificBase() {
 		assertHasRepo(StoreRepository.class, extension.getRepositoryConfigurations(configurationSource, loader, true));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void isNotStrictMatchIfDomainTypeIsNotAnnotatedWithDocument() {
 
 		assertDoesNotHaveRepo(UnannotatedRepository.class,
 				extension.getRepositoryConfigurations(configurationSource, loader, true));
 	}
 
-	/**
-	 * @see DATAREDIS-491
-	 */
-	@Test
+	@Test // DATAREDIS-491
 	public void picksUpEnableKeyspaceEventsOnStartupCorrectly() {
 
 		metadata = new StandardAnnotationMetadata(Config.class, true);
@@ -96,10 +84,7 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 		assertThat(getEnableKeyspaceEvents(beanDefintionRegistry), equalTo((Object) EnableKeyspaceEvents.ON_STARTUP));
 	}
 
-	/**
-	 * @see DATAREDIS-491
-	 */
-	@Test
+	@Test // DATAREDIS-491
 	public void picksUpEnableKeyspaceEventsDefaultCorrectly() {
 
 		metadata = new StandardAnnotationMetadata(ConfigWithKeyspaceEventsDisabled.class, true);
@@ -108,10 +93,7 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 		assertThat(getEnableKeyspaceEvents(beanDefintionRegistry), equalTo((Object) EnableKeyspaceEvents.OFF));
 	}
 
-	/**
-	 * @see DATAREDIS-505
-	 */
-	@Test
+	@Test // DATAREDIS-505
 	public void picksUpDefaultKeyspaceNotificationsConfigParameterCorrectly() {
 
 		metadata = new StandardAnnotationMetadata(Config.class, true);
@@ -120,10 +102,7 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 		assertThat(getKeyspaceNotificationsConfigParameter(beanDefintionRegistry), equalTo((Object) "Ex"));
 	}
 
-	/**
-	 * @see DATAREDIS-505
-	 */
-	@Test
+	@Test // DATAREDIS-505
 	public void picksUpCustomKeyspaceNotificationsConfigParameterCorrectly() {
 
 		metadata = new StandardAnnotationMetadata(ConfigWithKeyspaceEventsEnabledAndCustomEventConfig.class, true);

--- a/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationUnitTests.java
@@ -1,6 +1,5 @@
-package org.springframework.data.redis.repository.configuration;
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +13,7 @@ package org.springframework.data.redis.repository.configuration;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.springframework.data.redis.repository.configuration;
 
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsEqual.*;
@@ -86,10 +86,7 @@ public class RedisRepositoryConfigurationUnitTests {
 
 		@Autowired ApplicationContext ctx;
 
-		/**
-		 * @see DATAREDIS-425
-		 */
-		@Test
+		@Test // DATAREDIS-425
 		public void shouldPickUpReferenceResolver() {
 
 			RedisKeyValueAdapter adapter = (RedisKeyValueAdapter) ctx.getBean("redisKeyValueAdapter");
@@ -118,18 +115,12 @@ public class RedisRepositoryConfigurationUnitTests {
 
 		@Autowired ApplicationContext ctx;
 
-		/**
-		 * @see DATAREDIS-425
-		 */
-		@Test
+		@Test // DATAREDIS-425
 		public void shouldInitWithDefaults() {
 			assertThat(ctx.getBean(ContextSampleRepository.class), is(notNullValue()));
 		}
 
-		/**
-		 * @see DATAREDIS-425
-		 */
-		@Test
+		@Test // DATAREDIS-425
 		public void shouldRegisterDefaultBeans() {
 
 			assertThat(ctx.getBean(ContextSampleRepository.class), is(notNullValue()));

--- a/src/test/java/org/springframework/data/redis/repository/core/MappingRedisEntityInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/core/MappingRedisEntityInformationUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,7 @@ public class MappingRedisEntityInformationUnitTests<T, ID extends Serializable> 
 
 	@Mock RedisPersistentEntity<T> entity;
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test(expected = MappingException.class)
+	@Test(expected = MappingException.class) // DATAREDIS-425
 	@SuppressWarnings("unchecked")
 	public void throwsMappingExceptionWhenNoIdPropertyPresent() {
 

--- a/src/test/java/org/springframework/data/redis/repository/query/RedisQueryCreatorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/query/RedisQueryCreatorUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,10 +52,7 @@ public class RedisQueryCreatorUnitTests {
 
 	private @Mock RepositoryMetadata metadataMock;
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void findBySingleSimpleProperty() throws SecurityException, NoSuchMethodException {
 
 		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
@@ -67,10 +64,7 @@ public class RedisQueryCreatorUnitTests {
 		assertThat(query.getCritieria().getSismember(), hasItem(new PathAndValue("firstname", "eddard")));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void findByMultipleSimpleProperties() throws SecurityException, NoSuchMethodException {
 
 		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
@@ -84,10 +78,7 @@ public class RedisQueryCreatorUnitTests {
 		assertThat(query.getCritieria().getSismember(), hasItem(new PathAndValue("age", 43)));
 	}
 
-	/**
-	 * @see DATAREDIS-425
-	 */
-	@Test
+	@Test // DATAREDIS-425
 	public void findByMultipleSimplePropertiesUsingOr() throws SecurityException, NoSuchMethodException {
 
 		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
@@ -101,10 +92,7 @@ public class RedisQueryCreatorUnitTests {
 		assertThat(query.getCritieria().getOrSismember(), hasItem(new PathAndValue("firstname", "eddard")));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void findWithinCircle() throws SecurityException, NoSuchMethodException {
 
 		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
@@ -118,10 +106,7 @@ public class RedisQueryCreatorUnitTests {
 		assertThat(query.getCritieria().getNear().getDistance(), is(new Distance(200, Metrics.KILOMETERS)));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void findNearWithPointAndDistance() throws SecurityException, NoSuchMethodException {
 
 		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
@@ -135,10 +120,7 @@ public class RedisQueryCreatorUnitTests {
 		assertThat(query.getCritieria().getNear().getDistance(), is(new Distance(200, Metrics.KILOMETERS)));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void findNearWithPointAndNumericValueDefaultsToKilometers() throws SecurityException, NoSuchMethodException {
 
 		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
@@ -152,10 +134,7 @@ public class RedisQueryCreatorUnitTests {
 		assertThat(query.getCritieria().getNear().getDistance(), is(new Distance(200, Metrics.KILOMETERS)));
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void findNearWithInvalidShapeParameter() throws SecurityException, NoSuchMethodException {
 
 		exception.expect(InvalidDataAccessApiUsageException.class);
@@ -168,10 +147,7 @@ public class RedisQueryCreatorUnitTests {
 		creator.createQuery();
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void findNearWithInvalidDistanceParameter() throws SecurityException, NoSuchMethodException {
 
 		exception.expect(InvalidDataAccessApiUsageException.class);
@@ -184,10 +160,7 @@ public class RedisQueryCreatorUnitTests {
 		creator.createQuery();
 	}
 
-	/**
-	 * @see DATAREDIS-533
-	 */
-	@Test
+	@Test // DATAREDIS-533
 	public void findNearWithMissingDistanceParameter() throws SecurityException, NoSuchMethodException {
 
 		exception.expect(InvalidDataAccessApiUsageException.class);

--- a/src/test/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializerUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,72 +47,48 @@ public class GenericJackson2JsonRedisSerializerUnitTests {
 	private static final SimpleObject SIMPLE_OBJECT = new SimpleObject(1L);
 	private static final ComplexObject COMPLEX_OBJECT = new ComplexObject("steelheart", SIMPLE_OBJECT);
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test
+	@Test // DATAREDIS-392
 	public void shouldUseDefaultTyping() {
 		assertThat(extractTypeResolver(new GenericJackson2JsonRedisSerializer()), notNullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test
+	@Test // DATAREDIS-392
 	public void shouldUseDefaultTypingWhenClassPropertyNameIsEmpty() {
 
 		TypeResolverBuilder<?> typeResolver = extractTypeResolver(new GenericJackson2JsonRedisSerializer(""));
 		assertThat((String) getField(typeResolver, "_typeProperty"), is(JsonTypeInfo.Id.CLASS.getDefaultPropertyName()));
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test
+	@Test // DATAREDIS-392
 	public void shouldUseDefaultTypingWhenClassPropertyNameIsNull() {
 
 		TypeResolverBuilder<?> typeResolver = extractTypeResolver(new GenericJackson2JsonRedisSerializer((String) null));
 		assertThat((String) getField(typeResolver, "_typeProperty"), is(JsonTypeInfo.Id.CLASS.getDefaultPropertyName()));
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test
+	@Test // DATAREDIS-392
 	public void shouldUseDefaultTypingWhenClassPropertyNameIsProvided() {
 
 		TypeResolverBuilder<?> typeResolver = extractTypeResolver(new GenericJackson2JsonRedisSerializer("firefight"));
 		assertThat((String) getField(typeResolver, "_typeProperty"), is("firefight"));
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test
+	@Test // DATAREDIS-392
 	public void serializeShouldReturnEmptyByteArrayWhenSouceIsNull() {
 		assertThat(new GenericJackson2JsonRedisSerializer().serialize(null), is(SerializationUtils.EMPTY_ARRAY));
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test
+	@Test // DATAREDIS-392
 	public void deserializeShouldReturnNullWhenSouceIsNull() {
 		assertThat(new GenericJackson2JsonRedisSerializer().deserialize(null), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test
+	@Test // DATAREDIS-392
 	public void deserializeShouldReturnNullWhenSouceIsEmptyArray() {
 		assertThat(new GenericJackson2JsonRedisSerializer().deserialize(SerializationUtils.EMPTY_ARRAY), nullValue());
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test
+	@Test // DATAREDIS-392
 	public void deserializeShouldBeAbleToRestoreSimpleObjectAfterSerialization() {
 
 		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
@@ -120,10 +96,7 @@ public class GenericJackson2JsonRedisSerializerUnitTests {
 		assertThat((SimpleObject) serializer.deserialize(serializer.serialize(SIMPLE_OBJECT)), is(SIMPLE_OBJECT));
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test
+	@Test // DATAREDIS-392
 	public void deserializeShouldBeAbleToRestoreComplexObjectAfterSerialization() {
 
 		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
@@ -131,10 +104,7 @@ public class GenericJackson2JsonRedisSerializerUnitTests {
 		assertThat((ComplexObject) serializer.deserialize(serializer.serialize(COMPLEX_OBJECT)), is(COMPLEX_OBJECT));
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test(expected = SerializationException.class)
+	@Test(expected = SerializationException.class) // DATAREDIS-392
 	public void serializeShouldThrowSerializationExceptionProcessingError() throws JsonProcessingException {
 
 		ObjectMapper objectMapperMock = mock(ObjectMapper.class);
@@ -143,10 +113,7 @@ public class GenericJackson2JsonRedisSerializerUnitTests {
 		new GenericJackson2JsonRedisSerializer(objectMapperMock).serialize(SIMPLE_OBJECT);
 	}
 
-	/**
-	 * @see DATAREDIS-392
-	 */
-	@Test(expected = SerializationException.class)
+	@Test(expected = SerializationException.class) // DATAREDIS-392
 	public void deserializeShouldThrowSerializationExceptionProcessingError() throws IOException {
 
 		ObjectMapper objectMapperMock = mock(ObjectMapper.class);
@@ -156,10 +123,7 @@ public class GenericJackson2JsonRedisSerializerUnitTests {
 		new GenericJackson2JsonRedisSerializer(objectMapperMock).deserialize(new byte[] { 1 });
 	}
 
-	/**
-	 * @see DATAREDIS-553
-	 */
-	@Test
+	@Test // DATAREDIS-553
 	public void shouldSerializeNullValueSoThatItCanBeDeserializedWithDefaultTypingEnabled() {
 
 		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();

--- a/src/test/java/org/springframework/data/redis/serializer/Jackson2JsonRedisSerializerTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/Jackson2JsonRedisSerializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,36 +39,24 @@ public class Jackson2JsonRedisSerializerTests {
 		this.serializer = new Jackson2JsonRedisSerializer<Person>(Person.class);
 	}
 
-	/**
-	 * @see DATAREDIS-241
-	 */
-	@Test
+	@Test // DATAREDIS-241
 	public void testJackson2JsonSerializer() throws Exception {
 
 		Person person = new PersonObjectFactory().instance();
 		assertEquals(person, serializer.deserialize(serializer.serialize(person)));
 	}
 
-	/**
-	 * @see DATAREDIS-241
-	 */
-	@Test
+	@Test // DATAREDIS-241
 	public void testJackson2JsonSerializerShouldReturnEmptyByteArrayWhenSerializingNull() {
 		assertThat(serializer.serialize(null), Is.is(new byte[0]));
 	}
 
-	/**
-	 * @see DTATREDIS-241
-	 */
-	@Test
+	@Test // DTATREDIS-241
 	public void testJackson2JsonSerializerShouldReturnNullWhenDerserializingEmtyByteArray() {
 		assertThat(serializer.deserialize(new byte[0]), IsNull.nullValue());
 	}
 
-	/**
-	 * @see DTATREDIS-241
-	 */
-	@Test(expected = SerializationException.class)
+	@Test(expected = SerializationException.class) // DTATREDIS-241
 	public void testJackson2JsonSerilizerShouldThrowExceptionWhenDeserializingInvalidByteArray() {
 
 		Person person = new PersonObjectFactory().instance();
@@ -78,10 +66,7 @@ public class Jackson2JsonRedisSerializerTests {
 		serializer.deserialize(serializedValue);
 	}
 
-	/**
-	 * @see DTATREDIS-241
-	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class) // DTATREDIS-241
 	public void testJackson2JsonSerilizerThrowsExceptionWhenSettingNullObjectMapper() {
 		serializer.setObjectMapper(null);
 	}

--- a/src/test/java/org/springframework/data/redis/serializer/SimpleRedisSerializerTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/SimpleRedisSerializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,10 +122,7 @@ public class SimpleRedisSerializerTests {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-427
-	 */
-	@Test
+	@Test // DATAREDIS-427
 	public void jdkSerializerShouldUseCustomClassLoader() throws ClassNotFoundException {
 
 		ClassLoader customClassLoader = new ShadowingClassLoader(ClassLoader.getSystemClassLoader());

--- a/src/test/java/org/springframework/data/redis/support/BoundKeyOperationsTest.java
+++ b/src/test/java/org/springframework/data/redis/support/BoundKeyOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,10 +108,7 @@ public class BoundKeyOperationsTest {
 		assertEquals(key, keyOps.getKey());
 	}
 
-	/**
-	 * @see DATAREDIS-251
-	 */
-	@Test
+	@Test // DATAREDIS-251
 	public void testExpire() throws Exception {
 
 		assertEquals(keyOps.getClass().getName() + " -> " + keyOps.getKey(), Long.valueOf(-1), keyOps.getExpire());
@@ -122,10 +119,7 @@ public class BoundKeyOperationsTest {
 		}
 	}
 
-	/**
-	 * @see DATAREDIS-251
-	 */
-	@Test
+	@Test // DATAREDIS-251
 	public void testPersist() throws Exception {
 		assumeTrue(!ConnectionUtils.isJredis(template.getConnectionFactory()));
 

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,10 +178,7 @@ public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
 		assertNull(factory.getConnection().get((getClass().getSimpleName() + ":double").getBytes()));
 	}
 
-	/**
-	 * @see DATAREDIS-317
-	 */
-	@Test
+	@Test // DATAREDIS-317
 	public void testShouldThrowExceptionIfRedisAtomicDoubleIsUsedWithRedisTemplateAndNoKeySerializer() {
 
 		expectedException.expect(IllegalArgumentException.class);
@@ -190,10 +187,7 @@ public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
 		new RedisAtomicDouble("foo", new RedisTemplate<String, Double>());
 	}
 
-	/**
-	 * @see DATAREDIS-317
-	 */
-	@Test
+	@Test // DATAREDIS-317
 	public void testShouldThrowExceptionIfRedisAtomicDoubleIsUsedWithRedisTemplateAndNoValueSerializer() {
 
 		expectedException.expect(IllegalArgumentException.class);
@@ -204,10 +198,7 @@ public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
 		new RedisAtomicDouble("foo", template);
 	}
 
-	/**
-	 * @see DATAREDIS-317
-	 */
-	@Test
+	@Test // DATAREDIS-317
 	public void testShouldBeAbleToUseRedisAtomicDoubleWithProperlyConfiguredRedisTemplate() {
 
 		RedisAtomicDouble ral = new RedisAtomicDouble("DATAREDIS-317.atomicDouble", template);
@@ -216,10 +207,7 @@ public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
 		assertThat(ral.get(), is(32.23));
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void getThrowsExceptionWhenKeyHasBeenRemoved() {
 
 		expectedException.expect(DataRetrievalFailureException.class);
@@ -234,10 +222,7 @@ public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
 		test.get();
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void getAndSetReturnsZeroWhenKeyHasBeenRemoved() {
 
 		// setup double

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicIntegerTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicIntegerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,10 +115,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		assertEquals(0, intCounter.decrementAndGet());
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void testGetAndIncrement() {
 
 		intCounter.set(1);
@@ -126,10 +123,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		assertEquals(2, intCounter.get());
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void testGetAndAdd() {
 
 		intCounter.set(1);
@@ -137,10 +131,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		assertEquals(6, intCounter.get());
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void testGetAndDecrement() {
 
 		intCounter.set(1);
@@ -148,10 +139,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		assertEquals(0, intCounter.get());
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void testGetAndSet() {
 
 		intCounter.set(1);
@@ -193,10 +181,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		assertFalse("counter already modified", failed.get());
 	}
 
-	/**
-	 * @see DATAREDIS-317
-	 */
-	@Test
+	@Test // DATAREDIS-317
 	public void testShouldThrowExceptionIfRedisAtomicIntegerIsUsedWithRedisTemplateAndNoKeySerializer() {
 
 		expectedException.expect(IllegalArgumentException.class);
@@ -205,10 +190,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		new RedisAtomicInteger("foo", new RedisTemplate<String, Integer>());
 	}
 
-	/**
-	 * @see DATAREDIS-317
-	 */
-	@Test
+	@Test // DATAREDIS-317
 	public void testShouldThrowExceptionIfRedisAtomicIntegerIsUsedWithRedisTemplateAndNoValueSerializer() {
 
 		expectedException.expect(IllegalArgumentException.class);
@@ -219,10 +201,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		new RedisAtomicInteger("foo", template);
 	}
 
-	/**
-	 * @see DATAREDIS-317
-	 */
-	@Test
+	@Test // DATAREDIS-317
 	public void testShouldBeAbleToUseRedisAtomicIntegerWithProperlyConfiguredRedisTemplate() {
 
 		RedisAtomicInteger ral = new RedisAtomicInteger("DATAREDIS-317.atomicInteger", template);
@@ -231,10 +210,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		assertThat(ral.get(), is(32));
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void getThrowsExceptionWhenKeyHasBeenRemoved() {
 
 		expectedException.expect(DataRetrievalFailureException.class);
@@ -249,10 +225,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		test.get();
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void getAndSetReturnsZeroWhenKeyHasBeenRemoved() {
 
 		// setup integer

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicLongTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicLongTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,10 +111,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		assertEquals(0, longCounter.decrementAndGet());
 	}
 
-		/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+		@Test // DATAREDIS-469
 	public void testGetAndIncrement() {
 
 		longCounter.set(1);
@@ -122,10 +119,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		assertEquals(2, longCounter.get());
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void testGetAndAdd() {
 
 		longCounter.set(1);
@@ -133,10 +127,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		assertEquals(6, longCounter.get());
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void testGetAndDecrement() {
 
 		longCounter.set(1);
@@ -144,10 +135,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		assertEquals(0, longCounter.get());
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void testGetAndSet() {
 
 		longCounter.set(1);
@@ -163,10 +151,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		assertEquals(longCounter.get(), keyCopy.get());
 	}
 
-	/**
-	 * @see DATAREDIS-317
-	 */
-	@Test
+	@Test // DATAREDIS-317
 	public void testShouldThrowExceptionIfAtomicLongIsUsedWithRedisTemplateAndNoKeySerializer() {
 
 		expectedException.expect(IllegalArgumentException.class);
@@ -176,10 +161,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		new RedisAtomicLong("foo", template);
 	}
 
-	/**
-	 * @see DATAREDIS-317
-	 */
-	@Test
+	@Test // DATAREDIS-317
 	public void testShouldThrowExceptionIfAtomicLongIsUsedWithRedisTemplateAndNoValueSerializer() {
 
 		expectedException.expect(IllegalArgumentException.class);
@@ -190,10 +172,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		new RedisAtomicLong("foo", template);
 	}
 
-	/**
-	 * @see DATAREDIS-317
-	 */
-	@Test
+	@Test // DATAREDIS-317
 	public void testShouldBeAbleToUseRedisAtomicLongWithProperlyConfiguredRedisTemplate() {
 
 		RedisTemplate<String, Long> template = new RedisTemplate<String, Long>();
@@ -208,10 +187,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		assertThat(ral.get(), is(32L));
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void getThrowsExceptionWhenKeyHasBeenRemoved() {
 
 		expectedException.expect(DataRetrievalFailureException.class);
@@ -226,10 +202,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		test.get();
 	}
 
-	/**
-	 * @see DATAREDIS-469
-	 */
-	@Test
+	@Test // DATAREDIS-469
 	public void getAndSetReturnsZeroWhenKeyHasBeenRemoved() {
 
 		// setup long

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisCollectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisCollectionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,22 +92,16 @@ public class AbstractRedisCollectionUnitTests {
 		when(connectionFactoryMock.getConnection()).thenReturn(connectionMock);
 	}
 
-	/**
-	 * @see DATAREDIS-188
-	 */
 	@SuppressWarnings("unchecked")
-	@Test
+	@Test // DATAREDIS-188
 	public void testRenameOfEmptyCollectionShouldNotTriggerRedisOperation() {
 
 		collection.rename("new-key");
 		verify(redisTemplateSpy, never()).rename(eq("key"), eq("new-key"));
 	}
 
-	/**
-	 * @see DATAREDIS-188
-	 */
 	@SuppressWarnings("unchecked")
-	@Test
+	@Test // DATAREDIS-188
 	public void testRenameCollectionShouldTriggerRedisOperation() {
 
 		when(redisTemplateSpy.hasKey(anyObject())).thenReturn(Boolean.TRUE);

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisMapTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -488,10 +488,7 @@ public abstract class AbstractRedisMapTests<K, V> {
 		map.replace(getKey(), null);
 	}
 
-	/**
-	 * @see DATAREDIS-314
-	 */
-	@Test
+	@Test // DATAREDIS-314
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void testScanWorksCorrectly() throws IOException {

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisSetTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisSetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -303,9 +303,7 @@ public abstract class AbstractRedisSetTests<T> extends AbstractRedisCollectionTe
 		assertEquals(0, result.size());
 	}
 
-	/**
-	 * @see DATAREDIS-314
-	 */
+	// DATAREDIS-314
 	@SuppressWarnings("unchecked")
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
 	@Test

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisZSetTest.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisZSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -328,10 +328,7 @@ public abstract class AbstractRedisZSetTest<T> extends AbstractRedisCollectionTe
 		assertThat(tuple2.getScore(), isEqual(Double.valueOf(1)));
 	}
 
-	/**
-	 * @see DATAREDIS-407
-	 */
-	@Test
+	@Test // DATAREDIS-407
 	public void testRangeByLexUnbounded() {
 
 		assumeThat(
@@ -353,10 +350,7 @@ public abstract class AbstractRedisZSetTest<T> extends AbstractRedisCollectionTe
 		assertThat(tuple, isEqual(t1));
 	}
 
-	/**
-	 * @see DATAREDIS-407
-	 */
-	@Test
+	@Test // DATAREDIS-407
 	public void testRangeByLexBounded() {
 
 		assumeThat(
@@ -378,10 +372,7 @@ public abstract class AbstractRedisZSetTest<T> extends AbstractRedisCollectionTe
 		assertThat(tuple, isEqual(t2));
 	}
 
-	/**
-	 * @see DATAREDIS-407
-	 */
-	@Test
+	@Test // DATAREDIS-407
 	public void testRangeByLexUnboundedWithLimit() {
 
 		assumeThat(
@@ -404,10 +395,7 @@ public abstract class AbstractRedisZSetTest<T> extends AbstractRedisCollectionTe
 		assertThat(tuple, isEqual(t2));
 	}
 
-	/**
-	 * @see DATAREDIS-407
-	 */
-	@Test
+	@Test // DATAREDIS-407
 	public void testRangeByLexBoundedWithLimit() {
 
 		assumeThat(
@@ -641,11 +629,8 @@ public abstract class AbstractRedisZSetTest<T> extends AbstractRedisCollectionTe
 		assertArrayEquals(new Object[] { t1, t2, t3, t4 }, array);
 	}
 
-	/**
-	 * @see DATAREDIS-314
-	 */
 	@IfProfileValue(name = "redisVersion", value = "2.8+")
-	@Test
+	@Test // DATAREDIS-314
 	@WithRedisDriver({ RedisDriver.JEDIS, RedisDriver.LETTUCE })
 	public void testScanWorksCorrectly() throws IOException {
 

--- a/src/test/java/org/springframework/data/redis/support/collections/RedisMapTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/RedisMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,9 +63,7 @@ public class RedisMapTests extends AbstractRedisMapTests<Object, Object> {
 		return new DefaultRedisMap<Object, Object>(redisName, template);
 	}
 
-	/**
-	 * @see DATAREDIS-241
-	 */
+	// DATAREDIS-241
 	@SuppressWarnings("rawtypes")
 	@Parameters
 	public static Collection<Object[]> testParams() {

--- a/src/test/java/org/springframework/data/redis/support/collections/RedisPropertiesTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/RedisPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,9 +230,7 @@ public class RedisPropertiesTests extends RedisMapTests {
 		super.testScanWorksCorrectly();
 	}
 
-	/**
-	 * @see DATAREDIS-241
-	 */
+	// DATAREDIS-241
 	@Parameters
 	public static Collection<Object[]> testParams() {
 

--- a/src/test/resources/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests-context.xml
@@ -14,6 +14,7 @@
 			<bean class="org.springframework.data.redis.SettingsUtils"
 				factory-method="getPort" />
 		</property>
+		<property name="clientName" value="jedis-client" />
 	</bean>
 
 </beans>


### PR DESCRIPTION
I am using spring boot with 1.5.3 + spring-data-redis 1.8.3.RELEASE, and suffer NullPointer frequently,
Per check, it it due to RedisCache.get use exists/get command separately, and the ttl of my key offen between them.
I noticed RedisCache revised in 2.0.
But I need to solve my production issue with 1.8.x, hope it can be merge into 1.8.x so I can use official version again.

ps: last time the CI build failed, but I tried many time locally, it always pass, so re-pull again to try