### PR TITLE
DATAREDIS-684 - Release Jedis cluster node connections with close().

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-684-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -861,7 +861,7 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 					errors.put(entry.getKey(), ex);
 				} finally {
 					if (jedis != null) {
-						entry.getValue().returnResource(jedis);
+						jedis.close();
 					}
 				}
 			}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -804,9 +804,8 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 		 */
 		@Override
 		public void returnResourceForSpecificNode(RedisClusterNode node, Object client) {
-			getResourcePoolForSpecificNode(node).returnResource((Jedis) client);
+			((Jedis) client).close();
 		}
-
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -343,29 +343,27 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public void close() throws DataAccessException {
+
 		super.close();
+
 		// return the connection to the pool
 		if (pool != null) {
-			if (!broken) {
+
+			if (broken) {
+				pool.returnBrokenResource(jedis);
+			} else {
+
 				// reset the connection
 				try {
 					if (dbIndex > 0) {
 						jedis.select(0);
 					}
-					pool.returnResource(jedis);
 					return;
 				} catch (Exception ex) {
-					DataAccessException dae = convertJedisAccessException(ex);
-					if (broken) {
-						pool.returnBrokenResource(jedis);
-					} else {
-						pool.returnResource(jedis);
-					}
-					throw dae;
+					throw convertJedisAccessException(ex);
+				} finally {
+					jedis.close();
 				}
-			} else {
-				pool.returnBrokenResource(jedis);
-				return;
 			}
 		}
 		// else close the connection normally (doing the try/catch dance)
@@ -373,13 +371,13 @@ public class JedisConnection extends AbstractRedisConnection {
 		if (isQueueing()) {
 			try {
 				client.quit();
-			} catch (Exception ex) {
-				exc = ex;
+			} catch (Exception o_O) {
+				// ignore exception
 			}
 			try {
 				client.disconnect();
-			} catch (Exception ex) {
-				exc = ex;
+			} catch (Exception o_O) {
+				// ignore exception
 			}
 			return;
 		}

--- a/src/test/java/org/springframework/data/redis/connection/ClusterSlotHashUtilsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterSlotHashUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,11 @@ package org.springframework.data.redis.connection;
 
 import static org.junit.Assert.*;
 
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPool;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Random;
@@ -26,13 +31,9 @@ import org.junit.Test;
 import org.springframework.data.redis.test.util.RedisClusterRule;
 import org.springframework.util.StringUtils;
 
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.JedisPool;
-
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class ClusterSlotHashUtilsTests {
 
@@ -58,7 +59,7 @@ public class ClusterSlotHashUtilsTests {
 						serverSlot.intValue(), slot);
 
 			}
-			pool.returnResource(jedis);
+			jedis.close();
 		} finally {
 			if (cluster != null) {
 				cluster.close();
@@ -100,7 +101,7 @@ public class ClusterSlotHashUtilsTests {
 						serverSlot1.intValue(), slot1);
 
 			}
-			pool.returnResource(jedis);
+			jedis.close();
 		} finally {
 			if (cluster != null) {
 				cluster.close();
@@ -110,7 +111,7 @@ public class ClusterSlotHashUtilsTests {
 
 	/**
 	 * Generate random string using ascii chars {@code ' ' (space)} to {@code 'z'}. Explicitly skipping { and }.
-	 * 
+	 *
 	 * @return
 	 */
 	private String randomString() {

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
@@ -145,6 +145,7 @@ public class JedisClusterConnectionUnitTests {
 
 		verify(con2Mock, times(1)).clusterReplicate(CLUSTER_NODE_1.getId());
 		verify(con1Mock, times(1)).clusterNodes();
+		verify(con1Mock, times(1)).close();
 		verifyZeroInteractions(con1Mock);
 	}
 
@@ -259,7 +260,9 @@ public class JedisClusterConnectionUnitTests {
 		connection.time(CLUSTER_NODE_2);
 
 		verify(con2Mock, times(1)).time();
+		verify(con2Mock, times(1)).close();
 		verify(con1Mock, times(1)).clusterNodes();
+		verify(con1Mock, times(1)).close();
 		verifyZeroInteractions(con1Mock, con3Mock);
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
@@ -279,6 +279,7 @@ public class JedisClusterConnectionUnitTests {
 		connection.resetConfigStats(CLUSTER_NODE_2);
 
 		verify(con2Mock, times(1)).configResetStat();
+		verify(con2Mock, times(1)).close();
 		verify(con1Mock, never()).configResetStat();
 		verify(con3Mock, never()).configResetStat();
 	}


### PR DESCRIPTION
We now release Jedis cluster node connections with `Jedis.close()` to the pool instead of `Pool.returnResource(…)`. The `close()` method itself checks whether the connection was broken and if so, the connection gets destroyed. Destroying broken connections prevents the pool from supplying broken connections on borrow when `testOnBorrow` is disabled.

---

We now release pooled Jedis connections with `Jedis.close()` instead `returnResource(…)`. Jedis handles pool releasing/broken connection releasing since 2.5.0 itself.

The only case where we return broken resources ourselves to the Pool is when we discover a broken connection ourselves: If we run into a `NullPointerException` or `RedisConnectionFailureException`, then we consider a connection is broken.

--- 

We should backport c46d461d7197a834e738be6553c468a1a93e8fa1 as bugfix to Ingalls.

Related ticket: [DATAREDIS-684](https://jira.spring.io/browse/DATAREDIS-684).