### PR TITLE
DATAREDIS-673 - Gracefully return null if key gets deleted after checking for presence

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -181,7 +181,8 @@ public class RedisCache extends AbstractValueAdaptingCache {
 			return null;
 		}
 
-		return new RedisCacheElement(cacheKey, fromStoreValue(lookup(cacheKey)));
+		Object storeValue = lookup(cacheKey);
+		return (storeValue != null ? new RedisCacheElement(cacheKey,fromStoreValue(storeValue)) : null);
 	}
 
 	/*


### PR DESCRIPTION
I am using spring boot with 1.5.3 + spring-data-redis 1.8.3.RELEASE, and suffer NullPointer frequently,
Per check, it it due to RedisCache.get use exists/get command separately, and the ttl of my key offen between them.
I noticed RedisCache revised in 2.0.
But I need to solve my production issue with 1.8.x, hope it can be merge into 1.8.x so I can use official version again.
