### PR TITLE
DATAREDIS-688 - Return delete result via RedisOperations.delete(…).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAREDIS-688-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -159,10 +159,10 @@ public interface RedisOperations<K, V> {
 	 * Delete given {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @return The number of keys that were removed.
+	 * @return {@literal true} if the key was removed.
 	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
-	void delete(K key);
+	Boolean delete(K key);
 
 	/**
 	 * Delete given {@code keys}.
@@ -171,7 +171,7 @@ public interface RedisOperations<K, V> {
 	 * @return The number of keys that were removed.
 	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
-	void delete(Collection<K> keys);
+	Long delete(Collection<K> keys);
 
 	/**
 	 * Determine the type stored at {@code key}.

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -692,14 +692,13 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 * @see org.springframework.data.redis.core.RedisOperations#delete(java.lang.Object)
 	 */
 	@Override
-	public void delete(K key) {
+	public Boolean delete(K key) {
 
 		byte[] rawKey = rawKey(key);
 
-		execute(connection -> {
-			connection.del(rawKey);
-			return null;
-		}, true);
+		Long result = execute(connection -> connection.del(rawKey), true);
+
+		return result != null && result.intValue() == 1;
 	}
 
 	/*
@@ -707,18 +706,15 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 * @see org.springframework.data.redis.core.RedisOperations#delete(java.util.Collection)
 	 */
 	@Override
-	public void delete(Collection<K> keys) {
+	public Long delete(Collection<K> keys) {
 
 		if (CollectionUtils.isEmpty(keys)) {
-			return;
+			return 0L;
 		}
 
 		byte[][] rawKeys = rawKeys(keys);
 
-		execute(connection -> {
-			connection.del(rawKeys);
-			return null;
-		}, true);
+		return execute(connection -> connection.del(rawKeys), true);
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -383,9 +383,12 @@ public class RedisTemplateTests<K, V> {
 
 	@Test
 	public void testDelete() {
+		
 		K key1 = keyFactory.instance();
 		V value1 = valueFactory.instance();
+		
 		redisTemplate.opsForValue().set(key1, value1);
+		
 		assertTrue(redisTemplate.hasKey(key1));
 		assertTrue(redisTemplate.delete(key1));
 		assertFalse(redisTemplate.hasKey(key1));
@@ -393,26 +396,30 @@ public class RedisTemplateTests<K, V> {
 
 	@Test
 	public void testDeleteMultiple() {
+		
 		K key1 = keyFactory.instance();
 		K key2 = keyFactory.instance();
 		V value1 = valueFactory.instance();
 		V value2 = valueFactory.instance();
+		
 		redisTemplate.opsForValue().set(key1, value1);
 		redisTemplate.opsForValue().set(key2, value2);
-		List<K> keys = new ArrayList<>();
-		keys.add(key1);
-		keys.add(key2);
-		assertEquals(2L, redisTemplate.delete(keys).longValue());
+
+		assertEquals(2L, redisTemplate.delete(Arrays.asList(key1, key2)).longValue());
 		assertFalse(redisTemplate.hasKey(key1));
 		assertFalse(redisTemplate.hasKey(key2));
 	}
 
 	@Test
 	public void testSort() {
+		
 		K key1 = keyFactory.instance();
 		V value1 = valueFactory.instance();
+		
 		assumeTrue(value1 instanceof Number);
+		
 		redisTemplate.opsForList().rightPush(key1, value1);
+		
 		List<V> results = redisTemplate.sort(SortQueryBuilder.sort(key1).build());
 		assertEquals(Collections.singletonList(value1), results);
 	}

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -387,7 +387,7 @@ public class RedisTemplateTests<K, V> {
 		V value1 = valueFactory.instance();
 		redisTemplate.opsForValue().set(key1, value1);
 		assertTrue(redisTemplate.hasKey(key1));
-		redisTemplate.delete(key1);
+		assertTrue(redisTemplate.delete(key1));
 		assertFalse(redisTemplate.hasKey(key1));
 	}
 
@@ -402,7 +402,7 @@ public class RedisTemplateTests<K, V> {
 		List<K> keys = new ArrayList<>();
 		keys.add(key1);
 		keys.add(key2);
-		redisTemplate.delete(keys);
+		assertEquals(2L, redisTemplate.delete(keys).longValue());
 		assertFalse(redisTemplate.hasKey(key1));
 		assertFalse(redisTemplate.hasKey(key2));
 	}


### PR DESCRIPTION
We now return the deletion count for multi-key deletes and whether a single key was deleted for RedisOperations.delete(…).

---

Related ticket: [DATAREDIS-688](https://jira.spring.io/browse/DATAREDIS-688).