### PR TITLE
DATAREDIS-614 - Rename GeoOperations methods to better names.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-614-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
@@ -31,6 +31,7 @@ import org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusComma
  *
  * @author Ninad Divadkar
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.8
  */
 public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
@@ -41,9 +42,34 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added.
+	 * @since 2.0
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
-	Long geoAdd(Point point, M member);
+	Long add(Point point, M member);
+
+	/**
+	 * Add {@link Point} with given member {@literal name} to {@literal key}.
+	 * 
+	 * @param point must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @return Number of elements added.
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @deprecated since 2.0, use {@link #add(Point, Object)}.
+	 */
+	@Deprecated
+	default Long geoAdd(Point point, M member) {
+		return add(point, member);
+	}
+
+	/**
+	 * Add {@link GeoLocation} to {@literal key}.
+	 * 
+	 * @param location must not be {@literal null}.
+	 * @return Number of elements added.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 */
+	Long add(GeoLocation<M> location);
 
 	/**
 	 * Add {@link GeoLocation} to {@literal key}.
@@ -51,8 +77,22 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @deprecated since 2.0, use {@link #add(GeoLocation)}.
 	 */
-	Long geoAdd(GeoLocation<M> location);
+	@Deprecated
+	default Long geoAdd(GeoLocation<M> location) {
+		return add(location);
+	}
+
+	/**
+	 * Add {@link Map} of member / {@link Point} pairs to {@literal key}.
+	 * 
+	 * @param memberCoordinateMap must not be {@literal null}.
+	 * @return Number of elements added.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 */
+	Long add(Map<M, Point> memberCoordinateMap);
 
 	/**
 	 * Add {@link Map} of member / {@link Point} pairs to {@literal key}.
@@ -60,8 +100,22 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @deprecated since 2.0, use {@link #add(Map)}.
 	 */
-	Long geoAdd(Map<M, Point> memberCoordinateMap);
+	@Deprecated
+	default Long geoAdd(Map<M, Point> memberCoordinateMap) {
+		return add(memberCoordinateMap);
+	}
+
+	/**
+	 * Add {@link GeoLocation}s to {@literal key}
+	 * 
+	 * @param locations must not be {@literal null}.
+	 * @return Number of elements added.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 */
+	Long add(Iterable<GeoLocation<M>> locations);
 
 	/**
 	 * Add {@link GeoLocation}s to {@literal key}
@@ -69,8 +123,23 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @deprecated since 2.0, use {@link #add(Iterable)}.
 	 */
-	Long geoAdd(Iterable<GeoLocation<M>> locations);
+	@Deprecated
+	default Long geoAdd(Iterable<GeoLocation<M>> locations) {
+		return add(locations);
+	}
+
+	/**
+	 * Get the {@link Distance} between {@literal member1} and {@literal member2}.
+	 * 
+	 * @param member1 must not be {@literal null}.
+	 * @param member2 must not be {@literal null}.
+	 * @return can be {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 */
+	Distance distance(M member1, M member2);
 
 	/**
 	 * Get the {@link Distance} between {@literal member1} and {@literal member2}.
@@ -79,8 +148,24 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @deprecated since 2.0, use {@link #distance(Object, Object)}.
 	 */
-	Distance geoDist(M member1, M member2);
+	@Deprecated
+	default Distance geoDist(M member1, M member2) {
+		return distance(member1, member2);
+	}
+
+	/**
+	 * Get the {@link Distance} between {@literal member1} and {@literal member2} in the given {@link Metric}.
+	 * 
+	 * @param member1 must not be {@literal null}.
+	 * @param member2 must not be {@literal null}.
+	 * @param metric must not be {@literal null}.
+	 * @return can be {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 */
+	Distance distance(M member1, M member2, Metric metric);
 
 	/**
 	 * Get the {@link Distance} between {@literal member1} and {@literal member2} in the given {@link Metric}.
@@ -90,8 +175,22 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @deprecated since 2.0, use {@link #distance(Object, Object, Metric)}.
 	 */
-	Distance geoDist(M member1, M member2, Metric metric);
+	@Deprecated
+	default Distance geoDist(M member1, M member2, Metric metric) {
+		return distance(member1, member2, metric);
+	}
+
+	/**
+	 * Get Geohash representation of the position for one or more {@literal member}s.
+	 * 
+	 * @param members must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 */
+	List<String> hash(M... members);
 
 	/**
 	 * Get Geohash representation of the position for one or more {@literal member}s.
@@ -99,8 +198,22 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @deprecated since 2.0, use {@link #hash(Object[])}.
 	 */
-	List<String> geoHash(M... members);
+	@Deprecated
+	default List<String> geoHash(M... members) {
+		return hash(members);
+	}
+
+	/**
+	 * Get the {@link Point} representation of positions for one or more {@literal member}s.
+	 * 
+	 * @param members must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 */
+	List<Point> position(M... members);
 
 	/**
 	 * Get the {@link Point} representation of positions for one or more {@literal member}s.
@@ -108,8 +221,22 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @deprecated since 2.0, use {@link #position(Object[])}.
 	 */
-	List<Point> geoPos(M... members);
+	@Deprecated
+	default List<Point> geoPos(M... members) {
+		return position(members);
+	}
+
+	/**
+	 * Get the {@literal member}s within the boundaries of a given {@link Circle}.
+	 * 
+	 * @param within must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(Circle within);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle}.
@@ -117,8 +244,23 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @deprecated since 2.0, use {@link #radius(Circle)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadius(Circle within);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadius(Circle within) {
+		return radius(within);
+	}
+
+	/**
+	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying {@link GeoRadiusCommandArgs}.
+	 * 
+	 * @param within must not be {@literal null}.
+	 * @param args must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(Circle within, GeoRadiusCommandArgs args);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying {@link GeoRadiusCommandArgs}.
@@ -127,8 +269,24 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @deprecated since 2.0, use {@link #radius(Circle, GeoRadiusCommandArgs)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadius(Circle within, GeoRadiusCommandArgs args);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadius(Circle within, GeoRadiusCommandArgs args) {
+		return radius(within, args);
+	}
+
+	/**
+	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
+	 * {@literal radius}.
+	 * 
+	 * @param member must not be {@literal null}.
+	 * @param radius
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(K key, M member, double radius);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -138,8 +296,24 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param radius
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @deprecated since 2.0, use {@link #radius(Object, Object, double)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius) {
+		return radius(key, member, radius);
+	}
+
+	/**
+	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
+	 * {@literal radius} applying {@link Metric}.
+	 * 
+	 * @param member must not be {@literal null}.
+	 * @param distance must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(M member, Distance distance);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -149,8 +323,25 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param distance must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @deprecated since 2.0, use {@link #radius(Object, Distance)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance) {
+		return radius(member, distance);
+	}
+
+	/**
+	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
+	 * {@literal radius} applying {@link Metric} and {@link GeoRadiusCommandArgs}.
+	 * 
+	 * @param member must not be {@literal null}.
+	 * @param distance must not be {@literal null}.
+	 * @param args must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(M member, Distance distance, GeoRadiusCommandArgs args);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -161,14 +352,31 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @deprecated since 2.0, use {@link #radius(Object, Distance, GeoRadiusCommandArgs)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance, GeoRadiusCommandArgs args);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance, GeoRadiusCommandArgs args) {
+		return radius(member, distance, args);
+	}
 
 	/**
 	 * Remove the {@literal member}s.
 	 * 
 	 * @param members must not be {@literal null}.
 	 * @return Number of elements removed.
+	 * @since 2.0
 	 */
-	Long geoRemove(M... members);
+	Long remove(M... members);
+
+	/**
+	 * Remove the {@literal member}s.
+	 * 
+	 * @param members must not be {@literal null}.
+	 * @return Number of elements removed.
+	 * @deprecated since 2.0, use {@link #remove(Object[])}.
+	 */
+	@Deprecated
+	default Long geoRemove(M... members) {
+		return remove(members);
+	}
 }

--- a/src/main/java/org/springframework/data/redis/core/DefaultBoundGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultBoundGeoOperations.java
@@ -32,6 +32,7 @@ import org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusComma
  *
  * @author Ninad Divadkar
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.8
  */
 class DefaultBoundGeoOperations<K, M> extends DefaultBoundKeyOperations<K> implements BoundGeoOperations<K, M> {
@@ -52,128 +53,128 @@ class DefaultBoundGeoOperations<K, M> extends DefaultBoundKeyOperations<K> imple
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoAdd(org.springframework.data.geo.Point, java.lang.Object)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#add(org.springframework.data.geo.Point, java.lang.Object)
 	 */
 	@Override
-	public Long geoAdd(Point point, M member) {
-		return ops.geoAdd(getKey(), point, member);
+	public Long add(Point point, M member) {
+		return ops.add(getKey(), point, member);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoAdd(org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#add(org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation)
 	 */
 	@Override
-	public Long geoAdd(GeoLocation<M> location) {
-		return ops.geoAdd(getKey(), location);
+	public Long add(GeoLocation<M> location) {
+		return ops.add(getKey(), location);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoAdd(java.util.Map)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#add(java.util.Map)
 	 */
 	@Override
-	public Long geoAdd(Map<M, Point> memberCoordinateMap) {
-		return ops.geoAdd(getKey(), memberCoordinateMap);
+	public Long add(Map<M, Point> memberCoordinateMap) {
+		return ops.add(getKey(), memberCoordinateMap);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoAdd(java.lang.Iterable)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#add(java.lang.Iterable)
 	 */
 	@Override
-	public Long geoAdd(Iterable<GeoLocation<M>> locations) {
-		return ops.geoAdd(getKey(), locations);
+	public Long add(Iterable<GeoLocation<M>> locations) {
+		return ops.add(getKey(), locations);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoDist(java.lang.Object, java.lang.Object)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#distance(java.lang.Object, java.lang.Object)
 	 */
 	@Override
-	public Distance geoDist(M member1, M member2) {
-		return ops.geoDist(getKey(), member1, member2);
+	public Distance distance(M member1, M member2) {
+		return ops.distance(getKey(), member1, member2);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoDist(java.lang.Object, java.lang.Object, org.springframework.data.geo.Metric)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#distance(java.lang.Object, java.lang.Object, org.springframework.data.geo.Metric)
 	 */
 	@Override
-	public Distance geoDist(M member1, M member2, Metric unit) {
-		return ops.geoDist(getKey(), member1, member2, unit);
+	public Distance distance(M member1, M member2, Metric unit) {
+		return ops.distance(getKey(), member1, member2, unit);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoHash(java.lang.Object[])
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#hash(java.lang.Object[])
 	 */
 	@Override
-	public List<String> geoHash(M... members) {
-		return ops.geoHash(getKey(), members);
+	public List<String> hash(M... members) {
+		return ops.hash(getKey(), members);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoPos(java.lang.Object[])
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#position(java.lang.Object[])
 	 */
 	@Override
-	public List<Point> geoPos(M... members) {
-		return ops.geoPos(getKey(), members);
+	public List<Point> position(M... members) {
+		return ops.position(getKey(), members);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadius(org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#radius(org.springframework.data.geo.Circle)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadius(Circle within) {
-		return ops.geoRadius(getKey(), within);
+	public GeoResults<GeoLocation<M>> radius(Circle within) {
+		return ops.radius(getKey(), within);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadius(org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#radius(org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadius(Circle within, GeoRadiusCommandArgs param) {
-		return ops.geoRadius(getKey(), within, param);
+	public GeoResults<GeoLocation<M>> radius(Circle within, GeoRadiusCommandArgs param) {
+		return ops.radius(getKey(), within, param);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, double)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#radius(java.lang.Object, java.lang.Object, double)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius) {
-		return ops.geoRadiusByMember(getKey(), member, radius);
+	public GeoResults<GeoLocation<M>> radius(K key, M member, double radius) {
+		return ops.radius(getKey(), member, radius);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadiusByMember(java.lang.Object, org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#radius(java.lang.Object, org.springframework.data.geo.Distance)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance) {
-		return ops.geoRadiusByMember(getKey(), member, distance);
+	public GeoResults<GeoLocation<M>> radius(M member, Distance distance) {
+		return ops.radius(getKey(), member, distance);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRadiusByMember(java.lang.Object, org.springframework.data.geo.Distance, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#radius(java.lang.Object, org.springframework.data.geo.Distance, org.springframework.data.redis.core.radiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadiusByMember(M member, Distance distance, GeoRadiusCommandArgs param) {
-		return ops.geoRadiusByMember(getKey(), member, distance, param);
+	public GeoResults<GeoLocation<M>> radius(M member, Distance distance, GeoRadiusCommandArgs param) {
+		return ops.radius(getKey(), member, distance, param);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundGeoOperations#geoRemove(java.lang.Object[])
+	 * @see org.springframework.data.redis.core.BoundGeoOperations#remove(java.lang.Object[])
 	 */
 	@Override
-	public Long geoRemove(M... members) {
-		return ops.geoRemove(getKey(), members);
+	public Long remove(M... members) {
+		return ops.remove(getKey(), members);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultGeoOperations.java
@@ -33,6 +33,7 @@ import org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusComma
  *
  * @author Ninad Divadkar
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.8
  */
 class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements GeoOperations<K, M> {
@@ -48,10 +49,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoAdd(java.lang.Object, org.springframework.data.geo.Point, java.lang.Object)
+	 * @see org.springframework.data.redis.core.GeoOperations#add(java.lang.Object, org.springframework.data.geo.Point, java.lang.Object)
 	 */
 	@Override
-	public Long geoAdd(K key, Point point, M member) {
+	public Long add(K key, Point point, M member) {
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawMember = rawValue(member);
@@ -61,19 +62,19 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoAdd(java.lang.Object, org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation)
+	 * @see org.springframework.data.redis.core.GeoOperations#add(java.lang.Object, org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation)
 	 */
 	@Override
-	public Long geoAdd(K key, GeoLocation<M> location) {
-		return geoAdd(key, location.getPoint(), location.getName());
+	public Long add(K key, GeoLocation<M> location) {
+		return add(key, location.getPoint(), location.getName());
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoAdd(java.lang.Object, java.util.Map)
+	 * @see org.springframework.data.redis.core.GeoOperations#add(java.lang.Object, java.util.Map)
 	 */
 	@Override
-	public Long geoAdd(K key, Map<M, Point> memberCoordinateMap) {
+	public Long add(K key, Map<M, Point> memberCoordinateMap) {
 
 		byte[] rawKey = rawKey(key);
 		Map<byte[], Point> rawMemberCoordinateMap = new HashMap<>();
@@ -88,25 +89,25 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoAdd(java.lang.Object, java.lang.Iterable)
+	 * @see org.springframework.data.redis.core.GeoOperations#add(java.lang.Object, java.lang.Iterable)
 	 */
 	@Override
-	public Long geoAdd(K key, Iterable<GeoLocation<M>> locations) {
+	public Long add(K key, Iterable<GeoLocation<M>> locations) {
 
 		Map<M, Point> memberCoordinateMap = new LinkedHashMap<>();
 		for (GeoLocation<M> location : locations) {
 			memberCoordinateMap.put(location.getName(), location.getPoint());
 		}
 
-		return geoAdd(key, memberCoordinateMap);
+		return add(key, memberCoordinateMap);
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoDist(java.lang.Object, java.lang.Object, java.lang.Object)
+	 * @see org.springframework.data.redis.core.GeoOperations#distance(java.lang.Object, java.lang.Object, java.lang.Object)
 	 */
 	@Override
-	public Distance geoDist(K key, M member1, M member2) {
+	public Distance distance(K key, M member1, M member2) {
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawMember1 = rawValue(member1);
@@ -117,10 +118,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoDist(java.lang.Object, java.lang.Object, java.lang.Object, org.springframework.data.geo.Metric)
+	 * @see org.springframework.data.redis.core.GeoOperations#distance(java.lang.Object, java.lang.Object, java.lang.Object, org.springframework.data.geo.Metric)
 	 */
 	@Override
-	public Distance geoDist(K key, M member1, M member2, Metric metric) {
+	public Distance distance(K key, M member1, M member2, Metric metric) {
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawMember1 = rawValue(member1);
@@ -131,10 +132,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoHash(java.lang.Object, java.lang.Object[])
+	 * @see org.springframework.data.redis.core.GeoOperations#hash(java.lang.Object, java.lang.Object[])
 	 */
 	@Override
-	public List<String> geoHash(K key, M... members) {
+	public List<String> hash(K key, M... members) {
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawMembers = rawValues(members);
@@ -144,10 +145,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoPos(java.lang.Object, java.lang.Object[])
+	 * @see org.springframework.data.redis.core.GeoOperations#position(java.lang.Object, java.lang.Object[])
 	 */
 	@Override
-	public List<Point> geoPos(K key, M... members) {
+	public List<Point> position(K key, M... members) {
 		byte[] rawKey = rawKey(key);
 		byte[][] rawMembers = rawValues(members);
 
@@ -156,10 +157,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoRadius(java.lang.Object, org.springframework.data.geo.Circle)
+	 * @see org.springframework.data.redis.core.GeoOperations#radius(java.lang.Object, org.springframework.data.geo.Circle)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadius(K key, Circle within) {
+	public GeoResults<GeoLocation<M>> radius(K key, Circle within) {
 
 		byte[] rawKey = rawKey(key);
 
@@ -170,10 +171,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoRadius(java.lang.Object, org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.core.GeoOperations#radius(java.lang.Object, org.springframework.data.geo.Circle, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadius(K key, Circle within, GeoRadiusCommandArgs args) {
+	public GeoResults<GeoLocation<M>> radius(K key, Circle within, GeoRadiusCommandArgs args) {
 
 		byte[] rawKey = rawKey(key);
 
@@ -184,10 +185,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, double)
+	 * @see org.springframework.data.redis.core.GeoOperations#radius(java.lang.Object, java.lang.Object, double)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius) {
+	public GeoResults<GeoLocation<M>> radius(K key, M member, double radius) {
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawMember = rawValue(member);
@@ -199,10 +200,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, org.springframework.data.geo.Distance)
+	 * @see org.springframework.data.redis.core.GeoOperations#radius(java.lang.Object, java.lang.Object, org.springframework.data.geo.Distance)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance) {
+	public GeoResults<GeoLocation<M>> radius(K key, M member, Distance distance) {
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawMember = rawValue(member);
@@ -215,10 +216,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, double, org.springframework.data.geo.Metric, org.springframework.data.redis.core.GeoRadiusCommandArgs)
+	 * @see org.springframework.data.redis.core.GeoOperations#radius(java.lang.Object, java.lang.Object, double, org.springframework.data.geo.Metric, org.springframework.data.redis.core.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance, GeoRadiusCommandArgs param) {
+	public GeoResults<GeoLocation<M>> radius(K key, M member, Distance distance, GeoRadiusCommandArgs param) {
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawMember = rawValue(member);
@@ -231,10 +232,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.GeoOperations#geoRemove(java.lang.Object, java.lang.Object[])
+	 * @see org.springframework.data.redis.core.GeoOperations#remove(java.lang.Object, java.lang.Object[])
 	 */
 	@Override
-	public Long geoRemove(K key, M... members) {
+	public Long remove(K key, M... members) {
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawMembers = rawValues(members);

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveGeoOperations.java
@@ -65,11 +65,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 		this.serializationContext = serializationContext;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoAdd(java.lang.Object, org.springframework.data.geo.Point, java.lang.Object)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#add(java.lang.Object, org.springframework.data.geo.Point, java.lang.Object)
 	 */
 	@Override
-	public Mono<Long> geoAdd(K key, Point point, V member) {
+	public Mono<Long> add(K key, Point point, V member) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(point, "Point must not be null!");
@@ -78,11 +79,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 		return createMono(connection -> connection.geoAdd(rawKey(key), point, rawValue(member)));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoAdd(java.lang.Object, org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#add(java.lang.Object, org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation)
 	 */
 	@Override
-	public Mono<Long> geoAdd(K key, GeoLocation<V> location) {
+	public Mono<Long> add(K key, GeoLocation<V> location) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(location, "GeoLocation must not be null!");
@@ -91,11 +93,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 				new GeoLocation<>(rawValue(location.getName()), location.getPoint())));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoAdd(java.lang.Object, java.util.Map)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#add(java.lang.Object, java.util.Map)
 	 */
 	@Override
-	public Mono<Long> geoAdd(K key, Map<V, Point> memberCoordinateMap) {
+	public Mono<Long> add(K key, Map<V, Point> memberCoordinateMap) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(memberCoordinateMap, "MemberCoordinateMap must not be null!");
@@ -110,11 +113,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 		});
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoAdd(java.lang.Object, java.lang.Iterable)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#add(java.lang.Object, java.lang.Iterable)
 	 */
 	@Override
-	public Mono<Long> geoAdd(K key, Iterable<GeoLocation<V>> geoLocations) {
+	public Mono<Long> add(K key, Iterable<GeoLocation<V>> geoLocations) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(geoLocations, "GeoLocations must not be null!");
@@ -128,11 +132,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 		});
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoAdd(java.lang.Object, org.reactivestreams.Publisher)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#add(java.lang.Object, org.reactivestreams.Publisher)
 	 */
 	@Override
-	public Flux<Long> geoAdd(K key, Publisher<? extends Collection<GeoLocation<V>>> locations) {
+	public Flux<Long> add(K key, Publisher<? extends Collection<GeoLocation<V>>> locations) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(locations, "Locations must not be null!");
@@ -144,11 +149,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 				.flatMap(list -> connection.geoAdd(rawKey(key), list)));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoDist(java.lang.Object, java.lang.Object, java.lang.Object)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#distance(java.lang.Object, java.lang.Object, java.lang.Object)
 	 */
 	@Override
-	public Mono<Distance> geoDist(K key, V member1, V member2) {
+	public Mono<Distance> distance(K key, V member1, V member2) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(member1, "Member 1 must not be null!");
@@ -157,11 +163,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 		return createMono(connection -> connection.geoDist(rawKey(key), rawValue(member1), rawValue(member2)));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoDist(java.lang.Object, java.lang.Object, java.lang.Object, org.springframework.data.geo.Metric)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#distance(java.lang.Object, java.lang.Object, java.lang.Object, org.springframework.data.geo.Metric)
 	 */
 	@Override
-	public Mono<Distance> geoDist(K key, V member1, V member2, Metric metric) {
+	public Mono<Distance> distance(K key, V member1, V member2, Metric metric) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(member1, "Member 1 must not be null!");
@@ -171,11 +178,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 		return createMono(connection -> connection.geoDist(rawKey(key), rawValue(member1), rawValue(member2), metric));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoHash(java.lang.Object, java.lang.Object)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#hash(java.lang.Object, java.lang.Object)
 	 */
 	@Override
-	public Mono<String> geoHash(K key, V member) {
+	public Mono<String> hash(K key, V member) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(member, "Member must not be null!");
@@ -183,12 +191,13 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 		return createMono(connection -> connection.geoHash(rawKey(key), rawValue(member)));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoHash(java.lang.Object, java.lang.Object[])
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#hash(java.lang.Object, java.lang.Object[])
 	 */
 	@Override
 	@SafeVarargs
-	public final Mono<List<String>> geoHash(K key, V... members) {
+	public final Mono<List<String>> hash(K key, V... members) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notEmpty(members, "Members must not be null or empty!");
@@ -200,11 +209,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 				.flatMap(serialized -> connection.geoHash(rawKey(key), serialized)));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoPos(java.lang.Object, java.lang.Object)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#position(java.lang.Object, java.lang.Object)
 	 */
 	@Override
-	public Mono<Point> geoPos(K key, V member) {
+	public Mono<Point> position(K key, V member) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(member, "Member must not be null!");
@@ -212,12 +222,13 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 		return createMono(connection -> connection.geoPos(rawKey(key), rawValue(member)));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoPos(java.lang.Object, java.lang.Object[])
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#position(java.lang.Object, java.lang.Object[])
 	 */
 	@Override
 	@SafeVarargs
-	public final Mono<List<Point>> geoPos(K key, V... members) {
+	public final Mono<List<Point>> position(K key, V... members) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notEmpty(members, "Members must not be null or empty!");
@@ -229,11 +240,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 				.flatMap(serialized -> connection.geoPos(rawKey(key), serialized)));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoRadius(java.lang.Object, org.springframework.data.geo.Circle)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#radius(java.lang.Object, org.springframework.data.geo.Circle)
 	 */
 	@Override
-	public Flux<GeoResult<GeoLocation<V>>> geoRadius(K key, Circle within) {
+	public Flux<GeoResult<GeoLocation<V>>> radius(K key, Circle within) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(within, "Circle must not be null!");
@@ -241,11 +253,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 		return createFlux(connection -> connection.geoRadius(rawKey(key), within).map(this::readGeoResult));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoRadius(java.lang.Object, org.springframework.data.geo.Circle, org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#radius(java.lang.Object, org.springframework.data.geo.Circle, org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public Flux<GeoResult<GeoLocation<V>>> geoRadius(K key, Circle within, GeoRadiusCommandArgs args) {
+	public Flux<GeoResult<GeoLocation<V>>> radius(K key, Circle within, GeoRadiusCommandArgs args) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(within, "Circle must not be null!");
@@ -255,11 +268,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 				.map(this::readGeoResult));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, double)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#radius(java.lang.Object, java.lang.Object, double)
 	 */
 	@Override
-	public Flux<GeoResult<GeoLocation<V>>> geoRadiusByMember(K key, V member, double radius) {
+	public Flux<GeoResult<GeoLocation<V>>> radius(K key, V member, double radius) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(member, "Member must not be null!");
@@ -268,11 +282,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 				.map(this::readGeoResult));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, org.springframework.data.geo.Distance)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#radius(java.lang.Object, java.lang.Object, org.springframework.data.geo.Distance)
 	 */
 	@Override
-	public Flux<GeoResult<GeoLocation<V>>> geoRadiusByMember(K key, V member, Distance distance) {
+	public Flux<GeoResult<GeoLocation<V>>> radius(K key, V member, Distance distance) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(member, "Member must not be null!");
@@ -282,12 +297,12 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 				.map(this::readGeoResult));
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoRadiusByMember(java.lang.Object, java.lang.Object, org.springframework.data.geo.Distance, org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs)
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#radius(java.lang.Object, java.lang.Object, org.springframework.data.geo.Distance, org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs)
 	 */
 	@Override
-	public Flux<GeoResult<GeoLocation<V>>> geoRadiusByMember(K key, V member, Distance distance,
-			GeoRadiusCommandArgs args) {
+	public Flux<GeoResult<GeoLocation<V>>> radius(K key, V member, Distance distance, GeoRadiusCommandArgs args) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(member, "Member must not be null!");
@@ -298,12 +313,13 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 				.map(this::readGeoResult);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#geoRemove(java.lang.Object, java.lang.Object[])
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#remove(java.lang.Object, java.lang.Object[])
 	 */
 	@Override
 	@SafeVarargs
-	public final Mono<Long> geoRemove(K key, V... members) {
+	public final Mono<Long> remove(K key, V... members) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notEmpty(members, "Members must not be null or empty!");
@@ -315,7 +331,8 @@ class DefaultReactiveGeoOperations<K, V> implements ReactiveGeoOperations<K, V> 
 				.flatMap(serialized -> connection.zSetCommands().zRem(rawKey(key), serialized)));
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveGeoOperations#delete(java.lang.Object)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/GeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/GeoOperations.java
@@ -44,9 +44,36 @@ public interface GeoOperations<K, M> {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added.
+	 * @since 2.0
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
-	Long geoAdd(K key, Point point, M member);
+	Long add(K key, Point point, M member);
+
+	/**
+	 * Add {@link Point} with given member {@literal name} to {@literal key}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param point must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @return Number of elements added.
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @deprecated since 2.0, use {@link #add(Object, Point, Object)}.
+	 */
+	@Deprecated
+	default Long geoAdd(K key, Point point, M member) {
+		return add(key, point, member);
+	}
+
+	/**
+	 * Add {@link GeoLocation} to {@literal key}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param location must not be {@literal null}.
+	 * @return Number of elements added.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 */
+	Long add(K key, GeoLocation<M> location);
 
 	/**
 	 * Add {@link GeoLocation} to {@literal key}.
@@ -55,8 +82,23 @@ public interface GeoOperations<K, M> {
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @deprecated since 2.0, use {@link #add(Object, GeoLocation)}.
 	 */
-	Long geoAdd(K key, GeoLocation<M> location);
+	@Deprecated
+	default Long geoAdd(K key, GeoLocation<M> location) {
+		return add(key, location);
+	}
+
+	/**
+	 * Add {@link Map} of member / {@link Point} pairs to {@literal key}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param memberCoordinateMap must not be {@literal null}.
+	 * @return Number of elements added.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 */
+	Long add(K key, Map<M, Point> memberCoordinateMap);
 
 	/**
 	 * Add {@link Map} of member / {@link Point} pairs to {@literal key}.
@@ -65,8 +107,23 @@ public interface GeoOperations<K, M> {
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @deprecated since 2.0, use {@link #add(Object, Map)}.
 	 */
-	Long geoAdd(K key, Map<M, Point> memberCoordinateMap);
+	@Deprecated
+	default Long geoAdd(K key, Map<M, Point> memberCoordinateMap) {
+		return add(key, memberCoordinateMap);
+	}
+
+	/**
+	 * Add {@link GeoLocation}s to {@literal key}
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param locations must not be {@literal null}.
+	 * @return Number of elements added.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 */
+	Long add(K key, Iterable<GeoLocation<M>> locations);
 
 	/**
 	 * Add {@link GeoLocation}s to {@literal key}
@@ -75,8 +132,24 @@ public interface GeoOperations<K, M> {
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @deprecated since 2.0, use {@link #add(Object, Iterable)}.
 	 */
-	Long geoAdd(K key, Iterable<GeoLocation<M>> locations);
+	@Deprecated
+	default Long geoAdd(K key, Iterable<GeoLocation<M>> locations) {
+		return add(key, locations);
+	}
+
+	/**
+	 * Get the {@link Distance} between {@literal member1} and {@literal member2}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param member1 must not be {@literal null}.
+	 * @param member2 must not be {@literal null}.
+	 * @return can be {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 */
+	Distance distance(K key, M member1, M member2);
 
 	/**
 	 * Get the {@link Distance} between {@literal member1} and {@literal member2}.
@@ -86,8 +159,25 @@ public interface GeoOperations<K, M> {
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @deprecated since 2.0, use {@link #distance(Object, Object, Object)}.
 	 */
-	Distance geoDist(K key, M member1, M member2);
+	@Deprecated
+	default Distance geoDist(K key, M member1, M member2) {
+		return distance(key, member1, member2);
+	}
+
+	/**
+	 * Get the {@link Distance} between {@literal member1} and {@literal member2} in the given {@link Metric}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param member1 must not be {@literal null}.
+	 * @param member2 must not be {@literal null}.
+	 * @param metric must not be {@literal null}.
+	 * @return can be {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 */
+	Distance distance(K key, M member1, M member2, Metric metric);
 
 	/**
 	 * Get the {@link Distance} between {@literal member1} and {@literal member2} in the given {@link Metric}.
@@ -98,8 +188,23 @@ public interface GeoOperations<K, M> {
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @deprecated since 2.0, use {@link #distance(Object, Object, Object, Metric)}.
 	 */
-	Distance geoDist(K key, M member1, M member2, Metric metric);
+	@Deprecated
+	default Distance geoDist(K key, M member1, M member2, Metric metric) {
+		return distance(key, member1, member2, metric);
+	}
+
+	/**
+	 * Get Geohash representation of the position for one or more {@literal member}s.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param members must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 */
+	List<String> hash(K key, M... members);
 
 	/**
 	 * Get Geohash representation of the position for one or more {@literal member}s.
@@ -108,8 +213,23 @@ public interface GeoOperations<K, M> {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @deprecated since 2.0, use {@link #hash(Object, Object[])}.
 	 */
-	List<String> geoHash(K key, M... members);
+	@Deprecated
+	default List<String> geoHash(K key, M... members) {
+		return hash(key, members);
+	}
+
+	/**
+	 * Get the {@link Point} representation of positions for one or more {@literal member}s.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param members must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 */
+	List<Point> position(K key, M... members);
 
 	/**
 	 * Get the {@link Point} representation of positions for one or more {@literal member}s.
@@ -118,8 +238,23 @@ public interface GeoOperations<K, M> {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @deprecated since 2.0, use {@link #position(Object, Object[])}.
 	 */
-	List<Point> geoPos(K key, M... members);
+	@Deprecated
+	default List<Point> geoPos(K key, M... members) {
+		return position(key, members);
+	}
+
+	/**
+	 * Get the {@literal member}s within the boundaries of a given {@link Circle}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param within must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(K key, Circle within);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle}.
@@ -128,8 +263,24 @@ public interface GeoOperations<K, M> {
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @deprecated since 2.0, use {@link #radius(Object, Circle)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadius(K key, Circle within);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadius(K key, Circle within) {
+		return radius(key, within);
+	}
+
+	/**
+	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying {@link GeoRadiusCommandArgs}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param within must not be {@literal null}.
+	 * @param args must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(K key, Circle within, GeoRadiusCommandArgs args);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying {@link GeoRadiusCommandArgs}.
@@ -139,8 +290,25 @@ public interface GeoOperations<K, M> {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @deprecated since 2.0, use {@link #radius(Object, Circle, GeoRadiusCommandArgs)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadius(K key, Circle within, GeoRadiusCommandArgs args);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadius(K key, Circle within, GeoRadiusCommandArgs args) {
+		return radius(key, within, args);
+	}
+
+	/**
+	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
+	 * {@literal radius}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @param radius
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(K key, M member, double radius);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -151,8 +319,25 @@ public interface GeoOperations<K, M> {
 	 * @param radius
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @deprecated since 2.0, use {@link #radius(Object, Object, double)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, double radius) {
+		return radius(key, member, radius);
+	}
+
+	/**
+	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
+	 * {@literal radius} applying {@link Metric}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @param distance must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(K key, M member, Distance distance);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -163,8 +348,26 @@ public interface GeoOperations<K, M> {
 	 * @param distance must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @deprecated since 2.0, use {@link #radius(Object, Object, Distance)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance) {
+		return radius(key, member, distance);
+	}
+
+	/**
+	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
+	 * {@literal radius} applying {@link Metric} and {@link GeoRadiusCommandArgs}.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param member must not be {@literal null}.
+	 * @param distance must not be {@literal null}.
+	 * @param args must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.0
+	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 */
+	GeoResults<GeoLocation<M>> radius(K key, M member, Distance distance, GeoRadiusCommandArgs args);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -176,8 +379,12 @@ public interface GeoOperations<K, M> {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @deprecated since 2.0, use {@link #radius(Object, Object, Distance, GeoRadiusCommandArgs)}.
 	 */
-	GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance, GeoRadiusCommandArgs args);
+	@Deprecated
+	default GeoResults<GeoLocation<M>> geoRadiusByMember(K key, M member, Distance distance, GeoRadiusCommandArgs args) {
+		return radius(key, member, distance, args);
+	}
 
 	/**
 	 * Remove the {@literal member}s.
@@ -185,6 +392,20 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return Number of elements removed.
+	 * @since 2.0
 	 */
-	Long geoRemove(K key, M... members);
+	Long remove(K key, M... members);
+
+	/**
+	 * Remove the {@literal member}s.
+	 * 
+	 * @param key must not be {@literal null}.
+	 * @param members must not be {@literal null}.
+	 * @return Number of elements removed.
+	 * @deprecated since 2.0, use {@link #remove(Object, Object[])}.
+	 */
+	@Deprecated
+	default Long geoRemove(K key, M... members) {
+		return remove(key, members);
+	}
 }

--- a/src/main/java/org/springframework/data/redis/core/ReactiveGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveGeoOperations.java
@@ -50,7 +50,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
-	Mono<Long> geoAdd(K key, Point point, M member);
+	Mono<Long> add(K key, Point point, M member);
 
 	/**
 	 * Add {@link GeoLocation} to {@literal key}.
@@ -60,7 +60,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
-	Mono<Long> geoAdd(K key, GeoLocation<M> location);
+	Mono<Long> add(K key, GeoLocation<M> location);
 
 	/**
 	 * Add {@link Map} of member / {@link Point} pairs to {@literal key}.
@@ -70,7 +70,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
-	Mono<Long> geoAdd(K key, Map<M, Point> memberCoordinateMap);
+	Mono<Long> add(K key, Map<M, Point> memberCoordinateMap);
 
 	/**
 	 * Add {@link GeoLocation}s to {@literal key}
@@ -80,7 +80,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
-	Mono<Long> geoAdd(K key, Iterable<GeoLocation<M>> locations);
+	Mono<Long> add(K key, Iterable<GeoLocation<M>> locations);
 
 	/**
 	 * Add {@link GeoLocation}s to {@literal key}
@@ -90,7 +90,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return Number of elements added.
 	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
-	Flux<Long> geoAdd(K key, Publisher<? extends Collection<GeoLocation<M>>> locations);
+	Flux<Long> add(K key, Publisher<? extends Collection<GeoLocation<M>>> locations);
 
 	/**
 	 * Get the {@link Distance} between {@literal member1} and {@literal member2}.
@@ -101,7 +101,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return can be {@literal null}.
 	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
-	Mono<Distance> geoDist(K key, M member1, M member2);
+	Mono<Distance> distance(K key, M member1, M member2);
 
 	/**
 	 * Get the {@link Distance} between {@literal member1} and {@literal member2} in the given {@link Metric}.
@@ -113,7 +113,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return can be {@literal null}.
 	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
-	Mono<Distance> geoDist(K key, M member1, M member2, Metric metric);
+	Mono<Distance> distance(K key, M member1, M member2, Metric metric);
 
 	/**
 	 * Get Geohash representation of the position for one or more {@literal member}s.
@@ -123,7 +123,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
-	Mono<String> geoHash(K key, M member);
+	Mono<String> hash(K key, M member);
 
 	/**
 	 * Get Geohash representation of the position for one or more {@literal member}s.
@@ -133,7 +133,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
-	Mono<List<String>> geoHash(K key, M... members);
+	Mono<List<String>> hash(K key, M... members);
 
 	/**
 	 * Get the {@link Point} representation of positions for one or more {@literal member}s.
@@ -143,7 +143,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
-	Mono<Point> geoPos(K key, M member);
+	Mono<Point> position(K key, M member);
 
 	/**
 	 * Get the {@link Point} representation of positions for one or more {@literal member}s.
@@ -153,7 +153,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
-	Mono<List<Point>> geoPos(K key, M... members);
+	Mono<List<Point>> position(K key, M... members);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle}.
@@ -163,7 +163,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
-	Flux<GeoResult<GeoLocation<M>>> geoRadius(K key, Circle within);
+	Flux<GeoResult<GeoLocation<M>>> radius(K key, Circle within);
 
 	/**
 	 * Get the {@literal member}s within the boundaries of a given {@link Circle} applying {@link GeoRadiusCommandArgs}.
@@ -174,7 +174,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
-	Flux<GeoResult<GeoLocation<M>>> geoRadius(K key, Circle within, GeoRadiusCommandArgs args);
+	Flux<GeoResult<GeoLocation<M>>> radius(K key, Circle within, GeoRadiusCommandArgs args);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -186,7 +186,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
-	Flux<GeoResult<GeoLocation<M>>> geoRadiusByMember(K key, M member, double radius);
+	Flux<GeoResult<GeoLocation<M>>> radius(K key, M member, double radius);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -198,7 +198,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
-	Flux<GeoResult<GeoLocation<M>>> geoRadiusByMember(K key, M member, Distance distance);
+	Flux<GeoResult<GeoLocation<M>>> radius(K key, M member, Distance distance);
 
 	/**
 	 * Get the {@literal member}s within the circle defined by the {@literal members} coordinates and given
@@ -211,7 +211,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @return never {@literal null}.
 	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
-	Flux<GeoResult<GeoLocation<M>>> geoRadiusByMember(K key, M member, Distance distance, GeoRadiusCommandArgs args);
+	Flux<GeoResult<GeoLocation<M>>> radius(K key, M member, Distance distance, GeoRadiusCommandArgs args);
 
 	/**
 	 * Remove the {@literal member}s.
@@ -220,7 +220,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param members must not be {@literal null}.
 	 * @return Number of elements removed.
 	 */
-	Mono<Long> geoRemove(K key, M... members);
+	Mono<Long> remove(K key, M... members);
 
 	/**
 	 * Removes the given {@literal key}.

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveGeoOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveGeoOperationsIntegrationTests.java
@@ -109,28 +109,28 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		connection.close();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoAdd() {
 
 		K key = keyFactory.instance();
 		V value = valueFactory.instance();
 
-		StepVerifier.create(geoOperations.geoAdd(key, POINT_PALERMO, value)).expectNext(1L).verifyComplete();
+		StepVerifier.create(geoOperations.add(key, POINT_PALERMO, value)).expectNext(1L).verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoAddLocation() {
 
 		K key = keyFactory.instance();
 		V value = valueFactory.instance();
 
-		StepVerifier.create(geoOperations.geoAdd(key, new GeoLocation<>(value, POINT_PALERMO))) //
+		StepVerifier.create(geoOperations.add(key, new GeoLocation<>(value, POINT_PALERMO))) //
 				.expectNext(1L) //
 				.expectComplete() //
 				.verify();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoAddMapOfLocations() {
 
 		K key = keyFactory.instance();
@@ -139,12 +139,12 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		memberCoordinateMap.put(valueFactory.instance(), POINT_PALERMO);
 		memberCoordinateMap.put(valueFactory.instance(), POINT_CATANIA);
 
-		StepVerifier.create(geoOperations.geoAdd(key, memberCoordinateMap)) //
+		StepVerifier.create(geoOperations.add(key, memberCoordinateMap)) //
 				.expectNext(2L) //
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoAddIterableOfLocations() {
 
 		K key = keyFactory.instance();
@@ -152,12 +152,12 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		List<GeoLocation<V>> geoLocations = Arrays.asList(new GeoLocation<>(valueFactory.instance(), POINT_ARIGENTO),
 				new GeoLocation<>(valueFactory.instance(), POINT_PALERMO));
 
-		StepVerifier.create(geoOperations.geoAdd(key, geoLocations)) //
+		StepVerifier.create(geoOperations.add(key, geoLocations)) //
 				.expectNext(2L) //
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoAddPublisherOfLocations() {
 
 		K key = keyFactory.instance();
@@ -169,22 +169,22 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 
 		Flux<List<GeoLocation<V>>> geoLocations = Flux.just(batch1, batch2);
 
-		StepVerifier.create(geoOperations.geoAdd(key, geoLocations)).expectNext(2L) //
+		StepVerifier.create(geoOperations.add(key, geoLocations)).expectNext(2L) //
 				.expectNext(1L) //
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoDistShouldReturnDistanceInMetersByDefault() {
 
 		K key = keyFactory.instance();
 		V member1 = valueFactory.instance();
 		V member2 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoDist(key, member1, member2)) //
+		StepVerifier.create(geoOperations.distance(key, member1, member2)) //
 				.consumeNextWith(actual -> {
 
 					assertThat(actual.getValue()).isCloseTo(DISTANCE_PALERMO_CATANIA_METERS, offset(0.005));
@@ -193,17 +193,17 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoDistShouldReturnDistanceInKilometersCorrectly() {
 
 		K key = keyFactory.instance();
 		V member1 = valueFactory.instance();
 		V member2 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoDist(key, member1, member2, Metrics.KILOMETERS)) //
+		StepVerifier.create(geoOperations.distance(key, member1, member2, Metrics.KILOMETERS)) //
 				.consumeNextWith(actual -> {
 
 					assertThat(actual.getValue()).isCloseTo(DISTANCE_PALERMO_CATANIA_KILOMETERS, offset(0.005));
@@ -212,20 +212,20 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoHash() {
 
 		K key = keyFactory.instance();
 		V v1 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, v1).block();
+		geoOperations.add(key, POINT_PALERMO, v1).block();
 
-		StepVerifier.create(geoOperations.geoHash(key, v1)) //
+		StepVerifier.create(geoOperations.hash(key, v1)) //
 				.expectNext("sqc8b49rny0") //
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoHashShouldReturnMultipleElements() {
 
 		K key = keyFactory.instance();
@@ -233,23 +233,23 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		V v2 = valueFactory.instance();
 		V v3 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, v1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, v2).block();
+		geoOperations.add(key, POINT_PALERMO, v1).block();
+		geoOperations.add(key, POINT_CATANIA, v2).block();
 
-		StepVerifier.create(geoOperations.geoHash(key, v1, v3, v2)) //
+		StepVerifier.create(geoOperations.hash(key, v1, v3, v2)) //
 				.expectNext(Arrays.asList("sqc8b49rny0", null, "sqdtr74hyu0")) //
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoPos() {
 
 		K key = keyFactory.instance();
 		V v1 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, v1).block();
+		geoOperations.add(key, POINT_PALERMO, v1).block();
 
-		StepVerifier.create(geoOperations.geoPos(key, v1)) //
+		StepVerifier.create(geoOperations.position(key, v1)) //
 				.consumeNextWith(actual -> {
 
 					assertThat(actual.getX()).isCloseTo(POINT_PALERMO.getX(), offset(0.005));
@@ -258,7 +258,7 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoPosShouldReturnMultipleElements() {
 
 		K key = keyFactory.instance();
@@ -266,10 +266,10 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		V v2 = valueFactory.instance();
 		V v3 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, v1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, v2).block();
+		geoOperations.add(key, POINT_PALERMO, v1).block();
+		geoOperations.add(key, POINT_CATANIA, v2).block();
 
-		StepVerifier.create(geoOperations.geoPos(key, v1, v3, v2)) //
+		StepVerifier.create(geoOperations.position(key, v1, v3, v2)) //
 				.consumeNextWith(actual -> {
 
 					assertThat(actual.get(0).getX()).isCloseTo(POINT_PALERMO.getX(), offset(0.005));
@@ -281,33 +281,33 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-438
+	@Test // DATAREDIS-438, DATAREDIS-614
 	public void geoRadius() {
 
 		K key = keyFactory.instance();
 		V member1 = valueFactory.instance();
 		V member2 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)))) //
+		StepVerifier.create(geoOperations.radius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)))) //
 				.expectNextCount(2) //
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoRadiusShouldReturnLocationsWithDistance() {
 
 		K key = keyFactory.instance();
 		V member1 = valueFactory.instance();
 		V member2 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_CATANIA, member2).block();
 
 		StepVerifier
-				.create(geoOperations.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)),
+				.create(geoOperations.radius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)),
 						newGeoRadiusArgs().includeDistance().sortDescending())) //
 				.consumeNextWith(actual -> {
 
@@ -322,22 +322,22 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-438
+	@Test // DATAREDIS-438, DATAREDIS-614
 	public void geoRadiusByMemberShouldReturnMembersCorrectly() {
 
 		K key = keyFactory.instance();
 		V member1 = valueFactory.instance();
 		V member2 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoRadius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)))) //
+		StepVerifier.create(geoOperations.radius(key, new Circle(new Point(15D, 37D), new Distance(200D, KILOMETERS)))) //
 				.expectNextCount(2) //
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoRadiusByMemberWithin100_000MetersShouldReturnLocations() {
 
 		K key = keyFactory.instance();
@@ -345,11 +345,11 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		V member2 = valueFactory.instance();
 		V member3 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
-		geoOperations.geoAdd(key, POINT_ARIGENTO, member3).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_CATANIA, member2).block();
+		geoOperations.add(key, POINT_ARIGENTO, member3).block();
 
-		StepVerifier.create(geoOperations.geoRadiusByMember(key, member3, 100_000)) //
+		StepVerifier.create(geoOperations.radius(key, member3, 100_000)) //
 				.consumeNextWith(actual -> {
 					assertThat(actual.getContent().getName()).isEqualTo(member3);
 				}) //
@@ -359,7 +359,7 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoRadiusByMemberWithin100KMShouldReturnLocations() {
 
 		K key = keyFactory.instance();
@@ -367,11 +367,11 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		V member2 = valueFactory.instance();
 		V member3 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
-		geoOperations.geoAdd(key, POINT_ARIGENTO, member3).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_CATANIA, member2).block();
+		geoOperations.add(key, POINT_ARIGENTO, member3).block();
 
-		StepVerifier.create(geoOperations.geoRadiusByMember(key, member3, new Distance(100D, KILOMETERS))) //
+		StepVerifier.create(geoOperations.radius(key, member3, new Distance(100D, KILOMETERS))) //
 				.consumeNextWith(actual -> {
 					assertThat(actual.getContent().getName()).isEqualTo(member3);
 				}) //
@@ -381,7 +381,7 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoRadiusByMemberShouldReturnLocationsWithDistance() {
 
 		K key = keyFactory.instance();
@@ -389,12 +389,12 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 		V member2 = valueFactory.instance();
 		V member3 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
-		geoOperations.geoAdd(key, POINT_ARIGENTO, member3).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_CATANIA, member2).block();
+		geoOperations.add(key, POINT_ARIGENTO, member3).block();
 
 		StepVerifier
-				.create(geoOperations.geoRadiusByMember(key, member3, new Distance(100D, KILOMETERS),
+				.create(geoOperations.radius(key, member3, new Distance(100D, KILOMETERS),
 						newGeoRadiusArgs().includeDistance().sortDescending())) //
 				.consumeNextWith(actual -> {
 
@@ -409,35 +409,35 @@ public class DefaultReactiveGeoOperationsIntegrationTests<K, V> {
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void geoRemove() {
 
 		K key = keyFactory.instance();
 		V member1 = valueFactory.instance();
 		V member2 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
-		geoOperations.geoAdd(key, POINT_CATANIA, member2).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_CATANIA, member2).block();
 
-		StepVerifier.create(geoOperations.geoRemove(key, member1)) //
+		StepVerifier.create(geoOperations.remove(key, member1)) //
 				.expectNext(1L) //
 				.verifyComplete();
-		StepVerifier.create(geoOperations.geoPos(key, member1)) //
+		StepVerifier.create(geoOperations.position(key, member1)) //
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-614
 	public void delete() {
 
 		K key = keyFactory.instance();
 		V member1 = valueFactory.instance();
 
-		geoOperations.geoAdd(key, POINT_PALERMO, member1).block();
+		geoOperations.add(key, POINT_PALERMO, member1).block();
 
 		StepVerifier.create(geoOperations.delete(key)) //
 				.expectNext(true) //
 				.verifyComplete();
-		StepVerifier.create(geoOperations.geoPos(key, member1)) //
+		StepVerifier.create(geoOperations.position(key, member1)) //
 				.verifyComplete();
 	}
 }


### PR DESCRIPTION
We removed the geo prefix from the imperative and reactive `GeoOperations` interfaces and our methods to match a more expressive scheme:

* `geoAdd(…)` -> `add(…)`
* `geoDist(…)` -> `distance(…)`
* `geoHash(…)` -> `hash(…)`
* `geoPos(…)` -> `position(…)`
* `geoRadius(…)` -> `radius(…)`
* `geoRadiusByMember(…)`-> `radius(…)`
* `geoRemove(…)` -> `remove(…)`

Methods on the imperative API remain as deprecated default methods to retain compatibility and not enforce changes in the client code.

---

Related ticket: [DATAREDIS-614](https://jira.spring.io/browse/DATAREDIS-614).