### PR TITLE
DATAREDIS-728 - Fix unnecessary cache configurations map creation in RedisCacheManagerBuilder.withInitialCacheConfiguration

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
@@ -221,7 +221,7 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 
 		private final RedisCacheWriter cacheWriter;
 		private RedisCacheConfiguration defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig();
-		private Map<String, RedisCacheConfiguration> intialCaches = new LinkedHashMap<>();
+		private final Map<String, RedisCacheConfiguration> intialCaches = new LinkedHashMap<>();
 		private boolean enableTransactions;
 
 		private RedisCacheManagerBuilder(RedisCacheWriter cacheWriter) {
@@ -312,10 +312,7 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 			cacheConfigurations.forEach((cacheName, configuration) -> Assert.notNull(configuration,
 					String.format("RedisCacheConfiguration for cache %s must not be null!", cacheName)));
 
-			Map<String, RedisCacheConfiguration> cacheConfigMap = new LinkedHashMap<>(intialCaches);
-			cacheConfigMap.putAll(cacheConfigurations);
-
-			this.intialCaches = cacheConfigMap;
+			this.intialCaches.putAll(cacheConfigurations);
 
 			return this;
 		}


### PR DESCRIPTION
RedisCacheManagerBuilder.withInitialCacheConfiguration appends new cache configurations by doing:

1. Create a new map initialized with existing cache configuration.
2. Put all new cache configurations to that newly created map.
3. Assign the newly created map to field `initialCaches`.

While just Map.putAll can accomplish this.