### PR TITLE
 DATAREDIS-713, DATAREDIS-643 - Introduce constants for commonly used StringSerializers, provide ReactiveStringRedisTemplate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-713-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/reference/reactive-redis.adoc
+++ b/src/main/asciidoc/reference/reactive-redis.adoc
@@ -113,7 +113,7 @@ class RedisConfiguration {
 
   @Bean
   ReactiveRedisTemplate<String, String> reactiveRedisTemplate(ReactiveRedisConnectionFactory factory) {
-    return new ReactiveRedisTemplate<>(connectionFactory, RedisSerializationContext.string());
+    return new ReactiveRedisTemplate<>(factory, RedisSerializationContext.string());
   }
 }
 ----
@@ -127,6 +127,36 @@ public class Example {
 
   public Mono<Long> addLink(String userId, URL url) {
     return template.opsForList().leftPush(userId, url.toExternalForm());
+  }
+}
+----
+
+[[redis:reactive:string]]
+== String-focused convenience classes
+
+Since it's quite common for keys and values stored in Redis to be a `java.lang.String`, the Redis module provides a String-based extension to `ReactiveRedisTemplate`: `ReactiveStringRedisTemplate` is a convenient one-stop solution for intensive `String` operations. In addition to being bound to `String` keys, the template uses the String-based `RedisSerializationContext` underneath which means the stored keys and values are human readable (assuming the same encoding is used both in Redis and your code). For example:
+
+[source,java]
+----
+@Configuration
+class RedisConfiguration {
+
+  @Bean
+  ReactiveStringRedisTemplate reactiveRedisTemplate(ReactiveRedisConnectionFactory factory) {
+    return new ReactiveStringRedisTemplate<>(factory);
+  }
+}
+----
+
+[source,java]
+----
+public class Example {
+
+  @Autowired
+  private ReactiveStringRedisTemplate redisTemplate;
+
+  public Mono<Long> addLink(String userId, URL url) {
+    return redisTemplate.opsForList().leftPush(userId, url.toExternalForm());
   }
 }
 ----

--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -24,7 +24,7 @@ import org.springframework.cache.support.NullValue;
 import org.springframework.cache.support.SimpleValueWrapper;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -44,7 +44,7 @@ import org.springframework.util.ReflectionUtils;
  */
 public class RedisCache extends AbstractValueAdaptingCache {
 
-	private static final byte[] BINARY_NULL_VALUE = new JdkSerializationRedisSerializer().serialize(NullValue.INSTANCE);
+	private static final byte[] BINARY_NULL_VALUE = RedisSerializer.java().serialize(NullValue.INSTANCE);
 
 	private final String name;
 	private final RedisCacheWriter cacheWriter;

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
@@ -95,7 +95,7 @@ public class RedisCacheConfiguration {
 		registerDefaultConverters(conversionService);
 
 		return new RedisCacheConfiguration(Duration.ZERO, true, true, null,
-				SerializationPair.fromSerializer(new StringRedisSerializer()),
+				SerializationPair.fromSerializer(StringRedisSerializer.UTF_8),
 				SerializationPair.fromSerializer(new JdkSerializationRedisSerializer()), conversionService);
 	}
 

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
@@ -23,9 +23,8 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.interceptor.SimpleKey;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.ConverterRegistry;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -95,8 +94,8 @@ public class RedisCacheConfiguration {
 		registerDefaultConverters(conversionService);
 
 		return new RedisCacheConfiguration(Duration.ZERO, true, true, null,
-				SerializationPair.fromSerializer(StringRedisSerializer.UTF_8),
-				SerializationPair.fromSerializer(new JdkSerializationRedisSerializer()), conversionService);
+				SerializationPair.fromSerializer(RedisSerializer.string()),
+				SerializationPair.fromSerializer(RedisSerializer.java()), conversionService);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -117,7 +117,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	 * @param connection Redis connection
 	 */
 	public DefaultStringRedisConnection(RedisConnection connection) {
-		this(connection, new StringRedisSerializer());
+		this(connection, StringRedisSerializer.UTF_8);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -117,7 +117,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	 * @param connection Redis connection
 	 */
 	public DefaultStringRedisConnection(RedisConnection connection) {
-		this(connection, StringRedisSerializer.UTF_8);
+		this(connection, RedisSerializer.string());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/core/ReactiveStringRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveStringRedisTemplate.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+/**
+ * String-focused extension of {@link ReactiveRedisTemplate}. Since most operations against Redis are {@link String}
+ * based, this class provides a dedicated arrangement that minimizes configuration of its more generic
+ * {@link ReactiveRedisTemplate template} especially in terms of serializers.
+ * 
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public class ReactiveStringRedisTemplate extends ReactiveRedisTemplate<String, String> {
+
+	/**
+	 * Creates new {@link ReactiveRedisTemplate} using given {@link ReactiveRedisConnectionFactory} applying default
+	 * {@link String} serialization.
+	 *
+	 * @param connectionFactory must not be {@literal null}.
+	 * @see RedisSerializationContext#string()
+	 */
+	public ReactiveStringRedisTemplate(ReactiveRedisConnectionFactory connectionFactory) {
+		this(connectionFactory, RedisSerializationContext.string());
+	}
+
+	/**
+	 * Creates new {@link ReactiveRedisTemplate} using given {@link ReactiveRedisConnectionFactory} and
+	 * {@link RedisSerializationContext}.
+	 *
+	 * @param connectionFactory must not be {@literal null}.
+	 * @param serializationContext must not be {@literal null}.
+	 */
+	public ReactiveStringRedisTemplate(ReactiveRedisConnectionFactory connectionFactory,
+			RedisSerializationContext<String, String> serializationContext) {
+		super(connectionFactory, serializationContext);
+	}
+
+	/**
+	 * Creates new {@link ReactiveRedisTemplate} using given {@link ReactiveRedisConnectionFactory} and
+	 * {@link RedisSerializationContext}.
+	 *
+	 * @param connectionFactory must not be {@literal null}.
+	 * @param serializationContext must not be {@literal null}.
+	 * @param exposeConnection flag indicating to expose the connection used.
+	 */
+	public ReactiveStringRedisTemplate(ReactiveRedisConnectionFactory connectionFactory,
+			RedisSerializationContext<String, String> serializationContext, boolean exposeConnection) {
+		super(connectionFactory, serializationContext, exposeConnection);
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/ReactiveStringRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveStringRedisTemplate.java
@@ -19,11 +19,12 @@ import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 
 /**
- * String-focused extension of {@link ReactiveRedisTemplate}. Since most operations against Redis are {@link String}
- * based, this class provides a dedicated arrangement that minimizes configuration of its more generic
- * {@link ReactiveRedisTemplate template} especially in terms of serializers.
- * 
+ * {@link java.lang.String String-focused} extension of {@link ReactiveRedisTemplate}. As most operations against Redis
+ * are {@link String} based, this class provides a dedicated arrangement that minimizes configuration of its more
+ * generic {@link ReactiveRedisTemplate template} especially in terms of the used {@link RedisSerializationContext}.
+ *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.1
  */
 public class ReactiveStringRedisTemplate extends ReactiveRedisTemplate<String, String> {

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -96,7 +96,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	@SuppressWarnings("rawtypes") private @Nullable RedisSerializer valueSerializer = null;
 	@SuppressWarnings("rawtypes") private @Nullable RedisSerializer hashKeySerializer = null;
 	@SuppressWarnings("rawtypes") private @Nullable RedisSerializer hashValueSerializer = null;
-	private RedisSerializer<String> stringSerializer = new StringRedisSerializer();
+	private RedisSerializer<String> stringSerializer = StringRedisSerializer.UTF_8;
 
 	private @Nullable ScriptExecutor<K> scriptExecutor;
 

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -96,7 +96,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	@SuppressWarnings("rawtypes") private @Nullable RedisSerializer valueSerializer = null;
 	@SuppressWarnings("rawtypes") private @Nullable RedisSerializer hashKeySerializer = null;
 	@SuppressWarnings("rawtypes") private @Nullable RedisSerializer hashValueSerializer = null;
-	private RedisSerializer<String> stringSerializer = StringRedisSerializer.UTF_8;
+	private RedisSerializer<String> stringSerializer = RedisSerializer.string();
 
 	private @Nullable ScriptExecutor<K> scriptExecutor;
 

--- a/src/main/java/org/springframework/data/redis/core/StringRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/StringRedisTemplate.java
@@ -31,6 +31,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * {@link StringRedisConnection}.
  * 
  * @author Costin Leau
+ * @author Mark Paluch
  */
 public class StringRedisTemplate extends RedisTemplate<String, String> {
 
@@ -39,11 +40,10 @@ public class StringRedisTemplate extends RedisTemplate<String, String> {
 	 * and {@link #afterPropertiesSet()} still need to be called.
 	 */
 	public StringRedisTemplate() {
-		RedisSerializer<String> stringSerializer = new StringRedisSerializer();
-		setKeySerializer(stringSerializer);
-		setValueSerializer(stringSerializer);
-		setHashKeySerializer(stringSerializer);
-		setHashValueSerializer(stringSerializer);
+		setKeySerializer(StringRedisSerializer.UTF_8);
+		setValueSerializer(StringRedisSerializer.UTF_8);
+		setHashKeySerializer(StringRedisSerializer.UTF_8);
+		setHashValueSerializer(StringRedisSerializer.UTF_8);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/core/StringRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/StringRedisTemplate.java
@@ -40,10 +40,10 @@ public class StringRedisTemplate extends RedisTemplate<String, String> {
 	 * and {@link #afterPropertiesSet()} still need to be called.
 	 */
 	public StringRedisTemplate() {
-		setKeySerializer(StringRedisSerializer.UTF_8);
-		setValueSerializer(StringRedisSerializer.UTF_8);
-		setHashKeySerializer(StringRedisSerializer.UTF_8);
-		setHashValueSerializer(StringRedisSerializer.UTF_8);
+		setKeySerializer(RedisSerializer.string());
+		setValueSerializer(RedisSerializer.string());
+		setHashKeySerializer(RedisSerializer.string());
+		setHashValueSerializer(RedisSerializer.string());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -127,7 +127,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 	private final SubscriptionTask subscriptionTask = new SubscriptionTask();
 
-	private volatile RedisSerializer<String> serializer = new StringRedisSerializer();
+	private volatile RedisSerializer<String> serializer = StringRedisSerializer.UTF_8;
 
 	private long recoveryInterval = DEFAULT_RECOVERY_INTERVAL;
 

--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -127,7 +127,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 	private final SubscriptionTask subscriptionTask = new SubscriptionTask();
 
-	private volatile RedisSerializer<String> serializer = StringRedisSerializer.UTF_8;
+	private volatile RedisSerializer<String> serializer = RedisSerializer.string();
 
 	private long recoveryInterval = DEFAULT_RECOVERY_INTERVAL;
 
@@ -307,7 +307,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 	 * @param connectionFactory The connectionFactory to set.
 	 */
 	public void setConnectionFactory(RedisConnectionFactory connectionFactory) {
-		
+
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
 		this.connectionFactory = connectionFactory;
 	}

--- a/src/main/java/org/springframework/data/redis/listener/adapter/MessageListenerAdapter.java
+++ b/src/main/java/org/springframework/data/redis/listener/adapter/MessageListenerAdapter.java
@@ -92,6 +92,7 @@ import org.springframework.util.StringUtils;
  * @author Greg Turnquist
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @see org.springframework.jms.listener.adapter.MessageListenerAdapter
  */
 public class MessageListenerAdapter implements InitializingBean, MessageListener {
@@ -317,9 +318,8 @@ public class MessageListenerAdapter implements InitializingBean, MessageListener
 	 * @see JdkSerializationRedisSerializer
 	 */
 	protected void initDefaultStrategies() {
-		RedisSerializer<String> serializer = new StringRedisSerializer();
-		setSerializer(serializer);
-		setStringSerializer(serializer);
+		setSerializer(StringRedisSerializer.UTF_8);
+		setStringSerializer(StringRedisSerializer.UTF_8);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/listener/adapter/MessageListenerAdapter.java
+++ b/src/main/java/org/springframework/data/redis/listener/adapter/MessageListenerAdapter.java
@@ -318,8 +318,8 @@ public class MessageListenerAdapter implements InitializingBean, MessageListener
 	 * @see JdkSerializationRedisSerializer
 	 */
 	protected void initDefaultStrategies() {
-		setSerializer(StringRedisSerializer.UTF_8);
-		setStringSerializer(StringRedisSerializer.UTF_8);
+		setSerializer(RedisSerializer.string());
+		setStringSerializer(RedisSerializer.string());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/serializer/DefaultRedisSerializationContext.java
+++ b/src/main/java/org/springframework/data/redis/serializer/DefaultRedisSerializationContext.java
@@ -98,7 +98,7 @@ class DefaultRedisSerializationContext<K, V> implements RedisSerializationContex
 		private @Nullable SerializationPair<V> valueTuple;
 		private @Nullable SerializationPair<?> hashKeyTuple;
 		private @Nullable SerializationPair<?> hashValueTuple;
-		private SerializationPair<String> stringTuple = SerializationPair.fromSerializer(new StringRedisSerializer());
+		private SerializationPair<String> stringTuple = SerializationPair.fromSerializer(StringRedisSerializer.UTF_8);
 
 		/* (non-Javadoc)
 		 * @see org.springframework.data.redis.serializer.RedisSerializationContextBuilder#key(SerializationPair)

--- a/src/main/java/org/springframework/data/redis/serializer/DefaultRedisSerializationContext.java
+++ b/src/main/java/org/springframework/data/redis/serializer/DefaultRedisSerializationContext.java
@@ -98,7 +98,7 @@ class DefaultRedisSerializationContext<K, V> implements RedisSerializationContex
 		private @Nullable SerializationPair<V> valueTuple;
 		private @Nullable SerializationPair<?> hashKeyTuple;
 		private @Nullable SerializationPair<?> hashValueTuple;
-		private SerializationPair<String> stringTuple = SerializationPair.fromSerializer(StringRedisSerializer.UTF_8);
+		private SerializationPair<String> stringTuple = SerializationPair.fromSerializer(RedisSerializer.string());
 
 		/* (non-Javadoc)
 		 * @see org.springframework.data.redis.serializer.RedisSerializationContextBuilder#key(SerializationPair)

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
@@ -93,7 +93,7 @@ public interface RedisSerializationContext<K, V> {
 	 * @return
 	 */
 	static RedisSerializationContext<String, String> string() {
-		return fromSerializer(new StringRedisSerializer());
+		return fromSerializer(StringRedisSerializer.UTF_8);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
@@ -93,7 +93,7 @@ public interface RedisSerializationContext<K, V> {
 	 * @return
 	 */
 	static RedisSerializationContext<String, String> string() {
-		return fromSerializer(StringRedisSerializer.UTF_8);
+		return fromSerializer(RedisSerializer.string());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.springframework.lang.Nullable;
  * Basic interface serialization and deserialization of Objects to byte arrays (binary data). It is recommended that
  * implementations are designed to handle null objects/empty arrays on serialization and deserialization side. Note that
  * Redis does not accept null keys or values but can return null replies (for non existing keys).
- * 
+ *
  * @author Mark Pollack
  * @author Costin Leau
  * @author Christoph Strobl
@@ -45,4 +45,36 @@ public interface RedisSerializer<T> {
 	 */
 	@Nullable
 	T deserialize(@Nullable byte[] bytes) throws SerializationException;
+
+	/**
+	 * Obtain a {@link RedisSerializer} using java serialization.
+	 *
+	 * @return never {@literal null}.
+	 * @since 2.1
+	 */
+	static RedisSerializer<Object> java() {
+		return new JdkSerializationRedisSerializer();
+	}
+
+	/**
+	 * Obtain a {@link RedisSerializer} that can read and write JSON using
+	 * <a href="https://github.com/FasterXML/jackson-core">Jackson</a>.
+	 *
+	 * @return never {@literal null}.
+	 * @since 2.1
+	 */
+	static RedisSerializer<Object> json() {
+		return new GenericJackson2JsonRedisSerializer();
+	}
+
+	/**
+	 * Obtain a simple {@link java.lang.String} to {@literal byte[]} (and back) serializer using
+	 * {@link java.nio.charset.StandardCharsets#UTF_8 UTF-8} as the default {@link java.nio.charset.Charset}.
+	 *
+	 * @return never {@literal null}.
+	 * @since 2.1
+	 */
+	static RedisSerializer<String> string() {
+		return StringRedisSerializer.UTF_8;
+	}
 }

--- a/src/main/java/org/springframework/data/redis/serializer/StringRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/StringRedisSerializer.java
@@ -22,19 +22,41 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * Simple String to byte[] (and back) serializer. Converts Strings into bytes and vice-versa using the specified charset
- * (by default UTF-8).
+ * Simple {@literal} to {@literal byte[]} (and back) serializer. Converts Strings into bytes and vice-versa using the
+ * specified charset (by default UTF-8).
  * <p>
  * Useful when the interaction with the Redis happens mainly through Strings.
  * <p>
- * Does not perform any null conversion since empty strings are valid keys/values.
+ * Does not perform any {@literal null} conversion since empty strings are valid keys/values.
  *
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class StringRedisSerializer implements RedisSerializer<String> {
 
 	private final Charset charset;
+
+	/**
+	 * Serializer to use 7 bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the Unicode character set.
+	 * 
+	 * @since 2.1
+	 */
+	public static final StringRedisSerializer US_ASCII = new StringRedisSerializer(StandardCharsets.US_ASCII);
+
+	/**
+	 * Serializer to use ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.
+	 * 
+	 * @since 2.1
+	 */
+	public static final StringRedisSerializer ISO_8859_1 = new StringRedisSerializer(StandardCharsets.ISO_8859_1);
+
+	/**
+	 * Serializer to use 8 bit UCS Transformation Format.
+	 * 
+	 * @since 2.1
+	 */
+	public static final StringRedisSerializer UTF_8 = new StringRedisSerializer(StandardCharsets.UTF_8);
 
 	/**
 	 * Creates a new {@link StringRedisSerializer} using {@link StandardCharsets#UTF_8 UTF-8}.

--- a/src/main/java/org/springframework/data/redis/serializer/StringRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/StringRedisSerializer.java
@@ -22,8 +22,8 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * Simple {@literal} to {@literal byte[]} (and back) serializer. Converts Strings into bytes and vice-versa using the
- * specified charset (by default UTF-8).
+ * Simple {@link java.lang.String} to {@literal byte[]} (and back) serializer. Converts {@link java.lang.String Strings}
+ * into bytes and vice-versa using the specified charset (by default {@literal UTF-8}).
  * <p>
  * Useful when the interaction with the Redis happens mainly through Strings.
  * <p>
@@ -38,22 +38,26 @@ public class StringRedisSerializer implements RedisSerializer<String> {
 	private final Charset charset;
 
 	/**
-	 * Serializer to use 7 bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the Unicode character set.
-	 * 
+	 * {@link StringRedisSerializer} to use 7 bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the Unicode
+	 * character set.
+	 *
+	 * @see StandardCharsets#US_ASCII
 	 * @since 2.1
 	 */
 	public static final StringRedisSerializer US_ASCII = new StringRedisSerializer(StandardCharsets.US_ASCII);
 
 	/**
-	 * Serializer to use ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.
-	 * 
+	 * {@link StringRedisSerializer} to use ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.
+	 *
+	 * @see StandardCharsets#ISO_8859_1
 	 * @since 2.1
 	 */
 	public static final StringRedisSerializer ISO_8859_1 = new StringRedisSerializer(StandardCharsets.ISO_8859_1);
 
 	/**
-	 * Serializer to use 8 bit UCS Transformation Format.
-	 * 
+	 * {@link StringRedisSerializer} to use 8 bit UCS Transformation Format.
+	 *
+	 * @see StandardCharsets#UTF_8
 	 * @since 2.1
 	 */
 	public static final StringRedisSerializer UTF_8 = new StringRedisSerializer(StandardCharsets.UTF_8);

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -79,7 +79,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 		Assert.notNull(factory, "a valid factory is required");
 
 		RedisTemplate<String, Double> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
 		redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Double.class));
 		redisTemplate.setExposeConnection(true);
 		redisTemplate.setConnectionFactory(factory);

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -79,7 +79,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 		Assert.notNull(factory, "a valid factory is required");
 
 		RedisTemplate<String, Double> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
+		redisTemplate.setKeySerializer(RedisSerializer.string());
 		redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Double.class));
 		redisTemplate.setExposeConnection(true);
 		redisTemplate.setConnectionFactory(factory);

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -102,7 +102,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	private RedisAtomicInteger(String redisCounter, RedisConnectionFactory factory, @Nullable Integer initialValue) {
 
 		RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
 		redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
 		redisTemplate.setExposeConnection(true);
 		redisTemplate.setConnectionFactory(factory);

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -102,7 +102,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	private RedisAtomicInteger(String redisCounter, RedisConnectionFactory factory, @Nullable Integer initialValue) {
 
 		RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
+		redisTemplate.setKeySerializer(RedisSerializer.string());
 		redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
 		redisTemplate.setExposeConnection(true);
 		redisTemplate.setConnectionFactory(factory);

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -79,7 +79,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 		Assert.notNull(factory, "a valid factory is required");
 
 		RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
 		redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		redisTemplate.setExposeConnection(true);
 		redisTemplate.setConnectionFactory(factory);

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -79,7 +79,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 		Assert.notNull(factory, "a valid factory is required");
 
 		RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
+		redisTemplate.setKeySerializer(RedisSerializer.string());
 		redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		redisTemplate.setExposeConnection(true);
 		redisTemplate.setConnectionFactory(factory);

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheTests.java
@@ -61,7 +61,7 @@ public class RedisCacheTests {
 	Person sample = new Person("calmity", new Date());
 	byte[] binarySample;
 
-	byte[] binaryNullValue = new JdkSerializationRedisSerializer().serialize(NullValue.INSTANCE);
+	byte[] binaryNullValue = RedisSerializer.java().serialize(NullValue.INSTANCE);
 
 	RedisConnectionFactory connectionFactory;
 	RedisSerializer serializer;

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -100,7 +100,7 @@ public abstract class AbstractConnectionIntegrationTests {
 
 	protected StringRedisConnection connection;
 	protected RedisSerializer<Object> serializer = new JdkSerializationRedisSerializer();
-	protected RedisSerializer<String> stringSerializer = new StringRedisSerializer();
+	protected RedisSerializer<String> stringSerializer = StringRedisSerializer.UTF_8;
 
 	private static final byte[] EMPTY_ARRAY = new byte[0];
 

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -99,8 +99,8 @@ public abstract class AbstractConnectionIntegrationTests {
 	private static final GeoLocation<String> PALERMO = new GeoLocation<>("palermo", POINT_PALERMO);
 
 	protected StringRedisConnection connection;
-	protected RedisSerializer<Object> serializer = new JdkSerializationRedisSerializer();
-	protected RedisSerializer<String> stringSerializer = StringRedisSerializer.UTF_8;
+	protected RedisSerializer<Object> serializer = RedisSerializer.java();
+	protected RedisSerializer<String> stringSerializer = RedisSerializer.string();
 
 	private static final byte[] EMPTY_ARRAY = new byte[0];
 

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
@@ -58,7 +58,7 @@ public class DefaultStringRedisConnectionTests {
 
 	protected DefaultStringRedisConnection connection;
 
-	protected StringRedisSerializer serializer = new StringRedisSerializer();
+	protected StringRedisSerializer serializer = StringRedisSerializer.UTF_8;
 
 	protected String foo = "foo";
 

--- a/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
@@ -73,13 +73,13 @@ abstract public class AbstractOperationsTestParams {
 		stringTemplate.afterPropertiesSet();
 
 		RedisTemplate<String, Long> longTemplate = new RedisTemplate<>();
-		longTemplate.setKeySerializer(new StringRedisSerializer());
+		longTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
 		longTemplate.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		longTemplate.setConnectionFactory(jedisConnectionFactory);
 		longTemplate.afterPropertiesSet();
 
 		RedisTemplate<String, Double> doubleTemplate = new RedisTemplate<>();
-		doubleTemplate.setKeySerializer(new StringRedisSerializer());
+		doubleTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
 		doubleTemplate.setValueSerializer(new GenericToStringSerializer<>(Double.class));
 		doubleTemplate.setConnectionFactory(jedisConnectionFactory);
 		doubleTemplate.afterPropertiesSet();

--- a/src/test/java/org/springframework/data/redis/core/DefaultClusterOperationsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultClusterOperationsUnitTests.java
@@ -43,6 +43,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class DefaultClusterOperationsUnitTests {
@@ -66,7 +67,7 @@ public class DefaultClusterOperationsUnitTests {
 		when(connectionFactory.getConnection()).thenReturn(connection);
 		when(connectionFactory.getClusterConnection()).thenReturn(connection);
 
-		serializer = new StringRedisSerializer();
+		serializer = StringRedisSerializer.UTF_8;
 
 		RedisTemplate<String, String> template = new RedisTemplate<>();
 		template.setConnectionFactory(connectionFactory);

--- a/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsTests.java
@@ -55,6 +55,7 @@ import org.springframework.test.annotation.IfProfileValue;
  *
  * @author Ninad Divadkar
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(Parameterized.class)
 @IfProfileValue(name = "redisVersion", value = "3.2.0+")
@@ -202,8 +203,6 @@ public class DefaultGeoOperationsTests<K, M> {
 
 		List<String> result = geoOperations.hash(key, v1, v2);
 		assertThat(result, hasSize(2));
-
-		final RedisSerializer<String> serializer = new StringRedisSerializer();
 
 		assertThat(result.get(0), is(equalTo("sqc8b49rny0")));
 		assertThat(result.get(1), is(equalTo("sqdtr74hyu0")));

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
@@ -75,7 +75,7 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		lettuceConnectionFactory.afterPropertiesSet();
 
 		RedisSerializationContext<String, String> serializationContext = RedisSerializationContext
-				.fromSerializer(new StringRedisSerializer());
+				.fromSerializer(StringRedisSerializer.UTF_8);
 		ReactiveRedisTemplate<String, String> stringTemplate = new ReactiveRedisTemplate<>(lettuceConnectionFactory,
 				serializationContext);
 

--- a/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
@@ -104,7 +104,7 @@ abstract public class ReactiveOperationsTestParams {
 		ReactiveRedisTemplate<Object, Object> pooledObjectTemplate = new ReactiveRedisTemplate<>(poolingConnectionFactory,
 				RedisSerializationContext.fromSerializer(jdkSerializationRedisSerializer));
 
-		StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
+		StringRedisSerializer stringRedisSerializer = StringRedisSerializer.UTF_8;
 		ReactiveRedisTemplate<String, String> stringTemplate = new ReactiveRedisTemplate<>(lettuceConnectionFactory,
 				RedisSerializationContext.fromSerializer(stringRedisSerializer));
 

--- a/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
@@ -191,7 +191,7 @@ public class ReactiveRedisTemplateIntegrationTests<K, V> {
 		V value = valueFactory.instance();
 
 		SerializationPair json = SerializationPair.fromSerializer(new Jackson2JsonRedisSerializer<>(Person.class));
-		RedisElementReader<String> resultReader = RedisElementReader.from(new StringRedisSerializer());
+		RedisElementReader<String> resultReader = RedisElementReader.from(StringRedisSerializer.UTF_8);
 
 		assumeFalse(value instanceof Long);
 
@@ -346,7 +346,7 @@ public class ReactiveRedisTemplateIntegrationTests<K, V> {
 		RedisSerializationContext<K, V> objectSerializers = RedisSerializationContext.<K, V> newSerializationContext()
 				.key(serializationContext.getKeySerializationPair()) //
 				.value(serializationContext.getValueSerializationPair()) //
-				.hashKey(new StringRedisSerializer()) //
+				.hashKey(StringRedisSerializer.UTF_8) //
 				.hashValue(new JdkSerializationRedisSerializer()) //
 				.build();
 

--- a/src/test/java/org/springframework/data/redis/core/ReactiveStringRedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveStringRedisTemplateIntegrationTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import reactor.test.StepVerifier;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.data.redis.ConnectionFactoryTracker;
+import org.springframework.data.redis.SettingsUtils;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceTestClientConfiguration;
+
+/**
+ * Integration tests for {@link ReactiveStringRedisTemplate}.
+ * 
+ * @author Mark Paluch
+ */
+public class ReactiveStringRedisTemplateIntegrationTests {
+
+	private static ReactiveRedisConnectionFactory connectionFactory;
+
+	private ReactiveStringRedisTemplate template;
+
+	@BeforeClass
+	public static void beforeClass() {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(SettingsUtils.standaloneConfiguration(),
+				LettuceTestClientConfiguration.create());
+		connectionFactory.afterPropertiesSet();
+		ConnectionFactoryTracker.add(connectionFactory);
+
+		ReactiveStringRedisTemplateIntegrationTests.connectionFactory = connectionFactory;
+	}
+
+	@Before
+	public void before() {
+
+		template = new ReactiveStringRedisTemplate(connectionFactory);
+
+		StepVerifier.create(template.execute(connection -> connection.serverCommands().flushDb())).expectNext("OK")
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-643
+	public void shouldSetAndGetKeys() {
+
+		StepVerifier.create(template.opsForValue().set("key", "value")).expectNext(true).verifyComplete();
+		StepVerifier.create(template.opsForValue().get("key")).expectNext("value").verifyComplete();
+	}
+}

--- a/src/test/java/org/springframework/data/redis/core/ReactiveStringRedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveStringRedisTemplateIntegrationTests.java
@@ -28,7 +28,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceTestClientConfig
 
 /**
  * Integration tests for {@link ReactiveStringRedisTemplate}.
- * 
+ *
  * @author Mark Paluch
  */
 public class ReactiveStringRedisTemplateIntegrationTests {

--- a/src/test/java/org/springframework/data/redis/core/RedisClusterTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisClusterTemplateTests.java
@@ -166,12 +166,12 @@ public class RedisClusterTemplateTests<K, V> extends RedisTemplateTests<K, V> {
 		jedisConnectionFactory.afterPropertiesSet();
 
 		RedisTemplate<String, String> jedisStringTemplate = new RedisTemplate<>();
-		jedisStringTemplate.setDefaultSerializer(new StringRedisSerializer());
+		jedisStringTemplate.setDefaultSerializer(StringRedisSerializer.UTF_8);
 		jedisStringTemplate.setConnectionFactory(jedisConnectionFactory);
 		jedisStringTemplate.afterPropertiesSet();
 
 		RedisTemplate<String, Long> jedisLongTemplate = new RedisTemplate<>();
-		jedisLongTemplate.setKeySerializer(new StringRedisSerializer());
+		jedisLongTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
 		jedisLongTemplate.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		jedisLongTemplate.setConnectionFactory(jedisConnectionFactory);
 		jedisLongTemplate.afterPropertiesSet();
@@ -204,12 +204,12 @@ public class RedisClusterTemplateTests<K, V> extends RedisTemplateTests<K, V> {
 		lettuceConnectionFactory.afterPropertiesSet();
 
 		RedisTemplate<String, String> lettuceStringTemplate = new RedisTemplate<>();
-		lettuceStringTemplate.setDefaultSerializer(new StringRedisSerializer());
+		lettuceStringTemplate.setDefaultSerializer(StringRedisSerializer.UTF_8);
 		lettuceStringTemplate.setConnectionFactory(lettuceConnectionFactory);
 		lettuceStringTemplate.afterPropertiesSet();
 
 		RedisTemplate<String, Long> lettuceLongTemplate = new RedisTemplate<>();
-		lettuceLongTemplate.setKeySerializer(new StringRedisSerializer());
+		lettuceLongTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
 		lettuceLongTemplate.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		lettuceLongTemplate.setConnectionFactory(lettuceConnectionFactory);
 		lettuceLongTemplate.afterPropertiesSet();

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateTests.java
@@ -309,7 +309,7 @@ public class RedisTemplateTests<K, V> {
 
 		assumeTrue(redisTemplate instanceof StringRedisTemplate);
 
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setKeySerializer(StringRedisSerializer.UTF_8);
 		redisTemplate.setHashKeySerializer(new GenericToStringSerializer<>(Long.class));
 		redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(Person.class));
 
@@ -800,7 +800,7 @@ public class RedisTemplateTests<K, V> {
 		final DefaultRedisScript<String> script = new DefaultRedisScript<>();
 		script.setScriptText("return 'Hey'");
 		script.setResultType(String.class);
-		assertEquals("Hey", redisTemplate.execute(script, redisTemplate.getValueSerializer(), new StringRedisSerializer(),
+		assertEquals("Hey", redisTemplate.execute(script, redisTemplate.getValueSerializer(), StringRedisSerializer.UTF_8,
 				Collections.singletonList(key1)));
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/script/AbstractDefaultScriptExecutorTests.java
+++ b/src/test/java/org/springframework/data/redis/core/script/AbstractDefaultScriptExecutorTests.java
@@ -45,6 +45,7 @@ import org.springframework.test.annotation.IfProfileValue;
  * @author Jennifer Hickey
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @IfProfileValue(name = "redisVersion", value = "2.6+")
 public abstract class AbstractDefaultScriptExecutorTests {
@@ -90,7 +91,7 @@ public abstract class AbstractDefaultScriptExecutorTests {
 	@Test
 	public void testExecuteBooleanResult() {
 		this.template = new RedisTemplate<String, Long>();
-		template.setKeySerializer(new StringRedisSerializer());
+		template.setKeySerializer(StringRedisSerializer.UTF_8);
 		template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		template.setConnectionFactory(getConnectionFactory());
 		template.afterPropertiesSet();
@@ -155,7 +156,7 @@ public abstract class AbstractDefaultScriptExecutorTests {
 	@Test
 	public void testExecuteStatusResult() {
 		this.template = new RedisTemplate<String, Long>();
-		template.setKeySerializer(new StringRedisSerializer());
+		template.setKeySerializer(StringRedisSerializer.UTF_8);
 		template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		template.setConnectionFactory(getConnectionFactory());
 		template.afterPropertiesSet();
@@ -171,7 +172,7 @@ public abstract class AbstractDefaultScriptExecutorTests {
 	public void testExecuteCustomResultSerializer() {
 		Jackson2JsonRedisSerializer<Person> personSerializer = new Jackson2JsonRedisSerializer<>(Person.class);
 		this.template = new RedisTemplate<String, Person>();
-		template.setKeySerializer(new StringRedisSerializer());
+		template.setKeySerializer(StringRedisSerializer.UTF_8);
 		template.setValueSerializer(personSerializer);
 		template.setConnectionFactory(getConnectionFactory());
 		template.afterPropertiesSet();
@@ -180,7 +181,7 @@ public abstract class AbstractDefaultScriptExecutorTests {
 		script.setResultType(String.class);
 		ScriptExecutor<String> scriptExecutor = new DefaultScriptExecutor<String>(template);
 		Person joe = new Person("Joe", "Schmoe", 23);
-		String result = scriptExecutor.execute(script, personSerializer, new StringRedisSerializer(),
+		String result = scriptExecutor.execute(script, personSerializer, StringRedisSerializer.UTF_8,
 				Collections.singletonList("bar"), joe);
 		assertEquals("FOO", result);
 		assertEquals(joe, template.boundValueOps("bar").get());

--- a/src/test/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutorTests.java
+++ b/src/test/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutorTests.java
@@ -111,7 +111,7 @@ public class DefaultReactiveScriptExecutorTests {
 	public void shouldReturnBoolean() {
 
 		RedisSerializationContextBuilder<String, Long> builder = RedisSerializationContext
-				.newSerializationContext(new StringRedisSerializer());
+				.newSerializationContext(StringRedisSerializer.UTF_8);
 		builder.value(new GenericToStringSerializer<>(Long.class));
 
 		DefaultRedisScript<Boolean> script = new DefaultRedisScript<>();
@@ -142,7 +142,7 @@ public class DefaultReactiveScriptExecutorTests {
 
 		Flux<List<String>> mylist = stringScriptExecutor.execute(script, Collections.singletonList("mylist"),
 				Collections.singletonList(1L), RedisElementWriter.from(new GenericToStringSerializer<>(Long.class)),
-				(RedisElementReader) RedisElementReader.from(new StringRedisSerializer()));
+				(RedisElementReader) RedisElementReader.from(StringRedisSerializer.UTF_8));
 
 		StepVerifier.create(mylist).expectNext(Collections.singletonList("a")).verifyComplete();
 	}
@@ -185,7 +185,7 @@ public class DefaultReactiveScriptExecutorTests {
 		script.setScriptText("return redis.call('SET',KEYS[1], ARGV[1])");
 
 		RedisSerializationContextBuilder<String, Long> builder = RedisSerializationContext
-				.newSerializationContext(new StringRedisSerializer());
+				.newSerializationContext(StringRedisSerializer.UTF_8);
 		builder.value(new GenericToStringSerializer<>(Long.class));
 
 		ReactiveScriptExecutor<String> scriptExecutor = new DefaultReactiveScriptExecutor<>(connectionFactory,
@@ -203,7 +203,7 @@ public class DefaultReactiveScriptExecutorTests {
 		Jackson2JsonRedisSerializer<Person> personSerializer = new Jackson2JsonRedisSerializer<>(Person.class);
 
 		RedisTemplate<String, Person> template = new RedisTemplate<>();
-		template.setKeySerializer(new StringRedisSerializer());
+		template.setKeySerializer(StringRedisSerializer.UTF_8);
 		template.setValueSerializer(personSerializer);
 		template.setConnectionFactory(getConnectionFactory());
 		template.afterPropertiesSet();
@@ -215,7 +215,7 @@ public class DefaultReactiveScriptExecutorTests {
 		Person joe = new Person("Joe", "Schmoe", 23);
 		Flux<String> result = stringScriptExecutor.execute(script, Collections.singletonList("bar"),
 				Collections.singletonList(joe), RedisElementWriter.from(personSerializer),
-				RedisElementReader.from(new StringRedisSerializer()));
+				RedisElementReader.from(StringRedisSerializer.UTF_8));
 
 		StepVerifier.create(result).expectNext("FOO").verifyComplete();
 

--- a/src/test/java/org/springframework/data/redis/listener/adapter/MessageListenerTest.java
+++ b/src/test/java/org/springframework/data/redis/listener/adapter/MessageListenerTest.java
@@ -36,10 +36,11 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * @author Costin Leau
  * @author Greg Turnquist
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class MessageListenerTest {
 
-	private static final StringRedisSerializer serializer = new StringRedisSerializer();
+	private static final StringRedisSerializer serializer = StringRedisSerializer.UTF_8;
 	private static final String CHANNEL = "some::test:";
 	private static final byte[] RAW_CHANNEL = serializer.serialize(CHANNEL);
 	private static final String PAYLOAD = "do re mi";

--- a/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
@@ -33,9 +33,9 @@ public class RedisSerializationContextUnitTests {
 	public void shouldRejectBuildIfKeySerializerIsNotSet() {
 
 		RedisSerializationContext.<String, String> newSerializationContext() //
-				.value(new StringRedisSerializer()) //
-				.hashKey(new StringRedisSerializer()) //
-				.hashValue(new StringRedisSerializer()) //
+				.value(StringRedisSerializer.UTF_8) //
+				.hashKey(StringRedisSerializer.UTF_8) //
+				.hashValue(StringRedisSerializer.UTF_8) //
 				.build();
 	}
 
@@ -43,9 +43,9 @@ public class RedisSerializationContextUnitTests {
 	public void shouldRejectBuildIfValueSerializerIsNotSet() {
 
 		RedisSerializationContext.<String, String> newSerializationContext() //
-				.key(new StringRedisSerializer()) //
-				.hashKey(new StringRedisSerializer()) //
-				.hashValue(new StringRedisSerializer()) //
+				.key(StringRedisSerializer.UTF_8) //
+				.hashKey(StringRedisSerializer.UTF_8) //
+				.hashValue(StringRedisSerializer.UTF_8) //
 				.build();
 	}
 
@@ -53,9 +53,9 @@ public class RedisSerializationContextUnitTests {
 	public void shouldRejectBuildIfHashKeySerializerIsNotSet() {
 
 		RedisSerializationContext.<String, String> newSerializationContext() //
-				.key(new StringRedisSerializer()) //
-				.value(new StringRedisSerializer()) //
-				.hashValue(new StringRedisSerializer()) //
+				.key(StringRedisSerializer.UTF_8) //
+				.value(StringRedisSerializer.UTF_8) //
+				.hashValue(StringRedisSerializer.UTF_8) //
 				.build();
 	}
 
@@ -63,16 +63,16 @@ public class RedisSerializationContextUnitTests {
 	public void shouldRejectBuildIfHashValueSerializerIsNotSet() {
 
 		RedisSerializationContext.<String, String> newSerializationContext() //
-				.key(new StringRedisSerializer()) //
-				.value(new StringRedisSerializer()) //
-				.hashKey(new StringRedisSerializer()) //
+				.key(StringRedisSerializer.UTF_8) //
+				.value(StringRedisSerializer.UTF_8) //
+				.hashKey(StringRedisSerializer.UTF_8) //
 				.build();
 	}
 
 	@Test // DATAREDIS-602
 	public void shouldUseDefaultIfSet() {
 
-		RedisSerializationContext.<String, String> newSerializationContext(new StringRedisSerializer())
+		RedisSerializationContext.<String, String> newSerializationContext(StringRedisSerializer.UTF_8)
 				.key(new GenericToStringSerializer(Long.class))//
 				.build();
 	}
@@ -114,10 +114,10 @@ public class RedisSerializationContextUnitTests {
 	private RedisSerializationContext<String, Long> createSerializationContext() {
 
 		return RedisSerializationContext.<String, Long> newSerializationContext() //
-				.key(new StringRedisSerializer()) //
+				.key(StringRedisSerializer.UTF_8) //
 				.value(ByteBuffer::getLong, value -> (ByteBuffer) ByteBuffer.allocate(8).putLong(value).flip()) //
-				.hashKey(new StringRedisSerializer()) //
-				.hashValue(new StringRedisSerializer()) //
+				.hashKey(StringRedisSerializer.UTF_8) //
+				.hashValue(StringRedisSerializer.UTF_8) //
 				.build();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/serializer/StringRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/StringRedisSerializerUnitTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.serializer;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link StringRedisSerializer}.
+ * 
+ * @author Mark Paluch
+ */
+public class StringRedisSerializerUnitTests {
+
+	@Test
+	public void shouldSerializeToAscii() {
+
+		assertThat(StringRedisSerializer.US_ASCII.serialize("foo-bar"), is(equalTo("foo-bar".getBytes())));
+		assertThat(StringRedisSerializer.US_ASCII.serialize("üßØ"), is(equalTo("???".getBytes())));
+	}
+
+	@Test
+	public void shouldDeserializeFromAscii() {
+
+		assertThat(StringRedisSerializer.US_ASCII.deserialize("foo-bar".getBytes()), is(equalTo("foo-bar")));
+	}
+
+	@Test
+	public void shouldSerializeToIso88591() {
+
+		assertThat(StringRedisSerializer.ISO_8859_1.serialize("üßØ"),
+				is(equalTo("üßØ".getBytes(StandardCharsets.ISO_8859_1))));
+	}
+
+	@Test
+	public void shouldDeserializeFromIso88591() {
+
+		assertThat(StringRedisSerializer.ISO_8859_1.deserialize("üßØ".getBytes(StandardCharsets.ISO_8859_1)),
+				is(equalTo("üßØ")));
+	}
+
+	@Test
+	public void shouldSerializeToUtf8() {
+
+		assertThat(StringRedisSerializer.UTF_8.serialize("foo-bar"), is(equalTo("foo-bar".getBytes())));
+		assertThat(StringRedisSerializer.UTF_8.serialize("üßØ"), is(equalTo("üßØ".getBytes(StandardCharsets.UTF_8))));
+	}
+
+	@Test
+	public void shouldDeserializeFromUtf8() {
+		assertThat(StringRedisSerializer.UTF_8.deserialize("üßØ".getBytes(StandardCharsets.UTF_8)), is(equalTo("üßØ")));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleTests.java
@@ -62,7 +62,7 @@ public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
 
 		this.template = new RedisTemplate<>();
 		this.template.setConnectionFactory(factory);
-		this.template.setKeySerializer(new StringRedisSerializer());
+		this.template.setKeySerializer(StringRedisSerializer.UTF_8);
 		this.template.setValueSerializer(new GenericToStringSerializer<>(Double.class));
 		this.template.afterPropertiesSet();
 
@@ -192,7 +192,7 @@ public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
 		expectedException.expectMessage("a valid value serializer in template is required");
 
 		RedisTemplate<String, Double> template = new RedisTemplate<>();
-		template.setKeySerializer(new StringRedisSerializer());
+		template.setKeySerializer(StringRedisSerializer.UTF_8);
 		new RedisAtomicDouble("foo", template);
 	}
 

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicIntegerTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicIntegerTests.java
@@ -60,7 +60,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 
 		this.template = new RedisTemplate<>();
 		this.template.setConnectionFactory(factory);
-		this.template.setKeySerializer(new StringRedisSerializer());
+		this.template.setKeySerializer(StringRedisSerializer.UTF_8);
 		this.template.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
 		this.template.afterPropertiesSet();
 
@@ -191,7 +191,7 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		expectedException.expectMessage("a valid value serializer in template is required");
 
 		RedisTemplate<String, Integer> template = new RedisTemplate<>();
-		template.setKeySerializer(new StringRedisSerializer());
+		template.setKeySerializer(StringRedisSerializer.UTF_8);
 		new RedisAtomicInteger("foo", template);
 	}
 

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicLongTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicLongTests.java
@@ -41,6 +41,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * @author Jennifer Hickey
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(Parameterized.class)
 public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
@@ -56,7 +57,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 
 		this.template = new RedisTemplate<>();
 		this.template.setConnectionFactory(factory);
-		this.template.setKeySerializer(new StringRedisSerializer());
+		this.template.setKeySerializer(StringRedisSerializer.UTF_8);
 		this.template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		this.template.afterPropertiesSet();
 
@@ -165,7 +166,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		expectedException.expectMessage("a valid value serializer in template is required");
 
 		RedisTemplate<String, Long> template = new RedisTemplate<>();
-		template.setKeySerializer(new StringRedisSerializer());
+		template.setKeySerializer(StringRedisSerializer.UTF_8);
 		new RedisAtomicLong("foo", template);
 	}
 
@@ -174,7 +175,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 
 		RedisTemplate<String, Long> template = new RedisTemplate<>();
 		template.setConnectionFactory(factory);
-		template.setKeySerializer(new StringRedisSerializer());
+		template.setKeySerializer(StringRedisSerializer.UTF_8);
 		template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
 		template.afterPropertiesSet();
 

--- a/src/test/java/org/springframework/data/redis/support/collections/CollectionTestParams.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/CollectionTestParams.java
@@ -54,7 +54,7 @@ public abstract class CollectionTestParams {
 		}
 		OxmSerializer serializer = new OxmSerializer(xstream, xstream);
 		Jackson2JsonRedisSerializer<Person> jackson2JsonSerializer = new Jackson2JsonRedisSerializer<>(Person.class);
-		StringRedisSerializer stringSerializer = new StringRedisSerializer();
+		StringRedisSerializer stringSerializer = StringRedisSerializer.UTF_8;
 
 		// create Jedis Factory
 		ObjectFactory<String> stringFactory = new StringObjectFactory();

--- a/src/test/java/org/springframework/data/redis/support/collections/RedisMapTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/RedisMapTests.java
@@ -45,6 +45,7 @@ import org.springframework.oxm.xstream.XStreamMarshaller;
  * @author Jennifer Hickey
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class RedisMapTests extends AbstractRedisMapTests<Object, Object> {
 
@@ -75,7 +76,7 @@ public class RedisMapTests extends AbstractRedisMapTests<Object, Object> {
 		Jackson2JsonRedisSerializer<Person> jackson2JsonSerializer = new Jackson2JsonRedisSerializer<>(Person.class);
 		Jackson2JsonRedisSerializer<String> jackson2JsonStringSerializer = new Jackson2JsonRedisSerializer<>(
 				String.class);
-		StringRedisSerializer stringSerializer = new StringRedisSerializer();
+		StringRedisSerializer stringSerializer = StringRedisSerializer.UTF_8;
 
 		PoolConfig defaultPoolConfig = new PoolConfig();
 		defaultPoolConfig.setMaxActive(1000);


### PR DESCRIPTION
* Introduce constants for commonly used StringSerializers: We now provide constant StringSerializers for US-ASCII, ISO 8859-1 and UTF-8 encoding.
* Provide `ReactiveStringRedisTemplate`: Provide a String-focused convenience class for simpler bootstrapping and to provide a dedicated bean type for the application context when using auto-configuration.

These changes are more of a polishing nature.

---

Related tickets: [DATAREDIS-713](https://jira.spring.io/browse/DATAREDIS-713), [DATAREDIS-643](https://jira.spring.io/browse/DATAREDIS-643).