### PR TITLE
DATAREDIS-681 - Fix spelling in MultiNodeResult and ResultByReferenceKeyPositionComparator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-681-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ClusterCommandExecutor.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterCommandExecutor.java
@@ -182,7 +182,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 	 * @throws ClusterCommandExecutionFailureException
 	 * @throws IllegalArgumentException in case the node could not be resolved to a topology-known node
 	 */
-	public <S, T> MultiNodeResult<T> executeCommandAsyncOnNodes(final ClusterCommandCallback<S, T> callback,
+	public <S, T> MultiNodeResult<T> executeCommandAsyncOnNodes(ClusterCommandCallback<S, T> callback,
 			Iterable<RedisClusterNode> nodes) {
 
 		Assert.notNull(callback, "Callback must not be null!");
@@ -191,7 +191,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 		List<RedisClusterNode> resolvedRedisClusterNodes = new ArrayList<>();
 		ClusterTopology topology = topologyProvider.getTopology();
 
-		for (final RedisClusterNode node : nodes) {
+		for (RedisClusterNode node : nodes) {
 			try {
 				resolvedRedisClusterNodes.add(topology.lookup(node));
 			} catch (ClusterStateFailureException e) {
@@ -200,7 +200,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 		}
 
 		Map<NodeExecution, Future<NodeResult<T>>> futures = new LinkedHashMap<>();
-		for (final RedisClusterNode node : resolvedRedisClusterNodes) {
+		for (RedisClusterNode node : resolvedRedisClusterNodes) {
 
 			futures.put(new NodeExecution(node), executor.submit(() -> executeCommandOnSingleNode(callback, node)));
 		}
@@ -267,7 +267,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 	 * @return
 	 * @throws ClusterCommandExecutionFailureException
 	 */
-	public <S, T> MultiNodeResult<T> executeMultiKeyCommand(final MultiKeyClusterCommandCallback<S, T> cmd,
+	public <S, T> MultiNodeResult<T> executeMultiKeyCommand(MultiKeyClusterCommandCallback<S, T> cmd,
 			Iterable<byte[]> keys) {
 
 		Map<RedisClusterNode, Set<byte[]>> nodeKeyMap = new HashMap<>();
@@ -287,10 +287,10 @@ public class ClusterCommandExecutor implements DisposableBean {
 
 		Map<NodeExecution, Future<NodeResult<T>>> futures = new LinkedHashMap<>();
 
-		for (final Entry<RedisClusterNode, Set<byte[]>> entry : nodeKeyMap.entrySet()) {
+		for (Entry<RedisClusterNode, Set<byte[]>> entry : nodeKeyMap.entrySet()) {
 
 			if (entry.getKey().isMaster()) {
-				for (final byte[] key : entry.getValue()) {
+				for (byte[] key : entry.getValue()) {
 					futures.put(new NodeExecution(entry.getKey(), key),
 							executor.submit(() -> executeMultiKeyCommandOnSingleNode(cmd, entry.getKey(), key)));
 				}
@@ -363,7 +363,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 	 * @param <S>
 	 * @since 1.7
 	 */
-	public static interface ClusterCommandCallback<T, S> {
+	public interface ClusterCommandCallback<T, S> {
 		S doInCluster(T client);
 	}
 
@@ -374,7 +374,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 	 * @param <T> native driver connection
 	 * @param <S>
 	 */
-	public static interface MultiKeyClusterCommandCallback<T, S> {
+	public interface MultiKeyClusterCommandCallback<T, S> {
 		S doInCluster(T client, byte[] key);
 	}
 
@@ -550,7 +550,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 		public List<T> resultsAsListSortBy(byte[]... keys) {
 
 			ArrayList<NodeResult<T>> clone = new ArrayList<>(nodeResults);
-			Collections.sort(clone, new ResultByReferenceKeyPositionComparator(keys));
+			clone.sort(new ResultByReferenceKeyPositionComparator(keys));
 
 			return toList(clone);
 		}

--- a/src/main/java/org/springframework/data/redis/connection/ClusterCommandExecutor.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterCommandExecutor.java
@@ -171,7 +171,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 	 * @return
 	 * @throws ClusterCommandExecutionFailureException
 	 */
-	public <S, T> MulitNodeResult<T> executeCommandOnAllNodes(final ClusterCommandCallback<S, T> cmd) {
+	public <S, T> MultiNodeResult<T> executeCommandOnAllNodes(final ClusterCommandCallback<S, T> cmd) {
 		return executeCommandAsyncOnNodes(cmd, getClusterTopology().getActiveMasterNodes());
 	}
 
@@ -182,7 +182,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 	 * @throws ClusterCommandExecutionFailureException
 	 * @throws IllegalArgumentException in case the node could not be resolved to a topology-known node
 	 */
-	public <S, T> MulitNodeResult<T> executeCommandAsyncOnNodes(final ClusterCommandCallback<S, T> callback,
+	public <S, T> MultiNodeResult<T> executeCommandAsyncOnNodes(final ClusterCommandCallback<S, T> callback,
 			Iterable<RedisClusterNode> nodes) {
 
 		Assert.notNull(callback, "Callback must not be null!");
@@ -208,11 +208,11 @@ public class ClusterCommandExecutor implements DisposableBean {
 		return collectResults(futures);
 	}
 
-	private <T> MulitNodeResult<T> collectResults(Map<NodeExecution, Future<NodeResult<T>>> futures) {
+	private <T> MultiNodeResult<T> collectResults(Map<NodeExecution, Future<NodeResult<T>>> futures) {
 
 		boolean done = false;
 
-		MulitNodeResult<T> result = new MulitNodeResult<>();
+		MultiNodeResult<T> result = new MultiNodeResult<>();
 		Map<RedisClusterNode, Throwable> exceptions = new HashMap<>();
 
 		Set<String> saveGuard = new HashSet<>();
@@ -267,7 +267,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 	 * @return
 	 * @throws ClusterCommandExecutionFailureException
 	 */
-	public <S, T> MulitNodeResult<T> executeMuliKeyCommand(final MultiKeyClusterCommandCallback<S, T> cmd,
+	public <S, T> MultiNodeResult<T> executeMultiKeyCommand(final MultiKeyClusterCommandCallback<S, T> cmd,
 			Iterable<byte[]> keys) {
 
 		Map<RedisClusterNode, Set<byte[]>> nodeKeyMap = new HashMap<>();
@@ -445,7 +445,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 	}
 
 	/**
-	 * {@link NodeResult} encapsules the actual value returned by a {@link ClusterCommandCallback} on a given
+	 * {@link NodeResult} encapsulates the actual value returned by a {@link ClusterCommandCallback} on a given
 	 * {@link RedisClusterNode}.
 	 *
 	 * @author Christoph Strobl
@@ -510,13 +510,13 @@ public class ClusterCommandExecutor implements DisposableBean {
 	}
 
 	/**
-	 * {@link MulitNodeResult} holds all {@link NodeResult} of a command executed on multiple {@link RedisClusterNode}.
+	 * {@link MultiNodeResult} holds all {@link NodeResult} of a command executed on multiple {@link RedisClusterNode}.
 	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 * @since 1.7
 	 */
-	public static class MulitNodeResult<T> {
+	public static class MultiNodeResult<T> {
 
 		List<NodeResult<T>> nodeResults = new ArrayList<>();
 
@@ -550,7 +550,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 		public List<T> resultsAsListSortBy(byte[]... keys) {
 
 			ArrayList<NodeResult<T>> clone = new ArrayList<>(nodeResults);
-			Collections.sort(clone, new ResultByReferenceKeyPositionComperator(keys));
+			Collections.sort(clone, new ResultByReferenceKeyPositionComparator(keys));
 
 			return toList(clone);
 		}
@@ -591,12 +591,13 @@ public class ClusterCommandExecutor implements DisposableBean {
 		 * {@link Comparator} for sorting {@link NodeResult} by reference keys.
 		 *
 		 * @author Christoph Strobl
+		 * @author Mark Paluch
 		 */
-		private static class ResultByReferenceKeyPositionComperator implements Comparator<NodeResult<?>> {
+		private static class ResultByReferenceKeyPositionComparator implements Comparator<NodeResult<?>> {
 
 			List<ByteArrayWrapper> reference;
 
-			public ResultByReferenceKeyPositionComperator(byte[]... keys) {
+			ResultByReferenceKeyPositionComparator(byte[]... keys) {
 				reference = new ArrayList<>(new ByteArraySet(Arrays.asList(keys)));
 			}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterGeoCommands.java
@@ -34,13 +34,14 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisClusterGeoCommands implements RedisGeoCommands {
 
 	private final JedisClusterConnection connection;
 
-	public JedisClusterGeoCommands(JedisClusterConnection connection) {
+	JedisClusterGeoCommands(JedisClusterConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
@@ -32,13 +32,14 @@ import org.springframework.data.redis.core.ScanOptions;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisClusterHashCommands implements RedisHashCommands {
 
 	private final JedisClusterConnection connection;
 
-	public JedisClusterHashCommands(JedisClusterConnection connection) {
+	JedisClusterHashCommands(JedisClusterConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHyperLogLogCommands.java
@@ -23,13 +23,14 @@ import org.springframework.data.redis.util.ByteUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisClusterHyperLogLogCommands implements RedisHyperLogLogCommands {
 
 	private final JedisClusterConnection connection;
 
-	public JedisClusterHyperLogLogCommands(JedisClusterConnection connection) {
+	JedisClusterHyperLogLogCommands(JedisClusterConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
@@ -49,7 +49,7 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 
 	private final JedisClusterConnection connection;
 
-	public JedisClusterKeyCommands(JedisClusterConnection connection) {
+	JedisClusterKeyCommands(JedisClusterConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
@@ -42,6 +42,7 @@ import org.springframework.util.CollectionUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisClusterKeyCommands implements RedisKeyCommands {
@@ -70,7 +71,7 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 		}
 
 		return (long) connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand((JedisMultiKeyClusterCommandCallback<Long>) (client, key) -> client.del(key),
+				.executeMultiKeyCommand((JedisMultiKeyClusterCommandCallback<Long>) (client, key) -> client.del(key),
 						Arrays.asList(keys))
 				.resultsAsList().size();
 	}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterListCommands.java
@@ -34,7 +34,7 @@ class JedisClusterListCommands implements RedisListCommands {
 
 	private final JedisClusterConnection connection;
 
-	public JedisClusterListCommands(JedisClusterConnection connection) {
+	JedisClusterListCommands(JedisClusterConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterListCommands.java
@@ -27,6 +27,7 @@ import org.springframework.util.CollectionUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisClusterListCommands implements RedisListCommands {
@@ -235,7 +236,7 @@ class JedisClusterListCommands implements RedisListCommands {
 		}
 
 		return connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand(
+				.executeMultiKeyCommand(
 						(JedisMultiKeyClusterCommandCallback<List<byte[]>>) (client, key) -> client.blpop(timeout, key),
 						Arrays.asList(keys))
 				.getFirstNonNullNotEmptyOrDefault(Collections.<byte[]> emptyList());
@@ -249,7 +250,7 @@ class JedisClusterListCommands implements RedisListCommands {
 	public List<byte[]> bRPop(final int timeout, byte[]... keys) {
 
 		return connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand(
+				.executeMultiKeyCommand(
 						(JedisMultiKeyClusterCommandCallback<List<byte[]>>) (client, key) -> client.brpop(timeout, key),
 						Arrays.asList(keys))
 				.getFirstNonNullNotEmptyOrDefault(Collections.<byte[]> emptyList());

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterServerCommands.java
@@ -44,7 +44,7 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	private final JedisClusterConnection connection;
 
-	public JedisClusterServerCommands(JedisClusterConnection connection) {
+	JedisClusterServerCommands(JedisClusterConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterServerCommands.java
@@ -25,7 +25,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.data.redis.connection.ClusterCommandExecutor.MulitNodeResult;
+import org.springframework.data.redis.connection.ClusterCommandExecutor.MultiNodeResult;
 import org.springframework.data.redis.connection.ClusterCommandExecutor.NodeResult;
 import org.springframework.data.redis.connection.RedisClusterNode;
 import org.springframework.data.redis.connection.RedisClusterServerCommands;
@@ -510,7 +510,7 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 		return connection.getClusterCommandExecutor().executeCommandOnSingleNode(cmd, node);
 	}
 
-	private <T> MulitNodeResult<T> executeCommandOnAllNodes(JedisClusterCommandCallback<T> cmd) {
+	private <T> MultiNodeResult<T> executeCommandOnAllNodes(JedisClusterCommandCallback<T> cmd) {
 		return connection.getClusterCommandExecutor().executeCommandOnAllNodes(cmd);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterSetCommands.java
@@ -44,7 +44,7 @@ class JedisClusterSetCommands implements RedisSetCommands {
 
 	private final JedisClusterConnection connection;
 
-	public JedisClusterSetCommands(JedisClusterConnection connection) {
+	JedisClusterSetCommands(JedisClusterConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterSetCommands.java
@@ -37,6 +37,7 @@ import org.springframework.data.redis.util.ByteUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisClusterSetCommands implements RedisSetCommands {
@@ -169,7 +170,8 @@ class JedisClusterSetCommands implements RedisSetCommands {
 		}
 
 		Collection<Set<byte[]>> resultList = connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand((JedisMultiKeyClusterCommandCallback<Set<byte[]>>) (client, key) -> client.smembers(key),
+				.executeMultiKeyCommand(
+						(JedisMultiKeyClusterCommandCallback<Set<byte[]>>) (client, key) -> client.smembers(key),
 						Arrays.asList(keys))
 				.resultsAsList();
 
@@ -235,7 +237,8 @@ class JedisClusterSetCommands implements RedisSetCommands {
 		}
 
 		Collection<Set<byte[]>> resultList = connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand((JedisMultiKeyClusterCommandCallback<Set<byte[]>>) (client, key) -> client.smembers(key),
+				.executeMultiKeyCommand(
+						(JedisMultiKeyClusterCommandCallback<Set<byte[]>>) (client, key) -> client.smembers(key),
 						Arrays.asList(keys))
 				.resultsAsList();
 
@@ -295,7 +298,8 @@ class JedisClusterSetCommands implements RedisSetCommands {
 
 		ByteArraySet values = new ByteArraySet(sMembers(source));
 		Collection<Set<byte[]>> resultList = connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand((JedisMultiKeyClusterCommandCallback<Set<byte[]>>) (client, key) -> client.smembers(key),
+				.executeMultiKeyCommand(
+						(JedisMultiKeyClusterCommandCallback<Set<byte[]>>) (client, key) -> client.smembers(key),
 						Arrays.asList(others))
 				.resultsAsList();
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStringCommands.java
@@ -33,6 +33,7 @@ import org.springframework.util.ObjectUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisClusterStringCommands implements RedisStringCommands {
@@ -85,7 +86,7 @@ class JedisClusterStringCommands implements RedisStringCommands {
 		}
 
 		return connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand((JedisMultiKeyClusterCommandCallback<byte[]>) (client, key) -> client.get(key),
+				.executeMultiKeyCommand((JedisMultiKeyClusterCommandCallback<byte[]>) (client, key) -> client.get(key),
 						Arrays.asList(keys))
 				.resultsAsListSortBy(keys);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStringCommands.java
@@ -40,7 +40,7 @@ class JedisClusterStringCommands implements RedisStringCommands {
 
 	private final JedisClusterConnection connection;
 
-	public JedisClusterStringCommands(JedisClusterConnection jedisClusterConnection) {
+	JedisClusterStringCommands(JedisClusterConnection jedisClusterConnection) {
 		this.connection = jedisClusterConnection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
@@ -33,13 +33,14 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisClusterZSetCommands implements RedisZSetCommands {
 
 	private final JedisClusterConnection connection;
 
-	public JedisClusterZSetCommands(JedisClusterConnection connection) {
+	JedisClusterZSetCommands(JedisClusterConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisGeoCommands.java
@@ -35,13 +35,14 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisGeoCommands implements RedisGeoCommands {
 
 	private final JedisConnection connection;
 
-	public JedisGeoCommands(JedisConnection connection) {
+	JedisGeoCommands(JedisConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
@@ -32,13 +32,14 @@ import org.springframework.data.redis.core.ScanOptions;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisHashCommands implements RedisHashCommands {
 
 	private final JedisConnection connection;
 
-	public JedisHashCommands(JedisConnection connection) {
+	JedisHashCommands(JedisConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisHyperLogLogCommands.java
@@ -21,13 +21,14 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisHyperLogLogCommands implements RedisHyperLogLogCommands {
 
 	private final JedisConnection connection;
 
-	public JedisHyperLogLogCommands(JedisConnection connection) {
+	JedisHyperLogLogCommands(JedisConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -35,13 +35,14 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisKeyCommands implements RedisKeyCommands {
 
 	private final JedisConnection connection;
 
-	public JedisKeyCommands(JedisConnection connection) {
+	JedisKeyCommands(JedisConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisListCommands.java
@@ -25,13 +25,14 @@ import org.springframework.data.redis.connection.jedis.JedisConnection.JedisResu
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisListCommands implements RedisListCommands {
 
 	private final JedisConnection connection;
 
-	public JedisListCommands(JedisConnection connection) {
+	JedisListCommands(JedisConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisScriptingCommands.java
@@ -28,11 +28,11 @@ class JedisScriptingCommands implements RedisScriptingCommands {
 
 	private final JedisConnection connection;
 
-	public JedisScriptingCommands(JedisConnection connection) {
+	JedisScriptingCommands(JedisConnection connection) {
 		this.connection = connection;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#scriptFlush()
 	 */
@@ -51,7 +51,7 @@ class JedisScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#scriptKill()
 	 */
@@ -70,7 +70,7 @@ class JedisScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#scriptLoad(byte[])
 	 */
@@ -89,7 +89,7 @@ class JedisScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#scriptExists(java.lang.String[])
 	 */
@@ -108,7 +108,7 @@ class JedisScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#eval(byte[], org.springframework.data.redis.connection.ReturnType, int, byte[][])
 	 */
@@ -129,7 +129,7 @@ class JedisScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#evalSha(java.lang.String, org.springframework.data.redis.connection.ReturnType, int, byte[][])
 	 */
@@ -138,7 +138,7 @@ class JedisScriptingCommands implements RedisScriptingCommands {
 		return evalSha(JedisConverters.toBytes(scriptSha1), returnType, numKeys, keysAndArgs);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#evalSha(byte[], org.springframework.data.redis.connection.ReturnType, int, byte[][])
 	 */

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
@@ -36,7 +36,7 @@ class JedisServerCommands implements RedisServerCommands {
 
 	private final JedisConnection connection;
 
-	public JedisServerCommands(JedisConnection connection) {
+	JedisServerCommands(JedisConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisSetCommands.java
@@ -30,13 +30,14 @@ import org.springframework.data.redis.core.ScanOptions;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisSetCommands implements RedisSetCommands {
 
 	private final JedisConnection connection;
 
-	public JedisSetCommands(JedisConnection connection) {
+	JedisSetCommands(JedisConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisStringCommands.java
@@ -26,13 +26,14 @@ import org.springframework.util.ObjectUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class JedisStringCommands implements RedisStringCommands {
 
 	private final JedisConnection connection;
 
-	public JedisStringCommands(JedisConnection connection) {
+	JedisStringCommands(JedisConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterGeoCommands.java
@@ -17,11 +17,12 @@ package org.springframework.data.redis.connection.lettuce;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceClusterGeoCommands extends LettuceGeoCommands {
 
-	public LettuceClusterGeoCommands(LettuceClusterConnection connection) {
+	LettuceClusterGeoCommands(LettuceClusterConnection connection) {
 		super(connection);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterHashCommands.java
@@ -17,11 +17,12 @@ package org.springframework.data.redis.connection.lettuce;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceClusterHashCommands extends LettuceHashCommands {
 
-	public LettuceClusterHashCommands(LettuceClusterConnection connection) {
+	LettuceClusterHashCommands(LettuceClusterConnection connection) {
 		super(connection);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterHyperLogLogCommands.java
@@ -21,11 +21,12 @@ import org.springframework.data.redis.util.ByteUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceClusterHyperLogLogCommands extends LettuceHyperLogLogCommands {
 
-	public LettuceClusterHyperLogLogCommands(LettuceClusterConnection connection) {
+	LettuceClusterHyperLogLogCommands(LettuceClusterConnection connection) {
 		super(connection);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyCommands.java
@@ -33,13 +33,14 @@ import org.springframework.util.CollectionUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceClusterKeyCommands extends LettuceKeyCommands {
 
 	private final LettuceClusterConnection connection;
 
-	public LettuceClusterKeyCommands(LettuceClusterConnection connection) {
+	LettuceClusterKeyCommands(LettuceClusterConnection connection) {
 
 		super(connection);
 		this.connection = connection;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterListCommands.java
@@ -27,6 +27,7 @@ import org.springframework.util.CollectionUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceClusterListCommands extends LettuceListCommands {
@@ -50,7 +51,7 @@ class LettuceClusterListCommands extends LettuceListCommands {
 			return super.bLPop(timeout, keys);
 		}
 
-		List<KeyValue<byte[], byte[]>> resultList = connection.getClusterCommandExecutor().executeMuliKeyCommand(
+		List<KeyValue<byte[], byte[]>> resultList = connection.getClusterCommandExecutor().executeMultiKeyCommand(
 				(LettuceMultiKeyClusterCommandCallback<KeyValue<byte[], byte[]>>) (client, key) -> client.blpop(timeout, key),
 				Arrays.asList(keys)).resultsAsList();
 
@@ -74,7 +75,7 @@ class LettuceClusterListCommands extends LettuceListCommands {
 			return super.bRPop(timeout, keys);
 		}
 
-		List<KeyValue<byte[], byte[]>> resultList = connection.getClusterCommandExecutor().executeMuliKeyCommand(
+		List<KeyValue<byte[], byte[]>> resultList = connection.getClusterCommandExecutor().executeMultiKeyCommand(
 				(LettuceMultiKeyClusterCommandCallback<KeyValue<byte[], byte[]>>) (client, key) -> client.brpop(timeout, key),
 				Arrays.asList(keys)).resultsAsList();
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterListCommands.java
@@ -34,7 +34,7 @@ class LettuceClusterListCommands extends LettuceListCommands {
 
 	private final LettuceClusterConnection connection;
 
-	public LettuceClusterListCommands(LettuceClusterConnection connection) {
+	LettuceClusterListCommands(LettuceClusterConnection connection) {
 
 		super(connection);
 		this.connection = connection;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterServerCommands.java
@@ -43,7 +43,7 @@ class LettuceClusterServerCommands extends LettuceServerCommands implements Redi
 
 	private final LettuceClusterConnection connection;
 
-	public LettuceClusterServerCommands(LettuceClusterConnection connection) {
+	LettuceClusterServerCommands(LettuceClusterConnection connection) {
 
 		super(connection);
 		this.connection = connection;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterServerCommands.java
@@ -25,7 +25,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.data.redis.connection.ClusterCommandExecutor.MulitNodeResult;
+import org.springframework.data.redis.connection.ClusterCommandExecutor.MultiNodeResult;
 import org.springframework.data.redis.connection.ClusterCommandExecutor.NodeResult;
 import org.springframework.data.redis.connection.RedisClusterNode;
 import org.springframework.data.redis.connection.RedisClusterServerCommands;
@@ -361,7 +361,7 @@ class LettuceClusterServerCommands extends LettuceServerCommands implements Redi
 		return connection.getClusterCommandExecutor().executeCommandOnSingleNode(command, node);
 	}
 
-	private <T> MulitNodeResult<T> executeCommandOnAllNodes(final LettuceClusterCommandCallback<T> cmd) {
+	private <T> MultiNodeResult<T> executeCommandOnAllNodes(final LettuceClusterCommandCallback<T> cmd) {
 		return connection.getClusterCommandExecutor().executeCommandOnAllNodes(cmd);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSetCommands.java
@@ -29,6 +29,7 @@ import org.springframework.data.redis.util.ByteUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceClusterSetCommands extends LettuceSetCommands {
@@ -72,7 +73,7 @@ class LettuceClusterSetCommands extends LettuceSetCommands {
 		}
 
 		Collection<Set<byte[]>> nodeResult = connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand((LettuceMultiKeyClusterCommandCallback<Set<byte[]>>) RedisSetCommands::smembers,
+				.executeMultiKeyCommand((LettuceMultiKeyClusterCommandCallback<Set<byte[]>>) RedisSetCommands::smembers,
 						Arrays.asList(keys))
 				.resultsAsList();
 
@@ -129,7 +130,7 @@ class LettuceClusterSetCommands extends LettuceSetCommands {
 		}
 
 		Collection<Set<byte[]>> nodeResult = connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand((LettuceMultiKeyClusterCommandCallback<Set<byte[]>>) RedisSetCommands::smembers,
+				.executeMultiKeyCommand((LettuceMultiKeyClusterCommandCallback<Set<byte[]>>) RedisSetCommands::smembers,
 						Arrays.asList(keys))
 				.resultsAsList();
 
@@ -181,7 +182,7 @@ class LettuceClusterSetCommands extends LettuceSetCommands {
 
 		ByteArraySet values = new ByteArraySet(sMembers(source));
 		Collection<Set<byte[]>> nodeResult = connection.getClusterCommandExecutor()
-				.executeMuliKeyCommand((LettuceMultiKeyClusterCommandCallback<Set<byte[]>>) RedisSetCommands::smembers,
+				.executeMultiKeyCommand((LettuceMultiKeyClusterCommandCallback<Set<byte[]>>) RedisSetCommands::smembers,
 						Arrays.asList(others))
 				.resultsAsList();
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSetCommands.java
@@ -36,7 +36,7 @@ class LettuceClusterSetCommands extends LettuceSetCommands {
 
 	private final LettuceClusterConnection connection;
 
-	public LettuceClusterSetCommands(LettuceClusterConnection connection) {
+	LettuceClusterSetCommands(LettuceClusterConnection connection) {
 
 		super(connection);
 		this.connection = connection;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterStringCommands.java
@@ -21,16 +21,13 @@ import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceClusterStringCommands extends LettuceStringCommands {
 
-	private final LettuceClusterConnection connection;
-
-	public LettuceClusterStringCommands(LettuceClusterConnection connection) {
-
+	LettuceClusterStringCommands(LettuceClusterConnection connection) {
 		super(connection);
-		this.connection = connection;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterZSetCommands.java
@@ -17,11 +17,12 @@ package org.springframework.data.redis.connection.lettuce;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceClusterZSetCommands extends LettuceZSetCommands {
 
-	public LettuceClusterZSetCommands(LettuceClusterConnection connection) {
+	LettuceClusterZSetCommands(LettuceClusterConnection connection) {
 		super(connection);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterGeoCommands.java
@@ -19,16 +19,17 @@ import org.springframework.data.redis.connection.ReactiveClusterGeoCommands;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceReactiveClusterGeoCommands extends LettuceReactiveGeoCommands implements ReactiveClusterGeoCommands {
 
 	/**
-	 * Create new {@link LettuceReactiveGeoCommands}.
+	 * Create new {@link LettuceReactiveClusterGeoCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveClusterGeoCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveClusterGeoCommands(LettuceReactiveRedisConnection connection) {
 		super(connection);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHashCommands.java
@@ -19,16 +19,17 @@ import org.springframework.data.redis.connection.ReactiveClusterHashCommands;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceReactiveClusterHashCommands extends LettuceReactiveHashCommands implements ReactiveClusterHashCommands {
 
 	/**
-	 * Create new {@link LettuceReactiveHashCommands}.
+	 * Create new {@link LettuceReactiveClusterHashCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveClusterHashCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveClusterHashCommands(LettuceReactiveRedisConnection connection) {
 		super(connection);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommands.java
@@ -32,17 +32,18 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
- * @since @since 2.0
+ * @author Mark Paluch
+ * @since 2.0
  */
 class LettuceReactiveClusterHyperLogLogCommands extends LettuceReactiveHyperLogLogCommands
 		implements ReactiveClusterHyperLogLogCommands {
 
 	/**
-	 * Create new {@link LettuceReactiveHyperLogLogCommands}.
+	 * Create new {@link LettuceReactiveClusterHyperLogLogCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveClusterHyperLogLogCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveClusterHyperLogLogCommands(LettuceReactiveRedisConnection connection) {
 		super(connection);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
@@ -41,11 +41,11 @@ class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommands imple
 	private LettuceReactiveRedisClusterConnection connection;
 
 	/**
-	 * Create new {@link LettuceReactiveKeyCommands}.
+	 * Create new {@link LettuceReactiveClusterKeyCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveClusterKeyCommands(LettuceReactiveRedisClusterConnection connection) {
+	LettuceReactiveClusterKeyCommands(LettuceReactiveRedisClusterConnection connection) {
 
 		super(connection);
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
@@ -35,11 +35,11 @@ import org.springframework.util.Assert;
 class LettuceReactiveClusterListCommands extends LettuceReactiveListCommands implements ReactiveClusterListCommands {
 
 	/**
-	 * Create new {@link LettuceReactiveListCommands}.
+	 * Create new {@link LettuceReactiveClusterListCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveClusterListCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveClusterListCommands(LettuceReactiveRedisConnection connection) {
 		super(connection);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterNumberCommands.java
@@ -19,17 +19,18 @@ import org.springframework.data.redis.connection.ReactiveClusterNumberCommands;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceReactiveClusterNumberCommands extends LettuceReactiveNumberCommands
 		implements ReactiveClusterNumberCommands {
 
 	/**
-	 * Create new {@link LettuceReactiveStringCommands}.
+	 * Create new {@link LettuceReactiveClusterNumberCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveClusterNumberCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveClusterNumberCommands(LettuceReactiveRedisConnection connection) {
 		super(connection);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterServerCommands.java
@@ -58,14 +58,14 @@ class LettuceReactiveClusterServerCommands extends LettuceReactiveServerCommands
 	private final ClusterTopologyProvider topologyProvider;
 
 	/**
-	 * Create new {@link LettuceReactiveGeoCommands}.
+	 * Create new {@link LettuceReactiveClusterServerCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 * @param topologyProvider must not be {@literal null}.
 	 * @throws IllegalArgumentException when {@code connection} is {@literal null}.
 	 * @throws IllegalArgumentException when {@code topologyProvider} is {@literal null}.
 	 */
-	public LettuceReactiveClusterServerCommands(LettuceReactiveRedisClusterConnection connection,
+	LettuceReactiveClusterServerCommands(LettuceReactiveRedisClusterConnection connection,
 			ClusterTopologyProvider topologyProvider) {
 
 		super(connection);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
@@ -39,11 +39,11 @@ import org.springframework.util.Assert;
 class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands implements ReactiveClusterSetCommands {
 
 	/**
-	 * Create new {@link LettuceReactiveSetCommands}.
+	 * Create new {@link LettuceReactiveClusterSetCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveClusterSetCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveClusterSetCommands(LettuceReactiveRedisConnection connection) {
 		super(connection);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommands.java
@@ -30,17 +30,18 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceReactiveClusterStringCommands extends LettuceReactiveStringCommands
 		implements ReactiveClusterStringCommands {
 
 	/**
-	 * Create new {@link LettuceReactiveStringCommands}.
+	 * Create new {@link LettuceReactiveClusterStringCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveClusterStringCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveClusterStringCommands(LettuceReactiveRedisConnection connection) {
 		super(connection);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommands.java
@@ -27,16 +27,17 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
- * @since @since 2.0
+ * @author Mark Paluch
+ * @since 2.0
  */
 class LettuceReactiveClusterZSetCommands extends LettuceReactiveZSetCommands implements ReactiveClusterZSetCommands {
 
 	/**
-	 * Create new {@link LettuceReactiveSetCommands}.
+	 * Create new {@link LettuceReactiveClusterZSetCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveClusterZSetCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveClusterZSetCommands(LettuceReactiveRedisConnection connection) {
 		super(connection);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommands.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceReactiveGeoCommands implements ReactiveGeoCommands {
@@ -54,7 +55,7 @@ class LettuceReactiveGeoCommands implements ReactiveGeoCommands {
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveGeoCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveGeoCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
 		this.connection = connection;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
@@ -50,7 +50,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveHashCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveHashCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
 		this.connection = connection;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommands.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceReactiveHyperLogLogCommands implements ReactiveHyperLogLogCommands {
@@ -38,9 +39,10 @@ class LettuceReactiveHyperLogLogCommands implements ReactiveHyperLogLogCommands 
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveHyperLogLogCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveHyperLogLogCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
+
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
@@ -47,7 +47,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveKeyCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveKeyCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
@@ -49,7 +49,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveListCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveListCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
@@ -35,11 +35,11 @@ class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 	private final LettuceReactiveRedisConnection connection;
 
 	/**
-	 * Create new {@link LettuceReactiveStringCommands}.
+	 * Create new {@link LettuceReactiveNumberCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveNumberCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveNumberCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
@@ -43,7 +43,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveSetCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveSetCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
@@ -49,7 +49,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveStringCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveStringCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
@@ -53,11 +53,11 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	private final LettuceReactiveRedisConnection connection;
 
 	/**
-	 * Create new {@link LettuceReactiveSetCommands}.
+	 * Create new {@link LettuceReactiveZSetCommands}.
 	 *
 	 * @param connection must not be {@literal null}.
 	 */
-	public LettuceReactiveZSetCommands(LettuceReactiveRedisConnection connection) {
+	LettuceReactiveZSetCommands(LettuceReactiveRedisConnection connection) {
 
 		Assert.notNull(connection, "Connection must not be null!");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceScriptingCommands.java
@@ -36,11 +36,11 @@ class LettuceScriptingCommands implements RedisScriptingCommands {
 
 	private final LettuceConnection connection;
 
-	public LettuceScriptingCommands(LettuceConnection connection) {
+	LettuceScriptingCommands(LettuceConnection connection) {
 		this.connection = connection;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#scriptFlush()
 	 */
@@ -61,7 +61,7 @@ class LettuceScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#scriptKill()
 	 */
@@ -85,7 +85,7 @@ class LettuceScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#scriptLoad(byte[])
 	 */
@@ -106,7 +106,7 @@ class LettuceScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#scriptExists(java.lang.String[])
 	 */
@@ -127,7 +127,7 @@ class LettuceScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#eval(byte[], org.springframework.data.redis.connection.ReturnType, int, byte[][])
 	 */
@@ -156,7 +156,7 @@ class LettuceScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#evalSha(java.lang.String, org.springframework.data.redis.connection.ReturnType, int, byte[][])
 	 */
@@ -185,7 +185,7 @@ class LettuceScriptingCommands implements RedisScriptingCommands {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisScriptingCommands#evalSha(byte[], org.springframework.data.redis.connection.ReturnType, int, byte[][])
 	 */

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceServerCommands.java
@@ -38,7 +38,7 @@ class LettuceServerCommands implements RedisServerCommands {
 
 	private final LettuceConnection connection;
 
-	public LettuceServerCommands(LettuceConnection connection) {
+	LettuceServerCommands(LettuceConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSetCommands.java
@@ -36,13 +36,14 @@ import org.springframework.data.redis.core.ScanOptions;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceSetCommands implements RedisSetCommands {
 
 	private final LettuceConnection connection;
 
-	public LettuceSetCommands(LettuceConnection connection) {
+	LettuceSetCommands(LettuceConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStringCommands.java
@@ -30,13 +30,14 @@ import org.springframework.data.redis.core.types.Expiration;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceStringCommands implements RedisStringCommands {
 
 	private final LettuceConnection connection;
 
-	public LettuceStringCommands(LettuceConnection connection) {
+	LettuceStringCommands(LettuceConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceZSetCommands.java
@@ -37,13 +37,14 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0
  */
 class LettuceZSetCommands implements RedisZSetCommands {
 
 	private final LettuceConnection connection;
 
-	public LettuceZSetCommands(LettuceConnection connection) {
+	LettuceZSetCommands(LettuceConnection connection) {
 		this.connection = connection;
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/ClusterCommandExecutorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterCommandExecutorUnitTests.java
@@ -41,8 +41,8 @@ import org.springframework.data.redis.ClusterRedirectException;
 import org.springframework.data.redis.PassThroughExceptionTranslationStrategy;
 import org.springframework.data.redis.TooManyClusterRedirectionsException;
 import org.springframework.data.redis.connection.ClusterCommandExecutor.ClusterCommandCallback;
-import org.springframework.data.redis.connection.ClusterCommandExecutor.MulitNodeResult;
 import org.springframework.data.redis.connection.ClusterCommandExecutor.MultiKeyClusterCommandCallback;
+import org.springframework.data.redis.connection.ClusterCommandExecutor.MultiNodeResult;
 import org.springframework.data.redis.connection.RedisClusterNode.LinkState;
 import org.springframework.data.redis.connection.RedisClusterNode.SlotRange;
 import org.springframework.data.redis.connection.RedisNode.NodeType;
@@ -248,7 +248,7 @@ public class ClusterCommandExecutorUnitTests {
 		when(con2.theWheelWeavesAsTheWheelWills()).thenReturn("mat");
 		when(con3.theWheelWeavesAsTheWheelWills()).thenReturn("perrin");
 
-		MulitNodeResult<String> result = executor.executeCommandOnAllNodes(COMMAND_CALLBACK);
+		MultiNodeResult<String> result = executor.executeCommandOnAllNodes(COMMAND_CALLBACK);
 
 		assertThat(result.resultsAsList(), hasItems("rand", "mat", "perrin"));
 	}
@@ -263,7 +263,7 @@ public class ClusterCommandExecutorUnitTests {
 		when(con2.bloodAndAshes(any(byte[].class))).thenReturn("mat");
 		when(con3.bloodAndAshes(any(byte[].class))).thenReturn("perrin");
 
-		MulitNodeResult<String> result = executor.executeMuliKeyCommand(MULTIKEY_CALLBACK,
+		MultiNodeResult<String> result = executor.executeMultiKeyCommand(MULTIKEY_CALLBACK,
 				new HashSet<>(
 				Arrays.asList("key-1".getBytes(), "key-2".getBytes(), "key-3".getBytes(), "key-9".getBytes())));
 


### PR DESCRIPTION
Fix type and method names.  Remove `final` keywords from variables in `ClusterCommandExecutor`. Reduce constructor visibility of driver-specific commands classes. Fix Javadoc.

---

Related ticket: [DATAREDIS-681](https://jira.spring.io/browse/DATAREDIS-681).