### PR TITLE
DATAREDIS-693 - Add support for UNLINK.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-693-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -254,6 +254,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisKeyCommands#unlink(byte[][])
+	 */
+	@Override
+	public Long unlink(byte[]... keys) {
+		return convertAndReturn(delegate.unlink(keys), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisTxCommands#discard()
 	 */
 	@Override
@@ -1783,6 +1792,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	@Override
 	public Long del(String... keys) {
 		return del(serializeMulti(keys));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#unlink(java.lang.String[])
+	 */
+	@Override
+	public Long unlink(String... keys) {
+		return unlink(serializeMulti(keys));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -71,6 +71,13 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	/** @deprecated in favor of {@link RedisConnection#keyCommands()}. */
 	@Override
 	@Deprecated
+	default Long unlink(byte[]... keys) {
+		return keyCommands().unlink(keys);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#keyCommands()}. */
+	@Override
+	@Deprecated
 	default DataType type(byte[] pattern) {
 		return keyCommands().type(pattern);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
@@ -265,6 +265,31 @@ public interface ReactiveKeyCommands {
 	Flux<NumericResponse<KeyCommand, Long>> del(Publisher<KeyCommand> keys);
 
 	/**
+	 * Unlink {@literal key}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	default Mono<Long> unlink(List<ByteBuffer> keys) {
+
+		Assert.notNull(keys, "Key must not be null!");
+
+		return unlink(Mono.just(keys)).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Unlink {@literal keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} removed along with the deletion result.
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	Flux<NumericResponse<List<ByteBuffer>, Long>> unlink(Publisher<List<ByteBuffer>> keys);
+
+	/**
 	 * Delete multiple {@literal keys} one in one batch.
 	 *
 	 * @param keys must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
@@ -265,31 +265,6 @@ public interface ReactiveKeyCommands {
 	Flux<NumericResponse<KeyCommand, Long>> del(Publisher<KeyCommand> keys);
 
 	/**
-	 * Unlink {@literal key}.
-	 *
-	 * @param keys must not be {@literal null}.
-	 * @return
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
-	 * @since 2.1
-	 */
-	default Mono<Long> unlink(List<ByteBuffer> keys) {
-
-		Assert.notNull(keys, "Key must not be null!");
-
-		return unlink(Mono.just(keys)).next().map(NumericResponse::getOutput);
-	}
-
-	/**
-	 * Unlink {@literal keys}.
-	 *
-	 * @param keys must not be {@literal null}.
-	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} removed along with the deletion result.
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
-	 * @since 2.1
-	 */
-	Flux<NumericResponse<List<ByteBuffer>, Long>> unlink(Publisher<List<ByteBuffer>> keys);
-
-	/**
 	 * Delete multiple {@literal keys} one in one batch.
 	 *
 	 * @param keys must not be {@literal null}.
@@ -311,6 +286,60 @@ public interface ReactiveKeyCommands {
 	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	Flux<NumericResponse<List<ByteBuffer>, Long>> mDel(Publisher<List<ByteBuffer>> keys);
+
+	/**
+	 * Unlink the {@code key} from the keyspace. Unlike with {@link #del(ByteBuffer)} the actual memory reclaiming here
+	 * happens asynchronously.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	default Mono<Long> unlink(ByteBuffer key) {
+
+		Assert.notNull(key, "Keys must not be null!");
+
+		return unlink(Mono.just(key).map(KeyCommand::new)).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Unlink the {@code key} from the keyspace. Unlike with {@link #del(ByteBuffer)} the actual memory reclaiming here
+	 * happens asynchronously.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} removed along with the unlink result.
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	Flux<NumericResponse<KeyCommand, Long>> unlink(Publisher<KeyCommand> keys);
+
+	/**
+	 * Unlink the {@code keys} from the keyspace. Unlike with {@link #mDel(List)} the actual memory reclaiming here
+	 * happens asynchronously.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	default Mono<Long> mUnlink(List<ByteBuffer> keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+
+		return mUnlink(Mono.just(keys)).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Unlink the {@code keys} from the keyspace. Unlike with {@link #mDel(Publisher)} the actual memory reclaiming here
+	 * happens asynchronously.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} removed along with the deletion result.
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	Flux<NumericResponse<List<ByteBuffer>, Long>> mUnlink(Publisher<List<ByteBuffer>> keys);
 
 	/**
 	 * {@code EXPIRE}/{@code PEXPIRE} command parameters.

--- a/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
@@ -71,6 +71,18 @@ public interface RedisKeyCommands {
 	Long del(byte[]... keys);
 
 	/**
+	 * Unlinks the {@code keys} from the keyspace. Unlike with {@link #del(byte[]...)} the actual removal here happens
+	 * asynchronously.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	@Nullable
+	Long unlink(byte[]... keys);
+
+	/**
 	 * Determine the type stored at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
@@ -71,8 +71,8 @@ public interface RedisKeyCommands {
 	Long del(byte[]... keys);
 
 	/**
-	 * Unlinks the {@code keys} from the keyspace. Unlike with {@link #del(byte[]...)} the actual removal here happens
-	 * asynchronously.
+	 * Unlink the {@code keys} from the keyspace. Unlike with {@link #del(byte[]...)} the actual memory reclaiming here
+	 * happens asynchronously.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -114,8 +114,8 @@ public interface StringRedisConnection extends RedisConnection {
 	Long del(String... keys);
 
 	/**
-	 * Unlinks the {@code keys} from the keyspace. Unlike with {@link #del(byte[]...)} the actual removal here happens
-	 * asynchronously.
+	 * Unlink the {@code keys} from the keyspace. Unlike with {@link #del(String...)} the actual memory reclaiming here
+	 * happens asynchronously.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -114,6 +114,18 @@ public interface StringRedisConnection extends RedisConnection {
 	Long del(String... keys);
 
 	/**
+	 * Unlinks the {@code keys} from the keyspace. Unlike with {@link #del(byte[]...)} the actual removal here happens
+	 * asynchronously.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	@Nullable
+	Long unlink(String... keys);
+
+	/**
 	 * Determine the type stored at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
@@ -83,6 +83,20 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisKeyCommands#unlink(byte[][])
+	 */
+	@Nullable
+	@Override
+	public Long unlink(byte[]... keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+
+		return connection.<Long> execute("UNLINK", Arrays.asList(keys), Collections.emptyList()).stream()
+				.mapToLong(val -> val).sum();
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisKeyCommands#type(byte[])
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -122,6 +122,19 @@ class JedisKeyCommands implements RedisKeyCommands {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisKeyCommands#unlink(byte[][])
+	 */
+	@Nullable
+	@Override
+	public Long unlink(byte[]... keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+
+		return Long.class.cast(connection.execute("UNLINK", keys));
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisKeyCommands#type(byte[])
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
@@ -128,6 +128,30 @@ class LettuceKeyCommands implements RedisKeyCommands {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisKeyCommands#unlink(byte[][])
+	 */
+	@Override
+	public Long unlink(byte[]... keys) {
+
+		Assert.notNull(keys, "Keys must not be null!");
+
+		try {
+			if (isPipelined()) {
+				pipeline(connection.newLettuceResult(getAsyncConnection().unlink(keys)));
+				return null;
+			}
+			if (isQueueing()) {
+				transaction(connection.newLettuceResult(getAsyncConnection().unlink(keys)));
+				return null;
+			}
+			return getConnection().unlink(keys);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisKeyCommands#type(byte[])
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
@@ -177,6 +177,22 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#unlink(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<NumericResponse<List<ByteBuffer>, Long>> unlink(Publisher<List<ByteBuffer>> keysCollection) {
+
+		return connection.execute(cmd -> Flux.from(keysCollection).flatMap((keys) -> {
+
+			Assert.notEmpty(keys, "Keys must not be null!");
+
+			return cmd.unlink(keys.stream().collect(Collectors.toList()).toArray(new ByteBuffer[keys.size()]))
+					.map((value) -> new NumericResponse<>(keys, value));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#mDel(org.reactivestreams.Publisher)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
@@ -133,6 +133,28 @@ public interface ReactiveRedisOperations<K, V> {
 	Mono<Long> delete(Publisher<K> keys);
 
 	/**
+	 * Unlink the {@code key} from the keyspace. Unlike with {@link #delete(Object[])} the actual memory reclaiming here
+	 * happens asynchronously.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	Mono<Long> unlink(K... key);
+
+	/**
+	 * Unlink the {@code keys} from the keyspace. Unlike with {@link #delete(Publisher)} the actual memory reclaiming here
+	 * happens asynchronously.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	Mono<Long> unlink(Publisher<K> keys);
+
+	/**
 	 * Set time to live for given {@code key}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -195,6 +195,30 @@ public interface RedisOperations<K, V> {
 	Long delete(Collection<K> keys);
 
 	/**
+	 * Unlink the {@code key} from the keyspace. Unlike with {@link #delete(Object)} the actual memory reclaiming here
+	 * happens asynchronously.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	@Nullable
+	Boolean unlink(K key);
+
+	/**
+	 * Unlink the {@code keys} from the keyspace. Unlike with {@link #delete(Collection)} the actual memory reclaiming
+	 * here happens asynchronously.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @since 2.1
+	 */
+	@Nullable
+	Long unlink(Collection<K> keys);
+
+	/**
 	 * Determine the type stored at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -729,6 +729,36 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.RedisOperations#unlink(java.lang.Object)
+	 */
+	@Override
+	public Boolean unlink(K key) {
+
+		byte[] rawKey = rawKey(key);
+
+		Long result = execute(connection -> connection.unlink(rawKey), true);
+
+		return result != null && result.intValue() == 1;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.RedisOperations#unlink(java.util.Collection)
+	 */
+	@Override
+	public Long unlink(Collection<K> keys) {
+
+		if (CollectionUtils.isEmpty(keys)) {
+			return 0L;
+		}
+
+		byte[][] rawKeys = rawKeys(keys);
+
+		return execute(connection -> connection.unlink(rawKeys), true);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.RedisOperations#hasKey(java.lang.Object)
 	 */
 	@Override

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -2790,6 +2790,26 @@ public abstract class AbstractConnectionIntegrationTests {
 		verifyResults(Arrays.asList(new Object[] { 0L }));
 	}
 
+	@Test // DATAREDIS-693
+	@IfProfileValue(name = "redisVersion", value = "4.0+")
+	public void unlinkReturnsNrOfKeysRemoved() {
+
+		connection.set("unlink.this", "Can't track this!");
+
+		actual.add(connection.unlink("unlink.this", "unlink.that"));
+
+		verifyResults(Arrays.asList(new Object[] { 1L }));
+	}
+
+	@Test // DATAREDIS-693
+	@IfProfileValue(name = "redisVersion", value = "4.0+")
+	public void unlinkReturnsZeroIfNoKeysRemoved() {
+
+		actual.add(connection.unlink("unlink.this"));
+
+		verifyResults(Arrays.asList(new Object[] { 0L }));
+	}
+
 	protected void verifyResults(List<Object> expected) {
 		assertEquals(expected, getResults());
 	}

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -1128,6 +1128,38 @@ public abstract class AbstractConnectionIntegrationTests {
 		verifyResults(Arrays.asList(true, 1L, false));
 	}
 
+	@Test // DATAREDIS-693
+	@IfProfileValue(name = "redisVersion", value = "4.0+")
+	public void unlinkReturnsNrOfKeysRemoved() {
+
+		connection.set("unlink.this", "Can't track this!");
+
+		actual.add(connection.unlink("unlink.this", "unlink.that"));
+
+		verifyResults(Arrays.asList(new Object[] { 1L }));
+	}
+
+	@Test // DATAREDIS-693
+	@IfProfileValue(name = "redisVersion", value = "4.0+")
+	public void testUnlinkBatch() {
+
+		actual.add(connection.set("testing", "123"));
+		actual.add(connection.set("foo", "bar"));
+		actual.add(connection.unlink("testing", "foo"));
+		actual.add(connection.exists("testing"));
+
+		verifyResults(Arrays.asList(true, true, 2L, false));
+	}
+
+	@Test // DATAREDIS-693
+	@IfProfileValue(name = "redisVersion", value = "4.0+")
+	public void unlinkReturnsZeroIfNoKeysRemoved() {
+
+		actual.add(connection.unlink("unlink.this"));
+
+		verifyResults(Arrays.asList(new Object[] { 0L }));
+	}
+
 	@Test
 	public void testType() {
 
@@ -2786,26 +2818,6 @@ public abstract class AbstractConnectionIntegrationTests {
 	public void touchReturnsZeroIfNoKeysTouched() {
 
 		actual.add(connection.touch("touch.this", "touch.that"));
-
-		verifyResults(Arrays.asList(new Object[] { 0L }));
-	}
-
-	@Test // DATAREDIS-693
-	@IfProfileValue(name = "redisVersion", value = "4.0+")
-	public void unlinkReturnsNrOfKeysRemoved() {
-
-		connection.set("unlink.this", "Can't track this!");
-
-		actual.add(connection.unlink("unlink.this", "unlink.that"));
-
-		verifyResults(Arrays.asList(new Object[] { 1L }));
-	}
-
-	@Test // DATAREDIS-693
-	@IfProfileValue(name = "redisVersion", value = "4.0+")
-	public void unlinkReturnsZeroIfNoKeysRemoved() {
-
-		actual.add(connection.unlink("unlink.this"));
 
 		verifyResults(Arrays.asList(new Object[] { 0L }));
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -2219,4 +2219,18 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.keyCommands().touch(KEY_1_BYTES), is(0L));
 	}
 
+	@Test // DATAREDIS-693
+	public void unlinkReturnsNrOfKeysTouched() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+		nativeConnection.set(KEY_2, VALUE_1);
+
+		assertThat(clusterConnection.keyCommands().unlink(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES), is(2L));
+	}
+
+	@Test // DATAREDIS-693
+	public void unlinkReturnsZeroIfNoKeysTouched() {
+		assertThat(clusterConnection.keyCommands().unlink(KEY_1_BYTES), is(0L));
+	}
+
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -2182,4 +2182,32 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		assertThat(nativeConnection.zrange(SAME_SLOT_KEY_3, 0, -1), hasItems(VALUE_1, VALUE_2, VALUE_3));
 	}
+
+	@Test // DATAREDIS-694
+	public void touchReturnsNrOfKeysTouched() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+		nativeConnection.set(KEY_2, VALUE_1);
+
+		assertThat(clusterConnection.keyCommands().touch(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES), is(2L));
+	}
+
+	@Test // DATAREDIS-694
+	public void touchReturnsZeroIfNoKeysTouched() {
+		assertThat(clusterConnection.keyCommands().touch(KEY_1_BYTES), is(0L));
+	}
+
+	@Test // DATAREDIS-693
+	public void unlinkReturnsNrOfKeysTouched() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+		nativeConnection.set(KEY_2, VALUE_1);
+
+		assertThat(clusterConnection.keyCommands().unlink(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES), is(2L));
+	}
+
+	@Test // DATAREDIS-693
+	public void unlinkReturnsZeroIfNoKeysTouched() {
+		assertThat(clusterConnection.keyCommands().unlink(KEY_1_BYTES), is(0L));
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,12 +55,12 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 
 		nativeCommands.set(KEY_1, VALUE_1);
 
-		assertThat(connection.keyCommands().exists(KEY_1_BBUFFER).block(), is(true));
+		StepVerifier.create(connection.keyCommands().exists(KEY_1_BBUFFER)).expectNext(true).verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
 	public void existsShouldReturnFalseForNonExistingKeys() {
-		assertThat(connection.keyCommands().exists(KEY_1_BBUFFER).block(), is(false));
+		StepVerifier.create(connection.keyCommands().exists(KEY_1_BBUFFER)).expectNext(false).verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -69,9 +70,9 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 		nativeCommands.sadd(KEY_2, VALUE_2);
 		nativeCommands.hset(KEY_3, KEY_1, VALUE_1);
 
-		assertThat(connection.keyCommands().type(KEY_1_BBUFFER).block(), is(DataType.STRING));
-		assertThat(connection.keyCommands().type(KEY_2_BBUFFER).block(), is(DataType.SET));
-		assertThat(connection.keyCommands().type(KEY_3_BBUFFER).block(), is(DataType.HASH));
+		StepVerifier.create(connection.keyCommands().type(KEY_1_BBUFFER)).expectNext(DataType.STRING).verifyComplete();
+		StepVerifier.create(connection.keyCommands().type(KEY_2_BBUFFER)).expectNext(DataType.SET).verifyComplete();
+		StepVerifier.create(connection.keyCommands().type(KEY_3_BBUFFER)).expectNext(DataType.HASH).verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -85,8 +86,12 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 		nativeCommands.set(VALUE_2, KEY_2);
 		nativeCommands.set(VALUE_3, KEY_3);
 
-		assertThat(connection.keyCommands().keys(ByteBuffer.wrap("*".getBytes())).block(), hasSize(6));
-		assertThat(connection.keyCommands().keys(ByteBuffer.wrap("key*".getBytes())).block(), hasSize(3));
+		StepVerifier.create(connection.keyCommands().keys(ByteBuffer.wrap("*".getBytes())).flatMapIterable(it -> it)) //
+				.expectNextCount(6) //
+				.verifyComplete();
+
+		StepVerifier.create(connection.keyCommands().keys(ByteBuffer.wrap("key*".getBytes())).flatMapIterable(it -> it)) //
+				.expectNextCount(3).verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -96,12 +101,12 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 		nativeCommands.set(KEY_2, VALUE_2);
 		nativeCommands.set(KEY_3, VALUE_3);
 
-		assertThat(connection.keyCommands().randomKey().block(), is(notNullValue()));
+		StepVerifier.create(connection.keyCommands().randomKey()).expectNextCount(1).verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
 	public void randomKeyShouldReturnNullWhenNoKeyExists() {
-		assertThat(connection.keyCommands().randomKey().block(), is(nullValue()));
+		StepVerifier.create(connection.keyCommands().randomKey()).verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -109,14 +114,17 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 
 		nativeCommands.set(KEY_1, VALUE_2);
 
-		assertThat(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(true));
+		StepVerifier.create(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER)).expectNext(true)
+				.verifyComplete();
 		assertThat(nativeCommands.exists(KEY_2), is(1L));
 		assertThat(nativeCommands.exists(KEY_1), is(0L));
 	}
 
-	@Test(expected = RedisSystemException.class) // DATAREDIS-525
+	@Test // DATAREDIS-525
 	public void renameShouldThrowErrorWhenKeyDoesNotExist() {
-		assertThat(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(true));
+
+		StepVerifier.create(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER))
+				.expectError(RedisSystemException.class).verify();
 	}
 
 	@Test // DATAREDIS-525
@@ -124,7 +132,8 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 
 		nativeCommands.set(KEY_1, VALUE_2);
 
-		assertThat(connection.keyCommands().rename(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(true));
+		StepVerifier.create(connection.keyCommands().renameNX(KEY_1_BBUFFER, KEY_2_BBUFFER)).expectNext(true)
+				.verifyComplete();
 
 		assertThat(nativeCommands.exists(KEY_2), is(1L));
 		assertThat(nativeCommands.exists(KEY_1), is(0L));
@@ -136,7 +145,8 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 		nativeCommands.set(KEY_1, VALUE_2);
 		nativeCommands.set(KEY_2, VALUE_2);
 
-		assertThat(connection.keyCommands().renameNX(KEY_1_BBUFFER, KEY_2_BBUFFER).block(), is(false));
+		StepVerifier.create(connection.keyCommands().renameNX(KEY_1_BBUFFER, KEY_2_BBUFFER)).expectNext(false)
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -144,8 +154,7 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 
 		nativeCommands.set(KEY_1, VALUE_1);
 
-		Mono<Long> result = connection.keyCommands().del(KEY_1_BBUFFER);
-		assertThat(result.block(), is(1L));
+		StepVerifier.create(connection.keyCommands().del(KEY_1_BBUFFER)).expectNext(1L).verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -168,7 +177,7 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 
 		Mono<Long> result = connection.keyCommands().mDel(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER));
 
-		assertThat(result.block(), is(2L));
+		StepVerifier.create(result).expectNext(2L).verifyComplete();
 	}
 
 	@Test // DATAREDIS-525
@@ -177,9 +186,11 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 		nativeCommands.set(KEY_1, VALUE_1);
 		nativeCommands.set(KEY_2, VALUE_2);
 
+		Flux<List<ByteBuffer>> input = Flux.just(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER),
+				Collections.singletonList(KEY_1_BBUFFER));
+
 		Flux<Long> result = connection.keyCommands()
-				.mDel(
-						Flux.fromIterable(Arrays.asList(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), Arrays.asList(KEY_1_BBUFFER))))
+				.mDel(input)
 				.map(NumericResponse::getOutput);
 
 		StepVerifier.create(result).expectNextCount(2).verifyComplete();
@@ -216,7 +227,7 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 
 		Mono<Long> result = connection.keyCommands().mUnlink(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER));
 
-		assertThat(result.block(), is(2L));
+		StepVerifier.create(result).expectNext(2L).verifyComplete();
 	}
 
 	@Test // DATAREDIS-693
@@ -226,9 +237,11 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 		nativeCommands.set(KEY_1, VALUE_1);
 		nativeCommands.set(KEY_2, VALUE_2);
 
+		Flux<List<ByteBuffer>> input = Flux.just(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER),
+				Collections.singletonList(KEY_1_BBUFFER));
+
 		Flux<Long> result = connection.keyCommands()
-				.mUnlink(Flux.fromIterable(
-						Arrays.asList(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), Collections.singletonList(KEY_1_BBUFFER))))
+				.mUnlink(input)
 				.map(NumericResponse::getOutput);
 
 		StepVerifier.create(result).expectNextCount(2).verifyComplete();
@@ -357,7 +370,7 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 	@Test // DATAREDIS-694
 	public void touchReturnsZeroIfNoKeysTouched() {
 
-		StepVerifier.create(connection.keyCommands().touch(Arrays.asList(KEY_1_BBUFFER))) //
+		StepVerifier.create(connection.keyCommands().touch(Collections.singletonList(KEY_1_BBUFFER))) //
 				.expectNext(0L) //
 				.verifyComplete();
 	}

--- a/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
@@ -166,6 +166,36 @@ public class ReactiveRedisTemplateIntegrationTests<K, V> {
 				.verify();
 	}
 
+	@Test // DATAREDIS-693
+	public void unlink() {
+
+		K single = keyFactory.instance();
+
+		StepVerifier.create(redisTemplate.opsForValue().set(single, valueFactory.instance())).expectNext(true)
+				.verifyComplete();
+
+		StepVerifier.create(redisTemplate.unlink(single)).expectNext(1L).verifyComplete();
+
+		StepVerifier.create(redisTemplate.hasKey(single)).expectNext(false).verifyComplete();
+	}
+
+	@Test // DATAREDIS-693
+	public void unlinkMany() {
+
+		K key1 = keyFactory.instance();
+		K key2 = keyFactory.instance();
+
+		StepVerifier.create(redisTemplate.opsForValue().set(key1, valueFactory.instance())).expectNext(true)
+				.verifyComplete();
+		StepVerifier.create(redisTemplate.opsForValue().set(key2, valueFactory.instance())).expectNext(true)
+				.verifyComplete();
+
+		StepVerifier.create(redisTemplate.unlink(key1, key2)).expectNext(2L).verifyComplete();
+
+		StepVerifier.create(redisTemplate.hasKey(key1)).expectNext(false).verifyComplete();
+		StepVerifier.create(redisTemplate.hasKey(key2)).expectNext(false).verifyComplete();
+	}
+
 	@Test // DATAREDIS-683
 	@SuppressWarnings("unchecked")
 	public void executeScript() {


### PR DESCRIPTION
We now support `UNLINK` for both Jedis & Lettuce throughout the single node and cluster connection. Reactive support is only available for Lettuce.