### PR TITLE
DATAREDIS-674 - JedisClusterConnection to support zAdd with Set of Tuples.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
@@ -15,15 +15,10 @@
  */
 package org.springframework.data.redis.connection;
 
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-
-import org.springframework.data.redis.connection.jedis.JedisVersionUtil;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.util.Assert;
+import java.util.Set;
 
 /**
  * ZSet(SortedSet)-specific commands supported by Redis.
@@ -744,35 +739,5 @@ public interface RedisZSetCommands {
 	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Set<byte[]> zRangeByLex(byte[] key, Range range, Limit limit);
-
-	/**
-	 * Convert tuples to map of bytes and double.
-	 * Bytes represents the value of the element and double is for the score.
-	 * @param tuples
-	 * @return
-	 */
-	default Map<byte[], Double> zAddArgs(Set<Tuple> tuples) {
-
-		Map<byte[], Double> args = new LinkedHashMap<>(tuples.size(), 1);
-		Set<Double> scores = new HashSet<>(tuples.size(), 1);
-
-		boolean isAtLeastJedis24 = JedisVersionUtil.atLeastJedis24();
-
-		for (Tuple tuple : tuples) {
-
-			if (!isAtLeastJedis24) {
-				if (scores.contains(tuple.getScore())) {
-					throw new UnsupportedOperationException(
-						"Bulk add of multiple elements with the same score is not supported. Add the elements individually.");
-				}
-				scores.add(tuple.getScore());
-			}
-
-			args.put(tuple.getValue(), tuple.getScore());
-		}
-
-		return args;
-	}
-
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.data.redis.connection;
 
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 
+import org.springframework.data.redis.connection.jedis.JedisVersionUtil;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.util.Assert;
@@ -29,6 +33,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author David Liu
  * @author Mark Paluch
+ * @author Clement Ong
  */
 public interface RedisZSetCommands {
 
@@ -739,5 +744,35 @@ public interface RedisZSetCommands {
 	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Set<byte[]> zRangeByLex(byte[] key, Range range, Limit limit);
+
+	/**
+	 * Convert tuples to map of bytes and double.
+	 * Bytes represents the value of the element and double is for the score.
+	 * @param tuples
+	 * @return
+	 */
+	default Map<byte[], Double> zAddArgs(Set<Tuple> tuples) {
+
+		Map<byte[], Double> args = new LinkedHashMap<>(tuples.size(), 1);
+		Set<Double> scores = new HashSet<>(tuples.size(), 1);
+
+		boolean isAtLeastJedis24 = JedisVersionUtil.atLeastJedis24();
+
+		for (Tuple tuple : tuples) {
+
+			if (!isAtLeastJedis24) {
+				if (scores.contains(tuple.getScore())) {
+					throw new UnsupportedOperationException(
+						"Bulk add of multiple elements with the same score is not supported. Add the elements individually.");
+				}
+				scores.add(tuple.getScore());
+			}
+
+			args.put(tuple.getValue(), tuple.getScore());
+		}
+
+		return args;
+	}
+
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
@@ -19,6 +19,7 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ZParams;
 
 import java.util.Set;
+import java.util.Map;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -33,6 +34,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Clement Ong
  * @since 2.0
  */
 class JedisClusterZSetCommands implements RedisZSetCommands {
@@ -64,8 +66,13 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 	@Override
 	public Long zAdd(byte[] key, Set<Tuple> tuples) {
 
-		// TODO: need to move the tuple conversion form jedisconnection.
-		throw new UnsupportedOperationException();
+		Map<byte[], Double> args = zAddArgs(tuples);
+
+		try {
+			return connection.getCluster().zadd(key, args);
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
+		}
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
@@ -66,7 +66,7 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 	@Override
 	public Long zAdd(byte[] key, Set<Tuple> tuples) {
 
-		Map<byte[], Double> args = zAddArgs(tuples);
+		Map<byte[], Double> args = JedisConverters.zAddArgsConvertor(tuples);
 
 		try {
 			return connection.getCluster().zadd(key, args);

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
@@ -77,7 +77,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 			throw new UnsupportedOperationException("zAdd of multiple fields not supported " + "in pipeline or transaction");
 		}
 
-		Map<byte[], Double> args = zAddArgs(tuples);
+		Map<byte[], Double> args = JedisConverters.zAddArgsConvertor(tuples);
 		try {
 			return connection.getJedis().zadd(key, args);
 		} catch (Exception ex) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
@@ -19,8 +19,6 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.ZParams;
 
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -806,29 +804,6 @@ class JedisZSetCommands implements RedisZSetCommands {
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}
-	}
-
-	private Map<byte[], Double> zAddArgs(Set<Tuple> tuples) {
-
-		Map<byte[], Double> args = new LinkedHashMap<>(tuples.size(), 1);
-		Set<Double> scores = new HashSet<>(tuples.size(), 1);
-
-		boolean isAtLeastJedis24 = JedisVersionUtil.atLeastJedis24();
-
-		for (Tuple tuple : tuples) {
-
-			if (!isAtLeastJedis24) {
-				if (scores.contains(tuple.getScore())) {
-					throw new UnsupportedOperationException(
-							"Bulk add of multiple elements with the same score is not supported. Add the elements individually.");
-				}
-				scores.add(tuple.getScore());
-			}
-
-			args.put(tuple.getValue(), tuple.getScore());
-		}
-
-		return args;
 	}
 
 	private boolean isPipelined() {


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->
Zadd more multiple elements in cluster mode was added. 
I have not added any unit tests because i can't seem to find where the test cases of JedisClusterZSetCommands.java are being written or if there are any at all at the moment.

- [◯] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [◯ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [◯ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [◯ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
