### PR TITLE
DATAREDIS-679 - Reconfigure Jedis cluster connection pools for discovered cluster nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-679-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -780,11 +780,10 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 			this.topologyProvider = topologyProvider;
 
 			if (cluster != null) {
-				PropertyAccessor accessor = new DirectFieldAccessFallbackBeanWrapper(cluster);
 
+				PropertyAccessor accessor = new DirectFieldAccessFallbackBeanWrapper(cluster);
 				this.connectionHandler = accessor.isReadableProperty("connectionHandler")
-						? (JedisClusterConnectionHandler) accessor.getPropertyValue("connectionHandler")
-						: null;
+						? (JedisClusterConnectionHandler) accessor.getPropertyValue("connectionHandler") : null;
 			} else {
 				this.connectionHandler = null;
 			}
@@ -811,7 +810,7 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 				return connection;
 			}
 
-			throw new IllegalArgumentException(String.format("Node %s is unknown to cluster", node));
+			throw new IllegalStateException(String.format("Node %s is unknown to cluster", node));
 		}
 
 		private JedisPool getResourcePoolForSpecificNode(RedisClusterNode node) {
@@ -827,7 +826,8 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 		private Jedis getConnectionForSpecificNode(RedisClusterNode node) {
 
 			RedisClusterNode member = topologyProvider.getTopology().lookup(node);
-			if (connectionHandler != null && member != null) {
+
+			if (member != null && connectionHandler != null) {
 				return connectionHandler.getConnectionFromNode(new HostAndPort(member.getHost(), member.getPort()));
 			}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -59,6 +59,7 @@ import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisSentinelConnection;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisClusterConnection.JedisClusterTopologyProvider;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
@@ -389,9 +390,9 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	private JedisCluster createCluster() {
 
 		JedisCluster cluster = createCluster(this.clusterConfig, getPoolConfig());
-		this.clusterCommandExecutor = new ClusterCommandExecutor(
-				new JedisClusterConnection.JedisClusterTopologyProvider(cluster),
-				new JedisClusterConnection.JedisClusterNodeResourceProvider(cluster), EXCEPTION_TRANSLATION);
+		JedisClusterTopologyProvider topologyProvider = new JedisClusterTopologyProvider(cluster);
+		this.clusterCommandExecutor = new ClusterCommandExecutor(topologyProvider,
+				new JedisClusterConnection.JedisClusterNodeResourceProvider(cluster, topologyProvider), EXCEPTION_TRANSLATION);
 		return cluster;
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
@@ -276,12 +276,10 @@ public class JedisClusterConnectionUnitTests {
 
 		nodes.remove(CLUSTER_HOST + ":" + MASTER_NODE_3_PORT);
 
-		try {
-			connection.serverCommands().dbSize(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_3_PORT));
-		} catch (IllegalArgumentException e) {
-			assertThat(e.getMessage(),
-					containsString("Node " + CLUSTER_HOST + ":" + MASTER_NODE_3_PORT + " is unknown to cluster"));
-		}
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage("Node " + CLUSTER_HOST + ":" + MASTER_NODE_3_PORT + " is unknown to cluster");
+
+		connection.serverCommands().dbSize(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_3_PORT));
 	}
 
 	@Test // DATAREDIS-679
@@ -292,6 +290,7 @@ public class JedisClusterConnectionUnitTests {
 		when(connectionHandlerMock.getConnectionFromNode(new HostAndPort(CLUSTER_HOST, MASTER_NODE_3_PORT)))
 				.thenReturn(con3Mock);
 		when(con3Mock.dbSize()).thenAnswer(new Answer<Long>() {
+
 			@Override
 			public Long answer(InvocationOnMock invocation) throws Throwable {
 


### PR DESCRIPTION
We now request a cluster node connection directly from the driver's connection handler and initiate reconfiguration if a cluster node is known through the topology but has no connection pool yet. This can happen if a cluster node is added to the cluster after the connection was initialized.

The connection handler cannot be obtained directly although the field where it's held is protected which increases the amount of necessary test code and reflection access to the connection handler.

Jedis discovers nodes during startup, on demand (full scan) or when requested (e.g. by a cluster redirection).

--

Related ticket: [DATAREDIS-679](https://jira.spring.io/browse/DATAREDIS-679).	