### PR TITLE
DATAREDIS-682 - Connect to Redis using unix domain sockets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ work/redis-%.conf:
 	echo notify-keyspace-events Ex >> $@
 	echo pidfile $(shell pwd)/work/redis-$*.pid >> $@
 	echo logfile $(shell pwd)/work/redis-$*.log >> $@
+	echo unixsocket $(shell pwd)/work/redis-$*.sock >> $@
+	echo unixsocketperm 755 >> $@
 	echo save \"\" >> $@
 	echo slaveof 127.0.0.1 6379 >> $@
 
@@ -42,6 +44,8 @@ work/redis-6379.conf:
 	echo notify-keyspace-events Ex >> $@
 	echo pidfile $(shell pwd)/work/redis-6379.pid >> $@
 	echo logfile $(shell pwd)/work/redis-6379.log >> $@
+	echo unixsocket $(shell pwd)/work/redis-6379.sock >> $@
+	echo unixsocketperm 755 >> $@
 	echo save \"\" >> $@
 
 work/redis-%.pid: work/redis-%.conf work/redis/bin/redis-server
@@ -122,7 +126,7 @@ cluster-init: cluster-start cluster-meet cluster-slots
 # Global
 ########
 clean:
-	rm -rf work/*.conf work/*.log
+	rm -rf work/*.conf work/*.log dump.rdb
 
 clobber:
 	rm -rf work

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-682-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 		<lettuce>5.0.0.RELEASE</lettuce>
 		<jedis>2.9.0</jedis>
 		<multithreadedtc>1.01</multithreadedtc>
+		<netty>4.1.15.Final</netty>
 		<java-module-name>spring.data.redis</java-module-name>
 	</properties>
 
@@ -83,6 +84,22 @@
 			<artifactId>lettuce-core</artifactId>
 			<version>${lettuce}</version>
 			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-transport-native-epoll</artifactId>
+			<classifier>linux-x86_64</classifier>
+			<version>${netty}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-transport-native-kqueue</artifactId>
+			<classifier>osx-x86_64</classifier>
+			<version>${netty}</version>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- reactive -->

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -3,7 +3,11 @@
 
 New and noteworthy in the latest releases.
 
-[[new-in-2.0.0]]
+[[new-in-2.1.0]]
+== New in Spring Data Redis 2.1
+
+* Unix domain socket connections.
+
 == New in Spring Data Redis 2.0
 
 * Upgrade to Java 8.

--- a/src/main/asciidoc/reference/redis.adoc
+++ b/src/main/asciidoc/reference/redis.adoc
@@ -39,63 +39,77 @@ NOTE: Depending on the underlying configuration, the factory can return a new co
 
 The easiest way to work with a `RedisConnectionFactory` is to configure the appropriate connector through the IoC container and inject it into the using class.
 
-IMPORTANT: Unfortunately, currently, not all connectors support all Redis features.  When invoking a method on the Connection API that is unsupported by the underlying library, an `UnsupportedOperationException` is thrown.
-  This situation is likely to be fixed in the future, as the various connectors mature.
-
-[[redis:connectors:jedis]]
-=== Configuring Jedis connector
-
-http://github.com/xetorthio/jedis[Jedis] is one of the connectors supported by the Spring Data Redis module through the `org.springframework.data.redis.connection.jedis` package. In its simplest form, the Jedis configuration looks as follow:
-
-[source,xml]
-----
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
-
-  <!-- Jedis ConnectionFactory -->
-  <bean id="jedisConnectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory"/>
-
-</beans>
-----
-
-For production use however, one might want to tweak the settings such as the host or password:
-
-[source,xml]
-----
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:p="http://www.springframework.org/schema/p"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
-
-  <bean id="jedisConnectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory" p:host-name="server" p:port="6379" />
-
-</beans>
-----
+IMPORTANT: Unfortunately, currently, not all connectors support all Redis features. When invoking a method on the Connection API that is unsupported by the underlying library, an `UnsupportedOperationException` is thrown.
 
 [[redis:connectors:lettuce]]
 === Configuring Lettuce connector
 
-https://github.com/mp911de/lettuce[Lettuce] is a http://netty.io/[netty]-based open-source connector supported by Spring Data Redis through the `org.springframework.data.redis.connection.lettuce` package.
+https://github.com/lettuce-io/lettuce-core[Lettuce] is a http://netty.io/[netty]-based open-source connector supported by Spring Data Redis through the `org.springframework.data.redis.connection.lettuce` package.
 
-Its configuration is probably easy to guess:
-
-[source,xml]
+[source,java]
 ----
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:p="http://www.springframework.org/schema/p"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+@Configuration
+class AppConfig {
 
-  <bean id="lettuceConnectionFactory" class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory" p:host-name="server" p:port="6379"/>
+  @Bean
+  public LettuceConnectionFactory redisConnectionFactory() {
 
-</beans>
+    return new LettuceConnectionFactory(new RedisStandaloneConfiguration("server", 6379));
+  }
+}
 ----
 
 There are also a few Lettuce-specific connection parameters that can be tweaked. By default, all `LettuceConnection` s created by the `LettuceConnectionFactory` share the same thread-safe native connection for all non-blocking and non-transactional operations. Set `shareNativeConnection` to false to use a dedicated connection each time. `LettuceConnectionFactory` can also be configured with a `LettucePool` to use for pooling blocking and transactional connections, or all connections if `shareNativeConnection` is set to false.
+
+Lettuce integrates with netty's http://netty.io/wiki/native-transports.html[native transports] allowing to use unix domain sockets to communicate with Redis. Make sure to include the appropriate native transport dependencies that match your runtime environment.
+ 
+[source,java]
+----
+@Configuration
+class AppConfig {
+
+  @Bean
+  public LettuceConnectionFactory redisConnectionFactory() {
+
+    return new LettuceConnectionFactory(new RedisSocketConfiguration("/var/run/redis.sock"));
+  }
+}
+----
+
+NOTE: Netty currently supports epoll (Linux) and kqueue (BSD/macOS) interfaces for OS-native transport.
+
+[[redis:connectors:jedis]]
+=== Configuring Jedis connector
+
+http://github.com/xetorthio/jedis[Jedis] is a community-driven connector supported by the Spring Data Redis module through the `org.springframework.data.redis.connection.jedis` package. In its simplest form, the Jedis configuration looks as follow:
+
+[source,java]
+----
+@Configuration
+class AppConfig {
+
+  @Bean
+  public JedisConnectionFactory redisConnectionFactory() {
+    return new JedisConnectionFactory();
+  }
+}
+----
+
+For production use however, one might want to tweak the settings such as the host or password:
+
+[source,java]
+----
+@Configuration
+class RedisConfiguration {
+
+  @Bean
+  public JedisConnectionFactory redisConnectionFactory() {
+
+    RedisStandaloneConfiguration config = new RedisStandaloneConfiguration("server", 6379);
+    return new JedisConnectionFactory(config);
+  }
+}
+----
 
 [[redis:sentinel]]
 == Redis Sentinel Support
@@ -105,7 +119,7 @@ For dealing with high available Redis there is support for http://redis.io/topic
 [source,java]
 ----
 /**
- * jedis
+ * Jedis
  */
 @Bean
 public RedisConnectionFactory jedisConnectionFactory() {

--- a/src/main/java/org/springframework/data/redis/connection/DatabaseAware.java
+++ b/src/main/java/org/springframework/data/redis/connection/DatabaseAware.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+/**
+ * Interface to be implemented by any object that exposes a database index or wishes to be updated with a database
+ * index.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface DatabaseAware {
+
+	/**
+	 * @return the Redis database index.
+	 */
+	int getDatabase();
+
+	/**
+	 * Sets the index of the database used by this connection factory. Default is 0.
+	 *
+	 * @param index database index.
+	 */
+	void setDatabase(int index);
+}

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
@@ -41,12 +41,12 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @since 1.7
  */
-public class RedisClusterConfiguration {
+public class RedisClusterConfiguration implements RedisPasswordAware {
 
 	private static final String REDIS_CLUSTER_NODES_CONFIG_PROPERTY = "spring.redis.cluster.nodes";
 	private static final String REDIS_CLUSTER_MAX_REDIRECTS_CONFIG_PROPERTY = "spring.redis.cluster.max-redirects";
 
-	private Set<RedisNode> clusterNodes;
+	private final Set<RedisNode> clusterNodes;
 	private @Nullable Integer maxRedirects;
 	private RedisPassword password = RedisPassword.none();
 
@@ -181,20 +181,20 @@ public class RedisClusterConfiguration {
 		}
 	}
 
-	/**
-	 * Get the {@link RedisPassword} defined.
-	 *
-	 * @return never {@literal null}.
-	 * @since 2.0
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPasswordAware#getPassword()
 	 */
+	@Override
 	public RedisPassword getPassword() {
 		return password;
 	}
 
-	/**
-	 * @param password must not be {@literal null}.
-	 * @since 2.0
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPasswordAware#setPassword(org.springframework.data.redis.connection.RedisPassword)
 	 */
+	@Override
 	public void setPassword(RedisPassword password) {
 
 		Assert.notNull(password, "RedisPassword must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/RedisPasswordAware.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisPasswordAware.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+/**
+ * Interface to be implemented by any object that exposes a {@link RedisPassword} configuration or wishes to be updated
+ * with a password.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface RedisPasswordAware {
+
+	/**
+	 * @return the Redis password.
+	 */
+	RedisPassword getPassword();
+
+	/**
+	 * Sets the Redis password. Defaults to {@link RedisPassword#none()}.
+	 *
+	 * @param password the password to set, must not be {@literal null}.
+	 */
+	void setPassword(RedisPassword password);
+}

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -41,13 +41,13 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @since 1.4
  */
-public class RedisSentinelConfiguration {
+public class RedisSentinelConfiguration implements RedisPasswordAware, DatabaseAware {
 
 	private static final String REDIS_SENTINEL_MASTER_CONFIG_PROPERTY = "spring.redis.sentinel.master";
 	private static final String REDIS_SENTINEL_NODES_CONFIG_PROPERTY = "spring.redis.sentinel.nodes";
 
 	private @Nullable NamedNode master;
-	private Set<RedisNode> sentinels;
+	private final Set<RedisNode> sentinels;
 	private int database;
 	private RedisPassword password = RedisPassword.none();
 
@@ -217,20 +217,20 @@ public class RedisSentinelConfiguration {
 		}
 	}
 
-	/**
-	 * @return the initial db index.
-	 * @since 2.0
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.DatabaseAware#getDatabase()
 	 */
+	@Override
 	public int getDatabase() {
 		return database;
 	}
 
-	/**
-	 * Sets the index of the database used by this connection factory. Default is 0.
-	 *
-	 * @param index database index.
-	 * @since 2.0
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.DatabaseAware#setDatabase(int)
 	 */
+	@Override
 	public void setDatabase(int index) {
 
 		Assert.isTrue(index >= 0, () -> String.format("Invalid DB index '%s' (a positive index required)", index));
@@ -238,18 +238,20 @@ public class RedisSentinelConfiguration {
 		this.database = index;
 	}
 
-	/**
-	 * @return never {@literal null}.
-	 * @since 2.0
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPasswordAware#getPassword()
 	 */
+	@Override
 	public RedisPassword getPassword() {
 		return password;
 	}
 
-	/**
-	 * @param password must not be {@literal null}.
-	 * @since 2.0
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPasswordAware#setPassword(org.springframework.data.redis.connection.RedisPassword)
 	 */
+	@Override
 	public void setPassword(RedisPassword password) {
 
 		Assert.notNull(password, "RedisPassword must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/RedisSocketConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSocketConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @since 2.1
  */
-public class RedisSocketConfiguration {
+public class RedisSocketConfiguration implements RedisPasswordAware, DatabaseAware {
 
 	private static final String DEFAULT_SOCKET = "/tmp/redis.sock";
 
@@ -63,18 +63,20 @@ public class RedisSocketConfiguration {
 		this.socket = socket;
 	}
 
-	/**
-	 * @return the db index.
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.DatabaseAware#getDatabase()
 	 */
+	@Override
 	public int getDatabase() {
 		return database;
 	}
 
-	/**
-	 * Sets the index of the database used by this connection factory. Default is 0.
-	 *
-	 * @param index database index.
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.DatabaseAware#setDatabase(int)
 	 */
+	@Override
 	public void setDatabase(int index) {
 
 		Assert.isTrue(index >= 0, () -> String.format("Invalid DB index '%s' (a positive index required)", index));
@@ -82,16 +84,20 @@ public class RedisSocketConfiguration {
 		this.database = index;
 	}
 
-	/**
-	 * @return never {@literal null}.
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPasswordAware#getPassword()
 	 */
+	@Override
 	public RedisPassword getPassword() {
 		return password;
 	}
 
-	/**
-	 * @param password must not be {@literal null}.
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPasswordAware#setPassword(org.springframework.data.redis.connection.RedisPassword)
 	 */
+	@Override
 	public void setPassword(RedisPassword password) {
 
 		Assert.notNull(password, "RedisPassword must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/RedisSocketConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSocketConfiguration.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import org.springframework.util.Assert;
+
+/**
+ * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} by connecting to a
+ * single node <a href="http://redis.io/">Redis</a> using a local unix domain socket.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public class RedisSocketConfiguration {
+
+	private static final String DEFAULT_SOCKET = "/tmp/redis.sock";
+
+	private String socket = DEFAULT_SOCKET;
+	private int database;
+	private RedisPassword password = RedisPassword.none();
+
+	/**
+	 * Create a new default {@link RedisSocketConfiguration}.
+	 */
+	public RedisSocketConfiguration() {}
+
+	/**
+	 * Create a new {@link RedisSocketConfiguration} given {@code socket}.
+	 *
+	 * @param socket must not be {@literal null} or empty.
+	 */
+	public RedisSocketConfiguration(String socket) {
+
+		Assert.hasText(socket, "Socket path must not be null or empty!");
+
+		this.socket = socket;
+	}
+
+	/**
+	 * @return path to the Redis socket.
+	 */
+	public String getSocket() {
+		return socket;
+	}
+
+	/**
+	 * @param socket path to the Redis socket.
+	 */
+	public void setSocket(String socket) {
+		this.socket = socket;
+	}
+
+	/**
+	 * @return the db index.
+	 */
+	public int getDatabase() {
+		return database;
+	}
+
+	/**
+	 * Sets the index of the database used by this connection factory. Default is 0.
+	 *
+	 * @param index database index.
+	 */
+	public void setDatabase(int index) {
+
+		Assert.isTrue(index >= 0, () -> String.format("Invalid DB index '%s' (a positive index required)", index));
+
+		this.database = index;
+	}
+
+	/**
+	 * @return never {@literal null}.
+	 */
+	public RedisPassword getPassword() {
+		return password;
+	}
+
+	/**
+	 * @param password must not be {@literal null}.
+	 */
+	public void setPassword(RedisPassword password) {
+
+		Assert.notNull(password, "RedisPassword must not be null!");
+
+		this.password = password;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @since 2.0
  */
-public class RedisStandaloneConfiguration {
+public class RedisStandaloneConfiguration implements RedisPasswordAware, DatabaseAware {
 
 	private static final String DEFAULT_HOST = "localhost";
 	private static final int DEFAULT_PORT = 6379;
@@ -93,18 +93,20 @@ public class RedisStandaloneConfiguration {
 		this.port = port;
 	}
 
-	/**
-	 * @return the db index.
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.DatabaseAware#getDatabase()
 	 */
+	@Override
 	public int getDatabase() {
 		return database;
 	}
 
-	/**
-	 * Sets the index of the database used by this connection factory. Default is 0.
-	 *
-	 * @param index database index.
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.DatabaseAware#setDatabase(int)
 	 */
+	@Override
 	public void setDatabase(int index) {
 
 		Assert.isTrue(index >= 0, () -> String.format("Invalid DB index '%s' (a positive index required)", index));
@@ -112,16 +114,20 @@ public class RedisStandaloneConfiguration {
 		this.database = index;
 	}
 
-	/**
-	 * @return never {@literal null}.
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPasswordAware#getPassword()
 	 */
+	@Override
 	public RedisPassword getPassword() {
 		return password;
 	}
 
-	/**
-	 * @param password must not be {@literal null}.
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPasswordAware#setPassword(org.springframework.data.redis.connection.RedisPassword)
 	 */
+	@Override
 	public void setPassword(RedisPassword password) {
 
 		Assert.notNull(password, "RedisPassword must not be null!");

--- a/src/test/java/org/springframework/data/redis/SettingsUtils.java
+++ b/src/test/java/org/springframework/data/redis/SettingsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,19 +17,25 @@ package org.springframework.data.redis;
 
 import java.util.Properties;
 
+import org.springframework.data.redis.connection.RedisSocketConfiguration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 
 /**
+ * Utility class exposing connection settings to connect Redis instances during test execution. Settings can be adjusted
+ * by overriding these in {@literal org/springframework/data/redis/test.properties}.
+ * 
  * @author Costin Leau
  * @author Mark Paluch
  */
 public abstract class SettingsUtils {
+
 	private final static Properties DEFAULTS = new Properties();
 	private static final Properties SETTINGS;
 
 	static {
 		DEFAULTS.put("host", "127.0.0.1");
 		DEFAULTS.put("port", "6379");
+		DEFAULTS.put("socket", "work/redis-6379.sock");
 
 		SETTINGS = new Properties(DEFAULTS);
 
@@ -40,15 +46,44 @@ public abstract class SettingsUtils {
 		}
 	}
 
+	private SettingsUtils() {}
+
+	/**
+	 * @return the Redis hostname.
+	 */
 	public static String getHost() {
 		return SETTINGS.getProperty("host");
 	}
 
+	/**
+	 * @return the Redis port.
+	 */
 	public static int getPort() {
 		return Integer.valueOf(SETTINGS.getProperty("port"));
 	}
 
+	/**
+	 * @return path to the unix domain socket.
+	 */
+	public static String getSocket() {
+		return SETTINGS.getProperty("socket");
+	}
+
+	/**
+	 * Construct a new {@link RedisStandaloneConfiguration} initialized with test endpoint settings.
+	 * 
+	 * @return a new {@link RedisStandaloneConfiguration} initialized with test endpoint settings.
+	 */
 	public static RedisStandaloneConfiguration standaloneConfiguration() {
 		return new RedisStandaloneConfiguration(getHost(), getPort());
+	}
+
+	/**
+	 * Construct a new {@link RedisSocketConfiguration} initialized with test endpoint settings.
+	 * 
+	 * @return a new {@link RedisSocketConfiguration} initialized with test endpoint settings.
+	 */
+	public static RedisSocketConfiguration socketConfiguration() {
+		return new RedisSocketConfiguration(getSocket());
 	}
 }

--- a/src/test/resources/org/springframework/data/redis/test.properties
+++ b/src/test/resources/org/springframework/data/redis/test.properties
@@ -1,3 +1,4 @@
 # redis connection properties
 host=127.0.0.1
 port=6379
+socket=work/redis-6379.sock


### PR DESCRIPTION
We now support Redis connections using OS-native transports through unix domain sockets when using the Lettuce driver. Domain sockets do not require a roundtrip through the networking layer but directly use native epoll or kqueue interfaces.

```java
LettuceConnectionFactory factory = new LettuceConnectionFactory(new RedisSocketConfiguration("/var/run/redis.sock"));
```

Unix domain socket support requires netty's native epoll/kqueue dependencies matching the runtime environment:

```xml
<dependency>
	<groupId>io.netty</groupId>
	<artifactId>netty-transport-native-epoll</artifactId>
	<classifier>linux-x86_64</classifier>
	<version>${netty}</version>
</dependency>

<dependency>
	<groupId>io.netty</groupId>
	<artifactId>netty-transport-native-kqueue</artifactId>
	<classifier>osx-x86_64</classifier>
	<version>${netty}</version>
</dependency>
```

---

Related ticket: [DATAREDIS-682](https://jira.spring.io/browse/DATAREDIS-682).