### PR TITLE
DATAREDIS-603 - Fall back to RedisSystemException for non-translated exceptions thrown by the driver.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.8.BUILD-SNAPSHOT</version>
+	<version>1.8.8.DATAREDIS-603-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 
@@ -31,26 +31,26 @@
 
 	<dependencyManagement>
 		<dependencies>
-		
+
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-pool2</artifactId>
 				<version>${pool}</version>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>${guava}</version>
 			</dependency>
-			
+
 		</dependencies>
 	</dependencyManagement>
 
 	<dependencies>
 
 		<!-- Spring -->
-		
+
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-keyvalue</artifactId>
@@ -78,35 +78,35 @@
 		</dependency>
 
 		<!-- REDIS Drivers -->
-		
+
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
 			<version>${jedis}</version>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.jredis</groupId>
 			<artifactId>jredis-core-api</artifactId>
 			<version>${jredis}</version>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.jredis</groupId>
 			<artifactId>jredis-core-ri</artifactId>
 			<version>${jredis}</version>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>com.github.spullara.redis</groupId>
 			<artifactId>client</artifactId>
 			<version>${srp}</version>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>biz.paluch.redis</groupId>
 			<artifactId>lettuce</artifactId>
@@ -221,7 +221,7 @@
 
 	<build>
 		<plugins>
-		
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -242,12 +242,12 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>wagon-maven-plugin</artifactId>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>
@@ -261,13 +261,13 @@
 			<id>release</id>
 			<build>
 				<plugins>
-				
+
 					<plugin>
 						<groupId>org.jfrog.buildinfo</groupId>
 						<artifactId>artifactory-maven-plugin</artifactId>
 						<inherited>false</inherited>
 					</plugin>
-					
+
 				</plugins>
 			</build>
 		</profile>

--- a/src/main/java/org/springframework/data/redis/connection/ClusterCommandExecutor.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterCommandExecutor.java
@@ -149,7 +149,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 			return new NodeResult<T>(node, cmd.doInCluster(client));
 		} catch (RuntimeException ex) {
 
-			RuntimeException translatedException = convertToDataAccessExeption(ex);
+			RuntimeException translatedException = convertToDataAccessException(ex);
 			if (translatedException instanceof ClusterRedirectException) {
 				ClusterRedirectException cre = (ClusterRedirectException) translatedException;
 				return executeCommandOnSingleNode(cmd,
@@ -252,13 +252,13 @@ public class ClusterCommandExecutor implements DisposableBean {
 						}
 					} catch (ExecutionException e) {
 
-						RuntimeException ex = convertToDataAccessExeption((Exception) e.getCause());
+						RuntimeException ex = convertToDataAccessException((Exception) e.getCause());
 						exceptions.put(entry.getKey().getNode(), ex != null ? ex : e.getCause());
 					} catch (InterruptedException e) {
 
 						Thread.currentThread().interrupt();
 
-						RuntimeException ex = convertToDataAccessExeption((Exception) e.getCause());
+						RuntimeException ex = convertToDataAccessException((Exception) e.getCause());
 						exceptions.put(entry.getKey().getNode(), ex != null ? ex : e.getCause());
 						break;
 					}
@@ -338,7 +338,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 			return new NodeResult<T>(node, cmd.doInCluster(client, key), key);
 		} catch (RuntimeException ex) {
 
-			RuntimeException translatedException = convertToDataAccessExeption(ex);
+			RuntimeException translatedException = convertToDataAccessException(ex);
 			throw translatedException != null ? translatedException : ex;
 		} finally {
 			this.resourceProvider.returnResourceForSpecificNode(node, client);
@@ -349,7 +349,7 @@ public class ClusterCommandExecutor implements DisposableBean {
 		return this.topologyProvider.getTopology();
 	}
 
-	private DataAccessException convertToDataAccessExeption(Exception e) {
+	private DataAccessException convertToDataAccessException(Exception e) {
 		return exceptionTranslationStrategy.translate(e);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -44,7 +44,7 @@ import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.ClusterStateFailureException;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
-import org.springframework.data.redis.PassThroughExceptionTranslationStrategy;
+import org.springframework.data.redis.FallbackExceptionTranslationStrategy;
 import org.springframework.data.redis.connection.*;
 import org.springframework.data.redis.connection.ClusterCommandExecutor.ClusterCommandCallback;
 import org.springframework.data.redis.connection.ClusterCommandExecutor.MultiKeyClusterCommandCallback;
@@ -76,7 +76,7 @@ import org.springframework.util.ObjectUtils;
  */
 public class JedisClusterConnection implements RedisClusterConnection {
 
-	private static final ExceptionTranslationStrategy EXCEPTION_TRANSLATION = new PassThroughExceptionTranslationStrategy(
+	private static final ExceptionTranslationStrategy EXCEPTION_TRANSLATION = new FallbackExceptionTranslationStrategy(
 			JedisConverters.exceptionConverter());
 
 	private final Log log = LogFactory.getLog(getClass());
@@ -3978,7 +3978,6 @@ public class JedisClusterConnection implements RedisClusterConnection {
 	/*
 	 * --> Little helpers to make it work
 	 */
-
 	protected DataAccessException convertJedisAccessException(Exception ex) {
 		return EXCEPTION_TRANSLATION.translate(ex);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -20,8 +20,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +40,7 @@ import org.springframework.data.geo.Point;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
 import org.springframework.data.redis.FallbackExceptionTranslationStrategy;
 import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.AbstractRedisConnection;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.FutureResult;
@@ -244,7 +243,7 @@ public class JedisConnection extends AbstractRedisConnection {
 			broken = true;
 		}
 
-		return exception;
+		return exception != null ? exception : new RedisSystemException(ex.getMessage(), ex);
 	}
 
 	public Object execute(String command, byte[]... args) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -36,7 +36,7 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.ExceptionTranslationStrategy;
-import org.springframework.data.redis.PassThroughExceptionTranslationStrategy;
+import org.springframework.data.redis.FallbackExceptionTranslationStrategy;
 import org.springframework.data.redis.connection.ClusterCommandExecutor;
 import org.springframework.data.redis.connection.ClusterCommandExecutor.ClusterCommandCallback;
 import org.springframework.data.redis.connection.ClusterCommandExecutor.MultiKeyClusterCommandCallback;
@@ -79,7 +79,7 @@ import com.lambdaworks.redis.codec.RedisCodec;
 public class LettuceClusterConnection extends LettuceConnection
 		implements org.springframework.data.redis.connection.RedisClusterConnection {
 
-	static final ExceptionTranslationStrategy exceptionConverter = new PassThroughExceptionTranslationStrategy(
+	static final ExceptionTranslationStrategy exceptionConverter = new FallbackExceptionTranslationStrategy(
 			new LettuceExceptionConverter());
 	static final RedisCodec<byte[], byte[]> CODEC = ByteArrayCodec.INSTANCE;
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -124,7 +124,7 @@ import com.lambdaworks.redis.sentinel.api.StatefulRedisSentinelConnection;
 /**
  * {@code RedisConnection} implementation on top of <a href="https://github.com/mp911de/lettuce">Lettuce</a> Redis
  * client.
- * 
+ *
  * @author Costin Leau
  * @author Jennifer Hickey
  * @author Christoph Strobl
@@ -259,7 +259,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/**
 	 * Instantiates a new lettuce connection.
-	 * 
+	 *
 	 * @param timeout The connection timeout (in milliseconds)
 	 * @param client The {@link RedisClient} to use when instantiating a native connection
 	 */
@@ -269,7 +269,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/**
 	 * Instantiates a new lettuce connection.
-	 * 
+	 *
 	 * @param timeout The connection timeout (in milliseconds) * @param client The {@link RedisClient} to use when
 	 *          instantiating a pub/sub connection
 	 * @param pool The connection pool to use for all other native connections
@@ -280,7 +280,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/**
 	 * Instantiates a new lettuce connection.
-	 * 
+	 *
 	 * @param sharedConnection A native connection that is shared with other {@link LettuceConnection}s. Will not be used
 	 *          for transactions or blocking operations
 	 * @param timeout The connection timeout (in milliseconds)
@@ -292,7 +292,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/**
 	 * Instantiates a new lettuce connection.
-	 * 
+	 *
 	 * @param sharedConnection A native connection that is shared with other {@link LettuceConnection}s. Should not be
 	 *          used for transactions or blocking operations
 	 * @param timeout The connection timeout (in milliseconds)
@@ -332,6 +332,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 		if (exception instanceof RedisConnectionFailureException) {
 			broken = true;
 		}
+
 		return exception;
 	}
 
@@ -352,7 +353,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/**
 	 * 'Native' or 'raw' execution of the given command along-side the given arguments.
-	 * 
+	 *
 	 * @see RedisCommands#execute(String, byte[]...)
 	 * @param command Command to execute
 	 * @param commandOutputTypeHint Type of Output to use, may be (may be {@literal null}).
@@ -1173,7 +1174,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisKeyCommands#ttl(byte[])
 	 */
@@ -1198,7 +1199,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisKeyCommands#ttl(byte[], java.util.concurrent.TimeUnit)
 	 */
@@ -3888,7 +3889,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 	/**
 	 * Specifies if pipelined and transaction results should be converted to the expected data type. If false, results of
 	 * {@link #closePipeline()} and {@link #exec()} will be of the type returned by the Lettuce driver
-	 * 
+	 *
 	 * @param convertPipelineAndTxResults Whether or not to convert pipeline and tx results
 	 */
 	public void setConvertPipelineAndTxResults(boolean convertPipelineAndTxResults) {
@@ -4161,7 +4162,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	/**
 	 * {@link TypeHints} provide {@link CommandOutput} information for a given {@link CommandType}.
-	 * 
+	 *
 	 * @since 1.2.1
 	 */
 	static class TypeHints {
@@ -4322,7 +4323,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 		/**
 		 * Returns the {@link CommandOutput} mapped for given {@link CommandType} or {@link ByteArrayOutput} as default.
-		 * 
+		 *
 		 * @param type
 		 * @return {@link ByteArrayOutput} as default when no matching {@link CommandOutput} available.
 		 */
@@ -4333,7 +4334,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 		/**
 		 * Returns the {@link CommandOutput} mapped for given {@link CommandType} given {@link CommandOutput} as default.
-		 * 
+		 *
 		 * @param type
 		 * @return
 		 */


### PR DESCRIPTION
We now use a fallback exception translation strategy in JedisClusterConnection to map all non-mapped exceptions to RedisSystemException

We now fall back to `RedisSystemException` for exceptions thrown by Jedis/Lettuce that cannot be translated any further. The fallback prevents null pointer exceptions caused by not translated exceptions.

---
Related ticket: [DATAREDIS-603](https://jira.spring.io/browse/DATAREDIS-603).