### PR TITLE
DATAREDIS-694 - Add support for TOUCH.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-694-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -1216,6 +1216,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisKeyCommands#touch(byte[][])
+	 */
+	@Override
+	public Long touch(byte[]... keys) {
+		return convertAndReturn(delegate.touch(keys), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisTxCommands#unwatch()
 	 */
 	@Override
@@ -2503,6 +2512,16 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	@Override
 	public DataType type(String key) {
 		return type(serialize(key));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#touch(java.lang.String[])
+	 */
+	@Nullable
+	@Override
+	public Long touch(String... keys) {
+		return touch(serializeMulti(keys));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -78,6 +78,13 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	/** @deprecated in favor of {@link RedisConnection#keyCommands()}. */
 	@Override
 	@Deprecated
+	default Long touch(byte[]... keys) {
+		return keyCommands().touch(keys);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#keyCommands()}. */
+	@Override
+	@Deprecated
 	default Set<byte[]> keys(byte[] pattern) {
 		return keyCommands().keys(pattern);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 
 import org.reactivestreams.Publisher;
@@ -86,6 +87,28 @@ public interface ReactiveKeyCommands {
 	 * @see <a href="http://redis.io/commands/type">Redis Documentation: TYPE</a>
 	 */
 	Flux<CommandResponse<KeyCommand, DataType>> type(Publisher<KeyCommand> keys);
+
+	/**
+	 * Alter the last access time of given {@code key(s)}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@link Mono} emitting the number of keys touched.
+	 * @see <a href="http://redis.io/commands/touch">Redis Documentation: TOUCH</a>
+	 * @since 2.1
+	 */
+	default Mono<Long> touch(Collection<ByteBuffer> keys) {
+		return touch(Mono.just(keys)).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Alter the last access time of given {@code key(s)}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/touch">Redis Documentation: TOUCH</a>
+	 * @since 2.1
+	 */
+	Flux<NumericResponse<Collection<ByteBuffer>, Long>> touch(Publisher<Collection<ByteBuffer>> keys);
 
 	/**
 	 * Find all keys matching the given {@literal pattern}.

--- a/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
@@ -81,6 +81,17 @@ public interface RedisKeyCommands {
 	DataType type(byte[] key);
 
 	/**
+	 * Alter the last access time of given {@code key(s)}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/touch">Redis Documentation: TOUCH</a>
+	 * @since 2.1
+	 */
+	@Nullable
+	Long touch(byte[]... keys);
+
+	/**
 	 * Find all keys matching the given {@code pattern}.
 	 *
 	 * @param pattern must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -124,6 +124,17 @@ public interface StringRedisConnection extends RedisConnection {
 	DataType type(String key);
 
 	/**
+	 * Alter the last access time of given {@code key(s)}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/touch">Redis Documentation: TOUCH</a>
+	 * @since 2.1
+	 */
+	@Nullable
+	Long touch(String... keys);
+
+	/**
 	 * Find all keys matching the given {@code pattern}.
 	 *
 	 * @param pattern must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -177,14 +177,17 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 	}
 
 	/**
-	 * Execute the given command for the {@code key} provided potentially appending args. <br />
+	 * Execute the given command for each key in {@code keys} provided appending all {@code args} on each invocation.
+	 * <br />
 	 * This method, other than {@link #execute(String, byte[]...)}, dispatches the command to the {@code key} serving
-	 * master node.
+	 * master node and appends the {@code key} as first command argument to the {@code command}. {@code keys} are not
+	 * required to share the same slot for single-key commands. Multi-key commands carrying their keys in {@code args}
+	 * still require to share the same slot as the {@code key}.
 	 *
 	 * <pre>
 	 * <code>
 	 * // SET foo bar EX 10 NX
-	 * execute("SET", "foo".getBytes(), asBinaryList("bar", "EX", 10, "NX")
+	 * execute("SET", "foo".getBytes(), asBinaryList("bar", "EX", 10, "NX"))
 	 * </code>
 	 * </pre>
 	 *
@@ -860,7 +863,8 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 
 				PropertyAccessor accessor = new DirectFieldAccessFallbackBeanWrapper(cluster);
 				this.connectionHandler = accessor.isReadableProperty("connectionHandler")
-						? (JedisClusterConnectionHandler) accessor.getPropertyValue("connectionHandler") : null;
+						? (JedisClusterConnectionHandler) accessor.getPropertyValue("connectionHandler")
+						: null;
 			} else {
 				this.connectionHandler = null;
 			}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
@@ -20,6 +20,7 @@ import redis.clients.jedis.BinaryJedis;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -95,6 +96,20 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisKeyCommands#touch(byte[][])
+	 */
+	@Nullable
+	@Override
+	public Long touch(byte[]... keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+
+		return connection.<Long> execute("TOUCH", Arrays.asList(keys), Collections.emptyList()).stream()
+				.mapToLong(val -> val).sum();
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -148,6 +148,19 @@ class JedisKeyCommands implements RedisKeyCommands {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisKeyCommands#touch(byte[][])
+	 */
+	@Nullable
+	@Override
+	public Long touch(byte[]... keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+
+		return Long.class.cast(connection.execute("TOUCH", keys));
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisKeyCommands#keys(byte[])
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
@@ -152,6 +152,30 @@ class LettuceKeyCommands implements RedisKeyCommands {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisKeyCommands#touch(byte[][])
+	 */
+	@Override
+	public Long touch(byte[]... keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+
+		try {
+			if (isPipelined()) {
+				pipeline(connection.newLettuceResult(getAsyncConnection().touch(keys)));
+				return null;
+			}
+			if (isQueueing()) {
+				transaction(connection.newLettuceTxResult(getConnection().touch(keys)));
+				return null;
+			}
+			return getConnection().touch(keys);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisKeyCommands#keys(byte[])
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
@@ -165,7 +165,7 @@ class LettuceKeyCommands implements RedisKeyCommands {
 				return null;
 			}
 			if (isQueueing()) {
-				transaction(connection.newLettuceTxResult(getConnection().touch(keys)));
+				transaction(connection.newLettuceResult(getAsyncConnection().touch(keys)));
 				return null;
 			}
 			return getConnection().touch(keys);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
@@ -20,6 +20,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -83,6 +84,22 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 
 			return cmd.type(command.getKey()).map(LettuceConverters::toDataType)
 					.map(respValue -> new CommandResponse<>(command, respValue));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#touch(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<Collection<ByteBuffer>, Long>> touch(Publisher<Collection<ByteBuffer>> keysCollection) {
+
+		return connection.execute(cmd -> Flux.from(keysCollection).concatMap((keys) -> {
+
+			Assert.notEmpty(keys, "Keys must not be null!");
+
+			return cmd.touch(keys.toArray(new ByteBuffer[keys.size()]))
+					.map((value) -> new NumericResponse<>(keys, value));
 		}));
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -69,9 +69,7 @@ import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.data.redis.test.util.RedisClientRule;
 import org.springframework.data.redis.test.util.RedisDriver;
 import org.springframework.data.redis.test.util.WithRedisDriver;
@@ -2778,11 +2776,10 @@ public abstract class AbstractConnectionIntegrationTests {
 	@Test // DATAREDIS-694
 	public void touchReturnsNrOfKeysTouched() {
 
-		connection.set("touch.this", "Can't touch this! - oh-oh oh oh oh-oh-oh");
-
+		actual.add(connection.set("touch.this", "Can't touch this! - oh-oh oh oh oh-oh-oh"));
 		actual.add(connection.touch("touch.this", "touch.that"));
 
-		verifyResults(Arrays.asList(new Object[] { 1L }));
+		verifyResults(Arrays.asList(new Object[] { Boolean.TRUE, 1L }));
 	}
 
 	@Test // DATAREDIS-694

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -2771,6 +2771,25 @@ public abstract class AbstractConnectionIntegrationTests {
 
 		actual.add(connection.hStrLen("hash-no-exist", "key-2"));
 
+		verifyResults(
+				Arrays.asList(new Object[] { 0L }));
+	}
+
+	@Test // DATAREDIS-694
+	public void touchReturnsNrOfKeysTouched() {
+
+		connection.set("touch.this", "Can't touch this! - oh-oh oh oh oh-oh-oh");
+
+		actual.add(connection.touch("touch.this", "touch.that"));
+
+		verifyResults(Arrays.asList(new Object[] { 1L }));
+	}
+
+	@Test // DATAREDIS-694
+	public void touchReturnsZeroIfNoKeysTouched() {
+
+		actual.add(connection.touch("touch.this", "touch.that"));
+
 		verifyResults(Arrays.asList(new Object[] { 0L }));
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -28,7 +28,16 @@ import redis.clients.jedis.JedisPool;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
@@ -375,7 +384,7 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 
 	@Test(expected = IllegalArgumentException.class) // DATAREDIS-689
 	public void executeWithNoKeyAndArgsThrowsException() {
-		clusterConnection.execute("KEYS", null, Collections.singletonList("*".getBytes()));
+		clusterConnection.execute("KEYS", (byte[]) null, Collections.singletonList("*".getBytes()));
 	}
 
 	@Test // DATAREDIS-529
@@ -2195,4 +2204,19 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.zrange(SAME_SLOT_KEY_3_BYTES, 0, -1),
 				hasItems(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES));
 	}
+
+	@Test // DATAREDIS-694
+	public void touchReturnsNrOfKeysTouched() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+		nativeConnection.set(KEY_2, VALUE_1);
+
+		assertThat(clusterConnection.keyCommands().touch(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES), is(2L));
+	}
+
+	@Test // DATAREDIS-694
+	public void touchReturnsZeroIfNoKeysTouched() {
+		assertThat(clusterConnection.keyCommands().touch(KEY_1_BYTES), is(0L));
+	}
+
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
@@ -287,4 +287,23 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 				.verify();
 		assertThat(nativeCommands.exists(KEY_1), is(0L));
 	}
+
+	@Test // DATAREDIS-694
+	public void touchReturnsNrOfKeysTouched() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		StepVerifier.create(connection.keyCommands().touch(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER, KEY_3_BBUFFER)))
+				.expectNext(2L) //
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-694
+	public void touchReturnsZeroIfNoKeysTouched() {
+
+		StepVerifier.create(connection.keyCommands().touch(Arrays.asList(KEY_1_BBUFFER))) //
+				.expectNext(0L) //
+				.verifyComplete();
+	}
 }


### PR DESCRIPTION
We now support `TOUCH` for both [lettuce-io/lettuce-core](https://github.com/lettuce-io/lettuce-core) and [xetorthio/jedis](https://github.com/xetorthio/jedis/) in imperative and reactive (Lettuce only) KeyCommands.