### PR TITLE
DATAREDIS-711 - Emit Lua array responses as List.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-711-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveScriptingCommands.java
@@ -82,7 +82,8 @@ public interface ReactiveScriptingCommands {
 	 * Evaluate given {@code script}.
 	 *
 	 * @param script must not be {@literal null}.
-	 * @param returnType must not be {@literal null}.
+	 * @param returnType must not be {@literal null}. Using {@link ReturnType#MULTI} emits a {@link List} as-is instead of
+	 *          emitting the individual elements from the array response.
 	 * @param numKeys
 	 * @param keysAndArgs must not be {@literal null}.
 	 * @return never {@literal null}.
@@ -94,7 +95,8 @@ public interface ReactiveScriptingCommands {
 	 * Evaluate given {@code scriptSha}.
 	 *
 	 * @param scriptSha must not be {@literal null}.
-	 * @param returnType must not be {@literal null}.
+	 * @param returnType must not be {@literal null}. Using {@link ReturnType#MULTI} emits a {@link List} as-is instead of
+	 *          emitting the individual elements from the array response.
 	 * @param numKeys
 	 * @param keysAndArgs must not be {@literal null}.
 	 * @return never {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterHyperLogLogCommands.java
@@ -53,7 +53,7 @@ class LettuceReactiveClusterHyperLogLogCommands extends LettuceReactiveHyperLogL
 	@Override
 	public Flux<BooleanResponse<PfMergeCommand>> pfMerge(Publisher<PfMergeCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null for PFMERGE");
 			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty for PFMERGE!");
@@ -76,7 +76,7 @@ class LettuceReactiveClusterHyperLogLogCommands extends LettuceReactiveHyperLogL
 	@Override
 	public Flux<NumericResponse<PfCountCommand, Long>> pfCount(Publisher<PfCountCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notEmpty(command.getKeys(), "Keys must be null or empty for PFCOUNT!");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterKeyCommands.java
@@ -76,7 +76,7 @@ class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommands imple
 	@Override
 	public Flux<BooleanResponse<RenameCommand>> rename(Publisher<RenameCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "key must not be null.");
 			Assert.notNull(command.getNewName(), "NewName must not be null!");
@@ -102,7 +102,7 @@ class LettuceReactiveClusterKeyCommands extends LettuceReactiveKeyCommands imple
 	@Override
 	public Flux<BooleanResponse<RenameCommand>> renameNX(Publisher<RenameCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null.");
 			Assert.notNull(command.getNewName(), "NewName must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterListCommands.java
@@ -49,7 +49,7 @@ class LettuceReactiveClusterListCommands extends LettuceReactiveListCommands imp
 	@Override
 	public Flux<PopResponse> bPop(Publisher<BPopCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getDirection(), "Direction must not be null!");
@@ -68,7 +68,7 @@ class LettuceReactiveClusterListCommands extends LettuceReactiveListCommands imp
 	@Override
 	public Flux<ByteBufferResponse<RPopLPushCommand>> rPopLPush(Publisher<RPopLPushCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getDestination(), "Destination key must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterServerCommands.java
@@ -280,7 +280,7 @@ class LettuceReactiveClusterServerCommands extends LettuceReactiveServerCommands
 	public Flux<RedisClientInfo> getClientList(RedisClusterNode node) {
 
 		return connection.execute(node, RedisServerReactiveCommands::clientList)
-				.flatMapIterable(LettuceConverters.stringToRedisClientListConverter()::convert);
+				.concatMapIterable(LettuceConverters.stringToRedisClientListConverter()::convert);
 	}
 
 	private <T> Collection<Publisher<Tuple2<RedisClusterNode, T>>> executeOnAllNodes(

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterSetCommands.java
@@ -53,7 +53,7 @@ class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands imple
 	@Override
 	public Flux<CommandResponse<SUnionCommand, Flux<ByteBuffer>>> sUnion(Publisher<SUnionCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 
@@ -74,7 +74,7 @@ class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands imple
 	@Override
 	public Flux<NumericResponse<SUnionStoreCommand, Long>> sUnionStore(Publisher<SUnionStoreCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Source keys must not be null!");
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
@@ -99,7 +99,7 @@ class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands imple
 	@Override
 	public Flux<CommandResponse<SInterCommand, Flux<ByteBuffer>>> sInter(Publisher<SInterCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 
@@ -124,7 +124,7 @@ class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands imple
 				return source;
 			});
 
-			return Mono.just(new CommandResponse<>(command, result.flatMap(v -> Flux.fromStream(v.stream()))));
+			return Mono.just(new CommandResponse<>(command, result.concatMap(v -> Flux.fromStream(v.stream()))));
 		}));
 	}
 
@@ -134,7 +134,7 @@ class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands imple
 	@Override
 	public Flux<NumericResponse<SInterStoreCommand, Long>> sInterStore(Publisher<SInterStoreCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Source keys must not be null!");
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
@@ -159,7 +159,7 @@ class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands imple
 	@Override
 	public Flux<CommandResponse<SDiffCommand, Flux<ByteBuffer>>> sDiff(Publisher<SDiffCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 
@@ -185,7 +185,7 @@ class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands imple
 				return source;
 			});
 
-			return Mono.just(new CommandResponse<>(command, result.flatMap(v -> Flux.fromStream(v.stream()))));
+			return Mono.just(new CommandResponse<>(command, result.concatMap(v -> Flux.fromStream(v.stream()))));
 
 		}));
 	}
@@ -196,7 +196,7 @@ class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands imple
 	@Override
 	public Flux<NumericResponse<SDiffStoreCommand, Long>> sDiffStore(Publisher<SDiffStoreCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Source keys must not be null!");
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
@@ -221,7 +221,7 @@ class LettuceReactiveClusterSetCommands extends LettuceReactiveSetCommands imple
 	@Override
 	public Flux<BooleanResponse<SMoveCommand>> sMove(Publisher<SMoveCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Source key must not be null!");
 			Assert.notNull(command.getDestination(), "Destination key must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommands.java
@@ -51,7 +51,7 @@ class LettuceReactiveClusterStringCommands extends LettuceReactiveStringCommands
 	@Override
 	public Flux<ReactiveRedisConnection.NumericResponse<BitOpCommand, Long>> bitOp(Publisher<BitOpCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			List<ByteBuffer> keys = new ArrayList<>(command.getKeys());
 			keys.add(command.getDestinationKey());
@@ -71,7 +71,7 @@ class LettuceReactiveClusterStringCommands extends LettuceReactiveStringCommands
 	@Override
 	public Flux<ReactiveRedisConnection.BooleanResponse<MSetCommand>> mSetNX(Publisher<MSetCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			if (ClusterSlotHashUtil.isSameSlotForAllKeys(command.getKeyValuePairs().keySet())) {
 				return super.mSetNX(Mono.just(command));

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterZSetCommands.java
@@ -47,7 +47,7 @@ class LettuceReactiveClusterZSetCommands extends LettuceReactiveZSetCommands imp
 	@Override
 	public Flux<NumericResponse<ZUnionStoreCommand, Long>> zUnionStore(Publisher<ZUnionStoreCommand> commands) {
 
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty.");
 
@@ -65,7 +65,7 @@ class LettuceReactiveClusterZSetCommands extends LettuceReactiveZSetCommands imp
 	 */
 	@Override
 	public Flux<NumericResponse<ZInterStoreCommand, Long>> zInterStore(Publisher<ZInterStoreCommand> commands) {
-		return getConnection().execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return getConnection().execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty.");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveGeoCommands.java
@@ -68,7 +68,7 @@ class LettuceReactiveGeoCommands implements ReactiveGeoCommands {
 	@Override
 	public Flux<NumericResponse<GeoAddCommand, Long>> geoAdd(Publisher<GeoAddCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getGeoLocations(), "Locations must not be null!");
@@ -95,7 +95,7 @@ class LettuceReactiveGeoCommands implements ReactiveGeoCommands {
 	@Override
 	public Flux<CommandResponse<GeoDistCommand, Distance>> geoDist(Publisher<GeoDistCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getFrom(), "From member must not be null!");
@@ -121,7 +121,7 @@ class LettuceReactiveGeoCommands implements ReactiveGeoCommands {
 	@Override
 	public Flux<MultiValueResponse<GeoHashCommand, String>> geoHash(Publisher<GeoHashCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getMembers(), "Members must not be null!");
@@ -139,7 +139,7 @@ class LettuceReactiveGeoCommands implements ReactiveGeoCommands {
 	@Override
 	public Flux<MultiValueResponse<GeoPosCommand, Point>> geoPos(Publisher<GeoPosCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getMembers(), "Members must not be null!");
@@ -160,7 +160,7 @@ class LettuceReactiveGeoCommands implements ReactiveGeoCommands {
 	public Flux<CommandResponse<GeoRadiusCommand, Flux<GeoResult<GeoLocation<ByteBuffer>>>>> geoRadius(
 			Publisher<GeoRadiusCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getPoint(), "Point must not be null!");
@@ -187,7 +187,7 @@ class LettuceReactiveGeoCommands implements ReactiveGeoCommands {
 	public Flux<CommandResponse<GeoRadiusByMemberCommand, Flux<GeoResult<GeoLocation<ByteBuffer>>>>> geoRadiusByMember(
 			Publisher<GeoRadiusByMemberCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getMember(), "Member must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
@@ -63,7 +63,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 	@Override
 	public Flux<BooleanResponse<HSetCommand>> hSet(Publisher<HSetCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getFieldValueMap(), "FieldValueMap must not be null!");
@@ -95,7 +95,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 	@Override
 	public Flux<MultiValueResponse<HGetCommand, ByteBuffer>> hMGet(Publisher<HGetCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getFields(), "Fields must not be null!");
@@ -122,7 +122,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 	@Override
 	public Flux<BooleanResponse<HExistsCommand>> hExists(Publisher<HExistsCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getName(), "Name must not be null!");
@@ -138,7 +138,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 	@Override
 	public Flux<NumericResponse<HDelCommand, Long>> hDel(Publisher<HDelCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getFields(), "Fields must not be null!");
@@ -155,7 +155,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> hLen(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Command.getKey() must not be null!");
 
@@ -170,7 +170,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 	@Override
 	public Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> hKeys(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -187,7 +187,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 	@Override
 	public Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> hVals(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -205,7 +205,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 	public Flux<CommandResponse<KeyCommand, Flux<Map.Entry<ByteBuffer, ByteBuffer>>>> hGetAll(
 			Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHyperLogLogCommands.java
@@ -53,7 +53,7 @@ class LettuceReactiveHyperLogLogCommands implements ReactiveHyperLogLogCommands 
 	@Override
 	public Flux<NumericResponse<PfAddCommand, Long>> pfAdd(Publisher<PfAddCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "key must not be null!");
 
@@ -70,7 +70,7 @@ class LettuceReactiveHyperLogLogCommands implements ReactiveHyperLogLogCommands 
 	@Override
 	public Flux<NumericResponse<PfCountCommand, Long>> pfCount(Publisher<PfCountCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notEmpty(command.getKeys(), "Keys must not be empty for PFCOUNT.");
 
@@ -86,7 +86,7 @@ class LettuceReactiveHyperLogLogCommands implements ReactiveHyperLogLogCommands 
 	@Override
 	public Flux<BooleanResponse<PfMergeCommand>> pfMerge(Publisher<PfMergeCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Destination key must not be null for PFMERGE.");
 			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null for PFMERGE.");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
@@ -61,7 +61,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<BooleanResponse<KeyCommand>> exists(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap((command) -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -77,7 +77,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<CommandResponse<KeyCommand, DataType>> type(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -93,7 +93,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<MultiValueResponse<ByteBuffer, ByteBuffer>> keys(Publisher<ByteBuffer> patterns) {
 
-		return connection.execute(cmd -> Flux.from(patterns).flatMap(pattern -> {
+		return connection.execute(cmd -> Flux.from(patterns).concatMap(pattern -> {
 
 			Assert.notNull(pattern, "Pattern must not be null!");
 			// TODO: stream elements instead of collection
@@ -117,7 +117,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<BooleanResponse<RenameCommand>> rename(Publisher<RenameCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getNewName(), "New name must not be null!");
@@ -134,7 +134,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<BooleanResponse<RenameCommand>> renameNX(Publisher<RenameCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getNewName(), "New name must not be null!");
@@ -150,7 +150,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> del(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap((command) -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -165,7 +165,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<NumericResponse<List<ByteBuffer>, Long>> mDel(Publisher<List<ByteBuffer>> keysCollection) {
 
-		return connection.execute(cmd -> Flux.from(keysCollection).flatMap((keys) -> {
+		return connection.execute(cmd -> Flux.from(keysCollection).concatMap((keys) -> {
 
 			Assert.notEmpty(keys, "Keys must not be null!");
 
@@ -180,7 +180,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<BooleanResponse<ExpireCommand>> expire(Publisher<ExpireCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getTimeout(), "Timeout must not be null!");
@@ -196,7 +196,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<BooleanResponse<ExpireCommand>> pExpire(Publisher<ExpireCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getTimeout(), "Timeout must not be null!");
@@ -212,7 +212,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<BooleanResponse<ExpireAtCommand>> expireAt(Publisher<ExpireAtCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getExpireAt(), "Expire at must not be null!");
@@ -228,7 +228,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<BooleanResponse<ExpireAtCommand>> pExpireAt(Publisher<ExpireAtCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getExpireAt(), "Expire at must not be null!");
@@ -244,7 +244,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<BooleanResponse<KeyCommand>> persist(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -258,7 +258,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> ttl(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -272,7 +272,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> pTtl(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -286,7 +286,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 	@Override
 	public Flux<BooleanResponse<MoveCommand>> move(Publisher<MoveCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getDatabase(), "Database must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
@@ -63,7 +63,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<NumericResponse<PushCommand, Long>> push(Publisher<PushCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notEmpty(command.getValues(), "Values must not be null or empty!");
@@ -96,7 +96,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> lLen(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -111,7 +111,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<CommandResponse<RangeCommand, Flux<ByteBuffer>>> lRange(Publisher<RangeCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
@@ -129,7 +129,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<BooleanResponse<RangeCommand>> lTrim(Publisher<RangeCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
@@ -148,7 +148,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<ByteBufferResponse<LIndexCommand>> lIndex(Publisher<LIndexCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getIndex(), "Index value must not be null!");
@@ -164,7 +164,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<NumericResponse<LInsertCommand, Long>> lInsert(Publisher<LInsertCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -185,7 +185,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 
 		return connection.execute(cmd -> {
 
-			return Flux.from(commands).flatMap(command -> {
+			return Flux.from(commands).concatMap(command -> {
 
 				Assert.notNull(command.getKey(), "Key must not be null!");
 				Assert.notNull(command.getValue(), "value must not be null!");
@@ -204,7 +204,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<NumericResponse<LRemCommand, Long>> lRem(Publisher<LRemCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -222,7 +222,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<ByteBufferResponse<PopCommand>> pop(Publisher<PopCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getDirection(), "Direction must not be null!");
@@ -241,7 +241,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<PopResponse> bPop(Publisher<BPopCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getDirection(), "Direction must not be null!");
@@ -264,7 +264,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<ByteBufferResponse<RPopLPushCommand>> rPopLPush(Publisher<RPopLPushCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getDestination(), "Destination key must not be null!");
@@ -281,7 +281,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<ByteBufferResponse<BRPopLPushCommand>> bRPopLPush(Publisher<BRPopLPushCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getDestination(), "Destination key must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveNumberCommands.java
@@ -53,7 +53,7 @@ class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> incr(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -68,7 +68,7 @@ class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 	@Override
 	public <T extends Number> Flux<NumericResponse<IncrByCommand<T>, T>> incrBy(Publisher<IncrByCommand<T>> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value for INCRBY must not be null.");
@@ -94,7 +94,7 @@ class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> decr(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -109,7 +109,7 @@ class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 	@Override
 	public <T extends Number> Flux<NumericResponse<DecrByCommand<T>, T>> decrBy(Publisher<DecrByCommand<T>> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value for DECRBY must not be null.");
@@ -135,7 +135,7 @@ class LettuceReactiveNumberCommands implements ReactiveNumberCommands {
 	@Override
 	public <T extends Number> Flux<NumericResponse<HIncrByCommand<T>, T>> hIncrBy(Publisher<HIncrByCommand<T>> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommands.java
@@ -140,7 +140,7 @@ class LettuceReactiveScriptingCommands implements ReactiveScriptingCommands {
 
 		if (returnType == ReturnType.MULTI) {
 
-			return eval.flatMap(t -> {
+			return eval.concatMap(t -> {
 				return t instanceof Exception ? Flux.error(connection.translateException().apply((Exception) t)) : Flux.just(t);
 			});
 		}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommands.java
@@ -141,8 +141,6 @@ class LettuceReactiveScriptingCommands implements ReactiveScriptingCommands {
 		if (returnType == ReturnType.MULTI) {
 
 			return eval.flatMap(t -> {
-				return t instanceof Iterable ? Flux.fromIterable((Iterable<T>) t) : Flux.just(t);
-			}).flatMap(t -> {
 				return t instanceof Exception ? Flux.error(connection.translateException().apply((Exception) t)) : Flux.just(t);
 			});
 		}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveServerCommands.java
@@ -233,6 +233,6 @@ class LettuceReactiveServerCommands implements ReactiveServerCommands {
 	public Flux<RedisClientInfo> getClientList() {
 
 		return connection.execute(RedisServerReactiveCommands::clientList)
-				.flatMapIterable(s -> LettuceConverters.stringToRedisClientListConverter().convert(s));
+				.concatMapIterable(s -> LettuceConverters.stringToRedisClientListConverter().convert(s));
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
@@ -57,7 +57,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<NumericResponse<SAddCommand, Long>> sAdd(Publisher<SAddCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValues(), "Values must not be null!");
@@ -74,7 +74,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<NumericResponse<SRemCommand, Long>> sRem(Publisher<SRemCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValues(), "Values must not be null!");
@@ -91,7 +91,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<ByteBufferResponse<KeyCommand>> sPop(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -119,7 +119,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<BooleanResponse<SMoveCommand>> sMove(Publisher<SMoveCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getDestination(), "Destination key must not be null!");
@@ -137,7 +137,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> sCard(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -152,7 +152,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<BooleanResponse<SIsMemberCommand>> sIsMember(Publisher<SIsMemberCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -168,7 +168,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<CommandResponse<SInterCommand, Flux<ByteBuffer>>> sInter(Publisher<SInterCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 
@@ -184,7 +184,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<NumericResponse<SInterStoreCommand, Long>> sInterStore(Publisher<SInterStoreCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
@@ -201,7 +201,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<CommandResponse<SUnionCommand, Flux<ByteBuffer>>> sUnion(Publisher<SUnionCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 
@@ -217,7 +217,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<NumericResponse<SUnionStoreCommand, Long>> sUnionStore(Publisher<SUnionStoreCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
@@ -234,7 +234,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<CommandResponse<SDiffCommand, Flux<ByteBuffer>>> sDiff(Publisher<SDiffCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 
@@ -250,7 +250,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<NumericResponse<SDiffStoreCommand, Long>> sDiffStore(Publisher<SDiffStoreCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
@@ -267,7 +267,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	@Override
 	public Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> sMembers(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -284,7 +284,7 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 	public Flux<CommandResponse<SRandMembersCommand, Flux<ByteBuffer>>> sRandMember(
 			Publisher<SRandMembersCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
@@ -63,7 +63,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<MultiValueResponse<List<ByteBuffer>, ByteBuffer>> mGet(Publisher<List<ByteBuffer>> keyCollections) {
 
-		return connection.execute(cmd -> Flux.from(keyCollections).flatMap((keys) -> {
+		return connection.execute(cmd -> Flux.from(keyCollections).concatMap((keys) -> {
 
 			Assert.notNull(keys, "Keys must not be null!");
 
@@ -79,7 +79,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<BooleanResponse<SetCommand>> set(Publisher<SetCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap((command) -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -104,7 +104,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<ByteBufferResponse<SetCommand>> getSet(Publisher<SetCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap((command) -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -125,7 +125,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<ByteBufferResponse<KeyCommand>> get(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap((command) -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap((command) -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -141,7 +141,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<BooleanResponse<SetCommand>> setNX(Publisher<SetCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -156,7 +156,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	 */
 	@Override
 	public Flux<BooleanResponse<SetCommand>> setEX(Publisher<SetCommand> commands) {
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -174,7 +174,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<BooleanResponse<SetCommand>> pSetEX(Publisher<SetCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -193,7 +193,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<BooleanResponse<MSetCommand>> mSet(Publisher<MSetCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notEmpty(command.getKeyValuePairs(), "Pairs must not be null or empty!");
 
@@ -209,7 +209,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<BooleanResponse<MSetCommand>> mSetNX(Publisher<MSetCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notEmpty(command.getKeyValuePairs(), "Pairs must not be null or empty!");
 
@@ -224,7 +224,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<NumericResponse<AppendCommand, Long>> append(Publisher<AppendCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -240,7 +240,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<ByteBufferResponse<RangeCommand>> getRange(Publisher<RangeCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
@@ -259,7 +259,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<NumericResponse<SetRangeCommand, Long>> setRange(Publisher<SetRangeCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -277,7 +277,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<BooleanResponse<GetBitCommand>> getBit(Publisher<GetBitCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getOffset(), "Offset must not be null!");
@@ -294,7 +294,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<BooleanResponse<SetBitCommand>> setBit(Publisher<SetBitCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -312,7 +312,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<NumericResponse<BitCountCommand, Long>> bitCount(Publisher<BitCountCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -331,7 +331,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 	@Override
 	public Flux<NumericResponse<BitOpCommand, Long>> bitOp(Publisher<BitOpCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getDestinationKey(), "DestinationKey must not be null!");
 			Assert.notEmpty(command.getKeys(), "Keys must not be null or empty");
@@ -373,7 +373,7 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 
 		return connection.execute(cmd -> {
 
-			return Flux.from(commands).flatMap(command -> {
+			return Flux.from(commands).concatMap(command -> {
 				return cmd.strlen(command.getKey()).map(respValue -> new NumericResponse<>(command, respValue));
 			});
 		});

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
@@ -72,7 +72,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@SuppressWarnings("unchecked")
 	public Flux<NumericResponse<ZAddCommand, Number>> zAdd(Publisher<ZAddCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notEmpty(command.getTuples(), "Tuples must not be empty or null!");
@@ -121,7 +121,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@Override
 	public Flux<NumericResponse<ZRemCommand, Long>> zRem(Publisher<ZRemCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notEmpty(command.getValues(), "Values must not be null or empty!");
@@ -138,7 +138,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@Override
 	public Flux<NumericResponse<ZIncrByCommand, Double>> zIncrBy(Publisher<ZIncrByCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Member must not be null!");
@@ -156,7 +156,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@Override
 	public Flux<NumericResponse<ZRankCommand, Long>> zRank(Publisher<ZRankCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -175,7 +175,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@Override
 	public Flux<CommandResponse<ZRangeCommand, Flux<Tuple>>> zRange(Publisher<ZRangeCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
@@ -224,7 +224,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	public Flux<CommandResponse<ZRangeByScoreCommand, Flux<Tuple>>> zRangeByScore(
 			Publisher<ZRangeByScoreCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
@@ -298,7 +298,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@Override
 	public Flux<NumericResponse<ZCountCommand, Long>> zCount(Publisher<ZCountCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
@@ -317,7 +317,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@Override
 	public Flux<NumericResponse<KeyCommand, Long>> zCard(Publisher<KeyCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 
@@ -332,7 +332,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@Override
 	public Flux<NumericResponse<ZScoreCommand, Double>> zScore(Publisher<ZScoreCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getValue(), "Value must not be null!");
@@ -349,7 +349,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	public Flux<NumericResponse<ZRemRangeByRankCommand, Long>> zRemRangeByRank(
 			Publisher<ZRemRangeByRankCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
@@ -369,7 +369,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	public Flux<NumericResponse<ZRemRangeByScoreCommand, Long>> zRemRangeByScore(
 			Publisher<ZRemRangeByScoreCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getRange(), "Range must not be null!");
@@ -388,7 +388,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@Override
 	public Flux<NumericResponse<ZUnionStoreCommand, Long>> zUnionStore(Publisher<ZUnionStoreCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
 			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty!");
@@ -413,7 +413,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	@Override
 	public Flux<NumericResponse<ZInterStoreCommand, Long>> zInterStore(Publisher<ZInterStoreCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
 			Assert.notEmpty(command.getSourceKeys(), "Source keys must not be null or empty!");
@@ -439,7 +439,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 	public Flux<CommandResponse<ZRangeByLexCommand, Flux<ByteBuffer>>> zRangeByLex(
 			Publisher<ZRangeByLexCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Destination key must not be null!");
 

--- a/src/main/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutor.java
+++ b/src/main/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutor.java
@@ -75,9 +75,10 @@ public class DefaultReactiveScriptExecutor<K> implements ReactiveScriptExecutor<
 		Assert.notNull(keys, "Keys must not be null!");
 		Assert.notNull(args, "Args must not be null!");
 
-		// use the Template's value serializer for args and result
-		return execute(script, keys, args, serializationContext.getKeySerializationPair().getWriter(),
-				(RedisElementReader<T>) serializationContext.getValueSerializationPair().getReader());
+		SerializationPair<?> serializationPair = serializationContext.getValueSerializationPair();
+
+		return execute(script, keys, args, serializationPair.getWriter(),
+				(RedisElementReader<T>) serializationPair.getReader());
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/SettingsUtils.java
+++ b/src/test/java/org/springframework/data/redis/SettingsUtils.java
@@ -17,8 +17,11 @@ package org.springframework.data.redis;
 
 import java.util.Properties;
 
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+
 /**
  * @author Costin Leau
+ * @author Mark Paluch
  */
 public abstract class SettingsUtils {
 	private final static Properties DEFAULTS = new Properties();
@@ -43,5 +46,9 @@ public abstract class SettingsUtils {
 
 	public static int getPort() {
 		return Integer.valueOf(SETTINGS.getProperty("port"));
+	}
+
+	public static RedisStandaloneConfiguration standaloneConfiguration() {
+		return new RedisStandaloneConfiguration(getHost(), getPort());
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommandsTests.java
@@ -86,7 +86,7 @@ public class LettuceReactiveScriptingCommandsTests extends LettuceReactiveComman
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-683
+	@Test // DATAREDIS-683, DATAREDIS-711
 	public void evalShaShouldReturnMulti() {
 
 		assumeFalse(connection instanceof ReactiveRedisClusterConnection);
@@ -96,8 +96,7 @@ public class LettuceReactiveScriptingCommandsTests extends LettuceReactiveComman
 		StepVerifier
 				.create(connection.scriptingCommands().evalSha(sha1, ReturnType.MULTI, 1, SAME_SLOT_KEY_1_BBUFFER.duplicate(),
 						SAME_SLOT_KEY_2_BBUFFER.duplicate())) //
-				.expectNext(SAME_SLOT_KEY_1_BBUFFER) //
-				.expectNext(SAME_SLOT_KEY_2_BBUFFER) //
+				.expectNext(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER)) //
 				.verifyComplete();
 	}
 
@@ -133,14 +132,13 @@ public class LettuceReactiveScriptingCommandsTests extends LettuceReactiveComman
 				.verifyComplete();
 	}
 
-	@Test // DATAREDIS-683
+	@Test // DATAREDIS-683, DATAREDIS-711
 	public void evalShouldReturnMultiNumbers() {
 
 		ByteBuffer script = wrap("return {1,2}");
 
 		StepVerifier.create(connection.scriptingCommands().eval(script, ReturnType.MULTI, 0)) //
-				.expectNext(1L) //
-				.expectNext(2L) //
+				.expectNext(Arrays.asList(1L, 2L)) //
 				.verifyComplete();
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
+import org.springframework.data.redis.util.ByteUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -116,8 +117,8 @@ public class LettuceReactiveStringCommandsTests extends LettuceReactiveCommandsT
 		Stream<KeyCommand> stream = Stream.of(new KeyCommand(KEY_1_BBUFFER), new KeyCommand(KEY_2_BBUFFER));
 		Flux<ByteBufferResponse<KeyCommand>> result = connection.stringCommands().get(Flux.fromStream(stream));
 
-		StepVerifier.create(result.map(CommandResponse::getOutput)) //
-				.expectNext(VALUE_1_BBUFFER, VALUE_2_BBUFFER) //
+		StepVerifier.create(result.map(CommandResponse::getOutput).map(ByteUtils::getBytes).map(String::new)) //
+				.expectNext(new String(ByteUtils.getBytes(VALUE_1_BBUFFER)), new String(ByteUtils.getBytes(VALUE_2_BBUFFER))) //
 				.verifyComplete();
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceTestClientConfiguration.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceTestClientConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.resource.ClientResources;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder;
+
+/**
+ * Creates a specific client configuration for Lettuce tests.
+ * 
+ * @author Mark Paluch
+ */
+public class LettuceTestClientConfiguration {
+
+	/**
+	 * @return an initialized {@link LettuceClientConfigurationBuilder} with shutdown timeout and {@link ClientResources}.
+	 * @see LettuceTestClientResources#getSharedClientResources()
+	 */
+	public static LettuceClientConfigurationBuilder builder() {
+		return LettuceClientConfiguration.builder().shutdownTimeout(Duration.ZERO)
+				.clientResources(LettuceTestClientResources.getSharedClientResources());
+	}
+
+	/**
+	 * @return a defaulted {@link LettuceClientConfiguration} for testing.
+	 */
+	public static LettuceClientConfiguration create() {
+		return builder().build();
+	}
+}

--- a/src/test/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutorTests.java
+++ b/src/test/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutorTests.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.script;
+
+import static org.assertj.core.api.Assertions.*;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.Person;
+import org.springframework.data.redis.SettingsUtils;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceTestClientConfiguration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisElementReader;
+import org.springframework.data.redis.serializer.RedisElementWriter;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializationContext.RedisSerializationContextBuilder;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.scripting.support.StaticScriptSource;
+
+/**
+ * @author Mark Paluch
+ */
+public class DefaultReactiveScriptExecutorTests {
+
+	private static LettuceConnectionFactory connectionFactory;
+	private static StringRedisTemplate stringTemplate;
+	private static ReactiveScriptExecutor<String> stringScriptExecutor;
+
+	@BeforeClass
+	public static void setUp() {
+
+		connectionFactory = new LettuceConnectionFactory(SettingsUtils.standaloneConfiguration(),
+				LettuceTestClientConfiguration.create());
+		connectionFactory.afterPropertiesSet();
+
+		stringTemplate = new StringRedisTemplate(connectionFactory);
+		stringScriptExecutor = new DefaultReactiveScriptExecutor<>(connectionFactory, RedisSerializationContext.string());
+	}
+
+	@AfterClass
+	public static void cleanUp() {
+
+		if (connectionFactory != null) {
+			connectionFactory.destroy();
+		}
+	}
+
+	@Before
+	public void before() {
+
+		RedisConnection connection = connectionFactory.getConnection();
+		connection.flushDb();
+		connection.close();
+	}
+
+	protected RedisConnectionFactory getConnectionFactory() {
+		return connectionFactory;
+	}
+
+	@Test // DATAREDIS-711
+	public void shouldReturnLong() {
+
+		DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+		script.setLocation(new ClassPathResource("org/springframework/data/redis/core/script/increment.lua"));
+		script.setResultType(Long.class);
+
+		StepVerifier.create(stringScriptExecutor.execute(script, Collections.singletonList("mykey"))).verifyComplete();
+
+		stringTemplate.opsForValue().set("mykey", "2");
+
+		StepVerifier.create(stringScriptExecutor.execute(script, Collections.singletonList("mykey"))).expectNext(3L)
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-711
+	public void shouldReturnBoolean() {
+
+		RedisSerializationContextBuilder<String, Long> builder = RedisSerializationContext
+				.newSerializationContext(new StringRedisSerializer());
+		builder.value(new GenericToStringSerializer<>(Long.class));
+
+		DefaultRedisScript<Boolean> script = new DefaultRedisScript<>();
+		script.setLocation(new ClassPathResource("org/springframework/data/redis/core/script/cas.lua"));
+		script.setResultType(Boolean.class);
+
+		ReactiveScriptExecutor<String> scriptExecutor = new DefaultReactiveScriptExecutor<>(connectionFactory,
+				builder.build());
+
+		stringTemplate.opsForValue().set("counter", "0");
+
+		StepVerifier.create(scriptExecutor.execute(script, Collections.singletonList("counter"), Arrays.asList(0, 3)))
+				.expectNext(true).verifyComplete();
+
+		StepVerifier.create(scriptExecutor.execute(script, Collections.singletonList("counter"), Arrays.asList(0, 3)))
+				.expectNext(false).verifyComplete();
+	}
+
+	@Test // DATAREDIS-711
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void shouldApplyCustomArgsSerializer() {
+
+		DefaultRedisScript<List> script = new DefaultRedisScript<>();
+		script.setLocation(new ClassPathResource("org/springframework/data/redis/core/script/bulkpop.lua"));
+		script.setResultType(List.class);
+
+		stringTemplate.boundListOps("mylist").leftPushAll("a", "b", "c", "d");
+
+		Flux<List<String>> mylist = stringScriptExecutor.execute(script, Collections.singletonList("mylist"),
+				Collections.singletonList(1L), RedisElementWriter.from(new GenericToStringSerializer<>(Long.class)),
+				(RedisElementReader) RedisElementReader.from(new StringRedisSerializer()));
+
+		StepVerifier.create(mylist).expectNext(Collections.singletonList("a")).verifyComplete();
+	}
+
+	@Test // DATAREDIS-711
+	public void testExecuteMixedListResult() {
+
+		DefaultRedisScript<List> script = new DefaultRedisScript<>();
+		script.setLocation(new ClassPathResource("org/springframework/data/redis/core/script/popandlength.lua"));
+		script.setResultType(List.class);
+
+		StepVerifier.create(stringScriptExecutor.execute(script, Collections.singletonList("mylist")))
+				.expectNext(Arrays.asList(null, 0L)).verifyComplete();
+
+		stringTemplate.boundListOps("mylist").leftPushAll("a", "b");
+
+		StepVerifier.create(stringScriptExecutor.execute(script, Collections.singletonList("mylist")))
+				.expectNext(Arrays.asList("a", 1L)).verifyComplete();
+	}
+
+	@Test // DATAREDIS-711
+	public void shouldReturnValueResult() {
+
+		DefaultRedisScript<String> script = new DefaultRedisScript<>();
+		script.setScriptText("return redis.call('GET',KEYS[1])");
+		script.setResultType(String.class);
+
+		stringTemplate.opsForValue().set("foo", "bar");
+
+		Flux<String> foo = stringScriptExecutor.execute(script, Collections.singletonList("foo"));
+
+		StepVerifier.create(foo).expectNext("bar").expectNext();
+	}
+
+	@Test // DATAREDIS-711
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void shouldReturnStatusValue() {
+
+		DefaultRedisScript script = new DefaultRedisScript();
+		script.setScriptText("return redis.call('SET',KEYS[1], ARGV[1])");
+
+		RedisSerializationContextBuilder<String, Long> builder = RedisSerializationContext
+				.newSerializationContext(new StringRedisSerializer());
+		builder.value(new GenericToStringSerializer<>(Long.class));
+
+		ReactiveScriptExecutor<String> scriptExecutor = new DefaultReactiveScriptExecutor<>(connectionFactory,
+				builder.build());
+
+		StepVerifier.create(scriptExecutor.execute(script, Collections.singletonList("foo"), Collections.singletonList(3L)))
+				.expectNext("OK").verifyComplete();
+
+		assertThat(stringTemplate.opsForValue().get("foo")).isEqualTo("3");
+	}
+
+	@Test // DATAREDIS-711
+	public void shouldApplyCustomResultSerializer() {
+
+		Jackson2JsonRedisSerializer<Person> personSerializer = new Jackson2JsonRedisSerializer<>(Person.class);
+
+		RedisTemplate<String, Person> template = new RedisTemplate<>();
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(personSerializer);
+		template.setConnectionFactory(getConnectionFactory());
+		template.afterPropertiesSet();
+
+		DefaultRedisScript<String> script = new DefaultRedisScript<>();
+		script.setScriptSource(new StaticScriptSource("redis.call('SET',KEYS[1], ARGV[1])\nreturn 'FOO'"));
+		script.setResultType(String.class);
+
+		Person joe = new Person("Joe", "Schmoe", 23);
+		Flux<String> result = stringScriptExecutor.execute(script, Collections.singletonList("bar"),
+				Collections.singletonList(joe), RedisElementWriter.from(personSerializer),
+				RedisElementReader.from(new StringRedisSerializer()));
+
+		StepVerifier.create(result).expectNext("FOO").verifyComplete();
+
+		assertThat(template.opsForValue().get("bar")).isEqualTo(joe);
+	}
+
+	@Test // DATAREDIS-711
+	public void testExecuteCachedNullKeys() {
+
+		DefaultRedisScript<String> script = new DefaultRedisScript<>();
+		script.setScriptText("return 'HELLO'");
+		script.setResultType(String.class);
+
+		// Execute script twice, second time should be from cache
+		StepVerifier.create(stringScriptExecutor.execute(script, Collections.emptyList())).expectNext("HELLO")
+				.verifyComplete();
+		StepVerifier.create(stringScriptExecutor.execute(script, Collections.emptyList())).expectNext("HELLO")
+				.verifyComplete();
+	}
+}


### PR DESCRIPTION
We now emit array responses from Lua script execution as complete `List` instead of emitting the individual elements through the `Publisher`.

Lua scripts may return nil (`null`) elements that would be not emitted through a `Publisher`. Skipping `null` values would garble up the response – and in several cases, the response array is required as `List`. Emitting the whole `List` aligns the response to the signatures imposed by generics and aligns the behavior with the imperative API.

Fix value serialization by using the configured value serializer when serializing Lua script arguments.

---

Related ticket: [DATAREDIS-711](https://jira.spring.io/browse/DATAREDIS-711).