### PR TITLE
DATAREDIS-667 - Align Lettuce connection-pooling with LettuceClientConfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-667-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
@@ -25,6 +25,7 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
  * Connection provider for Cluster connections.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  */
 class ClusterConnectionProvider implements LettuceConnectionProvider {
@@ -42,17 +43,16 @@ class ClusterConnectionProvider implements LettuceConnectionProvider {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnection(java.lang.Class)
 	 */
-	@SuppressWarnings("rawtypes")
 	@Override
-	public StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType) {
+	public <T extends StatefulConnection<?, ?>> T getConnection(Class<T> connectionType) {
 
 		if (connectionType.equals(StatefulRedisPubSubConnection.class)) {
-			return client.connectPubSub(codec);
+			return connectionType.cast(client.connectPubSub(codec));
 		}
 
 		if (StatefulRedisClusterConnection.class.isAssignableFrom(connectionType)
 				|| connectionType.equals(StatefulConnection.class)) {
-			return client.connect(codec);
+			return connectionType.cast(client.connect(codec));
 		}
 
 		throw new UnsupportedOperationException("Connection type " + connectionType + " not supported!");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+
+/**
+ * Connection provider for Cluster connections.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+class ClusterConnectionProvider implements LettuceConnectionProvider {
+
+	private final RedisClusterClient client;
+	private final RedisCodec<?, ?> codec;
+
+	ClusterConnectionProvider(RedisClusterClient client, RedisCodec<?, ?> codec) {
+
+		this.client = client;
+		this.codec = codec;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnection(java.lang.Class)
+	 */
+	@SuppressWarnings("rawtypes")
+	@Override
+	public StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType) {
+
+		if (connectionType.equals(StatefulRedisPubSubConnection.class)) {
+			return client.connectPubSub(codec);
+		}
+
+		if (StatefulRedisClusterConnection.class.isAssignableFrom(connectionType)
+				|| connectionType.equals(StatefulConnection.class)) {
+			return client.connect(codec);
+		}
+
+		throw new UnsupportedOperationException("Connection type " + connectionType + " not supported!");
+	}
+
+	public RedisClusterClient getClient() {
+		return client;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
@@ -58,6 +58,14 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 	}
 
 	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isUsePooling()
+	 */
+	@Override
+	public boolean isUsePooling() {
+		return false;
+	}
+
+	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isVerifyPeer()
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Optional;
  * Default implementation of {@literal LettuceClientConfiguration}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  */
 class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
@@ -55,14 +56,6 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 	@Override
 	public boolean isUseSsl() {
 		return useSsl;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isUsePooling()
-	 */
-	@Override
-	public boolean isUsePooling() {
-		return false;
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
@@ -40,7 +40,9 @@ import org.springframework.util.StringUtils;
  * @author Jennifer Hickey
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @deprecated since 2.0, use pooling via {@link LettucePoolingClientConfiguration}.
  */
+@Deprecated
 public class DefaultLettucePool implements LettucePool, InitializingBean {
 
 	@SuppressWarnings("rawtypes") //
@@ -126,7 +128,8 @@ public class DefaultLettucePool implements LettucePool, InitializingBean {
 	private RedisURI getRedisURI() {
 
 		RedisURI redisUri = isRedisSentinelAware()
-				? LettuceConverters.sentinelConfigurationToRedisURI(sentinelConfiguration) : createSimpleHostRedisURI();
+				? LettuceConverters.sentinelConfigurationToRedisURI(sentinelConfiguration)
+				: createSimpleHostRedisURI();
 
 		if (StringUtils.hasText(password)) {
 			redisUri.setPassword(password);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolingClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolingClientConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.resource.ClientResources;
+
+import java.time.Duration;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+/**
+ * Default implementation of {@literal LettucePoolingClientConfiguration}.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+class DefaultLettucePoolingClientConfiguration extends DefaultLettuceClientConfiguration
+		implements LettucePoolingClientConfiguration {
+
+	private final GenericObjectPoolConfig poolConfig;
+
+	DefaultLettucePoolingClientConfiguration(boolean useSsl, boolean verifyPeer, boolean startTls,
+			ClientResources clientResources, ClientOptions clientOptions, Duration timeout, Duration shutdownTimeout,
+			GenericObjectPoolConfig poolConfig) {
+
+		super(useSsl, verifyPeer, startTls, clientResources, clientOptions, timeout, shutdownTimeout);
+
+		this.poolConfig = poolConfig;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isUsePooling()
+	 */
+	@Override
+	public boolean isUsePooling() {
+		return true;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration#getPoolConfig()
+	 */
+	@Override
+	public GenericObjectPoolConfig getPoolConfig() {
+		return poolConfig;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolingClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolingClientConfiguration.java
@@ -19,6 +19,7 @@ import io.lettuce.core.ClientOptions;
 import io.lettuce.core.resource.ClientResources;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
@@ -26,33 +27,87 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
  * Default implementation of {@literal LettucePoolingClientConfiguration}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  */
-class DefaultLettucePoolingClientConfiguration extends DefaultLettuceClientConfiguration
-		implements LettucePoolingClientConfiguration {
+class DefaultLettucePoolingClientConfiguration implements LettucePoolingClientConfiguration {
 
+	private final LettuceClientConfiguration clientConfiguration;
 	private final GenericObjectPoolConfig poolConfig;
 
-	DefaultLettucePoolingClientConfiguration(boolean useSsl, boolean verifyPeer, boolean startTls,
-			ClientResources clientResources, ClientOptions clientOptions, Duration timeout, Duration shutdownTimeout,
+	DefaultLettucePoolingClientConfiguration(LettuceClientConfiguration clientConfiguration,
 			GenericObjectPoolConfig poolConfig) {
 
-		super(useSsl, verifyPeer, startTls, clientResources, clientOptions, timeout, shutdownTimeout);
-
+		this.clientConfiguration = clientConfiguration;
 		this.poolConfig = poolConfig;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isUsePooling()
-	 */
-	@Override
-	public boolean isUsePooling() {
-		return true;
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration#getPoolConfig()
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isUseSsl()
+	 */
+	@Override
+	public boolean isUseSsl() {
+		return clientConfiguration.isUseSsl();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isVerifyPeer()
+	 */
+	@Override
+	public boolean isVerifyPeer() {
+		return clientConfiguration.isVerifyPeer();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isStartTls()
+	 */
+	@Override
+	public boolean isStartTls() {
+		return clientConfiguration.isStartTls();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientResources()
+	 */
+	@Override
+	public Optional<ClientResources> getClientResources() {
+		return clientConfiguration.getClientResources();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientOptions()
+	 */
+	@Override
+	public Optional<ClientOptions> getClientOptions() {
+		return clientConfiguration.getClientOptions();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getCommandTimeout()
+	 */
+	@Override
+	public Duration getCommandTimeout() {
+		return clientConfiguration.getCommandTimeout();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getShutdownTimeout()
+	 */
+	@Override
+	public Duration getShutdownTimeout() {
+		return clientConfiguration.getShutdownTimeout();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettucePoolingClientConfiguration#getPoolConfig()
 	 */
 	@Override
 	public GenericObjectPoolConfig getPoolConfig() {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -55,11 +55,6 @@ public interface LettuceClientConfiguration {
 	boolean isUseSsl();
 
 	/**
-	 * @return {@literal true} to use connection-pooling.
-	 */
-	boolean isUsePooling();
-
-	/**
 	 * @return {@literal true} to verify peers when using {@link #isUseSsl() SSL}.
 	 */
 	boolean isVerifyPeer();
@@ -97,7 +92,7 @@ public interface LettuceClientConfiguration {
 	 * @return a new {@link LettuceClientConfigurationBuilder} to build {@link LettuceClientConfiguration}.
 	 */
 	static LettuceClientConfigurationBuilder builder() {
-		return new DefaultLettuceClientConfigurationBuilder();
+		return new LettuceClientConfigurationBuilder();
 	}
 
 	/**
@@ -126,101 +121,10 @@ public interface LettuceClientConfiguration {
 	}
 
 	/**
-	 * Builder for {@link LettuceClientConfiguration}.
+	 * @author Mark Paluch
+	 * @author Christoph Strobl
 	 */
-	interface LettuceClientConfigurationBuilder {
-
-		/**
-		 * Enable SSL connections.
-		 *
-		 * @return {@link LettuceSslClientConfigurationBuilder}.
-		 */
-		LettuceSslClientConfigurationBuilder useSsl();
-
-		/**
-		 * Configure {@link ClientResources}.
-		 *
-		 * @param clientResources must not be {@literal null}.
-		 * @return {@literal this} builder.
-		 * @throws IllegalArgumentException if clientResources is {@literal null}.
-		 */
-		LettuceClientConfigurationBuilder clientResources(ClientResources clientResources);
-
-		/**
-		 * Configure {@link ClientOptions}.
-		 *
-		 * @param clientOptions must not be {@literal null}.
-		 * @return {@literal this} builder.
-		 * @throws IllegalArgumentException if clientOptions is {@literal null}.
-		 */
-		LettuceClientConfigurationBuilder clientOptions(ClientOptions clientOptions);
-
-		/**
-		 * Configure a command timeout.
-		 *
-		 * @param timeout must not be {@literal null}.
-		 * @return {@literal this} builder.
-		 * @throws IllegalArgumentException if timeout is {@literal null}.
-		 */
-		LettuceClientConfigurationBuilder commandTimeout(Duration timeout);
-
-		/**
-		 * Configure a shutdown timeout.
-		 *
-		 * @param shutdownTimeout must not be {@literal null}.
-		 * @return {@literal this} builder.
-		 * @throws IllegalArgumentException if shutdownTimeout is {@literal null}.
-		 */
-		LettuceClientConfigurationBuilder shutdownTimeout(Duration shutdownTimeout);
-
-		/**
-		 * Build the {@link LettuceClientConfiguration} with the configuration applied from this builder.
-		 *
-		 * @return a new {@link LettuceClientConfiguration} object.
-		 */
-		LettuceClientConfiguration build();
-	}
-
-	/**
-	 * Builder for SSL-related {@link LettuceClientConfiguration}.
-	 */
-	interface LettuceSslClientConfigurationBuilder {
-
-		/**
-		 * Disable peer verification.
-		 *
-		 * @return {@literal this} builder.
-		 */
-		LettuceSslClientConfigurationBuilder disablePeerVerification();
-
-		/**
-		 * Enable Start TLS to send the first bytes unencrypted.
-		 *
-		 * @return {@literal this} builder.
-		 */
-		LettuceSslClientConfigurationBuilder startTls();
-
-		/**
-		 * Return to {@link LettuceClientConfigurationBuilder}.
-		 *
-		 * @return {@link LettuceClientConfigurationBuilder}.
-		 */
-		LettuceClientConfigurationBuilder and();
-
-		/**
-		 * Build the {@link LettuceClientConfiguration} with the configuration applied from this builder.
-		 *
-		 * @return a new {@link LettuceClientConfiguration} object.
-		 */
-		LettuceClientConfiguration build();
-	}
-
-	/**
-	 * Default {@link LettuceClientConfigurationBuilder} implementation to build an immutable
-	 * {@link LettuceClientConfiguration}.
-	 */
-	class DefaultLettuceClientConfigurationBuilder
-			implements LettuceClientConfigurationBuilder, LettuceSslClientConfigurationBuilder {
+	class LettuceClientConfigurationBuilder {
 
 		boolean useSsl;
 		boolean verifyPeer = true;
@@ -230,55 +134,26 @@ public interface LettuceClientConfiguration {
 		Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
 		Duration shutdownTimeout = Duration.ofMillis(100);
 
-		DefaultLettuceClientConfigurationBuilder() {}
+		LettuceClientConfigurationBuilder() {}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#useSsl()
+		/**
+		 * Enable SSL connections.
+		 *
+		 * @return {@link LettuceSslClientConfigurationBuilder}.
 		 */
-		@Override
 		public LettuceSslClientConfigurationBuilder useSsl() {
 
 			this.useSsl = true;
-			return this;
+			return new LettuceSslClientConfigurationBuilder(this);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#disablePeerVerification()
+		/**
+		 * Configure {@link ClientResources}.
+		 *
+		 * @param clientResources must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 * @throws IllegalArgumentException if clientResources is {@literal null}.
 		 */
-		@Override
-		public LettuceSslClientConfigurationBuilder disablePeerVerification() {
-
-			this.verifyPeer = false;
-			return this;
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#startTls()
-		 */
-		@Override
-		public LettuceSslClientConfigurationBuilder startTls() {
-
-			this.startTls = true;
-			return this;
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#and()
-		 */
-		@Override
-		public LettuceClientConfigurationBuilder and() {
-			return this;
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#clientResources(io.lettuce.core.resource.ClientResources)
-		 */
-		@Override
 		public LettuceClientConfigurationBuilder clientResources(ClientResources clientResources) {
 
 			Assert.notNull(clientResources, "ClientResources must not be null!");
@@ -287,11 +162,13 @@ public interface LettuceClientConfiguration {
 			return this;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#clientOptions(io.lettuce.core.ClientOptions)
+		/**
+		 * Configure {@link ClientOptions}.
+		 *
+		 * @param clientOptions must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 * @throws IllegalArgumentException if clientOptions is {@literal null}.
 		 */
-		@Override
 		public LettuceClientConfigurationBuilder clientOptions(ClientOptions clientOptions) {
 
 			Assert.notNull(clientOptions, "ClientOptions must not be null!");
@@ -300,11 +177,13 @@ public interface LettuceClientConfiguration {
 			return this;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#timeout(java.time.Duration)
+		/**
+		 * Configure a command timeout.
+		 *
+		 * @param timeout must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 * @throws IllegalArgumentException if timeout is {@literal null}.
 		 */
-		@Override
 		public LettuceClientConfigurationBuilder commandTimeout(Duration timeout) {
 
 			Assert.notNull(timeout, "Duration must not be null!");
@@ -313,11 +192,13 @@ public interface LettuceClientConfiguration {
 			return this;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#shutdownTimeout(java.time.Duration)
+		/**
+		 * Configure a shutdown timeout.
+		 *
+		 * @param shutdownTimeout must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 * @throws IllegalArgumentException if shutdownTimeout is {@literal null}.
 		 */
-		@Override
 		public LettuceClientConfigurationBuilder shutdownTimeout(Duration shutdownTimeout) {
 
 			Assert.notNull(timeout, "Duration must not be null!");
@@ -326,14 +207,69 @@ public interface LettuceClientConfiguration {
 			return this;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#build()
+		/**
+		 * Build the {@link LettuceClientConfiguration} with the configuration applied from this builder.
+		 *
+		 * @return a new {@link LettuceClientConfiguration} object.
 		 */
-		@Override
 		public LettuceClientConfiguration build() {
+
 			return new DefaultLettuceClientConfiguration(useSsl, verifyPeer, startTls, clientResources, clientOptions,
 					timeout, shutdownTimeout);
+		}
+	}
+
+	/**
+	 * Builder for SSL-related {@link LettuceClientConfiguration}.
+	 */
+	class LettuceSslClientConfigurationBuilder {
+
+		private LettuceClientConfigurationBuilder delegate;
+
+		LettuceSslClientConfigurationBuilder(LettuceClientConfigurationBuilder delegate) {
+
+			Assert.notNull(delegate, "Delegate client configuration builder must not be null!");
+			this.delegate = delegate;
+		}
+
+		/**
+		 * Disable peer verification.
+		 *
+		 * @return {@literal this} builder.
+		 */
+		LettuceSslClientConfigurationBuilder disablePeerVerification() {
+
+			delegate.verifyPeer = false;
+			return this;
+		}
+
+		/**
+		 * Enable Start TLS to send the first bytes unencrypted.
+		 *
+		 * @return {@literal this} builder.
+		 */
+		LettuceSslClientConfigurationBuilder startTls() {
+
+			delegate.startTls = true;
+			return this;
+		}
+
+		/**
+		 * Return to {@link LettuceClientConfigurationBuilder}.
+		 *
+		 * @return {@link LettuceClientConfigurationBuilder}.
+		 */
+		LettuceClientConfigurationBuilder and() {
+			return delegate;
+		}
+
+		/**
+		 * Build the {@link LettuceClientConfiguration} with the configuration applied from this builder.
+		 *
+		 * @return a new {@link LettuceClientConfiguration} object.
+		 */
+		LettuceClientConfiguration build() {
+			return delegate.build();
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -55,6 +55,11 @@ public interface LettuceClientConfiguration {
 	boolean isUseSsl();
 
 	/**
+	 * @return {@literal true} to use connection-pooling.
+	 */
+	boolean isUsePooling();
+
+	/**
 	 * @return {@literal true} to verify peers when using {@link #isUseSsl() SSL}.
 	 */
 	boolean isVerifyPeer();
@@ -217,15 +222,15 @@ public interface LettuceClientConfiguration {
 	class DefaultLettuceClientConfigurationBuilder
 			implements LettuceClientConfigurationBuilder, LettuceSslClientConfigurationBuilder {
 
-		private boolean useSsl;
-		private boolean verifyPeer = true;
-		private boolean startTls;
-		private ClientResources clientResources;
-		private ClientOptions clientOptions;
-		private Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
-		private Duration shutdownTimeout = Duration.ofMillis(100);
+		boolean useSsl;
+		boolean verifyPeer = true;
+		boolean startTls;
+		ClientResources clientResources;
+		ClientOptions clientOptions;
+		Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
+		Duration shutdownTimeout = Duration.ofMillis(100);
 
-		private DefaultLettuceClientConfigurationBuilder() {}
+		DefaultLettuceClientConfigurationBuilder() {}
 
 		/*
 		 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -619,7 +619,7 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 			if (connection == null) {
 				synchronized (this) {
 					if (connection == null) {
-						this.connection = connectionProvider.getConnection();
+						this.connection = connectionProvider.getConnection(StatefulRedisClusterConnection.class);
 					}
 				}
 			}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -1206,9 +1206,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 		private final LettucePool pool;
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType) {
-			return pool.getResource();
+		public <T extends StatefulConnection<?, ?>> T getConnection(Class<T> connectionType) {
+			return connectionType.cast(pool.getResource());
 		}
 
 		@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -820,7 +820,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 	protected StatefulRedisPubSubConnection<byte[], byte[]> switchToPubSub() {
 
 		close();
-		return (StatefulRedisPubSubConnection) connectionProvider.getConnection(StatefulRedisPubSubConnection.class);
+		return connectionProvider.getConnection(StatefulRedisPubSubConnection.class);
 	}
 
 	void pipeline(LettuceResult result) {
@@ -910,7 +910,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 	}
 
 	protected StatefulConnection<byte[], byte[]> doGetAsyncDedicatedConnection() {
-		return connectionProvider.getConnection();
+		return connectionProvider.getConnection(StatefulConnection.class);
 	}
 
 	io.lettuce.core.ScanCursor getScanCursor(long cursorId) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -223,7 +223,9 @@ public class LettuceConnection extends AbstractRedisConnection {
 	 * @param timeout The connection timeout (in milliseconds) * @param client The {@link RedisClient} to use when
 	 *          instantiating a pub/sub connection
 	 * @param pool The connection pool to use for all other native connections
+	 * @deprecated since 2.0, use pooling via {@link LettucePoolingClientConfiguration}.
 	 */
+	@Deprecated
 	public LettuceConnection(long timeout, RedisClient client, LettucePool pool) {
 		this(null, timeout, client, pool);
 	}
@@ -248,7 +250,10 @@ public class LettuceConnection extends AbstractRedisConnection {
 	 * @param timeout The connection timeout (in milliseconds)
 	 * @param client The {@link RedisClient} to use when making pub/sub connections
 	 * @param pool The connection pool to use for blocking and tx operations
+	 * @deprecated since 2.0, use
+	 *             {@link #LettuceConnection(StatefulRedisConnection, LettuceConnectionProvider, long, int)}
 	 */
+	@Deprecated
 	public LettuceConnection(StatefulRedisConnection<byte[], byte[]> sharedConnection, long timeout, RedisClient client,
 			LettucePool pool) {
 
@@ -263,7 +268,10 @@ public class LettuceConnection extends AbstractRedisConnection {
 	 * @param pool The connection pool to use for blocking and tx operations.
 	 * @param defaultDbIndex The db index to use along with {@link RedisClient} when establishing a dedicated connection.
 	 * @since 1.7
+	 * @deprecated since 2.0, use
+	 *             {@link #LettuceConnection(StatefulRedisConnection, LettuceConnectionProvider, long, int)}
 	 */
+	@Deprecated
 	public LettuceConnection(StatefulRedisConnection<byte[], byte[]> sharedConnection, long timeout,
 			AbstractRedisClient client, LettucePool pool, int defaultDbIndex) {
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -151,6 +151,11 @@ public class LettuceConnectionFactory
 		this(clusterConfiguration, new MutableLettuceClientConfiguration());
 	}
 
+	/**
+	 * @param pool
+	 * @deprecated since 2.0, use pooling via {@link LettucePoolingClientConfiguration}.
+	 */
+	@Deprecated
 	public LettuceConnectionFactory(LettucePool pool) {
 		this(new MutableLettuceClientConfiguration());
 		this.pool = pool;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -768,7 +768,7 @@ public class LettuceConnectionFactory
 
 			StatefulRedisConnection<byte[], byte[]> connection;
 			if (!isClusterAware()) {
-				connection = connectionProvider.getConnection();
+				connection = connectionProvider.getConnection(StatefulRedisConnection.class);
 				if (getDatabase() > 0) {
 					connection.sync().select(getDatabase());
 				}
@@ -785,8 +785,9 @@ public class LettuceConnectionFactory
 
 		LettuceConnectionProvider connectionProvider = doConnectionProvider(client, codec);
 
-		if (this.clientConfiguration.isUsePooling()) {
-			return new LettucePoolingConnectionProvider(connectionProvider, this.clientConfiguration);
+		if (this.clientConfiguration instanceof LettucePoolingClientConfiguration) {
+			return new LettucePoolingConnectionProvider(connectionProvider,
+					(LettucePoolingClientConfiguration) this.clientConfiguration);
 		}
 
 		return connectionProvider;
@@ -902,14 +903,6 @@ public class LettuceConnectionFactory
 		@Override
 		public boolean isUseSsl() {
 			return useSsl;
-		}
-
-		/* (non-Javadoc)
-		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isUsePooling()
-		 */
-		@Override
-		public boolean isUsePooling() {
-			return false;
 		}
 
 		public void setUseSsl(boolean useSsl) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulConnection;
+
+/**
+ * Defines a provider for Lettuce connections.
+ * <p />
+ * This interface is typically used to encapsulate a native factory which returns a {@link StatefulConnection
+ * connection} of on each invocation.
+ * <p/>
+ * Connection providers may create a new connection on each invocation or return pooled instances. Each obtained
+ * connection must be released through its connection provider to allow disposal or release back to the pool.
+ * <p/>
+ * Connection providers are usually associated with a {@link io.lettuce.core.codec.RedisCodec} to create connections
+ * with an appropriate codec.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ * @see StatefulConnection
+ */
+@FunctionalInterface
+public interface LettuceConnectionProvider {
+
+	/**
+	 * Request a connection given {@code connectionType}. Providing a connection type allows specialization to provide a
+	 * more specific connection type.
+	 *
+	 * @param connectionType must not be {@literal null}.
+	 * @return the requested connection. Must be {@link #release(StatefulConnection) released} if the connection is no
+	 *         longer in use.
+	 */
+	@SuppressWarnings("rawtypes")
+	StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType);
+
+	/**
+	 * Request a connection.
+	 *
+	 * @return the requested connection. Must be {@link #release(StatefulConnection) released} if the connection is no
+	 *         longer in use.
+	 */
+	@SuppressWarnings("unchecked")
+	default <T> T getConnection() {
+		return (T) getConnection(StatefulConnection.class);
+	}
+
+	/**
+	 * Release the {@link StatefulConnection connection}. Closes connection {@link StatefulConnection#close()} by default.
+	 * Implementations may choose whether they override this method and return the connection to a pool.
+	 *
+	 * @param connection must not be {@literal null}.
+	 */
+	default void release(StatefulConnection<?, ?> connection) {
+		connection.close();
+	}
+
+	/**
+	 * Extension to {@link LettuceConnectionProvider} for providers that allow connection creation to specific nodes.
+	 */
+	interface TargetAware {
+
+		/**
+		 * Request a connection given {@code connectionType} for a specific {@link RedisURI}. Providing a connection type
+		 * allows specialization to provide a more specific connection type.
+		 *
+		 * @param connectionType must not be {@literal null}.
+		 * @param redisURI must not be {@literal null}.
+		 * @return the requested connection.
+		 */
+		@SuppressWarnings("rawtypes")
+		StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType, RedisURI redisURI);
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionProvider.java
@@ -50,17 +50,6 @@ public interface LettuceConnectionProvider {
 	<T extends StatefulConnection<?, ?>> T getConnection(Class<T> connectionType);
 
 	/**
-	 * Request a connection.
-	 *
-	 * @return the requested connection. Must be {@link #release(StatefulConnection) released} if the connection is no
-	 *         longer in use.
-	 */
-	@SuppressWarnings("unchecked")
-	default StatefulConnection getConnection() {
-		return getConnection(StatefulConnection.class);
-	}
-
-	/**
 	 * Release the {@link StatefulConnection connection}. Closes connection {@link StatefulConnection#close()} by default.
 	 * Implementations may choose whether they override this method and return the connection to a pool.
 	 *

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionProvider.java
@@ -31,6 +31,7 @@ import io.lettuce.core.api.StatefulConnection;
  * with an appropriate codec.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  * @see StatefulConnection
  */
@@ -46,7 +47,7 @@ public interface LettuceConnectionProvider {
 	 *         longer in use.
 	 */
 	@SuppressWarnings("rawtypes")
-	StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType);
+	<T extends StatefulConnection<?, ?>> T getConnection(Class<T> connectionType);
 
 	/**
 	 * Request a connection.
@@ -55,8 +56,8 @@ public interface LettuceConnectionProvider {
 	 *         longer in use.
 	 */
 	@SuppressWarnings("unchecked")
-	default <T> T getConnection() {
-		return (T) getConnection(StatefulConnection.class);
+	default StatefulConnection getConnection() {
+		return getConnection(StatefulConnection.class);
 	}
 
 	/**
@@ -83,6 +84,6 @@ public interface LettuceConnectionProvider {
 		 * @return the requested connection.
 		 */
 		@SuppressWarnings("rawtypes")
-		StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType, RedisURI redisURI);
+		<T extends StatefulConnection<?, ?>> T getConnection(Class<T> connectionType, RedisURI redisURI);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePool.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePool.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.AbstractRedisClient;
@@ -23,11 +22,13 @@ import org.springframework.data.redis.connection.Pool;
 
 /**
  * Pool of Lettuce {@link StatefulConnection}s
- * 
+ *
  * @author Jennifer Hickey
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @deprecated since 2.0, use pooling via {@link LettucePoolingClientConfiguration}.
  */
+@Deprecated
 public interface LettucePool extends Pool<StatefulConnection<byte[], byte[]>> {
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfiguration.java
@@ -15,32 +15,44 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.resource.ClientResources;
+
+import java.time.Duration;
+
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.springframework.data.redis.connection.jedis.JedisClientConfiguration;
 import org.springframework.util.Assert;
 
 /**
+ * Redis client configuration for lettuce using a driver level pooled connection by adding pooling specific
+ * configuration to {@link LettuceClientConfiguration}.
+ *
  * @author Mark Paluch
+ * @author Christoph Strobl
+ * @since 2.0
  */
 public interface LettucePoolingClientConfiguration extends LettuceClientConfiguration {
 
 	/**
+	 * @return the {@link GenericObjectPoolConfig}. Never {@literal null}.
+	 */
+	GenericObjectPoolConfig getPoolConfig();
+
+	/**
 	 * Creates a new {@link LettucePoolingClientConfigurationBuilder} to build {@link LettucePoolingClientConfiguration}
-	 * to be used with the jedis client.
+	 * to be used with the Lettuce client.
 	 *
 	 * @return a new {@link LettucePoolingClientConfigurationBuilder} to build {@link LettucePoolingClientConfiguration}.
 	 */
 	static LettucePoolingClientConfigurationBuilder builder() {
-		return new DefaultLettucePoolingClientConfigurationBuilder();
+		return new LettucePoolingClientConfigurationBuilder();
 	}
 
 	/**
-	 * Creates a default {@link LettucePoolingClientConfiguration} with:
+	 * Creates a default {@link LettucePoolingClientConfiguration} with
 	 * <dl>
 	 * <dt>SSL</dt>
 	 * <dd>no</dd>
-	 * <dt>Pooling</dt>
-	 * <dd>yes</dd>
 	 * <dt>Peer Verification</dt>
 	 * <dd>yes</dd>
 	 * <dt>Start TLS</dt>
@@ -53,6 +65,8 @@ public interface LettucePoolingClientConfiguration extends LettuceClientConfigur
 	 * <dd>60 Seconds</dd>
 	 * <dt>Shutdown Timeout</dt>
 	 * <dd>2 Seconds</dd>
+	 * <dt>pool config</dt>
+	 * <dd>default {@link GenericObjectPoolConfig}</dd>
 	 * </dl>
 	 *
 	 * @return a {@link LettucePoolingClientConfiguration} with defaults.
@@ -62,50 +76,80 @@ public interface LettucePoolingClientConfiguration extends LettuceClientConfigur
 	}
 
 	/**
-	 * @return the optional {@link GenericObjectPoolConfig}.
+	 * @author Mark Paluch
+	 * @author Christoph Strobl
 	 */
-	GenericObjectPoolConfig getPoolConfig();
-
-	/**
-	 * Builder for Pooling-related {@link LettuceClientConfiguration}.
-	 */
-	interface LettucePoolingClientConfigurationBuilder {
-
-		/**
-		 * @param poolConfig must not be {@literal null}.
-		 * @return {@literal this} builder.
-		 * @throws IllegalArgumentException if poolConfig is {@literal null}.
-		 */
-		LettucePoolingClientConfigurationBuilder poolConfig(GenericObjectPoolConfig poolConfig);
-
-		/**
-		 * Return to {@link LettuceClientConfigurationBuilder}.
-		 *
-		 * @return {@link LettuceClientConfigurationBuilder}.
-		 */
-		LettuceClientConfigurationBuilder and();
-
-		/**
-		 * Build the {@link JedisClientConfiguration} with the configuration applied from this builder.
-		 *
-		 * @return a new {@link JedisClientConfiguration} object.
-		 */
-		LettucePoolingClientConfiguration build();
-	}
-
-	/**
-	 * Default {@link LettuceClientConfigurationBuilder} implementation to build an immutable
-	 * {@link LettuceClientConfiguration}.
-	 */
-	class DefaultLettucePoolingClientConfigurationBuilder extends DefaultLettuceClientConfigurationBuilder
-			implements LettucePoolingClientConfigurationBuilder {
+	class LettucePoolingClientConfigurationBuilder extends LettuceClientConfigurationBuilder {
 
 		GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
 
+		LettucePoolingClientConfigurationBuilder() {
+			super();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#useSsl()
+		 */
 		@Override
+		public LettucePoolingSslClientConfigurationBuilder useSsl() {
+
+			super.useSsl();
+			return new LettucePoolingSslClientConfigurationBuilder(this);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#clientResources(io.lettuce.core.resource.ClientResources)
+		 */
+		@Override
+		public LettucePoolingClientConfigurationBuilder clientResources(ClientResources clientResources) {
+
+			super.clientResources(clientResources);
+			return this;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#clientOptions(io.lettuce.core.ClientOptions)
+		 */
+		@Override
+		public LettucePoolingClientConfigurationBuilder clientOptions(ClientOptions clientOptions) {
+
+			super.clientOptions(clientOptions);
+			return this;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#commandTimeout(java.time.Duration)
+		 */
+		@Override
+		public LettucePoolingClientConfigurationBuilder commandTimeout(Duration timeout) {
+
+			super.commandTimeout(timeout);
+			return this;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#shutdownTimeout(java.time.Duration)
+		 */
+		@Override
+		public LettucePoolingClientConfigurationBuilder shutdownTimeout(Duration shutdownTimeout) {
+
+			super.shutdownTimeout(shutdownTimeout);
+			return this;
+		}
+
+		/**
+		 * Set the {@link GenericObjectPoolConfig} used by the driver.
+		 *
+		 * @param poolConfig must not be {@literal null}.
+		 */
 		public LettucePoolingClientConfigurationBuilder poolConfig(GenericObjectPoolConfig poolConfig) {
 
-			Assert.notNull(poolConfig, "GenericObjectPoolConfig must not be null!");
+			Assert.notNull(poolConfig, "PoolConfig must not be null!");
 
 			this.poolConfig = poolConfig;
 			return this;
@@ -117,8 +161,57 @@ public interface LettucePoolingClientConfiguration extends LettuceClientConfigur
 		 */
 		@Override
 		public LettucePoolingClientConfiguration build() {
-			return new DefaultLettucePoolingClientConfiguration(useSsl, verifyPeer, startTls, clientResources, clientOptions,
-					timeout, shutdownTimeout, poolConfig);
+			return new DefaultLettucePoolingClientConfiguration(super.build(), poolConfig);
+		}
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 */
+	class LettucePoolingSslClientConfigurationBuilder extends LettuceSslClientConfigurationBuilder {
+
+		LettucePoolingSslClientConfigurationBuilder(LettucePoolingClientConfigurationBuilder delegate) {
+			super(delegate);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#and()
+		 */
+		@Override
+		LettucePoolingClientConfigurationBuilder and() {
+			return (LettucePoolingClientConfigurationBuilder) super.and();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#disablePeerVerification()
+		 */
+		@Override
+		LettucePoolingSslClientConfigurationBuilder disablePeerVerification() {
+
+			super.disablePeerVerification();
+			return this;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#startTls()
+		 */
+		@Override
+		LettucePoolingSslClientConfigurationBuilder startTls() {
+
+			super.startTls();
+			return this;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceSslClientConfigurationBuilder#build()
+		 */
+		@Override
+		LettucePoolingClientConfiguration build() {
+			return (LettucePoolingClientConfiguration) super.build();
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfiguration.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.springframework.data.redis.connection.jedis.JedisClientConfiguration;
+import org.springframework.util.Assert;
+
+/**
+ * @author Mark Paluch
+ */
+public interface LettucePoolingClientConfiguration extends LettuceClientConfiguration {
+
+	/**
+	 * Creates a new {@link LettucePoolingClientConfigurationBuilder} to build {@link LettucePoolingClientConfiguration}
+	 * to be used with the jedis client.
+	 *
+	 * @return a new {@link LettucePoolingClientConfigurationBuilder} to build {@link LettucePoolingClientConfiguration}.
+	 */
+	static LettucePoolingClientConfigurationBuilder builder() {
+		return new DefaultLettucePoolingClientConfigurationBuilder();
+	}
+
+	/**
+	 * Creates a default {@link LettucePoolingClientConfiguration} with:
+	 * <dl>
+	 * <dt>SSL</dt>
+	 * <dd>no</dd>
+	 * <dt>Pooling</dt>
+	 * <dd>yes</dd>
+	 * <dt>Peer Verification</dt>
+	 * <dd>yes</dd>
+	 * <dt>Start TLS</dt>
+	 * <dd>no</dd>
+	 * <dt>Client Options</dt>
+	 * <dd>none</dd>
+	 * <dt>Client Resources</dt>
+	 * <dd>none</dd>
+	 * <dt>Connect Timeout</dt>
+	 * <dd>60 Seconds</dd>
+	 * <dt>Shutdown Timeout</dt>
+	 * <dd>2 Seconds</dd>
+	 * </dl>
+	 *
+	 * @return a {@link LettucePoolingClientConfiguration} with defaults.
+	 */
+	static LettucePoolingClientConfiguration defaultConfiguration() {
+		return builder().build();
+	}
+
+	/**
+	 * @return the optional {@link GenericObjectPoolConfig}.
+	 */
+	GenericObjectPoolConfig getPoolConfig();
+
+	/**
+	 * Builder for Pooling-related {@link LettuceClientConfiguration}.
+	 */
+	interface LettucePoolingClientConfigurationBuilder {
+
+		/**
+		 * @param poolConfig must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 * @throws IllegalArgumentException if poolConfig is {@literal null}.
+		 */
+		LettucePoolingClientConfigurationBuilder poolConfig(GenericObjectPoolConfig poolConfig);
+
+		/**
+		 * Return to {@link LettuceClientConfigurationBuilder}.
+		 *
+		 * @return {@link LettuceClientConfigurationBuilder}.
+		 */
+		LettuceClientConfigurationBuilder and();
+
+		/**
+		 * Build the {@link JedisClientConfiguration} with the configuration applied from this builder.
+		 *
+		 * @return a new {@link JedisClientConfiguration} object.
+		 */
+		LettucePoolingClientConfiguration build();
+	}
+
+	/**
+	 * Default {@link LettuceClientConfigurationBuilder} implementation to build an immutable
+	 * {@link LettuceClientConfiguration}.
+	 */
+	class DefaultLettucePoolingClientConfigurationBuilder extends DefaultLettuceClientConfigurationBuilder
+			implements LettucePoolingClientConfigurationBuilder {
+
+		GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+
+		@Override
+		public LettucePoolingClientConfigurationBuilder poolConfig(GenericObjectPoolConfig poolConfig) {
+
+			Assert.notNull(poolConfig, "GenericObjectPoolConfig must not be null!");
+
+			this.poolConfig = poolConfig;
+			return this;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#build()
+		 */
+		@Override
+		public LettucePoolingClientConfiguration build() {
+			return new DefaultLettucePoolingClientConfiguration(useSsl, verifyPeer, startTls, clientResources, clientOptions,
+					timeout, shutdownTimeout, poolConfig);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingConnectionProvider.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.support.ConnectionPoolSupport;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.data.redis.connection.PoolException;
+
+/**
+ * {@link LettuceConnectionProvider} with connection pooling support. This connection provider holds multiple pools (one
+ * per connection type) for contextualized connection allocation.
+ * <p />
+ * Each allocated connection is tracked and to be returned into the pool which created the connection. Instances of this
+ * class require {@link #destroy() disposal} to de-allocate lingering connections that were not returned to the pool and
+ * to close the pools.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ * @see #getConnection(Class)
+ */
+class LettucePoolingConnectionProvider implements LettuceConnectionProvider, DisposableBean {
+
+	private final static Log log = LogFactory.getLog(LettucePoolingConnectionProvider.class);
+
+	private final LettuceConnectionProvider connectionProvider;
+	private final GenericObjectPoolConfig poolConfig;
+	private final Map<StatefulConnection<?, ?>, GenericObjectPool<StatefulConnection<?, ?>>> poolRef = new ConcurrentHashMap<>(
+			32);
+	private final Map<Class<?>, GenericObjectPool<StatefulConnection<?, ?>>> pools = new ConcurrentHashMap<>(32);
+
+	LettucePoolingConnectionProvider(LettuceConnectionProvider connectionProvider,
+			LettuceClientConfiguration clientConfiguration) {
+
+		this.connectionProvider = connectionProvider;
+		this.poolConfig = ((LettucePoolingClientConfiguration) clientConfiguration).getPoolConfig();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnection(java.lang.Class)
+	 */
+	@Override
+	@SuppressWarnings("rawtypes")
+	public StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType) {
+
+		GenericObjectPool<StatefulConnection<?, ?>> pool = pools.computeIfAbsent(connectionType, poolType -> {
+			return ConnectionPoolSupport.createGenericObjectPool(() -> connectionProvider.getConnection(connectionType),
+					poolConfig, false);
+		});
+
+		try {
+			StatefulConnection<?, ?> connection = pool.borrowObject();
+
+			poolRef.put(connection, pool);
+
+			return connection;
+		} catch (Exception e) {
+			throw new PoolException("Could not get a resource from the pool", e);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#release(io.lettuce.core.api.StatefulConnection)
+	 */
+	@Override
+	public void release(StatefulConnection<?, ?> connection) {
+
+		GenericObjectPool<StatefulConnection<?, ?>> pool = poolRef.remove(connection);
+
+		if (pool == null) {
+			throw new PoolException("Returned connection " + connection
+					+ " was either previously returned or does not belong to this connection provider");
+		}
+
+		pool.returnObject(connection);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.DisposableBean#destroy()
+	 */
+	@Override
+	public void destroy() throws Exception {
+
+		if (!poolRef.isEmpty()) {
+
+			log.warn("LettucePoolingConnectionProvider contains unreleased connections");
+
+			poolRef.forEach((connection, pool) -> pool.returnObject(connection));
+			poolRef.clear();
+		}
+
+		pools.forEach((type, pool) -> pool.close());
+		pools.clear();
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
@@ -52,11 +52,12 @@ class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisConnecti
 	 * @throws org.springframework.dao.InvalidDataAccessResourceUsageException when {@code client} is not suitable for
 	 *           cluster environment.
 	 */
-	LettuceReactiveRedisClusterConnection(RedisClusterClient client) {
+	LettuceReactiveRedisClusterConnection(LettuceConnectionProvider connectionProvider) {
 
-		super(client);
+		super(connectionProvider);
 
-		this.topologyProvider = new LettuceClusterTopologyProvider(client);
+		this.topologyProvider = new LettuceClusterTopologyProvider(
+				((ClusterConnectionProvider) connectionProvider).getClient());
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
@@ -21,7 +21,6 @@ import io.lettuce.core.api.reactive.BaseRedisReactiveCommands;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
 import io.lettuce.core.codec.RedisCodec;
-import org.springframework.data.redis.connection.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -31,6 +30,7 @@ import java.util.function.Function;
 import org.reactivestreams.Publisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
+import org.springframework.data.redis.connection.*;
 import org.springframework.util.Assert;
 
 /**
@@ -58,7 +58,7 @@ class LettuceReactiveRedisConnection implements ReactiveRedisConnection {
 		Assert.notNull(connectionProvider, "LettuceConnectionProvider must not be null!");
 
 		this.connectionProvider = connectionProvider;
-		this.connection = connectionProvider.getConnection();
+		this.connection = connectionProvider.getConnection(StatefulConnection.class);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnection.java
@@ -234,7 +234,7 @@ public class LettuceSentinelConnection implements RedisSentinelConnection {
 	private void init() {
 
 		if (connection == null) {
-			connection = (StatefulRedisSentinelConnection) provider.getConnection(StatefulRedisSentinelConnection.class);
+			connection = provider.getConnection(StatefulRedisSentinelConnection.class);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnection.java
@@ -94,7 +94,12 @@ public class LettuceSentinelConnection implements RedisSentinelConnection {
 	public LettuceSentinelConnection(RedisClient redisClient) {
 
 		Assert.notNull(redisClient, "Cannot create LettuceSentinelConnection using 'null' as client.");
-		this.provider = t -> redisClient.connectSentinel();
+		this.provider = new LettuceConnectionProvider() {
+			@Override
+			public <T extends StatefulConnection<?, ?>> T getConnection(Class<T> t) {
+				return t.cast(redisClient.connectSentinel());
+			}
+		};
 		init();
 	}
 
@@ -106,7 +111,12 @@ public class LettuceSentinelConnection implements RedisSentinelConnection {
 	protected LettuceSentinelConnection(StatefulRedisSentinelConnection<String, String> connection) {
 
 		Assert.notNull(connection, "Cannot create LettuceSentinelConnection using 'null' as connection.");
-		this.provider = t -> connection;
+		this.provider = new LettuceConnectionProvider() {
+			@Override
+			public <T extends StatefulConnection<?, ?>> T getConnection(Class<T> t) {
+				return t.cast(connection);
+			}
+		};
 		init();
 	}
 
@@ -263,10 +273,9 @@ public class LettuceSentinelConnection implements RedisSentinelConnection {
 		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnection(java.lang.Class)
 		 */
-		@SuppressWarnings("rawtypes")
 		@Override
-		public StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType) {
-			return redisClient.connectSentinel();
+		public <T extends StatefulConnection<?, ?>> T getConnection(Class<T> connectionType) {
+			return connectionType.cast(redisClient.connectSentinel());
 		}
 
 		/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StandaloneConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StandaloneConnectionProvider.java
@@ -26,6 +26,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionProvid
 
 /**
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.0
  */
 class StandaloneConnectionProvider implements LettuceConnectionProvider, TargetAware {
@@ -43,20 +44,18 @@ class StandaloneConnectionProvider implements LettuceConnectionProvider, TargetA
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnection(java.lang.Class)
 	 */
-	@SuppressWarnings("rawtypes")
 	@Override
-	public StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType) {
-
+	public <T extends StatefulConnection<?, ?>> T getConnection(Class<T> connectionType) {
 		if (connectionType.equals(StatefulRedisSentinelConnection.class)) {
-			return client.connectSentinel();
+			return connectionType.cast(client.connectSentinel());
 		}
 
 		if (connectionType.equals(StatefulRedisPubSubConnection.class)) {
-			return client.connectPubSub(codec);
+			return connectionType.cast(client.connectPubSub(codec));
 		}
 
 		if (StatefulConnection.class.isAssignableFrom(connectionType)) {
-			return client.connect(codec);
+			return connectionType.cast(client.connect(codec));
 		}
 
 		throw new UnsupportedOperationException("Connection type " + connectionType + " not supported!");
@@ -66,20 +65,19 @@ class StandaloneConnectionProvider implements LettuceConnectionProvider, TargetA
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider.TargetAware#getConnection(java.lang.Class, io.lettuce.core.RedisURI)
 	 */
-	@SuppressWarnings("rawtypes")
 	@Override
-	public StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType, RedisURI redisURI) {
+	public <T extends StatefulConnection<?, ?>> T getConnection(Class<T> connectionType, RedisURI redisURI) {
 
 		if (connectionType.equals(StatefulRedisSentinelConnection.class)) {
-			return client.connectSentinel(redisURI);
+			return connectionType.cast(client.connectSentinel(redisURI));
 		}
 
 		if (connectionType.equals(StatefulRedisPubSubConnection.class)) {
-			return client.connectPubSub(codec, redisURI);
+			return connectionType.cast(client.connectPubSub(codec, redisURI));
 		}
 
 		if (StatefulConnection.class.isAssignableFrom(connectionType)) {
-			return client.connect(codec, redisURI);
+			return connectionType.cast(client.connect(codec, redisURI));
 		}
 
 		throw new UnsupportedOperationException("Connection type " + connectionType + " not supported!");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StandaloneConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StandaloneConnectionProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
+
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider.TargetAware;
+
+/**
+ * @author Mark Paluch
+ * @since 2.0
+ */
+class StandaloneConnectionProvider implements LettuceConnectionProvider, TargetAware {
+
+	private final RedisClient client;
+	private final RedisCodec<?, ?> codec;
+
+	StandaloneConnectionProvider(RedisClient client, RedisCodec<?, ?> codec) {
+
+		this.client = client;
+		this.codec = codec;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnection(java.lang.Class)
+	 */
+	@SuppressWarnings("rawtypes")
+	@Override
+	public StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType) {
+
+		if (connectionType.equals(StatefulRedisSentinelConnection.class)) {
+			return client.connectSentinel();
+		}
+
+		if (connectionType.equals(StatefulRedisPubSubConnection.class)) {
+			return client.connectPubSub(codec);
+		}
+
+		if (StatefulConnection.class.isAssignableFrom(connectionType)) {
+			return client.connect(codec);
+		}
+
+		throw new UnsupportedOperationException("Connection type " + connectionType + " not supported!");
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider.TargetAware#getConnection(java.lang.Class, io.lettuce.core.RedisURI)
+	 */
+	@SuppressWarnings("rawtypes")
+	@Override
+	public StatefulConnection<?, ?> getConnection(Class<? extends StatefulConnection> connectionType, RedisURI redisURI) {
+
+		if (connectionType.equals(StatefulRedisSentinelConnection.class)) {
+			return client.connectSentinel(redisURI);
+		}
+
+		if (connectionType.equals(StatefulRedisPubSubConnection.class)) {
+			return client.connectPubSub(codec, redisURI);
+		}
+
+		if (StatefulConnection.class.isAssignableFrom(connectionType)) {
+			return client.connect(codec, redisURI);
+		}
+
+		throw new UnsupportedOperationException("Connection type " + connectionType + " not supported!");
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
@@ -28,6 +28,7 @@ import org.junit.Test;
  * Unit tests for {@link LettuceClientConfiguration}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class LettuceClientConfigurationUnitTests {
 
@@ -36,7 +37,6 @@ public class LettuceClientConfigurationUnitTests {
 
 		LettuceClientConfiguration configuration = LettuceClientConfiguration.defaultConfiguration();
 
-		assertThat(configuration.isUsePooling()).isFalse();
 		assertThat(configuration.isUseSsl()).isFalse();
 		assertThat(configuration.isVerifyPeer()).isTrue();
 		assertThat(configuration.isStartTls()).isFalse();
@@ -62,7 +62,6 @@ public class LettuceClientConfigurationUnitTests {
 				.shutdownTimeout(Duration.ofHours(2)) //
 				.build();
 
-		assertThat(configuration.isUsePooling()).isFalse();
 		assertThat(configuration.isUseSsl()).isTrue();
 		assertThat(configuration.isVerifyPeer()).isFalse();
 		assertThat(configuration.isStartTls()).isTrue();

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -338,7 +338,7 @@ public class LettuceConnectionFactoryTests {
 
 		GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
 
-		LettuceClientConfiguration configuration = LettucePoolingClientConfiguration.builder().poolConfig(poolConfig).and()
+		LettuceClientConfiguration configuration = LettucePoolingClientConfiguration.builder().poolConfig(poolConfig)
 				.clientResources(LettuceTestClientResources.getSharedClientResources()).shutdownTimeout(Duration.ZERO).build();
 
 		LettuceConnectionFactory factory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(), configuration);

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfigurationUnitTests.java
@@ -29,6 +29,7 @@ import org.junit.Test;
  * Unit tests for {@link LettucePoolingClientConfiguration}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class LettucePoolingClientConfigurationUnitTests {
 
@@ -37,7 +38,6 @@ public class LettucePoolingClientConfigurationUnitTests {
 
 		LettucePoolingClientConfiguration configuration = LettucePoolingClientConfiguration.defaultConfiguration();
 
-		assertThat(configuration.isUsePooling()).isTrue();
 		assertThat(configuration.getPoolConfig()).isNotNull();
 		assertThat(configuration.isUseSsl()).isFalse();
 		assertThat(configuration.isVerifyPeer()).isTrue();
@@ -55,19 +55,17 @@ public class LettucePoolingClientConfigurationUnitTests {
 		ClientResources sharedClientResources = LettuceTestClientResources.getSharedClientResources();
 		GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
 
-		LettucePoolingClientConfiguration configuration = (LettucePoolingClientConfiguration) LettucePoolingClientConfiguration
-				.builder() //
-				.poolConfig(poolConfig).and() //
+		LettucePoolingClientConfiguration configuration = LettucePoolingClientConfiguration.builder() //
 				.useSsl() //
 				.disablePeerVerification() //
 				.startTls().and() //
+				.poolConfig(poolConfig) //
 				.clientOptions(clientOptions) //
 				.clientResources(sharedClientResources) //
 				.commandTimeout(Duration.ofMinutes(5)) //
 				.shutdownTimeout(Duration.ofHours(2)) //
 				.build();
 
-		assertThat(configuration.isUsePooling()).isTrue();
 		assertThat(configuration.getPoolConfig()).isEqualTo(poolConfig);
 		assertThat(configuration.isUseSsl()).isTrue();
 		assertThat(configuration.isVerifyPeer()).isFalse();

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfigurationUnitTests.java
@@ -22,21 +22,23 @@ import io.lettuce.core.resource.ClientResources;
 
 import java.time.Duration;
 
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link LettuceClientConfiguration}.
+ * Unit tests for {@link LettucePoolingClientConfiguration}.
  *
  * @author Mark Paluch
  */
-public class LettuceClientConfigurationUnitTests {
+public class LettucePoolingClientConfigurationUnitTests {
 
-	@Test // DATAREDIS-574, DATAREDIS-667
+	@Test // DATAREDIS-667
 	public void shouldCreateEmptyConfiguration() {
 
-		LettuceClientConfiguration configuration = LettuceClientConfiguration.defaultConfiguration();
+		LettucePoolingClientConfiguration configuration = LettucePoolingClientConfiguration.defaultConfiguration();
 
-		assertThat(configuration.isUsePooling()).isFalse();
+		assertThat(configuration.isUsePooling()).isTrue();
+		assertThat(configuration.getPoolConfig()).isNotNull();
 		assertThat(configuration.isUseSsl()).isFalse();
 		assertThat(configuration.isVerifyPeer()).isTrue();
 		assertThat(configuration.isStartTls()).isFalse();
@@ -46,13 +48,16 @@ public class LettuceClientConfigurationUnitTests {
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofMillis(100));
 	}
 
-	@Test // DATAREDIS-574, DATAREDIS-667
+	@Test // DATAREDIS-667
 	public void shouldConfigureAllProperties() {
 
 		ClientOptions clientOptions = ClientOptions.create();
 		ClientResources sharedClientResources = LettuceTestClientResources.getSharedClientResources();
+		GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
 
-		LettuceClientConfiguration configuration = LettuceClientConfiguration.builder() //
+		LettucePoolingClientConfiguration configuration = (LettucePoolingClientConfiguration) LettucePoolingClientConfiguration
+				.builder() //
+				.poolConfig(poolConfig).and() //
 				.useSsl() //
 				.disablePeerVerification() //
 				.startTls().and() //
@@ -62,7 +67,8 @@ public class LettuceClientConfigurationUnitTests {
 				.shutdownTimeout(Duration.ofHours(2)) //
 				.build();
 
-		assertThat(configuration.isUsePooling()).isFalse();
+		assertThat(configuration.isUsePooling()).isTrue();
+		assertThat(configuration.getPoolConfig()).isEqualTo(poolConfig);
 		assertThat(configuration.isUseSsl()).isTrue();
 		assertThat(configuration.isVerifyPeer()).isFalse();
 		assertThat(configuration.isStartTls()).isTrue();

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
@@ -29,6 +29,7 @@ import org.springframework.data.redis.test.util.LettuceRedisClusterClientProvide
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public abstract class LettuceReactiveClusterCommandsTestsBase {
 
@@ -41,7 +42,8 @@ public abstract class LettuceReactiveClusterCommandsTestsBase {
 	public void before() {
 		assumeThat(clientProvider.test(), is(true));
 		nativeCommands = clientProvider.getClient().connect().sync();
-		connection = new LettuceReactiveRedisClusterConnection(clientProvider.getClient());
+		connection = new LettuceReactiveRedisClusterConnection(
+				new ClusterConnectionProvider(clientProvider.getClient(), LettuceReactiveRedisConnection.CODEC));
 	}
 
 	@After
@@ -63,5 +65,4 @@ public abstract class LettuceReactiveClusterCommandsTestsBase {
 			connection.close();
 		}
 	}
-
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
@@ -115,11 +115,11 @@ public abstract class LettuceReactiveCommandsTestsBase {
 	public void setUp() {
 
 		if (nativeConnectionProvider instanceof StandaloneConnectionProvider) {
-			nativeCommands = ((StatefulRedisConnection) nativeConnectionProvider.getConnection()).sync();
+			nativeCommands = nativeConnectionProvider.getConnection(StatefulRedisConnection.class).sync();
 			this.connection = new LettuceReactiveRedisConnection(connectionProvider);
 
 		} else {
-			nativeCommands = ((StatefulRedisClusterConnection) nativeConnectionProvider.getConnection()).sync();
+			nativeCommands = nativeConnectionProvider.getConnection(StatefulRedisClusterConnection.class).sync();
 			this.connection = new LettuceReactiveRedisClusterConnection(connectionProvider);
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
@@ -39,6 +39,7 @@ import org.springframework.data.redis.test.util.LettuceRedisClusterClientProvide
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(Parameterized.class)
 public abstract class LettuceReactiveCommandsTestsBase {
@@ -100,11 +101,13 @@ public abstract class LettuceReactiveCommandsTestsBase {
 
 		if (abstractRedisClient instanceof RedisClient) {
 			nativeCommands = ((RedisClient) abstractRedisClient).connect().sync();
-			connection = new LettuceReactiveRedisConnection(abstractRedisClient);
+			connection = new LettuceReactiveRedisConnection(
+					new StandaloneConnectionProvider(((RedisClient) abstractRedisClient), LettuceReactiveRedisConnection.CODEC));
 
 		} else if (abstractRedisClient instanceof RedisClusterClient) {
 			nativeCommands = ((RedisClusterClient) abstractRedisClient).connect().sync();
-			connection = new LettuceReactiveRedisClusterConnection((RedisClusterClient) abstractRedisClient);
+			connection = new LettuceReactiveRedisClusterConnection(new ClusterConnectionProvider(
+					((RedisClusterClient) abstractRedisClient), LettuceReactiveRedisConnection.CODEC));
 		}
 
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommandsTests.java
@@ -26,6 +26,7 @@ import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class LettuceReactiveHyperLogLogCommandsTests extends LettuceReactiveCommandsTestsBase {
 
@@ -56,7 +57,7 @@ public class LettuceReactiveHyperLogLogCommandsTests extends LettuceReactiveComm
 	@Test // DATAREDIS-525
 	public void pfCountWithMultipleKeysShouldReturnCorrectly() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.pfadd(KEY_1, new String[] { VALUE_1, VALUE_2 });
 		nativeCommands.pfadd(KEY_2, new String[] { VALUE_2, VALUE_3 });
@@ -67,7 +68,7 @@ public class LettuceReactiveHyperLogLogCommandsTests extends LettuceReactiveComm
 	@Test // DATAREDIS-525
 	public void pfMergeShouldWorkCorrectly() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.pfadd(KEY_1, new String[] { VALUE_1, VALUE_2 });
 		nativeCommands.pfadd(KEY_2, new String[] { VALUE_2, VALUE_3 });
@@ -78,5 +79,4 @@ public class LettuceReactiveHyperLogLogCommandsTests extends LettuceReactiveComm
 
 		assertThat(nativeCommands.pfcount(new String[] { KEY_3 }), is(3L));
 	}
-
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommandTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommandTests.java
@@ -38,6 +38,7 @@ import reactor.core.publisher.Mono;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class LettuceReactiveListCommandTests extends LettuceReactiveCommandsTestsBase {
 
@@ -203,7 +204,7 @@ public class LettuceReactiveListCommandTests extends LettuceReactiveCommandsTest
 	@Test // DATAREDIS-525
 	public void blPopShouldReturnFirstAvailable() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
 
@@ -216,7 +217,7 @@ public class LettuceReactiveListCommandTests extends LettuceReactiveCommandsTest
 	@Test // DATAREDIS-525
 	public void brPopShouldReturnLastAvailable() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
 
@@ -242,7 +243,7 @@ public class LettuceReactiveListCommandTests extends LettuceReactiveCommandsTest
 	@Test // DATAREDIS-525
 	public void brPopLPushShouldWorkCorrectly() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.rpush(KEY_1, VALUE_1, VALUE_2, VALUE_3);
 		nativeCommands.rpush(KEY_2, VALUE_1);

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveServerCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveServerCommandsTests.java
@@ -38,8 +38,11 @@ public class LettuceReactiveServerCommandsTests extends LettuceReactiveCommandsT
 		StepVerifier.create(connection.serverCommands().bgReWriteAof()).expectNextCount(1).verifyComplete();
 	}
 
-	@Test // DATAREDIS-659
+	@Test // DATAREDIS-659, DATAREDIS-667
 	public void bgSaveShouldRespondCorrectly() {
+
+		assumeTrue(connectionProvider instanceof StandaloneConnectionProvider);
+
 		StepVerifier.create(connection.serverCommands().bgSave()).expectNextCount(1).verifyComplete();
 	}
 
@@ -48,8 +51,11 @@ public class LettuceReactiveServerCommandsTests extends LettuceReactiveCommandsT
 		StepVerifier.create(connection.serverCommands().lastSave()).expectNextCount(1).verifyComplete();
 	}
 
-	@Test // DATAREDIS-659
+	@Test // DATAREDIS-659, DATAREDIS-667
 	public void saveShouldRespondCorrectly() {
+
+		assumeTrue(connectionProvider instanceof StandaloneConnectionProvider);
+
 		StepVerifier.create(connection.serverCommands().save()).expectNext("OK").verifyComplete();
 	}
 
@@ -61,9 +67,8 @@ public class LettuceReactiveServerCommandsTests extends LettuceReactiveCommandsT
 	@Test // DATAREDIS-659
 	public void flushDbShouldRespondCorrectly() {
 
-		StepVerifier
-				.create(connection.serverCommands().flushDb() //
-						.then(connection.stringCommands().set(KEY_1_BBUFFER, VALUE_1_BBUFFER))) //
+		StepVerifier.create(connection.serverCommands().flushDb() //
+				.then(connection.stringCommands().set(KEY_1_BBUFFER, VALUE_1_BBUFFER))) //
 				.expectNextCount(1) //
 				.verifyComplete();
 
@@ -77,9 +82,8 @@ public class LettuceReactiveServerCommandsTests extends LettuceReactiveCommandsT
 	@Test // DATAREDIS-659
 	public void flushAllShouldRespondCorrectly() {
 
-		StepVerifier
-				.create(connection.serverCommands().flushAll() //
-						.then(connection.stringCommands().set(KEY_1_BBUFFER, VALUE_1_BBUFFER))) //
+		StepVerifier.create(connection.serverCommands().flushAll() //
+				.then(connection.stringCommands().set(KEY_1_BBUFFER, VALUE_1_BBUFFER))) //
 				.expectNextCount(1) //
 				.verifyComplete();
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
@@ -236,7 +236,7 @@ public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsT
 	@Test // DATAREDIS-525
 	public void mSetNXShouldAddMultipleKeyValuePairs() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		Map<ByteBuffer, ByteBuffer> map = new LinkedHashMap<>();
 		map.put(KEY_1_BBUFFER, VALUE_1_BBUFFER);
@@ -251,7 +251,7 @@ public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsT
 	@Test // DATAREDIS-525
 	public void mSetNXShouldNotAddMultipleKeyValuePairsWhenAlreadyExit() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.set(KEY_2, VALUE_2);
 
@@ -346,7 +346,7 @@ public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsT
 	@Test // DATAREDIS-525
 	public void bitOpAndShouldWorkAsExpected() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.set(KEY_1, VALUE_1);
 		nativeCommands.set(KEY_2, VALUE_2);
@@ -363,7 +363,7 @@ public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsT
 	@Test // DATAREDIS-525
 	public void bitOpOrShouldWorkAsExpected() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.set(KEY_1, VALUE_1);
 		nativeCommands.set(KEY_2, VALUE_2);
@@ -380,7 +380,7 @@ public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsT
 	@Test // DATAREDIS-525
 	public void bitNotShouldThrowExceptionWhenMoreThanOnSourceKey() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		StepVerifier
 				.create(connection.stringCommands().bitOp(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), BitOperation.NOT,

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
@@ -415,7 +415,7 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 	@Test // DATAREDIS-525
 	public void zUnionStoreShouldWorkCorrectly() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
@@ -432,7 +432,7 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 	@Test // DATAREDIS-525
 	public void zInterStoreShouldWorkCorrectly() {
 
-		assumeThat(clientProvider instanceof LettuceRedisClientProvider, is(true));
+		assumeThat(connectionProvider instanceof StandaloneConnectionProvider, is(true));
 
 		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
 		nativeCommands.zadd(KEY_1, 2D, VALUE_2);

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
@@ -80,8 +80,8 @@ public class LettuceSentinelIntegrationTests extends AbstractConnectionIntegrati
 		lettuceConnectionFactory.afterPropertiesSet();
 
 		LettuceConnectionFactory pooledConnectionFactory = new LettuceConnectionFactory(SENTINEL_CONFIG,
-				LettucePoolingClientConfiguration.builder().build());
-		pooledConnectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+				LettucePoolingClientConfiguration.builder()
+						.clientResources(LettuceTestClientResources.getSharedClientResources()).build());
 		pooledConnectionFactory.setShareNativeConnection(false);
 		pooledConnectionFactory.afterPropertiesSet();
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
@@ -63,7 +63,9 @@ public class LettuceSentinelIntegrationTests extends AbstractConnectionIntegrati
 	public @Rule MinimumRedisVersionRule minimumVersionRule = new MinimumRedisVersionRule();
 
 	public LettuceSentinelIntegrationTests(LettuceConnectionFactory connectionFactory, String displayName) {
+
 		this.connectionFactory = connectionFactory;
+		ConnectionFactoryTracker.add(connectionFactory);
 	}
 
 	@Parameters(name = "{1}")
@@ -79,11 +81,9 @@ public class LettuceSentinelIntegrationTests extends AbstractConnectionIntegrati
 
 		LettuceConnectionFactory pooledConnectionFactory = new LettuceConnectionFactory(SENTINEL_CONFIG,
 				LettucePoolingClientConfiguration.builder().build());
+		pooledConnectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
 		pooledConnectionFactory.setShareNativeConnection(false);
 		pooledConnectionFactory.afterPropertiesSet();
-
-		ConnectionFactoryTracker.add(lettuceConnectionFactory);
-		ConnectionFactoryTracker.add(pooledConnectionFactory);
 
 		parameters.add(new Object[] { lettuceConnectionFactory, "Sentinel" });
 		parameters.add(new Object[] { pooledConnectionFactory, "Sentinel/Pooled" });

--- a/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
@@ -66,8 +66,8 @@ abstract public class ReactiveOperationsTestParams {
 				.clientResources(LettuceTestClientResources.getSharedClientResources()) //
 				.build();
 
-		LettuceClientConfiguration poolingConfiguration = LettucePoolingClientConfiguration.builder() //
-				.and().shutdownTimeout(Duration.ZERO) //
+		LettucePoolingClientConfiguration poolingConfiguration = LettucePoolingClientConfiguration.builder() //
+				.shutdownTimeout(Duration.ZERO) //
 				.clientResources(LettuceTestClientResources.getSharedClientResources()) //
 				.build();
 


### PR DESCRIPTION
We now support Lettuce connection pooling by configuring a specialized client configuration via `LettucePoolingClientConfiguration.builder()`. Pooling settings can be configured through the builder and used with `LettuceConnectionFactory`.  Connection pooling is supported with Standalone and Sentinel-managed connections.  

```java
LettucePoolingClientConfiguration.builder()
    .poolConfig(poolConfig)
    .and() // allows configuration of further settings.
```

We also now create and release Lettuce connections using `LettuceConnectionProvider`. Connection providers encapsulate the underlying client and expose only creation and release methods. A connection provider can provide connections for Standalone or Cluster connections or wrap a LettucePool.

Previously we used RedisClient and `RedisClusterClient` directly which required context propagation (pooling/non-pooling) conditional code to obtain the appropriate connection type.

---

Related ticket: [DATAREDIS-667](https://jira.spring.io/browse/DATAREDIS-667).


