### PR TITLE
DATAREDIS-576 - Support client name for Redis connections using Lettuce.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REDIS_VERSION:=4.0.1
+REDIS_VERSION:=4.0.2
 SPRING_PROFILE?=ci
 
 #######

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-576-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.util.Assert;
  * <li>Optional {@link HostnameVerifier}</li>
  * <li>Whether to use connection-pooling</li>
  * <li>Optional {@link GenericObjectPoolConfig}</li>
+ * <li>Optional client name</li>
  * <li>Connect {@link Duration timeout}</li>
  * <li>Read {@link Duration timeout}</li>
  * </ul>

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
@@ -55,7 +55,8 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 		this.shutdownTimeout = shutdownTimeout;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#useSsl()
 	 */
 	@Override
@@ -63,7 +64,8 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 		return useSsl;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isVerifyPeer()
 	 */
 	@Override
@@ -71,7 +73,8 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 		return verifyPeer;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isStartTls()
 	 */
 	@Override
@@ -79,7 +82,8 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 		return startTls;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientResources()
 	 */
 	@Override
@@ -87,7 +91,8 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 		return clientResources;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientOptions()
 	 */
 	@Override
@@ -95,7 +100,8 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 		return clientOptions;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientName()
 	 */
 	@Override
@@ -103,7 +109,8 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 		return clientName;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getTimeout()
 	 */
 	@Override
@@ -111,7 +118,8 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 		return timeout;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getShutdownTimeout()
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
@@ -37,18 +37,20 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 	private final boolean startTls;
 	private final Optional<ClientResources> clientResources;
 	private final Optional<ClientOptions> clientOptions;
+	private final Optional<String> clientName;
 	private final Duration timeout;
 	private final Duration shutdownTimeout;
 
 	DefaultLettuceClientConfiguration(boolean useSsl, boolean verifyPeer, boolean startTls,
-			@Nullable ClientResources clientResources, @Nullable ClientOptions clientOptions, Duration timeout,
-			Duration shutdownTimeout) {
+			@Nullable ClientResources clientResources, @Nullable ClientOptions clientOptions, @Nullable String clientName,
+			Duration timeout, Duration shutdownTimeout) {
 
 		this.useSsl = useSsl;
 		this.verifyPeer = verifyPeer;
 		this.startTls = startTls;
 		this.clientResources = Optional.ofNullable(clientResources);
 		this.clientOptions = Optional.ofNullable(clientOptions);
+		this.clientName = Optional.ofNullable(clientName);
 		this.timeout = timeout;
 		this.shutdownTimeout = shutdownTimeout;
 	}
@@ -91,6 +93,14 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 	@Override
 	public Optional<ClientOptions> getClientOptions() {
 		return clientOptions;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientName()
+	 */
+	@Override
+	public Optional<String> getClientName() {
+		return clientName;
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolingClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolingClientConfiguration.java
@@ -89,6 +89,15 @@ class DefaultLettucePoolingClientConfiguration implements LettucePoolingClientCo
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientName()
+	 */
+	@Override
+	public Optional<String> getClientName() {
+		return clientConfiguration.getClientName();
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getCommandTimeout()
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  * <li>Whether to use StartTLS</li>
  * <li>Optional {@link ClientResources}</li>
  * <li>Optional {@link ClientOptions}</li>
+ * <li>Optional client name</li>
  * <li>Client {@link Duration timeout}</li>
  * <li>Shutdown {@link Duration timeout}</li>
  * </ul>
@@ -76,6 +77,12 @@ public interface LettuceClientConfiguration {
 	Optional<ClientOptions> getClientOptions();
 
 	/**
+	 * @return the optional client name to be set with {@code CLIENT SETNAME}.
+	 * @since 2.1
+	 */
+	Optional<String> getClientName();
+
+	/**
 	 * @return the timeout.
 	 */
 	Duration getCommandTimeout();
@@ -109,6 +116,8 @@ public interface LettuceClientConfiguration {
 	 * <dd>none</dd>
 	 * <dt>Client Resources</dt>
 	 * <dd>none</dd>
+	 * <dt>Client name</dt>
+	 * <dd>none</dd>
 	 * <dt>Connect Timeout</dt>
 	 * <dd>60 Seconds</dd>
 	 * <dt>Shutdown Timeout</dt>
@@ -132,6 +141,7 @@ public interface LettuceClientConfiguration {
 		boolean startTls;
 		@Nullable ClientResources clientResources;
 		@Nullable ClientOptions clientOptions;
+		@Nullable String clientName;
 		Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
 		Duration shutdownTimeout = Duration.ofMillis(100);
 
@@ -179,6 +189,21 @@ public interface LettuceClientConfiguration {
 		}
 
 		/**
+		 * Configure a {@code clientName} to be set with {@code CLIENT SETNAME}.
+		 *
+		 * @param clientName must not be {@literal null} or empty.
+		 * @return {@literal this} builder.
+		 * @throws IllegalArgumentException if clientName is {@literal null}.
+		 */
+		public LettuceClientConfigurationBuilder clientName(String clientName) {
+
+			Assert.hasText(clientName, "Client name must not be null or empty!");
+
+			this.clientName = clientName;
+			return this;
+		}
+
+		/**
 		 * Configure a command timeout.
 		 *
 		 * @param timeout must not be {@literal null}.
@@ -216,7 +241,7 @@ public interface LettuceClientConfiguration {
 		public LettuceClientConfiguration build() {
 
 			return new DefaultLettuceClientConfiguration(useSsl, verifyPeer, startTls, clientResources, clientOptions,
-					timeout, shutdownTimeout);
+					clientName, timeout, shutdownTimeout);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -193,7 +193,8 @@ public interface LettuceClientConfiguration {
 		 *
 		 * @param clientName must not be {@literal null} or empty.
 		 * @return {@literal this} builder.
-		 * @throws IllegalArgumentException if clientName is {@literal null}.
+		 * @throws IllegalArgumentException if clientName is {@literal null} or empty.
+		 * @since 2.1
 		 */
 		public LettuceClientConfigurationBuilder clientName(String clientName) {
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -587,6 +587,30 @@ public class LettuceConnectionFactory
 	}
 
 	/**
+	 * Returns the client name.
+	 *
+	 * @return the client name.
+	 * @since 2.1
+	 */
+	@Nullable
+	public String getClientName() {
+		return clientConfiguration.getClientName().orElse(null);
+	}
+
+	/**
+	 * Sets the client name used by this connection factory. Defaults to none which does not set a client name.
+	 *
+	 * @param clientName the client name.
+	 * @since 2.1
+	 * @deprecated configure the client name using {@link LettuceClientConfiguration}.
+	 * @throws IllegalStateException if {@link JedisClientConfiguration} is immutable.
+	 */
+	@Deprecated
+	public void setClientName(String clientName) {
+		this.getMutableConfiguration().setClientName(clientName);
+	}
+
+	/**
 	 * Returns the password used for authenticating with the Redis server.
 	 *
 	 * @return password for authentication.

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -849,6 +849,7 @@ public class LettuceConnectionFactory
 		RedisURI redisUri = LettuceConverters.sentinelConfigurationToRedisURI(sentinelConfiguration);
 
 		getRedisPassword().toOptional().ifPresent(redisUri::setPassword);
+		clientConfiguration.getClientName().ifPresent(redisUri::setClientName);
 		redisUri.setTimeout(clientConfiguration.getCommandTimeout());
 
 		return redisUri;
@@ -859,6 +860,7 @@ public class LettuceConnectionFactory
 		RedisURI.Builder builder = RedisURI.Builder.redis(host, port);
 
 		getRedisPassword().toOptional().ifPresent(builder::withPassword);
+		clientConfiguration.getClientName().ifPresent(builder::withClientName);
 
 		builder.withSsl(clientConfiguration.isUseSsl());
 		builder.withVerifyPeer(clientConfiguration.isVerifyPeer());
@@ -897,6 +899,7 @@ public class LettuceConnectionFactory
 		private boolean verifyPeer = true;
 		private boolean startTls;
 		private @Nullable ClientResources clientResources;
+		private @Nullable String clientName;
 		private Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
 		private Duration shutdownTimeout = Duration.ofMillis(100);
 
@@ -954,6 +957,19 @@ public class LettuceConnectionFactory
 		@Override
 		public Optional<ClientOptions> getClientOptions() {
 			return Optional.empty();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientName()
+		 */
+		@Override
+		public Optional<String> getClientName() {
+			return Optional.ofNullable(clientName);
+		}
+
+		public void setClientName(String clientName) {
+			this.clientName = clientName;
 		}
 
 		/* (non-Javadoc)

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -935,7 +935,7 @@ public class LettuceConnectionFactory
 			return useSsl;
 		}
 
-		public void setUseSsl(boolean useSsl) {
+		void setUseSsl(boolean useSsl) {
 			this.useSsl = useSsl;
 		}
 
@@ -947,7 +947,7 @@ public class LettuceConnectionFactory
 			return verifyPeer;
 		}
 
-		public void setVerifyPeer(boolean verifyPeer) {
+		void setVerifyPeer(boolean verifyPeer) {
 			this.verifyPeer = verifyPeer;
 		}
 
@@ -959,7 +959,7 @@ public class LettuceConnectionFactory
 			return startTls;
 		}
 
-		public void setStartTls(boolean startTls) {
+		void setStartTls(boolean startTls) {
 			this.startTls = startTls;
 		}
 
@@ -971,7 +971,7 @@ public class LettuceConnectionFactory
 			return Optional.ofNullable(clientResources);
 		}
 
-		public void setClientResources(ClientResources clientResources) {
+		void setClientResources(ClientResources clientResources) {
 			this.clientResources = clientResources;
 		}
 
@@ -992,7 +992,7 @@ public class LettuceConnectionFactory
 			return Optional.ofNullable(clientName);
 		}
 
-		public void setClientName(String clientName) {
+		void setClientName(String clientName) {
 			this.clientName = clientName;
 		}
 
@@ -1004,7 +1004,7 @@ public class LettuceConnectionFactory
 			return timeout;
 		}
 
-		public void setTimeout(Duration timeout) {
+		void setTimeout(Duration timeout) {
 			this.timeout = timeout;
 		}
 
@@ -1016,7 +1016,7 @@ public class LettuceConnectionFactory
 			return shutdownTimeout;
 		}
 
-		public void setShutdownTimeout(Duration shutdownTimeout) {
+		void setShutdownTimeout(Duration shutdownTimeout) {
 			this.shutdownTimeout = shutdownTimeout;
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -589,7 +589,7 @@ public class LettuceConnectionFactory
 	/**
 	 * Returns the client name.
 	 *
-	 * @return the client name.
+	 * @return the client name or {@literal null} if not set.
 	 * @since 2.1
 	 */
 	@Nullable
@@ -598,23 +598,24 @@ public class LettuceConnectionFactory
 	}
 
 	/**
-	 * Sets the client name used by this connection factory. Defaults to none which does not set a client name.
+	 * Sets the client name used by this connection factory.
 	 *
-	 * @param clientName the client name.
+	 * @param clientName the client name. Can be {@literal null}.
 	 * @since 2.1
 	 * @deprecated configure the client name using {@link LettuceClientConfiguration}.
-	 * @throws IllegalStateException if {@link JedisClientConfiguration} is immutable.
+	 * @throws IllegalStateException if {@link LettuceClientConfiguration} is immutable.
 	 */
 	@Deprecated
-	public void setClientName(String clientName) {
+	public void setClientName(@Nullable String clientName) {
 		this.getMutableConfiguration().setClientName(clientName);
 	}
 
 	/**
 	 * Returns the password used for authenticating with the Redis server.
 	 *
-	 * @return password for authentication.
+	 * @return password for authentication or {@literal null} if not set.
 	 */
+	@Nullable
 	public String getPassword() {
 		return getRedisPassword().map(String::new).orElse(null);
 	}
@@ -916,6 +917,7 @@ public class LettuceConnectionFactory
 	 * Mutable implementation of {@link LettuceClientConfiguration}.
 	 *
 	 * @author Mark Paluch
+	 * @author Christoph Strobl
 	 */
 	static class MutableLettuceClientConfiguration implements LettuceClientConfiguration {
 
@@ -927,7 +929,8 @@ public class LettuceConnectionFactory
 		private Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
 		private Duration shutdownTimeout = Duration.ofMillis(100);
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isUseSsl()
 		 */
 		@Override
@@ -939,7 +942,8 @@ public class LettuceConnectionFactory
 			this.useSsl = useSsl;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isVerifyPeer()
 		 */
 		@Override
@@ -951,7 +955,8 @@ public class LettuceConnectionFactory
 			this.verifyPeer = verifyPeer;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#isStartTls()
 		 */
 		@Override
@@ -963,7 +968,8 @@ public class LettuceConnectionFactory
 			this.startTls = startTls;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientResources()
 		 */
 		@Override
@@ -975,7 +981,8 @@ public class LettuceConnectionFactory
 			this.clientResources = clientResources;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getClientOptions()
 		 */
 		@Override
@@ -992,11 +999,16 @@ public class LettuceConnectionFactory
 			return Optional.ofNullable(clientName);
 		}
 
-		void setClientName(String clientName) {
+		/**
+		 * @param clientName can be {@litearl null}.
+		 * @since 2.1
+		 */
+		void setClientName(@Nullable String clientName) {
 			this.clientName = clientName;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getTimeout()
 		 */
 		@Override
@@ -1008,7 +1020,8 @@ public class LettuceConnectionFactory
 			this.timeout = timeout;
 		}
 
-		/* (non-Javadoc)
+		/*
+		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getShutdownTimeout()
 		 */
 		@Override

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactorySentinelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactorySentinelIntegrationTests.java
@@ -48,7 +48,7 @@ public class JedisConnectionFactorySentinelIntegrationTests {
 	}
 
 	@Test // DATAREDIS-574
-	public void shouldInitiaizeWithSentinelConfiguration() {
+	public void shouldInitializeWithSentinelConfiguration() {
 
 		JedisClientConfiguration clientConfiguration = JedisClientConfiguration.builder() //
 				.clientName("clientName") //

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  */
 public class LettuceClientConfigurationUnitTests {
 
-	@Test // DATAREDIS-574, DATAREDIS-667
+	@Test // DATAREDIS-574, DATAREDIS-576, DATAREDIS-667
 	public void shouldCreateEmptyConfiguration() {
 
 		LettuceClientConfiguration configuration = LettuceClientConfiguration.defaultConfiguration();
@@ -42,11 +42,12 @@ public class LettuceClientConfigurationUnitTests {
 		assertThat(configuration.isStartTls()).isFalse();
 		assertThat(configuration.getClientOptions()).isEmpty();
 		assertThat(configuration.getClientResources()).isEmpty();
+		assertThat(configuration.getClientName()).isEmpty();
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofSeconds(60));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofMillis(100));
 	}
 
-	@Test // DATAREDIS-574, DATAREDIS-667
+	@Test // DATAREDIS-574, DATAREDIS-576, DATAREDIS-667
 	public void shouldConfigureAllProperties() {
 
 		ClientOptions clientOptions = ClientOptions.create();
@@ -58,6 +59,7 @@ public class LettuceClientConfigurationUnitTests {
 				.startTls().and() //
 				.clientOptions(clientOptions) //
 				.clientResources(sharedClientResources) //
+				.clientName("foo") //
 				.commandTimeout(Duration.ofMinutes(5)) //
 				.shutdownTimeout(Duration.ofHours(2)) //
 				.build();
@@ -67,6 +69,7 @@ public class LettuceClientConfigurationUnitTests {
 		assertThat(configuration.isStartTls()).isTrue();
 		assertThat(configuration.getClientOptions()).contains(clientOptions);
 		assertThat(configuration.getClientResources()).contains(sharedClientResources);
+		assertThat(configuration.getClientName()).contains("foo");
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofMinutes(5));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofHours(2));
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
@@ -73,4 +73,14 @@ public class LettuceClientConfigurationUnitTests {
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofMinutes(5));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofHours(2));
 	}
+
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-576
+	public void clientConfigurationThrowsExceptionForNullClientName() {
+		LettuceClientConfiguration.builder().clientName(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class) // DATAREDIS-576
+	public void clientConfigurationThrowsExceptionForEmptyClientName() {
+		LettuceClientConfiguration.builder().clientName(" ");
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -361,4 +361,22 @@ public class LettuceConnectionFactoryTests {
 
 		factory.destroy();
 	}
+
+	@Test // DATAREDIS-576
+	public void connectionAppliesClientName() {
+
+		LettuceClientConfiguration configuration = LettuceClientConfiguration.builder()
+				.clientResources(LettuceTestClientResources.getSharedClientResources()).clientName("clientName").build();
+
+		LettuceConnectionFactory factory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(), configuration);
+		factory.setShareNativeConnection(false);
+		factory.afterPropertiesSet();
+
+		RedisConnection connection = factory.getConnection();
+
+		assertThat(connection.getClientName(), is(equalTo("clientName")));
+		connection.close();
+
+		factory.destroy();
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -379,4 +379,20 @@ public class LettuceConnectionFactoryTests {
 
 		factory.destroy();
 	}
+
+	@Test // DATAREDIS-576
+	public void getClientNameShouldEqualWithFactorySetting() {
+
+		LettuceConnectionFactory factory = new LettuceConnectionFactory(new RedisStandaloneConfiguration());
+		factory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		factory.setClientName("clientName");
+		factory.afterPropertiesSet();
+
+		RedisConnection connection = factory.getConnection();
+		assertThat(connection.getClientName(), equalTo("clientName"));
+
+		connection.close();
+
+		factory.destroy();
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -372,12 +372,12 @@ public class LettuceConnectionFactoryTests {
 		factory.setShareNativeConnection(false);
 		factory.afterPropertiesSet();
 
+		ConnectionFactoryTracker.add(factory);
+
 		RedisConnection connection = factory.getConnection();
 
 		assertThat(connection.getClientName(), is(equalTo("clientName")));
 		connection.close();
-
-		factory.destroy();
 	}
 
 	@Test // DATAREDIS-576
@@ -388,11 +388,11 @@ public class LettuceConnectionFactoryTests {
 		factory.setClientName("clientName");
 		factory.afterPropertiesSet();
 
+		ConnectionFactoryTracker.add(factory);
+
 		RedisConnection connection = factory.getConnection();
 		assertThat(connection.getClientName(), equalTo("clientName"));
 
 		connection.close();
-
-		factory.destroy();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
@@ -43,6 +43,8 @@ import org.springframework.data.redis.test.util.MinimumRedisVersionRule;
 import org.springframework.data.redis.test.util.RedisSentinelRule;
 
 /**
+ * Integration tests for Lettuce and Redis Sentinel interaction.
+ *
  * @author Mark Paluch
  * @author Christoph Strobl
  */
@@ -144,6 +146,26 @@ public class LettuceSentinelIntegrationTests extends AbstractConnectionIntegrati
 
 		try {
 			assertThat(connection.ping(), is(equalTo("PONG")));
+		} finally {
+			connection.close();
+		}
+	}
+
+	@Test // DATAREDIS-576
+	public void connectionAppliesClientName() {
+
+		LettuceClientConfiguration clientName = LettuceClientConfiguration.builder()
+				.clientResources(LettuceTestClientResources.getSharedClientResources()).clientName("clientName").build();
+
+		LettuceConnectionFactory factory = new LettuceConnectionFactory(SENTINEL_CONFIG, clientName);
+		factory.afterPropertiesSet();
+
+		ConnectionFactoryTracker.add(factory);
+
+		StringRedisConnection connection = new DefaultStringRedisConnection(factory.getConnection());
+
+		try {
+			assertThat(connection.getClientName(), is(equalTo("clientName")));
 		} finally {
 			connection.close();
 		}


### PR DESCRIPTION
We now allow configuration of the client name that is applied to connections using the Lettuce driver.

```java
LettuceClientConfiguration configuration = LettuceClientConfiguration.builder().clientName("foo-bar").build();
LettuceConnectionFactory factory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(), configuration);
```

---

Related ticket: [DATAREDIS-576](https://jira.spring.io/browse/DATAREDIS-576).