### PR TITLE
DATAREDIS-720 - Reuse shared connection across reactive connection wrappers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-720-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveListCommands.java
@@ -241,7 +241,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<PopResponse> bPop(Publisher<BPopCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
+		return connection.executeDedicated(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKeys(), "Keys must not be null!");
 			Assert.notNull(command.getDirection(), "Direction must not be null!");
@@ -281,7 +281,7 @@ class LettuceReactiveListCommands implements ReactiveListCommands {
 	@Override
 	public Flux<ByteBufferResponse<BRPopLPushCommand>> bRPopLPush(Publisher<BRPopLPushCommand> commands) {
 
-		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
+		return connection.executeDedicated(cmd -> Flux.from(commands).concatMap(command -> {
 
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getDestination(), "Destination key must not be null!");

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTestsBase.java
@@ -43,7 +43,8 @@ public abstract class LettuceReactiveClusterCommandsTestsBase {
 		assumeThat(clientProvider.test(), is(true));
 		nativeCommands = clientProvider.getClient().connect().sync();
 		connection = new LettuceReactiveRedisClusterConnection(
-				new ClusterConnectionProvider(clientProvider.getClient(), LettuceReactiveRedisConnection.CODEC));
+				new ClusterConnectionProvider(clientProvider.getClient(), LettuceReactiveRedisConnection.CODEC),
+				clientProvider.getClient());
 	}
 
 	@After

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
@@ -119,8 +119,10 @@ public abstract class LettuceReactiveCommandsTestsBase {
 			this.connection = new LettuceReactiveRedisConnection(connectionProvider);
 
 		} else {
+			ClusterConnectionProvider clusterConnectionProvider = (ClusterConnectionProvider) nativeConnectionProvider;
 			nativeCommands = nativeConnectionProvider.getConnection(StatefulRedisClusterConnection.class).sync();
-			this.connection = new LettuceReactiveRedisClusterConnection(connectionProvider);
+			this.connection = new LettuceReactiveRedisClusterConnection(connectionProvider,
+					clusterConnectionProvider.getClient());
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnectionUnitTests.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.lettuce.core.RedisConnectionException;
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.api.StatefulRedisConnection;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.redis.RedisConnectionFailureException;
+
+/**
+ * Unit tests for {@link LettuceReactiveRedisConnection}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LettuceReactiveRedisConnectionUnitTests {
+
+	@Mock(answer = Answers.RETURNS_MOCKS) StatefulRedisConnection<ByteBuffer, ByteBuffer> sharedConnection;
+
+	@Mock LettuceConnectionProvider connectionProvider;
+
+	@Before
+	public void before() {
+		when(connectionProvider.getConnection(any())).thenReturn(sharedConnection);
+	}
+
+	@Test // DATAREDIS-720
+	public void shouldLazilyInitializeConnection() {
+
+		new LettuceReactiveRedisConnection(connectionProvider);
+
+		verifyZeroInteractions(connectionProvider);
+	}
+
+	@Test // DATAREDIS-720
+	public void shouldExecuteUsingConnectionProvider() {
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(connectionProvider);
+
+		StepVerifier.create(connection.execute(cmd -> Mono.just("foo"))).expectNext("foo").verifyComplete();
+
+		verify(connectionProvider).getConnection(StatefulConnection.class);
+	}
+
+	@Test // DATAREDIS-720
+	public void shouldExecuteDedicatedUsingConnectionProvider() {
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(connectionProvider);
+
+		StepVerifier.create(connection.executeDedicated(cmd -> Mono.just("foo"))).expectNext("foo").verifyComplete();
+
+		verify(connectionProvider).getConnection(StatefulConnection.class);
+	}
+
+	@Test // DATAREDIS-720
+	public void shouldExecuteOnSharedConnection() {
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(sharedConnection,
+				connectionProvider);
+
+		StepVerifier.create(connection.execute(cmd -> Mono.just("foo"))).expectNext("foo").verifyComplete();
+
+		verifyZeroInteractions(connectionProvider);
+	}
+
+	@Test // DATAREDIS-720
+	public void shouldExecuteDedicatedWithSharedConnection() {
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(sharedConnection,
+				connectionProvider);
+
+		StepVerifier.create(connection.executeDedicated(cmd -> Mono.just("foo"))).expectNext("foo").verifyComplete();
+
+		verify(connectionProvider).getConnection(StatefulConnection.class);
+	}
+
+	@Test // DATAREDIS-720
+	public void shouldOperateOnDedicatedConnection() {
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(connectionProvider);
+
+		StepVerifier.create(connection.getConnection()).expectNextCount(1).verifyComplete();
+
+		verify(connectionProvider).getConnection(StatefulConnection.class);
+	}
+
+	@Test // DATAREDIS-720
+	public void shouldCloseOnlyDedicatedConnection() {
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(sharedConnection,
+				connectionProvider);
+
+		StepVerifier.create(connection.getConnection()).expectNextCount(1).verifyComplete();
+		StepVerifier.create(connection.getDedicatedConnection()).expectNextCount(1).verifyComplete();
+
+		connection.close();
+
+		verify(sharedConnection, never()).close();
+		verify(connectionProvider, times(1)).release(sharedConnection);
+	}
+
+	@Test // DATAREDIS-720
+	public void shouldCloseConnectionOnlyOnce() {
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(connectionProvider);
+
+		StepVerifier.create(connection.getConnection()).expectNextCount(1).verifyComplete();
+
+		connection.close();
+		connection.close();
+
+		verify(connectionProvider, times(1)).release(sharedConnection);
+	}
+
+	@Test // DATAREDIS-720
+	@SuppressWarnings("unchecked")
+	public void multipleCallsInProgressShouldConnectOnlyOnce() throws Exception {
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		reset(connectionProvider);
+		when(connectionProvider.getConnection(any())).thenAnswer(invocation -> {
+
+			latch.await();
+			return sharedConnection;
+		});
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(connectionProvider);
+
+		CompletableFuture<StatefulConnection<ByteBuffer, ByteBuffer>> first = (CompletableFuture) connection.getConnection()
+				.toFuture();
+		CompletableFuture<StatefulConnection<ByteBuffer, ByteBuffer>> second = (CompletableFuture) connection
+				.getConnection().toFuture();
+
+		assertThat(first).isNotDone();
+		assertThat(second).isNotDone();
+
+		verify(connectionProvider, times(1)).getConnection(StatefulConnection.class);
+
+		latch.countDown();
+
+		first.get(10, TimeUnit.SECONDS);
+		second.get(10, TimeUnit.SECONDS);
+
+		assertThat(first).isCompletedWithValue(sharedConnection);
+		assertThat(second).isCompletedWithValue(sharedConnection);
+	}
+
+	@Test // DATAREDIS-720
+	public void shouldPropagateConnectionFailures() {
+
+		reset(connectionProvider);
+		when(connectionProvider.getConnection(any())).thenThrow(new RedisConnectionException("something went wrong"));
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(connectionProvider);
+
+		StepVerifier.create(connection.getConnection()).expectError(RedisConnectionFailureException.class).verify();
+	}
+
+	@Test(expected = IllegalStateException.class) // DATAREDIS-720
+	public void shouldRejectCommandsAfterClose() {
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(connectionProvider);
+		connection.close();
+
+		connection.getConnection();
+	}
+}


### PR DESCRIPTION
We now reuse a shared Lettuce connection across our reactive connection wrappers if LettuceConnectionFactory is configured to provide a shared connection instance. Reactive connections can either operate with a shared connection or with a connection provider only.

We also now execute blocking Redis commands (`BLPOP`, `BRPOP`, `BRPOPLPUSH`) on a dedicated connection.

---

We should backport 33ba8ca0a67d18295ac57cbae0c13961dd9f98c0 to 2.0.1.

Related ticket: [DATAREDIS-720](https://jira.spring.io/browse/DATAREDIS-720).