### PR TITLE
DATAREDIS-698 - Add support for HSTRLEN. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-698-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -15,17 +15,8 @@
  */
 package org.springframework.data.redis.connection;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
@@ -3047,7 +3038,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	 */
 	@Override
 	public Object execute(String command) {
-		return execute(command, (byte[][]) null);
+		return execute(command, EMPTY_2D_BYTE_ARRAY);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -3203,6 +3203,16 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisSetCommands#hStrLen(byte[], byte[])
+	 */
+	@Nullable
+	@Override
+	public Long hStrLen(byte[] key, byte[] field) {
+		return convertAndReturn(delegate.hStrLen(key, field), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisServerCommands#setClientName(java.lang.String)
 	 */
 	@Override
@@ -3261,6 +3271,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 						throw new UnsupportedOperationException("Cannot set value for entry in cursor");
 					}
 				});
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#hStrLen(java.lang.String, java.lang.String)
+	 */
+	@Override
+	public Long hStrLen(String key, String field) {
+		return hStrLen(serialize(key), serialize(field));
 	}
 
 	/*
@@ -3472,8 +3491,8 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 			return null;
 		}
 
-
-		return value == null ? null : ObjectUtils.nullSafeEquals(converter, identityConverter) ? (T) value : (T) converter.convert(value);
+		return value == null ? null
+				: ObjectUtils.nullSafeEquals(converter, identityConverter) ? (T) value : (T) converter.convert(value);
 	}
 
 	private void addResultConverter(Converter<?, ?> converter) {

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisClusterConnection.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.redis.connection;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
@@ -142,16 +141,22 @@ public interface DefaultedRedisClusterConnection extends RedisClusterConnection,
 	 */
 	@Nullable
 	@Override
+	@SuppressWarnings("unchecked")
 	default <T> T execute(String command, byte[] key, Collection<byte[]> args) {
 
 		Assert.notNull(command, "Command must not be null!");
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(args, "Args must not be null!");
 
-		ArrayList<byte[]> allArgs = new ArrayList();
-		allArgs.add(key);
-		allArgs.addAll(args);
+		byte[][] commandArgs = new byte[args.size() + 1][];
 
-		return (T) execute(command, allArgs.toArray(new byte[allArgs.size()][]));
+		commandArgs[0] = key;
+		int targetIndex = 1;
+
+		for (byte[] binaryArgument : args) {
+			commandArgs[targetIndex++] = binaryArgument;
+		}
+
+		return (T) execute(command, commandArgs);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisClusterConnection.java
@@ -15,10 +15,14 @@
  */
 package org.springframework.data.redis.connection;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
 import org.springframework.data.redis.core.types.RedisClientInfo;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
@@ -130,5 +134,24 @@ public interface DefaultedRedisClusterConnection extends RedisClusterConnection,
 	@Deprecated
 	default List<RedisClientInfo> getClientList(RedisClusterNode node) {
 		return serverCommands().getClientList(node);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisClusterConnection#execute(String, byte[], Collection)
+	 */
+	@Nullable
+	@Override
+	default <T> T execute(String command, byte[] key, Collection<byte[]> args) {
+
+		Assert.notNull(command, "Command must not be null!");
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(args, "Args must not be null!");
+
+		ArrayList<byte[]> allArgs = new ArrayList();
+		allArgs.add(key);
+		allArgs.addAll(args);
+
+		return (T) execute(command, allArgs.toArray(new byte[allArgs.size()][]));
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -916,6 +916,13 @@ public interface DefaultedRedisConnection extends RedisConnection {
 		return hashCommands().hScan(key, options);
 	}
 
+	/** @deprecated in favor of {@link RedisConnection#hashCommands()}. */
+	@Override
+	@Deprecated
+	default Long hStrLen(byte[] key, byte[] field) {
+		return hashCommands().hStrLen(key, field);
+	}
+
 	// GEO COMMANDS
 
 	/** @deprecated in favor of {@link RedisConnection#geoCommands()}}. */

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -623,17 +623,16 @@ public interface ReactiveHashCommands {
 		}
 
 		/**
-		 * @return {@literal null} if not already set.
+		 * @return the field.
 		 */
-		@Nullable
 		public ByteBuffer getField() {
 			return field;
 		}
 	}
 
 	/**
-	 * Get the length of the value associated with {@code hashKey}. If either the {@code key} or the {@code hashKey} do
-	 * not exist, {@code 0} is emitted.
+	 * Get the length of the value associated with {@code field}. If either the {@code key} or the {@code field} do not
+	 * exist, {@code 0} is emitted.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param field must not be {@literal null}.
@@ -649,8 +648,8 @@ public interface ReactiveHashCommands {
 	}
 
 	/**
-	 * Get the length of the value associated with {@code hashKey}. If either the {@code key} or the {@code hashKey} do
-	 * not exist, {@code 0} is emitted.
+	 * Get the length of the value associated with {@code field}. If either the {@code key} or the {@code field} do not
+	 * exist, {@code 0} is emitted.
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return never {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -578,4 +578,83 @@ public interface ReactiveHashCommands {
 	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<Map.Entry<ByteBuffer, ByteBuffer>>>> hGetAll(Publisher<KeyCommand> commands);
+
+	/**
+	 * @author Christoph Strobl
+	 * @see <a href="http://redis.io/commands/hstrlen">Redis Documentation: HSTRLEN</a>
+	 * @since 2.1
+	 */
+	class HStrLenCommand extends KeyCommand {
+
+		private ByteBuffer field;
+
+		/**
+		 * Creates a new {@link HStrLenCommand} given a {@code key}.
+		 *
+		 * @param key can be {@literal null}.
+		 * @param field must not be {@literal null}.
+		 */
+		private HStrLenCommand(@Nullable ByteBuffer key, ByteBuffer field) {
+
+			super(key);
+			this.field = field;
+		}
+
+		/**
+		 * Specify the {@code field} within the hash to get the length of the {@code value} of.ø
+		 *
+		 * @param field must not be {@literal null}.
+		 * @return new instance of {@link HStrLenCommand}.
+		 */
+		public static HStrLenCommand lengthOf(ByteBuffer field) {
+
+			Assert.notNull(field, "Field must not be null!");
+			return new HStrLenCommand(null, field);
+		}
+
+		/**
+		 * Define the {@code key} the hash is stored at.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return new instance of {@link HStrLenCommand}.
+		 */
+		public HStrLenCommand from(ByteBuffer key) {
+			return new HStrLenCommand(key, field);
+		}
+
+		/**
+		 * @return {@literal null} if not already set.
+		 */
+		@Nullable
+		public ByteBuffer getField() {
+			return field;
+		}
+	}
+
+	/**
+	 * Get the length of the value associated with {@code hashKey}. If either the {@code key} or the {@code hashKey} do
+	 * not exist, {@code 0} is emitted.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.1
+	 */
+	default Mono<Long> hStrLen(ByteBuffer key, ByteBuffer field) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(field, "Field must not be null!");
+
+		return hStrLen(Mono.just(HStrLenCommand.lengthOf(field).from(key))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Get the length of the value associated with {@code hashKey}. If either the {@code key} or the {@code hashKey} do
+	 * not exist, {@code 0} is emitted.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.1
+	 */
+	Flux<NumericResponse<HStrLenCommand, Long>> hStrLen(Publisher<HStrLenCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConnection.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection;
 
+import java.util.Collection;
 import java.util.Set;
 
 import org.springframework.lang.Nullable;
@@ -55,6 +56,27 @@ public interface RedisClusterConnection extends RedisConnection, RedisClusterCom
 	 */
 	@Nullable
 	byte[] randomKey(RedisClusterNode node);
+
+	/**
+	 * Execute the given command for the {@code key} provided potentially appending args. <br />
+	 * This method, other than {@link #execute(String, byte[]...)}, dispatches the command to the {@code key} serving
+	 * master node.
+	 *
+	 * <pre>
+	 * <code>
+	 * // SET foo bar EX 10 NX
+	 * execute("SET", "foo".getBytes(), asBinaryList("bar", "EX", 10, "NX")
+	 * </code>
+	 * </pre>
+	 *
+	 * @param command must not be {@literal null}.
+	 * @param key must not be {@literal null}.
+	 * @param args must not be {@literal null}.
+	 * @return command result as delivered by the underlying Redis driver. Can be {@literal null}.
+	 * @since 2.1
+	 */
+	@Nullable
+	<T> T execute(String command, byte[] key, Collection<byte[]> args);
 
 	/**
 	 * Get {@link RedisClusterServerCommands}.

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConnection.java
@@ -65,7 +65,7 @@ public interface RedisClusterConnection extends RedisConnection, RedisClusterCom
 	 * <pre>
 	 * <code>
 	 * // SET foo bar EX 10 NX
-	 * execute("SET", "foo".getBytes(), asBinaryList("bar", "EX", 10, "NX")
+	 * execute("SET", "foo".getBytes(), asBinaryList("bar", "EX", 10, "NX"))
 	 * </code>
 	 * </pre>
 	 *

--- a/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
@@ -183,4 +183,16 @@ public interface RedisHashCommands {
 	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
 	 */
 	Cursor<Map.Entry<byte[], byte[]>> hScan(byte[] key, ScanOptions options);
+
+	/**
+	 * Returns the length of the value associated with {@code field} in the hash stored at {@code key}. If the key or the
+	 * field do not exist, {@code 0} is returned.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @since 2.1
+	 */
+	@Nullable
+	Long hStrLen(byte[] key, byte[] field);
 }

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -1509,6 +1509,18 @@ public interface StringRedisConnection extends RedisConnection {
 	 */
 	Cursor<Map.Entry<String, String>> hScan(String key, ScanOptions options);
 
+	/**
+	 * Returns the length of the value associated with {@code field} in the hash stored at {@code key}. If the key or the
+	 * field do not exist, {@code 0} is returned.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param field must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @since 2.1
+	 */
+	@Nullable
+	Long hStrLen(String key, String field);
+
 	// -------------------------------------------------------------------------
 	// Methods dealing with HyperLogLog
 	// -------------------------------------------------------------------------

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientUtils.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientUtils.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.jedis;
+
+import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.Builder;
+import redis.clients.jedis.Client;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.Protocol.Command;
+import redis.clients.jedis.Queable;
+import redis.clients.jedis.Response;
+import redis.clients.util.RedisOutputStream;
+import redis.clients.util.SafeEncoder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.lang.Nullable;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * @author Christoph Strobl
+ * @since 2.1
+ */
+class JedisClientUtils {
+
+	private static final Field CLIENT_FIELD;
+	private static final Method SEND_COMMAND;
+	private static final Method GET_RESPONSE;
+	private static final Method PROTOCOL_SEND_COMMAND;
+
+	static {
+
+		CLIENT_FIELD = ReflectionUtils.findField(BinaryJedis.class, "client", Client.class);
+		ReflectionUtils.makeAccessible(CLIENT_FIELD);
+
+		PROTOCOL_SEND_COMMAND = ReflectionUtils.findMethod(Protocol.class, "sendCommand", RedisOutputStream.class,
+				byte[].class, byte[][].class);
+		ReflectionUtils.makeAccessible(PROTOCOL_SEND_COMMAND);
+
+		try {
+			Class<?> commandType = ClassUtils.isPresent("redis.clients.jedis.ProtocolCommand", null)
+					? ClassUtils.forName("redis.clients.jedis.ProtocolCommand", null)
+					: ClassUtils.forName("redis.clients.jedis.Protocol$Command", null);
+
+			SEND_COMMAND = ReflectionUtils.findMethod(Connection.class, "sendCommand",
+					new Class[] { commandType, byte[][].class });
+		} catch (Exception e) {
+			throw new NoClassDefFoundError(
+					"Could not find required flavor of command required by 'redis.clients.jedis.Connection#sendCommand'.");
+		}
+
+		ReflectionUtils.makeAccessible(SEND_COMMAND);
+
+		GET_RESPONSE = ReflectionUtils.findMethod(Queable.class, "getResponse", Builder.class);
+		ReflectionUtils.makeAccessible(GET_RESPONSE);
+	}
+
+	@Nullable
+	static <T> T execute(String command, Collection<byte[]> keys, Collection<byte[]> args, Supplier<Jedis> jedis) {
+
+		List<byte[]> mArgs = new ArrayList<>(keys);
+		mArgs.addAll(args);
+
+		Client client = retrieveClient(jedis.get());
+		sendCommand(client, command, mArgs.toArray(new byte[mArgs.size()][]));
+
+		return (T) client.getOne();
+	}
+
+	static Client retrieveClient(Jedis jedis) {
+		return (Client) ReflectionUtils.getField(CLIENT_FIELD, jedis);
+	}
+
+	static Client sendCommand(Jedis jedis, String command, byte[][] args) {
+
+		Client client = retrieveClient(jedis);
+
+		if (isKnownCommand(command)) {
+			ReflectionUtils.invokeMethod(SEND_COMMAND, client, Command.valueOf(command.trim().toUpperCase()), args);
+		} else {
+			sendProtocolCommand(client, command, args);
+		}
+
+		return client;
+	}
+
+	static void sendCommand(Client client, String command, byte[][] args) {
+
+		if (isKnownCommand(command)) {
+			ReflectionUtils.invokeMethod(SEND_COMMAND, client, Command.valueOf(command.trim().toUpperCase()), args);
+		} else {
+			sendProtocolCommand(client, command, args);
+		}
+	}
+
+	static void sendProtocolCommand(Client client, String command, byte[][] args) {
+
+		DirectFieldAccessor dfa = new DirectFieldAccessor(client);
+
+		client.connect();
+
+		RedisOutputStream os = (RedisOutputStream) dfa.getPropertyValue("outputStream");
+		ReflectionUtils.invokeMethod(PROTOCOL_SEND_COMMAND, null, os, SafeEncoder.encode(command), args);
+
+		Integer pipelinedCommands = (Integer) dfa.getPropertyValue("pipelinedCommands");
+		dfa.setPropertyValue("pipelinedCommands", pipelinedCommands.intValue() + 1);
+	}
+
+	static boolean isKnownCommand(String command) {
+
+		try {
+			Command.valueOf(command);
+			return true;
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+	}
+
+	static boolean isInMulti(Jedis jedis) {
+		return retrieveClient(jedis).isInMulti();
+	}
+
+	static Response<Object> getGetResponse(Object target) {
+
+		return (Response<Object>) ReflectionUtils.invokeMethod(GET_RESPONSE, target, new Builder<Object>() {
+			public Object build(Object data) {
+				return data;
+			}
+
+			public String toString() {
+				return "Object";
+			}
+		});
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.jedis;
 import redis.clients.jedis.ScanParams;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -29,6 +30,7 @@ import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanCursor;
 import org.springframework.data.redis.core.ScanIteration;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -286,7 +288,18 @@ class JedisClusterHashCommands implements RedisHashCommands {
 		}.open();
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisHashCommands#hStrLen(byte[], byte[])
+	 */
+	@Nullable
+	@Override
+	public Long hStrLen(byte[] key, byte[] field) {
+		return Long.class.cast(connection.execute("HSTRLEN", key, Collections.singleton(field)));
+	}
+
 	private DataAccessException convertJedisAccessException(Exception ex) {
+
 		return connection.convertJedisAccessException(ex);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -42,7 +42,6 @@ import org.springframework.data.redis.connection.convert.TransactionResultConver
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -273,20 +272,18 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public Object execute(String command, byte[]... args) {
-		Assert.hasText(command, "a valid command needs to be specified");
-		try {
-			List<byte[]> mArgs = new ArrayList<>();
-			if (!ObjectUtils.isEmpty(args)) {
-				Collections.addAll(mArgs, args);
-			}
 
-			Client client = JedisClientUtils.sendCommand(this.jedis, command, mArgs.toArray(new byte[mArgs.size()][]));
+		Assert.hasText(command, "A valid command needs to be specified!");
+		Assert.notNull(args, "Arguments must not be null!");
+
+		try {
+
+			Client client = JedisClientUtils.sendCommand(command, args, this.jedis);
 
 			if (isQueueing() || isPipelined()) {
-				Object target = (isPipelined() ? pipeline : transaction);
-				@SuppressWarnings("unchecked")
 
-				Response<Object> result = JedisClientUtils.getGetResponse(target);
+				Response<Object> result = JedisClientUtils
+						.getResponse(isPipelined() ? getRequiredPipeline() : getRequiredTransaction());
 				if (isPipelined()) {
 					pipeline(new JedisResult(result));
 				} else {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
@@ -31,6 +31,7 @@ import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.KeyBoundCursor;
 import org.springframework.data.redis.core.ScanIteration;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -412,6 +413,20 @@ class JedisHashCommands implements RedisHashCommands {
 			};
 
 		}.open();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisHashCommands#hStrLen(byte[], byte[])
+	 */
+	@Nullable
+	@Override
+	public Long hStrLen(byte[] key, byte[] field) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(field, "Field must not be null!");
+
+		return Long.class.cast(connection.execute("HSTRLEN", key, field));
 	}
 
 	private boolean isPipelined() {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
@@ -35,6 +35,7 @@ import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.KeyBoundCursor;
 import org.springframework.data.redis.core.ScanIteration;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -416,6 +417,31 @@ class LettuceHashCommands implements RedisHashCommands {
 			}
 
 		}.open();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisHashCommands#hStrLen(byte[], byte[])
+	 */
+	@Nullable
+	@Override
+	public Long hStrLen(byte[] key, byte[] field) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(field, "Field must not be null!");
+		try {
+			if (isPipelined()) {
+				pipeline(connection.newLettuceResult(getAsyncConnection().hstrlen(key, field)));
+				return null;
+			}
+			if (isQueueing()) {
+				transaction(connection.newLettuceTxResult(getConnection().hstrlen(key, field)));
+				return null;
+			}
+			return getConnection().hstrlen(key, field);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
+		}
 	}
 
 	private boolean isPipelined() {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
@@ -224,8 +224,8 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 
 		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
 
-			Assert.notNull(command.getKey(), "Command.getKey() must not be null!");
-			Assert.notNull(command.getField(), "Command.getField() must not be null!");
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getField(), "Field must not be null!");
 
 			return cmd.hstrlen(command.getKey(), command.getField()).map(value -> new NumericResponse<>(command, value));
 		}));

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
@@ -214,4 +214,20 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 			return Mono.just(new CommandResponse<>(command, result.flatMapMany(v -> Flux.fromStream(v.entrySet().stream()))));
 		}));
 	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hstrlen(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<HStrLenCommand, Long>> hStrLen(Publisher<HStrLenCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).flatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Command.getKey() must not be null!");
+			Assert.notNull(command.getField(), "Command.getField() must not be null!");
+
+			return cmd.hstrlen(command.getKey(), command.getField()).map(value -> new NumericResponse<>(command, value));
+		}));
+	}
 }

--- a/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
@@ -97,6 +97,17 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 	Set<HK> keys();
 
 	/**
+	 * Returns the length of the value associated with {@code hashKey}. If the {@code hashKey} do not exist, {@code 0} is
+	 * returned.
+	 *
+	 * @param hashKey must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @since 2.1
+	 */
+	@Nullable
+	Long lengthOfValue(HK hashKey);
+
+	/**
 	 * Get size of hash at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.

--- a/src/main/java/org/springframework/data/redis/core/DefaultBoundHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultBoundHashOperations.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.springframework.data.redis.connection.DataType;
+import org.springframework.lang.Nullable;
 
 /**
  * Default implementation for {@link HashOperations}.
@@ -116,6 +117,16 @@ class DefaultBoundHashOperations<H, HK, HV> extends DefaultBoundKeyOperations<H>
 	@Override
 	public Set<HK> keys() {
 		return ops.keys(getKey());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.BoundHashOperations#lengthOfValue(java.lang.Object, java.lang.Object)
+	 */
+	@Nullable
+	@Override
+	public Long lengthOfValue(HK hashKey) {
+		return ops.lengthOfValue(getKey(), hashKey);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.Nullable;
 
 /**
  * Default implementation of {@link HashOperations}.
@@ -112,6 +113,19 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 
 		byte[] rawKey = rawKey(key);
 		return execute(connection -> connection.hLen(rawKey), true);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.HashOperations#lengthOfValue(java.lang.Object, java.lang.Object)
+	 */
+	@Nullable
+	@Override
+	public Long lengthOfValue(K key, HK hashKey) {
+
+		byte[] rawKey = rawKey(key);
+		byte[] rawHashKey = rawHashKey(hashKey);
+		return execute(connection -> connection.hStrLen(rawKey, rawHashKey), true);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/HashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/HashOperations.java
@@ -97,6 +97,18 @@ public interface HashOperations<H, HK, HV> {
 	Set<HK> keys(H key);
 
 	/**
+	 * Returns the length of the value associated with {@code hashKey}. If either the {@code key} or the {@code hashKey}
+	 * do not exist, {@code 0} is returned.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param hashKey must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @since 2.1
+	 */
+	@Nullable
+	Long lengthOfValue(H key, HK hashKey);
+
+	/**
 	 * Get size of hash at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -2648,6 +2648,36 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(((GeoResults<GeoLocation<String>>) results.get(1)).getContent(), hasSize(2));
 	}
 
+	@Test // DATAREDIS-698
+	public void hStrLenReturnsFieldLength() {
+
+		actual.add(connection.hSet("hash-hstrlen", "key-1", "value-1"));
+		actual.add(connection.hSet("hash-hstrlen", "key-2", "value-2"));
+		actual.add(connection.hStrLen("hash-hstrlen", "key-2"));
+
+		verifyResults(
+				Arrays.asList(new Object[] { Boolean.TRUE, Boolean.TRUE, Long.valueOf("value-2".length()) }));
+	}
+
+	@Test // DATAREDIS-698
+	public void hStrLenReturnsZeroWhenFieldDoesNotExist() {
+
+		actual.add(connection.hSet("hash-hstrlen", "key-1", "value-1"));
+		actual.add(connection.hStrLen("hash-hstrlen", "key-2"));
+
+		verifyResults(
+				Arrays.asList(new Object[] { Boolean.TRUE, 0L }));
+	}
+
+	@Test // DATAREDIS-698
+	public void hStrLenReturnsZeroWhenKeyDoesNotExist() {
+
+		actual.add(connection.hStrLen("hash-no-exist", "key-2"));
+
+		verifyResults(
+				Arrays.asList(new Object[] { 0L }));
+	}
+
 	protected void verifyResults(List<Object> expected) {
 		assertEquals(expected, getResults());
 	}

--- a/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
@@ -633,4 +633,13 @@ public interface ClusterConnectionTests {
 
 	// DATAREDIS-438
 	void geoRemoveDeletesMembers();
+
+	// DATAREDIS-698
+	void hStrLenReturnsFieldLength();
+
+	// DATAREDIS-698
+	void hStrLenReturnsZeroWhenFieldDoesNotExist();
+
+	// DATAREDIS-698
+	void hStrLenReturnsZeroWhenKeyDoesNotExist();
 }

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
@@ -18,16 +18,7 @@ package org.springframework.data.redis.connection;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
@@ -1702,7 +1693,7 @@ public class DefaultStringRedisConnectionTests {
 
 	@Test
 	public void testExecute() {
-		doReturn("foo").when(nativeConnection).execute("something", (byte[][]) null);
+		doReturn("foo").when(nativeConnection).execute("something", new byte[0][]);
 		actual.add(connection.execute("something"));
 		verifyResults(Arrays.asList(new Object[] { "foo" }));
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -2145,4 +2145,25 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		assertThat(clusterConnection.geoRemove(KEY_1_BYTES, ARIGENTO_BYTES.getName()), is(1L));
 	}
+
+	@Test // DATAREDIS-698
+	public void hStrLenReturnsFieldLength() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_3);
+
+		assertThat(clusterConnection.hashCommands().hStrLen(KEY_1_BYTES, KEY_2_BYTES), is(Long.valueOf(VALUE_3.length())));
+	}
+
+	@Test // DATAREDIS-698
+	public void hStrLenReturnsZeroWhenFieldDoesNotExist() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_3);
+
+		assertThat(clusterConnection.hashCommands().hStrLen(KEY_1_BYTES, KEY_3_BYTES), is(0L));
+	}
+
+	@Test // DATAREDIS-698
+	public void hStrLenReturnsZeroWhenKeyDoesNotExist() {
+		assertThat(clusterConnection.hashCommands().hStrLen(KEY_1_BYTES, KEY_1_BYTES), is(0L));
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
@@ -205,6 +205,32 @@ public class LettuceReactiveHashCommandsTests extends LettuceReactiveCommandsTes
 					assertTrue(list.containsAll(expected.entrySet()));
 				}) //
 				.verifyComplete();
+	}
 
+	@Test // DATAREDIS-698
+	public void hStrLenReturnsFieldLength() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+
+		StepVerifier.create(connection.hashCommands().hStrLen(KEY_1_BBUFFER, FIELD_1_BBUFFER))
+				.expectNext(Long.valueOf(VALUE_1.length())) //
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-698
+	public void hStrLenReturnsZeroWhenFieldDoesNotExist() {
+
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_3);
+
+		StepVerifier.create(connection.hashCommands().hStrLen(KEY_1_BBUFFER, FIELD_1_BBUFFER)).expectNext(0L) //
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-698
+	public void hStrLenReturnsZeroWhenKeyDoesNotExist() {
+
+		StepVerifier.create(connection.hashCommands().hStrLen(KEY_1_BBUFFER, FIELD_1_BBUFFER)).expectNext(0L) //
+				.verifyComplete();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/DefaultHashOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultHashOperationsTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.core;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -170,6 +171,24 @@ public class DefaultHashOperationsTests<K, HK, HV> {
 
 		it.close();
 		assertThat(count, is(hashOps.size(key)));
+	}
+
+	@Test // DATAREDIS-698
+	@IfProfileValue(name = "redisVersion", value = "3.0.3+")
+	public void lengthOfValue() throws IOException {
+
+		assumeThat(hashValueFactory instanceof StringObjectFactory, is(true));
+
+		K key = keyFactory.instance();
+		HK key1 = hashKeyFactory.instance();
+		HV val1 = hashValueFactory.instance();
+		HK key2 = hashKeyFactory.instance();
+		HV val2 = hashValueFactory.instance();
+
+		hashOps.put(key, key1, val1);
+		hashOps.put(key, key2, val2);
+
+		assertThat(hashOps.lengthOfValue(key, key1), is(Long.valueOf(val1.toString().length())));
 	}
 
 }


### PR DESCRIPTION
We now support `HSTRLEN` command throughout `RedisHashCommand` for Lettuce and Jedis in both an imperative and reactive (Lettuce only) manner.

However as Jedis does not natively support `HSTRLEN` via its API we’ve come up with some more reflective invocation allowing to execute commands currently not known by Jedis. We also added this behavior to the cluster implementation which as of now also supports `RedisClusterConnection#execute`.