### PR TITLE
DATAREDIS-612 - Send and receive Pub/Sub messages using reactive connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-612-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -11,6 +11,7 @@ New and noteworthy in the latest releases.
 * <<query-by-example,Query by Example>> integration.
 * `@TypeAlias` Support for Redis repositories.
 * Cluster-wide `SCAN` using Lettuce and `SCAN` execution on a selected node supported by both drivers.
+* <<redis:reactive:pubsub,Reactive Pub/Sub>> to send and receive a message stream.
 
 [[new-in-2.0.0]]
 == New in Spring Data Redis 2.0

--- a/src/main/asciidoc/reference/reactive-messaging.adoc
+++ b/src/main/asciidoc/reference/reactive-messaging.adoc
@@ -53,5 +53,5 @@ The message listener container itself does not require external threading resour
 ReactiveRedisConnectionFactory factory = …
 ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(factory);
 
-Flux<ChannelMessage<String, String>> stream = container.receive(new ChannelTopic("my-chanel"));
+Flux<ChannelMessage<String, String>> stream = container.receive(ChannelTopic.of("my-chanel"));
 ----

--- a/src/main/asciidoc/reference/reactive-messaging.adoc
+++ b/src/main/asciidoc/reference/reactive-messaging.adoc
@@ -4,6 +4,7 @@
 Spring Data provides dedicated messaging integration for Redis, very similar in functionality and naming to the JMS integration in Spring Framework; in fact, users familiar with the JMS support in Spring should feel right at home.
 
 Redis messaging can be roughly divided into two areas of functionality, namely the production or publication and consumption or subscription of messages, hence the shortcut pubsub (Publish/Subscribe). The `ReactiveRedisTemplate` class is used for message production. For asynchronous reception, Spring Data provides a dedicated message listener container that is used consume a stream of messages.
+For the purpose of just subscribing `ReactiveRedisTemplate` offers stripped down alternatives to utilizing a listener container.
 
 The package `org.springframework.data.redis.connection` and `org.springframework.data.redis.listener` provide the core functionality for using Redis messaging.
 
@@ -21,7 +22,7 @@ Mono<Long> publish = con.publish(msg, channel);
 
 // send message through ReactiveRedisTemplate
 ReactiveRedisTemplate template = …
-Mono<Long> publish = template.convertAndSend("hello!", "world");
+Mono<Long> publish = template.convertAndSend("channel", "message");
 ----
 
 [[redis:reactive:pubsub:subscribe]]
@@ -31,7 +32,7 @@ On the receiving side, one can subscribe to one or multiple channels either by n
 
 At the low-level, `ReactiveRedisConnection` offers `subscribe` and `pSubscribe` methods that map the Redis commands for subscribing by channel respectively by pattern. Note that multiple channels or patterns can be used as arguments. To change a subscription, simply query the channels and patterns of `ReactiveSubscription`.
 
-NOTE: Reactive subscription commands in Spring Data Redis non-blocking and terminate without emitting an element.
+NOTE: Reactive subscription commands in Spring Data Redis are non-blocking and may terminate without emitting an element.
 
 As mentioned above, once subscribed a connection starts waiting for messages. No other commands can be invoked on it except for adding new subscriptions or modifying/canceling the existing ones. Commands other than `subscribe`, `pSubscribe`, `unsubscribe`, or `pUnsubscribe` are illegal and will cause an exception.
 
@@ -42,7 +43,7 @@ In order to receive messages, one needs to obtain the message stream. Note that 
 
 Spring Data offers `ReactiveRedisMessageListenerContainer` which does all the heavy lifting of conversion and subscription state management on behalf of the user.
 
-`ReactiveRedisMessageListenerContainer` acts as a message listener container; it is used to receive messages from a Redis channel and expose a stream of messages that emits channel messages with deserialization applied. It takes care of registering to receive messages, resource acquisition and release, exception conversion and the like. This allows you as an application developer to write the (possibly complex) business logic associated with receiving a message (and reacting to it), and delegates boilerplate Redis infrastructure concerns to the framework. Message streams register a subscription in Redis upon publisher subscription and unregister if the subscription gets canceled.
+`ReactiveRedisMessageListenerContainer` acts as a message listener container. It is used to receive messages from a Redis channel and expose a stream of messages that emits channel messages with deserialization applied. It takes care of registering to receive messages, resource acquisition and release, exception conversion and the like. This allows you as an application developer to write the (possibly complex) business logic associated with receiving a message (and reacting to it), and delegates boilerplate Redis infrastructure concerns to the framework. Message streams register a subscription in Redis upon publisher subscription and unregister if the subscription gets canceled.
 
 Furthermore, to minimize the application footprint, `ReactiveRedisMessageListenerContainer` allows one connection and one thread to be shared by multiple listeners even though they do not share a subscription. Thus no matter how many listeners or channels an application tracks, the runtime cost will remain the same through out its lifetime. Moreover, the container allows runtime configuration changes so one can add or remove listeners while an application is running without the need for restart. Additionally, the container uses a lazy subscription approach, using a `ReactiveRedisConnection` only when needed - if all the listeners are unsubscribed, cleanup is automatically performed.
 
@@ -54,4 +55,19 @@ ReactiveRedisConnectionFactory factory = …
 ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(factory);
 
 Flux<ChannelMessage<String, String>> stream = container.receive(ChannelTopic.of("my-chanel"));
+----
+
+[[redis:reactive:pubsub:subscribe:template]]
+=== Subscribing via template API
+
+As mentioned above you can directly use `ReactiveRedisTemplate` to subscribe to channels / patterns. This approach
+offers a straight forward, though limited solution as you loose the option to add subscriptions after the initial
+ones. Nevertheless you still can control the message stream via the returned `Flux` using eg. `take(Duration)`. When
+done reading, on error or cancellation all bound resources are freed again.
+
+[source,java]
+----
+redisTemplate.listenToChannel("channel1", "channel2").doOnNext(msg -> {
+    // message processing ...
+}).subscribe();
 ----

--- a/src/main/asciidoc/reference/reactive-messaging.adoc
+++ b/src/main/asciidoc/reference/reactive-messaging.adoc
@@ -1,0 +1,57 @@
+[[redis:reactive:pubsub]]
+= Redis Messaging/PubSub
+
+Spring Data provides dedicated messaging integration for Redis, very similar in functionality and naming to the JMS integration in Spring Framework; in fact, users familiar with the JMS support in Spring should feel right at home.
+
+Redis messaging can be roughly divided into two areas of functionality, namely the production or publication and consumption or subscription of messages, hence the shortcut pubsub (Publish/Subscribe). The `ReactiveRedisTemplate` class is used for message production. For asynchronous reception, Spring Data provides a dedicated message listener container that is used consume a stream of messages.
+
+The package `org.springframework.data.redis.connection` and `org.springframework.data.redis.listener` provide the core functionality for using Redis messaging.
+
+[[redis:reactive:pubsub:publish]]
+== Sending/Publishing messages
+
+To publish a message, one can use, as with the other operations, either the low-level `ReactiveRedisConnection` or the high-level `ReactiveRedisTemplate`. Both entities offer a publish method that accepts as an argument the message that needs to be sent as well as the destination channel. While `ReactiveRedisConnection` requires raw-data, the `ReactiveRedisTemplate` allow arbitrary objects to be passed in as messages:
+
+[source,java]
+----
+// send message through ReactiveRedisConnection
+ByteBuffer msg = …
+ByteBuffer channel = …
+Mono<Long> publish = con.publish(msg, channel);
+
+// send message through ReactiveRedisTemplate
+ReactiveRedisTemplate template = …
+Mono<Long> publish = template.convertAndSend("hello!", "world");
+----
+
+[[redis:reactive:pubsub:subscribe]]
+== Receiving/Subscribing for messages
+
+On the receiving side, one can subscribe to one or multiple channels either by naming them directly or by using pattern matching. The latter approach is quite useful as it not only allows multiple subscriptions to be created with one command but to also listen on channels not yet created at subscription time (as long as they match the pattern).
+
+At the low-level, `ReactiveRedisConnection` offers `subscribe` and `pSubscribe` methods that map the Redis commands for subscribing by channel respectively by pattern. Note that multiple channels or patterns can be used as arguments. To change a subscription, simply query the channels and patterns of `ReactiveSubscription`.
+
+NOTE: Reactive subscription commands in Spring Data Redis non-blocking and terminate without emitting an element.
+
+As mentioned above, once subscribed a connection starts waiting for messages. No other commands can be invoked on it except for adding new subscriptions or modifying/canceling the existing ones. Commands other than `subscribe`, `pSubscribe`, `unsubscribe`, or `pUnsubscribe` are illegal and will cause an exception.
+
+In order to receive messages, one needs to obtain the message stream. Note that a subscription only publishes messages for channels and patterns that are registered with that particular subscription. The message stream itself is a hot sequence that produces elements without regard to demand. Make sure to register sufficient demand to not exhaust the message buffer.
+
+[[redis:reactive:pubsub:subscribe:containers]]
+=== Message Listener Containers
+
+Spring Data offers `ReactiveRedisMessageListenerContainer` which does all the heavy lifting of conversion and subscription state management on behalf of the user.
+
+`ReactiveRedisMessageListenerContainer` acts as a message listener container; it is used to receive messages from a Redis channel and expose a stream of messages that emits channel messages with deserialization applied. It takes care of registering to receive messages, resource acquisition and release, exception conversion and the like. This allows you as an application developer to write the (possibly complex) business logic associated with receiving a message (and reacting to it), and delegates boilerplate Redis infrastructure concerns to the framework. Message streams register a subscription in Redis upon publisher subscription and unregister if the subscription gets canceled.
+
+Furthermore, to minimize the application footprint, `ReactiveRedisMessageListenerContainer` allows one connection and one thread to be shared by multiple listeners even though they do not share a subscription. Thus no matter how many listeners or channels an application tracks, the runtime cost will remain the same through out its lifetime. Moreover, the container allows runtime configuration changes so one can add or remove listeners while an application is running without the need for restart. Additionally, the container uses a lazy subscription approach, using a `ReactiveRedisConnection` only when needed - if all the listeners are unsubscribed, cleanup is automatically performed.
+
+The message listener container itself does not require external threading resources. It uses the driver threads to publish messages.
+
+[source,java]
+----
+ReactiveRedisConnectionFactory factory = …
+ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(factory);
+
+Flux<ChannelMessage<String, String>> stream = container.receive(new ChannelTopic("my-chanel"));
+----

--- a/src/main/asciidoc/reference/reactive-redis.adoc
+++ b/src/main/asciidoc/reference/reactive-redis.adoc
@@ -161,6 +161,8 @@ public class Example {
 }
 ----
 
+include::{referenceDir}/reactive-messaging.adoc[leveloffset=+1]
+
 == Reactive Scripting
 
 Executing Redis scripts via the reactive infrastructure can be done using the `ReactiveScriptExecutor` accessed best via `ReactiveRedisTemplate`.

--- a/src/main/java/org/springframework/data/redis/connection/ReactivePubSubCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactivePubSubCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,10 @@ import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMes
  * Redis <a href="https://redis.io/commands/#pubsub">Pub/Sub</a> commands executed using reactive infrastructure.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.1
  */
-public interface ReactiveRedisPubSubCommands {
+public interface ReactivePubSubCommands {
 
 	/**
 	 * Creates a subscription for this connection. Connections can have multiple {@link ReactiveSubscription}s.
@@ -63,7 +64,7 @@ public interface ReactiveRedisPubSubCommands {
 	 * Subscribes the connection to the given {@code channels}. Once subscribed, a connection enters listening mode and
 	 * can only subscribe to other channels or unsubscribe. No other commands are accepted until the connection is
 	 * unsubscribed.
-	 * <p/>
+	 * <p />
 	 * Note that cancellation of the {@link Flux} will unsubscribe from {@code channels}.
 	 *
 	 * @param channels channel names, must not be {@literal null}.
@@ -82,4 +83,5 @@ public interface ReactiveRedisPubSubCommands {
 	 * @see <a href="http://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
 	 */
 	Mono<Void> pSubscribe(ByteBuffer... patterns);
+
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
@@ -50,8 +50,21 @@ import org.springframework.util.Assert;
  */
 public interface ReactiveRedisConnection extends Closeable {
 
+	/*
+	 * (non-Javadoc)
+	 * @see java.io.Closeable#close()
+	 */
 	@Override
-	void close();
+	default void close() {
+		closeLater().block();
+	}
+
+	/**
+	 * Asynchronously close the connection and release associated resources.
+	 *
+	 * @return the {@link Mono} signaling when done.
+	 */
+	Mono<Void> closeLater();
 
 	/**
 	 * Get {@link ReactiveKeyCommands}.
@@ -117,12 +130,12 @@ public interface ReactiveRedisConnection extends Closeable {
 	ReactiveHyperLogLogCommands hyperLogLogCommands();
 
 	/**
-	 * Get {@link ReactiveRedisPubSubCommands}.
+	 * Get {@link ReactivePubSubCommands}.
 	 *
 	 * @return never {@literal null}.
 	 * @since 2.1
 	 */
-	ReactiveRedisPubSubCommands pubSubCommands();
+	ReactivePubSubCommands pubSubCommands();
 
 	/**
 	 * Get {@link ReactiveScriptingCommands}.

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
@@ -117,6 +117,14 @@ public interface ReactiveRedisConnection extends Closeable {
 	ReactiveHyperLogLogCommands hyperLogLogCommands();
 
 	/**
+	 * Get {@link ReactiveRedisPubSubCommands}.
+	 *
+	 * @return never {@literal null}.
+	 * @since 2.1
+	 */
+	ReactiveRedisPubSubCommands pubSubCommands();
+
+	/**
 	 * Get {@link ReactiveScriptingCommands}.
 	 *
 	 * @return never {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisPubSubCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisPubSubCommands.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
+
+/**
+ * Redis <a href="https://redis.io/commands/#pubsub">Pub/Sub</a> commands executed using reactive infrastructure.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ReactiveRedisPubSubCommands {
+
+	/**
+	 * Creates a subscription for this connection. Connections can have multiple {@link ReactiveSubscription}s.
+	 *
+	 * @return the subscription.
+	 */
+	Mono<ReactiveSubscription> createSubscription();
+
+	/**
+	 * Publishes the given {@code message} to the given {@code channel}.
+	 *
+	 * @param channel the channel to publish to. Must not be {@literal null}.
+	 * @param message message to publish. Must not be {@literal null}.
+	 * @return the number of clients that received the message.
+	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 */
+	default Mono<Long> publish(ByteBuffer channel, ByteBuffer message) {
+		return publish(Mono.just(new ChannelMessage<>(channel, message))).next();
+	}
+
+	/**
+	 * Publishes the given messages to the {@link ChannelMessage#getChannel() appropriate channels}.
+	 *
+	 * @param messageStream the messages to publish to. Must not be {@literal null}.
+	 * @return the number of clients that received the message.
+	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 */
+	Flux<Long> publish(Publisher<ChannelMessage<ByteBuffer, ByteBuffer>> messageStream);
+
+	/**
+	 * Subscribes the connection to the given {@code channels}. Once subscribed, a connection enters listening mode and
+	 * can only subscribe to other channels or unsubscribe. No other commands are accepted until the connection is
+	 * unsubscribed.
+	 * <p/>
+	 * Note that cancellation of the {@link Flux} will unsubscribe from {@code channels}.
+	 *
+	 * @param channels channel names, must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/subscribe">Redis Documentation: SUBSCRIBE</a>
+	 */
+	Mono<Void> subscribe(ByteBuffer... channels);
+
+	/**
+	 * Subscribes the connection to all channels matching the given {@code patterns}. Once subscribed, a connection enters
+	 * listening mode and can only subscribe to other channels or unsubscribe. No other commands are accepted until the
+	 * connection is unsubscribed.
+	 * <p />
+	 * Note that cancellation of the {@link Flux} will unsubscribe from {@code patterns}.
+	 *
+	 * @param patterns channel name patterns, must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
+	 */
+	Mono<Void> pSubscribe(ByteBuffer... patterns);
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,19 +20,22 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
-import java.util.Collection;
+import java.util.Set;
+
+import org.springframework.util.Assert;
 
 /**
- * Subscription for Redis channels using reactive infrastructure. A {@link ReactiveSubscription} allows subscription to
+ * Subscription for Redis channels using reactive infrastructure. A {@link ReactiveSubscription} allows subscribing to
  * {@link #subscribe(ByteBuffer...) channels} and {@link #pSubscribe(ByteBuffer...) patterns}. It provides access to the
  * {@link ChannelMessage} {@link #receive() stream} that emits only messages for channels and patterns registered in
  * this {@link ReactiveSubscription}.
- * <p/>
+ * <p />
  * A reactive Redis connection can have multiple subscriptions. If two or more subscriptions subscribe to the same
  * target (channel/pattern) and one unsubscribes, then the other one will no longer receive messages for the target due
  * to how Redis handled Pub/Sub subscription.
  * 
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.1
  */
 public interface ReactiveSubscription {
@@ -54,8 +57,8 @@ public interface ReactiveSubscription {
 	Mono<Void> pSubscribe(ByteBuffer... patterns);
 
 	/**
-	 * Cancels the current subscription for all {@link #getChannels() channels} given by name.
-	 * 
+	 * Cancels the current subscription for all {@link #getChannels() channels}.
+	 *
 	 * @return empty {@link Mono} that completes once the channel subscriptions are unregistered.
 	 */
 	Mono<Void> unsubscribe();
@@ -64,13 +67,13 @@ public interface ReactiveSubscription {
 	 * Cancels the current subscription for all given channels.
 	 *
 	 * @param channels channel names. Must not be empty.
-	 * @return empty {@link Mono} that completes once the channel subscription is unregistered.
+	 * @return empty {@link Mono} that completes once the channel subscriptions are unregistered.
 	 */
 	Mono<Void> unsubscribe(ByteBuffer... channels);
 
 	/**
 	 * Cancels the subscription for all channels matched by {@link #getPatterns()} patterns}.
-	 * 
+	 *
 	 * @return empty {@link Mono} that completes once the patterns subscriptions are unregistered.
 	 */
 	Mono<Void> pUnsubscribe();
@@ -79,91 +82,136 @@ public interface ReactiveSubscription {
 	 * Cancels the subscription for all channels matching the given patterns.
 	 *
 	 * @param patterns must not be empty.
-	 * @return empty {@link Mono} that completes once the patterns subscription is unregistered.
+	 * @return empty {@link Mono} that completes once the patterns subscriptions are unregistered.
 	 */
 	Mono<Void> pUnsubscribe(ByteBuffer... patterns);
 
 	/**
 	 * Returns the (named) channels for this subscription.
 	 *
-	 * @return collection of named channels
+	 * @return {@link Set} of named channels.
 	 */
-	Collection<ByteBuffer> getChannels();
+	Set<ByteBuffer> getChannels();
 
 	/**
 	 * Returns the channel patters for this subscription.
 	 *
-	 * @return collection of channel patterns
+	 * @return {@link Set} of channel patterns.
 	 */
-	Collection<ByteBuffer> getPatterns();
+	Set<ByteBuffer> getPatterns();
 
 	/**
-	 * Retrieve the message stream emitting {@link ChannelMessage} and {@link PatternMessage}. The resulting message
-	 * stream contains only messages for subscribed and registered {@link #getChannels() channels} and
-	 * {@link #getPatterns() patterns}.
-	 * <p/>
+	 * Retrieve the message stream emitting {@link Message messages}. The resulting message stream contains only messages
+	 * for subscribed and registered {@link #getChannels() channels} and {@link #getPatterns() patterns}.
+	 * <p />
 	 * Stream publishing uses {@link reactor.core.publisher.ConnectableFlux} turning the stream into a hot sequence.
 	 * Emission is paused if there is no demand. Messages received in that time are buffered. This stream terminates
-	 * either if all subscribers unsubscribe or if this {@link Subscription} is {@link #terminate() is terminated}.
-	 * 
-	 * @return the message stream.
+	 * either if all subscribers unsubscribe or if this {@link Subscription} is {@link #cancel() is terminated}.
+	 *
+	 * @return {@link Flux} emitting the {@link Message} stream.
 	 */
-	Flux<ChannelMessage<ByteBuffer, ByteBuffer>> receive();
+	Flux<Message<ByteBuffer, ByteBuffer>> receive();
 
 	/**
 	 * Unsubscribe from all {@link #getChannels() channels} and {@link #getPatterns() patterns} and request termination of
 	 * all active {@link #receive() message streams}. Active streams will terminate with a
 	 * {@link java.util.concurrent.CancellationException}.
-	 * 
+	 *
 	 * @return a {@link Mono} that completes once termination is finished.
 	 */
-	Mono<Void> terminate();
+	Mono<Void> cancel();
+
+	/**
+	 * {@link Message} represents a Redis channel message within Redis pub/sub.
+	 *
+	 * @param <C> channel representation type.
+	 * @param <M> message representation type.
+	 * @author Christoph Strobl
+	 * @since 2.1
+	 */
+	interface Message<C, M> {
+
+		/**
+		 * Get the channel the message published to.
+		 *
+		 * @return never {@literal null}.
+		 */
+		C getChannel();
+
+		/**
+		 * Get the actual message body.
+		 *
+		 * @return never {@literal null}.
+		 */
+		M getMessage();
+	}
 
 	/**
 	 * Value object for a Redis channel message.
-	 * 
+	 *
 	 * @param <C> type of how the channel name is represented.
-	 * @param <B> type of how the message is represented.
+	 * @param <M> type of how the message is represented.
 	 * @author Mark Paluch
+	 * @author Christoph Strobl
 	 * @since 2.1
 	 */
 	@EqualsAndHashCode
-	class ChannelMessage<C, B> {
+	class ChannelMessage<C, M> implements Message<C, M> {
 
 		private final C channel;
-		private final B message;
+		private final M message;
 
 		/**
 		 * Create a new {@link ChannelMessage}.
-		 * 
+		 *
 		 * @param channel must not be {@literal null}.
 		 * @param message must not be {@literal null}.
 		 */
-		public ChannelMessage(C channel, B message) {
+		public ChannelMessage(C channel, M message) {
+
+			Assert.notNull(channel, "Channel must not be null!");
+			Assert.notNull(message, "Message must not be null!");
+
 			this.channel = channel;
 			this.message = message;
 		}
 
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.ReactiveSubscription.Message#getChannel()
+		 */
+		@Override
 		public C getChannel() {
 			return channel;
 		}
 
-		public B getMessage() {
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.ReactiveSubscription.Message#getMessage()
+		 */
+		@Override
+		public M getMessage() {
 			return message;
+		}
+
+		@Override
+		public String toString() {
+			return "ChannelMessage {" + "channel=" + channel + ", message=" + message + '}';
 		}
 	}
 
 	/**
 	 * Value object for a Redis channel message received from a pattern subscription.
-	 * 
-	 * @param <C> type of how the pattern is represented.
+	 *
+	 * @param <P> type of how the pattern is represented.
 	 * @param <C> type of how the channel name is represented.
-	 * @param <B> type of how the message is represented.
+	 * @param <M> type of how the message is represented.
 	 * @author Mark Paluch
+	 * @author Christoph Strobl
 	 * @since 2.1
 	 */
 	@EqualsAndHashCode(callSuper = true)
-	class PatternMessage<P, C, B> extends ChannelMessage<C, B> {
+	class PatternMessage<P, C, M> extends ChannelMessage<C, M> {
 
 		private final P pattern;
 
@@ -174,14 +222,26 @@ public interface ReactiveSubscription {
 		 * @param channel must not be {@literal null}.
 		 * @param message must not be {@literal null}.
 		 */
-		public PatternMessage(P pattern, C channel, B message) {
+		public PatternMessage(P pattern, C channel, M message) {
 
 			super(channel, message);
+
+			Assert.notNull(pattern, "Pattern must not be null!");
 			this.pattern = pattern;
 		}
 
+		/**
+		 * Get the pattern that matched the channel.
+		 *
+		 * @return never {@literal null}.
+		 */
 		public P getPattern() {
 			return pattern;
+		}
+
+		@Override
+		public String toString() {
+			return "PatternMessage{" + "channel=" + getChannel() + ", pattern=" + pattern + ", message=" + getMessage() + '}';
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveSubscription.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import lombok.EqualsAndHashCode;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+
+/**
+ * Subscription for Redis channels using reactive infrastructure. A {@link ReactiveSubscription} allows subscription to
+ * {@link #subscribe(ByteBuffer...) channels} and {@link #pSubscribe(ByteBuffer...) patterns}. It provides access to the
+ * {@link ChannelMessage} {@link #receive() stream} that emits only messages for channels and patterns registered in
+ * this {@link ReactiveSubscription}.
+ * <p/>
+ * A reactive Redis connection can have multiple subscriptions. If two or more subscriptions subscribe to the same
+ * target (channel/pattern) and one unsubscribes, then the other one will no longer receive messages for the target due
+ * to how Redis handled Pub/Sub subscription.
+ * 
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public interface ReactiveSubscription {
+
+	/**
+	 * Subscribes to the {@code channels} and adds these to the current subscription.
+	 *
+	 * @param channels channel names. Must not be empty.
+	 * @return empty {@link Mono} that completes once the channel subscription is registered.
+	 */
+	Mono<Void> subscribe(ByteBuffer... channels);
+
+	/**
+	 * Subscribes to the channel {@code patterns} and adds these to the current subscription.
+	 *
+	 * @param patterns channel patterns. Must not be empty.
+	 * @return empty {@link Mono} that completes once the pattern subscription is registered.
+	 */
+	Mono<Void> pSubscribe(ByteBuffer... patterns);
+
+	/**
+	 * Cancels the current subscription for all {@link #getChannels() channels} given by name.
+	 * 
+	 * @return empty {@link Mono} that completes once the channel subscriptions are unregistered.
+	 */
+	Mono<Void> unsubscribe();
+
+	/**
+	 * Cancels the current subscription for all given channels.
+	 *
+	 * @param channels channel names. Must not be empty.
+	 * @return empty {@link Mono} that completes once the channel subscription is unregistered.
+	 */
+	Mono<Void> unsubscribe(ByteBuffer... channels);
+
+	/**
+	 * Cancels the subscription for all channels matched by {@link #getPatterns()} patterns}.
+	 * 
+	 * @return empty {@link Mono} that completes once the patterns subscriptions are unregistered.
+	 */
+	Mono<Void> pUnsubscribe();
+
+	/**
+	 * Cancels the subscription for all channels matching the given patterns.
+	 *
+	 * @param patterns must not be empty.
+	 * @return empty {@link Mono} that completes once the patterns subscription is unregistered.
+	 */
+	Mono<Void> pUnsubscribe(ByteBuffer... patterns);
+
+	/**
+	 * Returns the (named) channels for this subscription.
+	 *
+	 * @return collection of named channels
+	 */
+	Collection<ByteBuffer> getChannels();
+
+	/**
+	 * Returns the channel patters for this subscription.
+	 *
+	 * @return collection of channel patterns
+	 */
+	Collection<ByteBuffer> getPatterns();
+
+	/**
+	 * Retrieve the message stream emitting {@link ChannelMessage} and {@link PatternMessage}. The resulting message
+	 * stream contains only messages for subscribed and registered {@link #getChannels() channels} and
+	 * {@link #getPatterns() patterns}.
+	 * <p/>
+	 * Stream publishing uses {@link reactor.core.publisher.ConnectableFlux} turning the stream into a hot sequence.
+	 * Emission is paused if there is no demand. Messages received in that time are buffered. This stream terminates
+	 * either if all subscribers unsubscribe or if this {@link Subscription} is {@link #terminate() is terminated}.
+	 * 
+	 * @return the message stream.
+	 */
+	Flux<ChannelMessage<ByteBuffer, ByteBuffer>> receive();
+
+	/**
+	 * Unsubscribe from all {@link #getChannels() channels} and {@link #getPatterns() patterns} and request termination of
+	 * all active {@link #receive() message streams}. Active streams will terminate with a
+	 * {@link java.util.concurrent.CancellationException}.
+	 * 
+	 * @return a {@link Mono} that completes once termination is finished.
+	 */
+	Mono<Void> terminate();
+
+	/**
+	 * Value object for a Redis channel message.
+	 * 
+	 * @param <C> type of how the channel name is represented.
+	 * @param <B> type of how the message is represented.
+	 * @author Mark Paluch
+	 * @since 2.1
+	 */
+	@EqualsAndHashCode
+	class ChannelMessage<C, B> {
+
+		private final C channel;
+		private final B message;
+
+		/**
+		 * Create a new {@link ChannelMessage}.
+		 * 
+		 * @param channel must not be {@literal null}.
+		 * @param message must not be {@literal null}.
+		 */
+		public ChannelMessage(C channel, B message) {
+			this.channel = channel;
+			this.message = message;
+		}
+
+		public C getChannel() {
+			return channel;
+		}
+
+		public B getMessage() {
+			return message;
+		}
+	}
+
+	/**
+	 * Value object for a Redis channel message received from a pattern subscription.
+	 * 
+	 * @param <C> type of how the pattern is represented.
+	 * @param <C> type of how the channel name is represented.
+	 * @param <B> type of how the message is represented.
+	 * @author Mark Paluch
+	 * @since 2.1
+	 */
+	@EqualsAndHashCode(callSuper = true)
+	class PatternMessage<P, C, B> extends ChannelMessage<C, B> {
+
+		private final P pattern;
+
+		/**
+		 * Create a new {@link PatternMessage}.
+		 * 
+		 * @param pattern must not be {@literal null}.
+		 * @param channel must not be {@literal null}.
+		 * @param message must not be {@literal null}.
+		 */
+		public PatternMessage(P pattern, C channel, B message) {
+
+			super(channel, message);
+			this.pattern = pattern;
+		}
+
+		public P getPattern() {
+			return pattern;
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactivePubSubCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactivePubSubCommands.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import org.springframework.data.redis.connection.ReactiveRedisPubSubCommands;
+import org.springframework.data.redis.connection.ReactiveSubscription;
+import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
+import org.springframework.util.Assert;
+
+/**
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@RequiredArgsConstructor
+class LettuceReactivePubSubCommands implements ReactiveRedisPubSubCommands {
+
+	private final @NonNull LettuceReactiveRedisConnection connection;
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisPubSubCommands#createSubscription()
+	 */
+	@Override
+	public Mono<ReactiveSubscription> createSubscription() {
+		return connection.getPubSubConnection()
+				.map(c -> new LettuceReactiveSubscription(c.reactive(), connection.translateException()));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisPubSubCommands#publish(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<Long> publish(Publisher<ChannelMessage<ByteBuffer, ByteBuffer>> messageStream) {
+
+		Assert.notNull(messageStream, "ChannelMessage stream must not be null!");
+
+		return connection.getCommands().flatMapMany(
+				c -> Flux.from(messageStream).flatMap(message -> c.publish(message.getChannel(), message.getMessage())));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisPubSubCommands#subscribe(java.nio.ByteBuffer[])
+	 */
+	@Override
+	public Mono<Void> subscribe(ByteBuffer... channels) {
+
+		Assert.notNull(channels, "Channels must not be null!");
+
+		return doWithPubSub(c -> c.subscribe(channels));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisPubSubCommands#pSubscribe(java.nio.ByteBuffer[])
+	 */
+	@Override
+	public Mono<Void> pSubscribe(ByteBuffer... patterns) {
+
+		Assert.notNull(patterns, "Patterns must not be null!");
+
+		return doWithPubSub(c -> c.psubscribe(patterns));
+	}
+
+	private <T> Mono<T> doWithPubSub(Function<RedisPubSubReactiveCommands<ByteBuffer, ByteBuffer>, Mono<T>> function) {
+		return connection.getPubSubConnection().flatMap(c -> function.apply(c.reactive()))
+				.onErrorMap(connection.translateException());
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
@@ -175,7 +175,7 @@ class LettuceReactiveRedisConnection implements ReactiveRedisConnection {
 	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#pubSubCommands()
 	 */
 	@Override
-	public ReactiveRedisPubSubCommands pubSubCommands() {
+	public ReactivePubSubCommands pubSubCommands() {
 		return new LettuceReactivePubSubCommands(this);
 	}
 
@@ -225,11 +225,10 @@ class LettuceReactiveRedisConnection implements ReactiveRedisConnection {
 
 	/*
 	 * (non-Javadoc)
-	 * @see java.io.Closeable#close()
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection#closeLater()
 	 */
-	@Override
-	public void close() {
-		dedicatedConnection.close();
+	public Mono<Void> closeLater() {
+		return Mono.fromRunnable(() -> dedicatedConnection.close());
 	}
 
 	protected Mono<? extends StatefulConnection<ByteBuffer, ByteBuffer>> getConnection() {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSubscription.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
+import lombok.RequiredArgsConstructor;
+import reactor.core.Disposable;
+import reactor.core.publisher.ConnectableFlux;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.springframework.data.redis.connection.ReactiveSubscription;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Lettuce-specific implementation of {@link ReactiveSubscription}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+class LettuceReactiveSubscription implements ReactiveSubscription {
+
+	private final RedisPubSubReactiveCommands<ByteBuffer, ByteBuffer> commands;
+
+	private final State patternState;
+	private final State channelState;
+
+	LettuceReactiveSubscription(RedisPubSubReactiveCommands<ByteBuffer, ByteBuffer> commands,
+			Function<Throwable, Throwable> exceptionTranslator) {
+
+		this.commands = commands;
+		this.patternState = new State(exceptionTranslator);
+		this.channelState = new State(exceptionTranslator);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#subscribe(java.nio.ByteBuffer[])
+	 */
+	@Override
+	public Mono<Void> subscribe(ByteBuffer... channels) {
+
+		Assert.notNull(channels, "Channels must not be null!");
+		Assert.noNullElements(channels, "Channels must not contain null elements!");
+
+		return channelState.subscribe(channels, commands::subscribe);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#pSubscribe(java.nio.ByteBuffer[])
+	 */
+	@Override
+	public Mono<Void> pSubscribe(ByteBuffer... patterns) {
+
+		Assert.notNull(patterns, "Patterns must not be null!");
+		Assert.noNullElements(patterns, "Patterns must not contain null elements!");
+
+		return patternState.subscribe(patterns, commands::psubscribe);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#unsubscribe()
+	 */
+	@Override
+	public Mono<Void> unsubscribe() {
+		return unsubscribe(channelState.getTargets().toArray(new ByteBuffer[0]));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#unsubscribe(java.nio.ByteBuffer[])
+	 */
+	@Override
+	public Mono<Void> unsubscribe(ByteBuffer... channels) {
+
+		Assert.notNull(channels, "Channels must not be null!");
+		Assert.noNullElements(channels, "Channels must not contain null elements!");
+
+		return channels.length == 0 ? Mono.empty() : channelState.unsubscribe(channels, commands::unsubscribe);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#pUnsubscribe()
+	 */
+	@Override
+	public Mono<Void> pUnsubscribe() {
+		return pUnsubscribe(patternState.getTargets().toArray(new ByteBuffer[0]));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#pUnsubscribe(java.nio.ByteBuffer[])
+	 */
+	@Override
+	public Mono<Void> pUnsubscribe(ByteBuffer... patterns) {
+
+		Assert.notNull(patterns, "Patterns must not be null!");
+		Assert.noNullElements(patterns, "Patterns must not contain null elements!");
+
+		return patterns.length == 0 ? Mono.empty() : patternState.unsubscribe(patterns, commands::punsubscribe);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#getChannels()
+	 */
+	@Override
+	public Collection<ByteBuffer> getChannels() {
+		return Collections.unmodifiableCollection(channelState.getTargets());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#getPatterns()
+	 */
+	@Override
+	public Collection<ByteBuffer> getPatterns() {
+		return Collections.unmodifiableCollection(patternState.getTargets());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#receive()
+	 */
+	@Override
+	public Flux<ChannelMessage<ByteBuffer, ByteBuffer>> receive() {
+
+		Flux<ChannelMessage<ByteBuffer, ByteBuffer>> channelMessages = channelState.receive(() -> commands.observeChannels() //
+				.filter(m -> channelState.getTargets().contains(m.getChannel())) //
+				.map(m -> new ChannelMessage<>(m.getChannel(), m.getMessage())));
+
+		Flux<ChannelMessage<ByteBuffer, ByteBuffer>> patternMessages = patternState.receive(() -> commands.observePatterns() //
+				.filter(m -> patternState.getTargets().contains(m.getPattern())) //
+				.map(m -> new PatternMessage<>(m.getPattern(), m.getChannel(), m.getMessage())));
+
+		return channelMessages.mergeWith(patternMessages);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveSubscription#terminate()
+	 */
+	@Override
+	public Mono<Void> terminate() {
+
+		return unsubscribe().then(pUnsubscribe()).then(Mono.defer(() -> {
+
+			channelState.terminate();
+			patternState.terminate();
+			return Mono.empty();
+		}));
+	}
+
+	/**
+	 * Subscription state holder.
+	 * 
+	 * @author Mark Paluch
+	 */
+	@RequiredArgsConstructor
+	static class State {
+
+		private final Set<ByteBuffer> targets = new ConcurrentSkipListSet<>();
+		private final AtomicLong subscribers = new AtomicLong();
+		private final AtomicReference<Flux<?>> flux = new AtomicReference<>();
+		private final Function<Throwable, Throwable> exceptionTranslator;
+
+		private volatile @Nullable Disposable disposable;
+
+		/**
+		 * Subscribe to {@code targets} using subscribe {@link Function} and register {@code targets} after subscription.
+		 * 
+		 * @param targets
+		 * @param subscribeFunction
+		 * @return
+		 */
+		Mono<Void> subscribe(ByteBuffer[] targets, Function<ByteBuffer[], Mono<Void>> subscribeFunction) {
+
+			return subscribeFunction.apply(targets).doOnSuccess((v) -> {
+				this.targets.addAll(Arrays.asList(targets));
+			}).onErrorMap(exceptionTranslator);
+		}
+
+		/**
+		 * Unsubscribe from to {@code targets} using unsubscribe {@link Function} and register {@code targets} after
+		 * subscription.
+		 * 
+		 * @param targets
+		 * @param unsubscribeFunction
+		 * @return
+		 */
+		Mono<Void> unsubscribe(ByteBuffer[] targets, Function<ByteBuffer[], Mono<Void>> unsubscribeFunction) {
+
+			return Mono.defer(() -> {
+
+				List<ByteBuffer> targetCollection = Arrays.asList(targets);
+
+				return unsubscribeFunction.apply(targets).doOnSuccess((v) -> {
+					this.targets.removeAll(targetCollection);
+				}).onErrorMap(exceptionTranslator);
+			});
+		}
+
+		Collection<ByteBuffer> getTargets() {
+			return targets;
+		}
+
+		/**
+		 * Create a message stream from connect {@link Function}. Multiple calls to this method are lock-free synchronized.
+		 * The first successful caller creates the actual stream. Other concurrent callers that do not pass the
+		 * synchronization use the stream created by the first successful caller.
+		 * <p/>
+		 * The stream registers a disposal function upon subscription for external {@link #terminate() termination}.
+		 *
+		 * @param connectFunction
+		 * @param <T> message type.
+		 * @return
+		 */
+		@SuppressWarnings("unchecked")
+		<T> Flux<T> receive(Supplier<Flux<T>> connectFunction) {
+
+			Flux<?> fastPath = flux.get();
+
+			if (fastPath != null) {
+				return (Flux) fastPath;
+			}
+
+			ConnectableFlux<T> connectableFlux = connectFunction.get().onErrorMap(exceptionTranslator).publish();
+			Flux<T> fluxToUse = connectableFlux.doOnSubscribe(s -> {
+
+				if (subscribers.incrementAndGet() == 1) {
+					disposable = connectableFlux.connect();
+				}
+			}).doFinally(s -> {
+
+				if (subscribers.decrementAndGet() == 0) {
+
+					this.flux.compareAndSet(connectableFlux, null);
+					terminate();
+				}
+			});
+
+			if (this.flux.compareAndSet(null, fluxToUse)) {
+				return fluxToUse;
+			}
+
+			return (Flux) this.flux.get();
+		}
+
+		void terminate() {
+
+			this.flux.set(null);
+
+			Disposable disposable = this.disposable;
+
+			if (disposable != null && !disposable.isDisposed()) {
+				disposable.dispose();
+			}
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSubscription.java
@@ -24,7 +24,6 @@ import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -37,11 +36,13 @@ import java.util.function.Supplier;
 import org.springframework.data.redis.connection.ReactiveSubscription;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Lettuce-specific implementation of {@link ReactiveSubscription}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.1
  */
 class LettuceReactiveSubscription implements ReactiveSubscription {
@@ -91,7 +92,7 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 	 */
 	@Override
 	public Mono<Void> unsubscribe() {
-		return unsubscribe(channelState.getTargets().toArray(new ByteBuffer[0]));
+		return unsubscribe(channelState.getTargets().toArray(new ByteBuffer[channelState.getTargets().size()]));
 	}
 
 	/*
@@ -104,7 +105,7 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 		Assert.notNull(channels, "Channels must not be null!");
 		Assert.noNullElements(channels, "Channels must not contain null elements!");
 
-		return channels.length == 0 ? Mono.empty() : channelState.unsubscribe(channels, commands::unsubscribe);
+		return ObjectUtils.isEmpty(channels) ? Mono.empty() : channelState.unsubscribe(channels, commands::unsubscribe);
 	}
 
 	/*
@@ -113,7 +114,7 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 	 */
 	@Override
 	public Mono<Void> pUnsubscribe() {
-		return pUnsubscribe(patternState.getTargets().toArray(new ByteBuffer[0]));
+		return pUnsubscribe(patternState.getTargets().toArray(new ByteBuffer[patternState.getTargets().size()]));
 	}
 
 	/*
@@ -126,7 +127,7 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 		Assert.notNull(patterns, "Patterns must not be null!");
 		Assert.noNullElements(patterns, "Patterns must not contain null elements!");
 
-		return patterns.length == 0 ? Mono.empty() : patternState.unsubscribe(patterns, commands::punsubscribe);
+		return ObjectUtils.isEmpty(patterns) ? Mono.empty() : patternState.unsubscribe(patterns, commands::punsubscribe);
 	}
 
 	/*
@@ -134,8 +135,8 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 	 * @see org.springframework.data.redis.connection.ReactiveSubscription#getChannels()
 	 */
 	@Override
-	public Collection<ByteBuffer> getChannels() {
-		return Collections.unmodifiableCollection(channelState.getTargets());
+	public Set<ByteBuffer> getChannels() {
+		return channelState.getTargets();
 	}
 
 	/*
@@ -143,8 +144,8 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 	 * @see org.springframework.data.redis.connection.ReactiveSubscription#getPatterns()
 	 */
 	@Override
-	public Collection<ByteBuffer> getPatterns() {
-		return Collections.unmodifiableCollection(patternState.getTargets());
+	public Set<ByteBuffer> getPatterns() {
+		return patternState.getTargets();
 	}
 
 	/*
@@ -152,15 +153,15 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 	 * @see org.springframework.data.redis.connection.ReactiveSubscription#receive()
 	 */
 	@Override
-	public Flux<ChannelMessage<ByteBuffer, ByteBuffer>> receive() {
+	public Flux<Message<ByteBuffer, ByteBuffer>> receive() {
 
-		Flux<ChannelMessage<ByteBuffer, ByteBuffer>> channelMessages = channelState.receive(() -> commands.observeChannels() //
-				.filter(m -> channelState.getTargets().contains(m.getChannel())) //
-				.map(m -> new ChannelMessage<>(m.getChannel(), m.getMessage())));
+		Flux<Message<ByteBuffer, ByteBuffer>> channelMessages = channelState.receive(() -> commands.observeChannels() //
+				.filter(message -> channelState.getTargets().contains(message.getChannel())) //
+				.map(message -> new ChannelMessage<>(message.getChannel(), message.getMessage())));
 
-		Flux<ChannelMessage<ByteBuffer, ByteBuffer>> patternMessages = patternState.receive(() -> commands.observePatterns() //
-				.filter(m -> patternState.getTargets().contains(m.getPattern())) //
-				.map(m -> new PatternMessage<>(m.getPattern(), m.getChannel(), m.getMessage())));
+		Flux<Message<ByteBuffer, ByteBuffer>> patternMessages = patternState.receive(() -> commands.observePatterns() //
+				.filter(message -> patternState.getTargets().contains(message.getPattern())) //
+				.map(message -> new PatternMessage<>(message.getPattern(), message.getChannel(), message.getMessage())));
 
 		return channelMessages.mergeWith(patternMessages);
 	}
@@ -170,7 +171,7 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 	 * @see org.springframework.data.redis.connection.ReactiveSubscription#terminate()
 	 */
 	@Override
-	public Mono<Void> terminate() {
+	public Mono<Void> cancel() {
 
 		return unsubscribe().then(pUnsubscribe()).then(Mono.defer(() -> {
 
@@ -204,9 +205,8 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 		 */
 		Mono<Void> subscribe(ByteBuffer[] targets, Function<ByteBuffer[], Mono<Void>> subscribeFunction) {
 
-			return subscribeFunction.apply(targets).doOnSuccess((v) -> {
-				this.targets.addAll(Arrays.asList(targets));
-			}).onErrorMap(exceptionTranslator);
+			return subscribeFunction.apply(targets).doOnSuccess((discard) -> this.targets.addAll(Arrays.asList(targets)))
+					.onErrorMap(exceptionTranslator);
 		}
 
 		/**
@@ -223,14 +223,14 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 
 				List<ByteBuffer> targetCollection = Arrays.asList(targets);
 
-				return unsubscribeFunction.apply(targets).doOnSuccess((v) -> {
+				return unsubscribeFunction.apply(targets).doOnSuccess((discard) -> {
 					this.targets.removeAll(targetCollection);
 				}).onErrorMap(exceptionTranslator);
 			});
 		}
 
-		Collection<ByteBuffer> getTargets() {
-			return targets;
+		Set<ByteBuffer> getTargets() {
+			return Collections.unmodifiableSet(targets);
 		}
 
 		/**
@@ -254,13 +254,14 @@ class LettuceReactiveSubscription implements ReactiveSubscription {
 			}
 
 			ConnectableFlux<T> connectableFlux = connectFunction.get().onErrorMap(exceptionTranslator).publish();
-			Flux<T> fluxToUse = connectableFlux.doOnSubscribe(s -> {
+			Flux<T> fluxToUse = connectableFlux.doOnSubscribe(subscription -> {
 
 				if (subscribers.incrementAndGet() == 1) {
 					disposable = connectableFlux.connect();
 				}
-			}).doFinally(s -> {
+			}).doFinally(signalType -> {
 
+				// TODO: do new need to care about what happened?
 				if (subscribers.decrementAndGet() == 0) {
 
 					this.flux.compareAndSet(connectableFlux, null);

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
@@ -20,16 +20,22 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.reactivestreams.Publisher;
 import org.springframework.data.redis.connection.DataType;
+import org.springframework.data.redis.connection.ReactiveSubscription.Message;
 import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.Topic;
 import org.springframework.data.redis.serializer.RedisElementReader;
 import org.springframework.data.redis.serializer.RedisElementWriter;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.util.Assert;
 
 /**
  * Interface that specified a basic set of Redis operations, implemented by {@link ReactiveRedisTemplate}. Not often
@@ -56,16 +62,58 @@ public interface ReactiveRedisOperations<K, V> {
 	 */
 	<T> Flux<T> execute(ReactiveRedisCallback<T> action);
 
+	// -------------------------------------------------------------------------
+	// Methods dealing with Redis Pub/Sub
+	// -------------------------------------------------------------------------
+
 	/**
 	 * Publishes the given message to the given channel.
 	 *
-	 * @param destination the channel to publish to, must not be {@literal null} or empty.
-	 * @param message message to publish.
+	 * @param destination the channel to publish to, must not be {@literal null} nor empty.
+	 * @param message message to publish. Must not be {@literal null}.
 	 * @return the number of clients that received the message
 	 * @since 2.1
 	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
 	 */
 	Mono<Long> convertAndSend(String destination, V message);
+
+	/**
+	 * Subscribe to the given Redis {@code channels} and emit {@link Message messages} received for those.
+	 *
+	 * @param channels must not be {@literal null}.
+	 * @return a hot sequence of {@link Message messages}.
+	 * @since 2.1
+	 */
+	default Flux<? extends Message<String, V>> listenToChannel(String... channels) {
+
+		Assert.notNull(channels, "Channels must not be null!");
+
+		return listenTo(Arrays.stream(channels).map(ChannelTopic::of).toArray(ChannelTopic[]::new));
+	}
+
+	/**
+	 * Subscribe to the Redis channels matching the given {@code pattern} and emit {@link Message messages} received for
+	 * those.
+	 *
+	 * @param patterns must not be {@literal null}.
+	 * @return a hot sequence of {@link Message messages}.
+	 * @since 2.1
+	 */
+	default Flux<? extends Message<String, V>> listenToPattern(String... patterns) {
+
+		Assert.notNull(patterns, "Patterns must not be null!");
+		return listenTo(Arrays.stream(patterns).map(PatternTopic::of).toArray(PatternTopic[]::new));
+	}
+
+	/**
+	 * Subscribe to the Redis channels for the given {@link Topic topics} and emit {@link Message messages} received for
+	 * those.
+	 *
+	 * @param topics must not be {@literal null}.
+	 * @return a hot sequence of {@link Message messages}.
+	 * @since 2.1
+	 */
+	Flux<? extends Message<String, V>> listenTo(Topic... topics);
 
 	// -------------------------------------------------------------------------
 	// Methods dealing with Redis Keys

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
@@ -56,6 +56,17 @@ public interface ReactiveRedisOperations<K, V> {
 	 */
 	<T> Flux<T> execute(ReactiveRedisCallback<T> action);
 
+	/**
+	 * Publishes the given message to the given channel.
+	 *
+	 * @param destination the channel to publish to, must not be {@literal null} or empty.
+	 * @param message message to publish.
+	 * @return the number of clients that received the message
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 */
+	Mono<Long> convertAndSend(String destination, V message);
+
 	// -------------------------------------------------------------------------
 	// Methods dealing with Redis Keys
 	// -------------------------------------------------------------------------

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
@@ -193,6 +193,16 @@ public class ReactiveRedisTemplate<K, V> implements ReactiveRedisOperations<K, V
 		return Flux.from(postProcessResult(result, connToUse, false)).doFinally(signal -> conn.close());
 	}
 
+	@Override
+	public Mono<Long> convertAndSend(String destination, V message) {
+
+		Assert.hasText(destination, "Destination channel must not be empty!");
+
+		return createMono(connection -> connection.pubSubCommands().publish(
+				getSerializationContext().getStringSerializationPair().write(destination),
+				getSerializationContext().getValueSerializationPair().write(message)));
+	}
+
 	// -------------------------------------------------------------------------
 	// Methods dealing with Redis keys
 	// -------------------------------------------------------------------------

--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -21,8 +21,17 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,7 +44,6 @@ import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.EntityInstantiator;
 import org.springframework.data.convert.EntityInstantiators;
-import org.springframework.data.keyvalue.core.mapping.KeySpaceResolver;
 import org.springframework.data.mapping.AssociationHandler;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
@@ -450,9 +458,10 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 			targetProperty = getTargetPropertyOrNullForPath(path.replaceAll("\\.\\[.*\\]", ""), update.getTarget());
 
 			TypeInformation<?> ti = targetProperty == null ? ClassTypeInformation.OBJECT
-					: (targetProperty.isMap() ? (targetProperty.getTypeInformation().getMapValueType() != null
-							? targetProperty.getTypeInformation().getRequiredMapValueType()
-							: ClassTypeInformation.OBJECT) : targetProperty.getTypeInformation().getActualType());
+					: (targetProperty.isMap()
+							? (targetProperty.getTypeInformation().getMapValueType() != null
+									? targetProperty.getTypeInformation().getRequiredMapValueType() : ClassTypeInformation.OBJECT)
+							: targetProperty.getTypeInformation().getActualType());
 
 			writeInternal(entity.getKeySpace(), pUpdate.getPropertyPath(), pUpdate.getValue(), ti, sink);
 			return;

--- a/src/main/java/org/springframework/data/redis/listener/ChannelTopic.java
+++ b/src/main/java/org/springframework/data/redis/listener/ChannelTopic.java
@@ -43,6 +43,17 @@ public class ChannelTopic implements Topic {
 	}
 
 	/**
+	 * Create a new {@link ChannelTopic} for channel subscriptions.
+	 * 
+	 * @param name the channel name, must not be {@literal null} or empty.
+	 * @return the {@link ChannelTopic} for {@code channelName}.
+	 * @since 2.1
+	 */
+	public static ChannelTopic of(String name) {
+		return new ChannelTopic(name);
+	}
+
+	/**
 	 * @return topic name.
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/listener/ChannelTopic.java
+++ b/src/main/java/org/springframework/data/redis/listener/ChannelTopic.java
@@ -44,7 +44,7 @@ public class ChannelTopic implements Topic {
 
 	/**
 	 * Create a new {@link ChannelTopic} for channel subscriptions.
-	 * 
+	 *
 	 * @param name the channel name, must not be {@literal null} or empty.
 	 * @return the {@link ChannelTopic} for {@code channelName}.
 	 * @since 2.1

--- a/src/main/java/org/springframework/data/redis/listener/PatternTopic.java
+++ b/src/main/java/org/springframework/data/redis/listener/PatternTopic.java
@@ -43,6 +43,17 @@ public class PatternTopic implements Topic {
 	}
 
 	/**
+	 * Create a new {@link PatternTopic} for channel subscriptions based on a {@code pattern}.
+	 *
+	 * @param pattern the channel pattern, must not be {@literal null} or empty.
+	 * @return the {@link PatternTopic} for {@code pattern}.
+	 * @since 2.1
+	 */
+	static PatternTopic of(String pattern) {
+		return new PatternTopic(pattern);
+	}
+
+	/**
 	 * @return channel pattern.
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/listener/PatternTopic.java
+++ b/src/main/java/org/springframework/data/redis/listener/PatternTopic.java
@@ -24,6 +24,7 @@ import org.springframework.util.Assert;
  *
  * @author Costin Leau
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @EqualsAndHashCode
 public class PatternTopic implements Topic {
@@ -49,7 +50,7 @@ public class PatternTopic implements Topic {
 	 * @return the {@link PatternTopic} for {@code pattern}.
 	 * @since 2.1
 	 */
-	static PatternTopic of(String pattern) {
+	public static PatternTopic of(String pattern) {
 		return new PatternTopic(pattern);
 	}
 

--- a/src/main/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainer.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.listener;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.ReactiveSubscription;
+import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
+import org.springframework.data.redis.connection.ReactiveSubscription.PatternMessage;
+import org.springframework.data.redis.serializer.RedisElementReader;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Container providing a stream of {@link ChannelMessage} for messages received via Redis Pub/Sub listeners. The stream
+ * is infinite and registers Redis subscriptions. Handles the low level details of listening, converting and message
+ * dispatching.
+ * <p />
+ * Note the container allocates a single connection when it is created and releases the connection on
+ * {@link #destroy()}. Connections are allocated eagerly to not interfere with non-blocking use during application
+ * operations. Using reactive infrastructure allows usage of a single connection due to channel multiplexing.
+ * <p />
+ * This class is thread-safe and allows subscription by multiple concurrent threads.
+ * 
+ * @author Mark Paluch
+ * @since 2.1
+ * @see ReactiveSubscription
+ * @see org.springframework.data.redis.connection.ReactiveRedisPubSubCommands
+ */
+public class ReactiveRedisMessageListenerContainer implements DisposableBean {
+
+	private final SerializationPair<String> stringSerializationPair = SerializationPair
+			.fromSerializer(RedisSerializer.string());
+	private final Map<ReactiveSubscription, Subscribers> subscriptions = new ConcurrentHashMap<>();
+
+	private volatile @Nullable ReactiveRedisConnection connection;
+
+	/**
+	 * Create a new {@link ReactiveRedisMessageListenerContainer} given {@link ReactiveRedisConnectionFactory}.
+	 * 
+	 * @param connectionFactory must not be {@literal null}.
+	 */
+	public ReactiveRedisMessageListenerContainer(ReactiveRedisConnectionFactory connectionFactory) {
+
+		Assert.notNull(connectionFactory, "ReactiveRedisConnectionFactory must not be null!");
+		this.connection = connectionFactory.getReactiveConnection();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.DisposableBean#destroy()
+	 */
+	@Override
+	public void destroy() {
+
+		ReactiveRedisConnection connection = this.connection;
+
+		if (connection != null) {
+
+			Flux<Void> terminationSignals = null;
+			while (!subscriptions.isEmpty()) {
+
+				Map<ReactiveSubscription, Subscribers> local = new HashMap<>(subscriptions);
+				List<Mono<Void>> monos = local.keySet().stream() //
+						.peek(subscriptions::remove) //
+						.map(ReactiveSubscription::terminate) //
+						.collect(Collectors.toList());
+
+				if (terminationSignals == null) {
+					terminationSignals = Flux.merge(monos);
+				} else {
+					terminationSignals = terminationSignals.mergeWith(Flux.merge(monos));
+				}
+			}
+
+			if (terminationSignals != null) {
+				terminationSignals.blockLast();
+			}
+
+			connection.close();
+			this.connection = null;
+		}
+	}
+
+	/**
+	 * Return the currently active {@link ReactiveSubscription subscriptions}.
+	 * 
+	 * @return {@link Set} of active {@link ReactiveSubscription}
+	 */
+	public Collection<ReactiveSubscription> getActiveSubscriptions() {
+
+		Set<ReactiveSubscription> subscriptions = new HashSet<>(this.subscriptions.size(), 1);
+
+		this.subscriptions.forEach((subscription, subscribers) -> {
+
+			if (subscribers.hasRegistration()) {
+				subscriptions.add(subscription);
+			}
+		});
+
+		return subscriptions;
+	}
+
+	/**
+	 * Subscribe to one or more {@link ChannelTopic}s and receive a stream of {@link ChannelMessage}. Messages and channel
+	 * names are treated as {@link String}. The message stream subscribes lazily to the Redis channels and unsubscribes if
+	 * the {@link org.reactivestreams.Subscription} is {@link org.reactivestreams.Subscription#cancel() cancelled}.
+	 * 
+	 * @param channelTopics the channels to subscribe.
+	 * @return the message stream.
+	 * @throws InvalidDataAccessApiUsageException if {@code patternTopics} is empty.
+	 * @see #receive(Iterable, SerializationPair, SerializationPair)
+	 */
+	public Flux<ChannelMessage<String, String>> receive(ChannelTopic... channelTopics) {
+
+		Assert.notNull(channelTopics, "ChannelTopics must not be null!");
+		Assert.noNullElements(channelTopics, "ChannelTopics must not contain null elements!");
+
+		return receive(Arrays.asList(channelTopics), stringSerializationPair, stringSerializationPair);
+	}
+
+	/**
+	 * Subscribe to one or more {@link PatternTopic}s and receive a stream of {@link PatternMessage}. Messages, pattern,
+	 * and channel names are treated as {@link String}. The message stream subscribes lazily to the Redis channels and
+	 * unsubscribes if the {@link org.reactivestreams.Subscription} is {@link org.reactivestreams.Subscription#cancel()
+	 * cancelled}.
+	 * 
+	 * @param channelTopics the channels to subscribe.
+	 * @return the message stream.
+	 * @throws InvalidDataAccessApiUsageException if {@code patternTopics} is empty.
+	 * @see #receive(Iterable, SerializationPair, SerializationPair)
+	 */
+	@SuppressWarnings("unchecked")
+	public Flux<PatternMessage<String, String, String>> receive(PatternTopic... patternTopics) {
+
+		Assert.notNull(patternTopics, "PatternTopic must not be null!");
+		Assert.noNullElements(patternTopics, "PatternTopic must not contain null elements!");
+
+		return receive(Arrays.asList(patternTopics), stringSerializationPair, stringSerializationPair)
+				.map(m -> (PatternMessage<String, String, String>) m);
+	}
+
+	/**
+	 * Subscribe to one or more {@link Topic}s and receive a stream of {@link ChannelMessage} The stream may contain
+	 * {@link PatternMessage} if subscribed to patterns. Messages, and channel names are serialized/deserialized using the
+	 * given {@code channelSerializer} and {@code messageSerializer}. The message stream subscribes lazily to the Redis
+	 * channels and unsubscribes if the {@link org.reactivestreams.Subscription} is
+	 * {@link org.reactivestreams.Subscription#cancel() cancelled}.
+	 * 
+	 * @param topics the channels to subscribe.
+	 * @return the message stream.
+	 * @see #receive(Iterable, SerializationPair, SerializationPair)
+	 * @throws InvalidDataAccessApiUsageException if {@code topics} is empty.
+	 */
+	public <C, B> Flux<ChannelMessage<C, B>> receive(Iterable<? extends Topic> topics,
+			SerializationPair<C> channelSerializer, SerializationPair<B> messageSerializer) {
+
+		Assert.notNull(topics, "Topics must not be null!");
+
+		ReactiveRedisConnection connection = this.connection;
+		if (connection == null) {
+			throw new IllegalStateException("ReactiveRedisMessageListenerContainer is already disposed!");
+		}
+
+		Mono<ReactiveSubscription> subscription = connection.pubSubCommands().createSubscription();
+
+		ByteBuffer[] patterns = getTargets(topics, PatternTopic.class);
+		ByteBuffer[] channels = getTargets(topics, ChannelTopic.class);
+
+		if (patterns.length == 0 && channels.length == 0) {
+			throw new InvalidDataAccessApiUsageException("No channels or patterns to subscribe");
+		}
+
+		return doReceive(channelSerializer, messageSerializer, subscription, patterns, channels);
+	}
+
+	private <C, B> Flux<ChannelMessage<C, B>> doReceive(SerializationPair<C> channelSerializer,
+			SerializationPair<B> messageSerializer, Mono<ReactiveSubscription> subscription, ByteBuffer[] patterns,
+			ByteBuffer[] channels) {
+
+		Flux<ChannelMessage<ByteBuffer, ByteBuffer>> messageStream = subscription.flatMapMany(it -> {
+
+			Mono<Void> subscribe = subscribe(patterns, channels, it);
+
+			MonoProcessor<ChannelMessage<ByteBuffer, ByteBuffer>> terminalProcessor = MonoProcessor.create();
+			return it.receive().mergeWith(subscribe.then(Mono.defer(() -> {
+
+				getSubscribers(it).registered();
+
+				return Mono.empty();
+			}))).doOnCancel(() -> {
+
+				Subscribers subscribers = getSubscribers(it);
+				if (subscribers.unregister()) {
+					subscriptions.remove(it);
+					it.unsubscribe().subscribe(v -> terminalProcessor.onComplete(), terminalProcessor::onError);
+				}
+			}).mergeWith(terminalProcessor);
+		});
+
+		return messageStream
+				.map(message -> readMessage(channelSerializer.getReader(), messageSerializer.getReader(), message));
+	}
+
+	private static Mono<Void> subscribe(ByteBuffer[] patterns, ByteBuffer[] channels, ReactiveSubscription it) {
+
+		Assert.isTrue(channels.length != 0 || patterns.length != 0, "Must provide either channels or patterns!");
+
+		Mono<Void> subscribe = null;
+
+		if (patterns.length != 0) {
+			subscribe = it.pSubscribe(patterns);
+		}
+
+		if (channels.length != 0) {
+
+			Mono<Void> channelsSubscribe = it.subscribe(channels);
+
+			if (subscribe == null) {
+				subscribe = channelsSubscribe;
+			} else {
+				subscribe = subscribe.and(channelsSubscribe);
+			}
+		}
+
+		return subscribe;
+	}
+
+	private Subscribers getSubscribers(ReactiveSubscription it) {
+		return subscriptions.computeIfAbsent(it, key -> new Subscribers());
+	}
+
+	private ByteBuffer[] getTargets(Iterable<? extends Topic> topics, Class<?> classFilter) {
+
+		return StreamSupport.stream(topics.spliterator(), false) //
+				.filter(classFilter::isInstance) //
+				.map(Topic::getTopic) //
+				.map(stringSerializationPair::write) //
+				.toArray(ByteBuffer[]::new);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <C, B> ChannelMessage<C, B> readMessage(RedisElementReader<C> channelSerializer,
+			RedisElementReader<B> messageSerializer, ChannelMessage<ByteBuffer, ByteBuffer> message) {
+
+		if (message instanceof PatternMessage) {
+
+			PatternMessage<ByteBuffer, ByteBuffer, ByteBuffer> patternMessage = (PatternMessage) message;
+
+			String pattern = read(stringSerializationPair.getReader(), patternMessage.getPattern());
+			C channel = read(channelSerializer, patternMessage.getChannel());
+			B body = read(messageSerializer, patternMessage.getMessage());
+
+			return new PatternMessage<>(pattern, channel, body);
+		}
+
+		C channel = read(channelSerializer, message.getChannel());
+		B body = read(messageSerializer, message.getMessage());
+
+		return new ChannelMessage<>(channel, body);
+	}
+
+	private static <C> C read(RedisElementReader<C> reader, ByteBuffer buffer) {
+
+		try {
+			buffer.mark();
+			return reader.read(buffer);
+		} finally {
+			buffer.reset();
+		}
+	}
+
+	/**
+	 * Object to track subscriber count and to determine the last unsubscribed subscriber.
+	 * 
+	 * @author Mark Paluch
+	 */
+	static class Subscribers {
+
+		private static final AtomicLongFieldUpdater<Subscribers> SUBSCRIBERS = AtomicLongFieldUpdater
+				.newUpdater(Subscribers.class, "subscribers");
+
+		// accessed via SUBSCRIBERS
+		@SuppressWarnings("unused") private volatile long subscribers;
+
+		/**
+		 * Register a subscriber and increment subscriber count.
+		 */
+		void registered() {
+			SUBSCRIBERS.incrementAndGet(this);
+		}
+
+		/**
+		 * @return {@literal true} if at least one subscriber registered via {@link #registered()}.
+		 */
+		boolean hasRegistration() {
+			return SUBSCRIBERS.get(this) > 0;
+		}
+
+		/**
+		 * Unregister a subscriber and decrement subscriber count.
+		 * 
+		 * @return {@literal true} if this was the last unregistered subscriber.
+		 */
+		boolean unregister() {
+
+			long value = SUBSCRIBERS.get(this);
+
+			if (value <= 0) {
+				return false;
+			}
+
+			if (SUBSCRIBERS.compareAndSet(this, value, value - 1) && value == 1) {
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ package org.springframework.data.redis.listener;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
+import reactor.core.scheduler.Schedulers;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,16 +34,19 @@ import java.util.stream.StreamSupport;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ReactivePubSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.ReactiveSubscription;
 import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
+import org.springframework.data.redis.connection.ReactiveSubscription.Message;
 import org.springframework.data.redis.connection.ReactiveSubscription.PatternMessage;
 import org.springframework.data.redis.serializer.RedisElementReader;
 import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Container providing a stream of {@link ChannelMessage} for messages received via Redis Pub/Sub listeners. The stream
@@ -55,11 +58,12 @@ import org.springframework.util.Assert;
  * operations. Using reactive infrastructure allows usage of a single connection due to channel multiplexing.
  * <p />
  * This class is thread-safe and allows subscription by multiple concurrent threads.
- * 
+ *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.1
  * @see ReactiveSubscription
- * @see org.springframework.data.redis.connection.ReactiveRedisPubSubCommands
+ * @see ReactivePubSubCommands
  */
 public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 
@@ -71,7 +75,7 @@ public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 
 	/**
 	 * Create a new {@link ReactiveRedisMessageListenerContainer} given {@link ReactiveRedisConnectionFactory}.
-	 * 
+	 *
 	 * @param connectionFactory must not be {@literal null}.
 	 */
 	public ReactiveRedisMessageListenerContainer(ReactiveRedisConnectionFactory connectionFactory) {
@@ -86,8 +90,13 @@ public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 	 */
 	@Override
 	public void destroy() {
+		destroyLater().block();
+	}
 
-		ReactiveRedisConnection connection = this.connection;
+	/**
+	 * @return the {@link Mono} signalling container termination.
+	 */
+	public Mono<Void> destroyLater() {
 
 		if (connection != null) {
 
@@ -97,55 +106,49 @@ public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 				Map<ReactiveSubscription, Subscribers> local = new HashMap<>(subscriptions);
 				List<Mono<Void>> monos = local.keySet().stream() //
 						.peek(subscriptions::remove) //
-						.map(ReactiveSubscription::terminate) //
+						.map(ReactiveSubscription::cancel) //
 						.collect(Collectors.toList());
 
 				if (terminationSignals == null) {
-					terminationSignals = Flux.merge(monos);
+					terminationSignals = Flux.concat(monos);
 				} else {
-					terminationSignals = terminationSignals.mergeWith(Flux.merge(monos));
+					terminationSignals = terminationSignals.mergeWith(Flux.concat(monos));
 				}
 			}
 
 			if (terminationSignals != null) {
-				terminationSignals.blockLast();
+				return terminationSignals.collectList()
+						.doFinally(signalType -> connection.closeLater().subscribeOn(Schedulers.immediate()))
+						.flatMap(all -> Mono.empty());
 			}
-
-			connection.close();
 			this.connection = null;
 		}
+
+		return Mono.empty();
 	}
 
 	/**
 	 * Return the currently active {@link ReactiveSubscription subscriptions}.
-	 * 
+	 *
 	 * @return {@link Set} of active {@link ReactiveSubscription}
 	 */
 	public Collection<ReactiveSubscription> getActiveSubscriptions() {
 
-		Set<ReactiveSubscription> subscriptions = new HashSet<>(this.subscriptions.size(), 1);
-
-		this.subscriptions.forEach((subscription, subscribers) -> {
-
-			if (subscribers.hasRegistration()) {
-				subscriptions.add(subscription);
-			}
-		});
-
-		return subscriptions;
+		return subscriptions.entrySet().stream().filter(entry -> entry.getValue().hasRegistration())
+				.map(entry -> entry.getKey()).collect(Collectors.toList());
 	}
 
 	/**
 	 * Subscribe to one or more {@link ChannelTopic}s and receive a stream of {@link ChannelMessage}. Messages and channel
 	 * names are treated as {@link String}. The message stream subscribes lazily to the Redis channels and unsubscribes if
 	 * the {@link org.reactivestreams.Subscription} is {@link org.reactivestreams.Subscription#cancel() cancelled}.
-	 * 
+	 *
 	 * @param channelTopics the channels to subscribe.
 	 * @return the message stream.
 	 * @throws InvalidDataAccessApiUsageException if {@code patternTopics} is empty.
 	 * @see #receive(Iterable, SerializationPair, SerializationPair)
 	 */
-	public Flux<ChannelMessage<String, String>> receive(ChannelTopic... channelTopics) {
+	public Flux<Message<String, String>> receive(ChannelTopic... channelTopics) {
 
 		Assert.notNull(channelTopics, "ChannelTopics must not be null!");
 		Assert.noNullElements(channelTopics, "ChannelTopics must not contain null elements!");
@@ -158,8 +161,8 @@ public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 	 * and channel names are treated as {@link String}. The message stream subscribes lazily to the Redis channels and
 	 * unsubscribes if the {@link org.reactivestreams.Subscription} is {@link org.reactivestreams.Subscription#cancel()
 	 * cancelled}.
-	 * 
-	 * @param channelTopics the channels to subscribe.
+	 *
+	 * @param patternTopics the channels to subscribe.
 	 * @return the message stream.
 	 * @throws InvalidDataAccessApiUsageException if {@code patternTopics} is empty.
 	 * @see #receive(Iterable, SerializationPair, SerializationPair)
@@ -180,39 +183,35 @@ public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 	 * given {@code channelSerializer} and {@code messageSerializer}. The message stream subscribes lazily to the Redis
 	 * channels and unsubscribes if the {@link org.reactivestreams.Subscription} is
 	 * {@link org.reactivestreams.Subscription#cancel() cancelled}.
-	 * 
+	 *
 	 * @param topics the channels to subscribe.
 	 * @return the message stream.
 	 * @see #receive(Iterable, SerializationPair, SerializationPair)
 	 * @throws InvalidDataAccessApiUsageException if {@code topics} is empty.
 	 */
-	public <C, B> Flux<ChannelMessage<C, B>> receive(Iterable<? extends Topic> topics,
-			SerializationPair<C> channelSerializer, SerializationPair<B> messageSerializer) {
+	public <C, B> Flux<Message<C, B>> receive(Iterable<? extends Topic> topics, SerializationPair<C> channelSerializer,
+			SerializationPair<B> messageSerializer) {
 
 		Assert.notNull(topics, "Topics must not be null!");
 
-		ReactiveRedisConnection connection = this.connection;
-		if (connection == null) {
-			throw new IllegalStateException("ReactiveRedisMessageListenerContainer is already disposed!");
-		}
-
-		Mono<ReactiveSubscription> subscription = connection.pubSubCommands().createSubscription();
+		verifyConnection();
 
 		ByteBuffer[] patterns = getTargets(topics, PatternTopic.class);
 		ByteBuffer[] channels = getTargets(topics, ChannelTopic.class);
 
-		if (patterns.length == 0 && channels.length == 0) {
-			throw new InvalidDataAccessApiUsageException("No channels or patterns to subscribe");
+		if (ObjectUtils.isEmpty(patterns) && ObjectUtils.isEmpty(channels)) {
+			throw new InvalidDataAccessApiUsageException("No channels or patterns to subscribe to.");
 		}
 
-		return doReceive(channelSerializer, messageSerializer, subscription, patterns, channels);
+		return doReceive(channelSerializer, messageSerializer, connection.pubSubCommands().createSubscription(), patterns,
+				channels);
 	}
 
-	private <C, B> Flux<ChannelMessage<C, B>> doReceive(SerializationPair<C> channelSerializer,
+	private <C, B> Flux<Message<C, B>> doReceive(SerializationPair<C> channelSerializer,
 			SerializationPair<B> messageSerializer, Mono<ReactiveSubscription> subscription, ByteBuffer[] patterns,
 			ByteBuffer[] channels) {
 
-		Flux<ChannelMessage<ByteBuffer, ByteBuffer>> messageStream = subscription.flatMapMany(it -> {
+		Flux<Message<ByteBuffer, ByteBuffer>> messageStream = subscription.flatMapMany(it -> {
 
 			Mono<Void> subscribe = subscribe(patterns, channels, it);
 
@@ -238,15 +237,16 @@ public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 
 	private static Mono<Void> subscribe(ByteBuffer[] patterns, ByteBuffer[] channels, ReactiveSubscription it) {
 
-		Assert.isTrue(channels.length != 0 || patterns.length != 0, "Must provide either channels or patterns!");
+		Assert.isTrue(!ObjectUtils.isEmpty(channels) || !ObjectUtils.isEmpty(patterns),
+				"Must provide either channels or patterns!");
 
 		Mono<Void> subscribe = null;
 
-		if (patterns.length != 0) {
+		if (!ObjectUtils.isEmpty(patterns)) {
 			subscribe = it.pSubscribe(patterns);
 		}
 
-		if (channels.length != 0) {
+		if (!ObjectUtils.isEmpty(channels)) {
 
 			Mono<Void> channelsSubscribe = it.subscribe(channels);
 
@@ -258,6 +258,17 @@ public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 		}
 
 		return subscribe;
+	}
+
+	private boolean isActive() {
+		return connection != null;
+	}
+
+	private void verifyConnection() {
+
+		if (!isActive()) {
+			throw new IllegalStateException("ReactiveRedisMessageListenerContainer is already disposed!");
+		}
 	}
 
 	private Subscribers getSubscribers(ReactiveSubscription it) {
@@ -274,8 +285,8 @@ public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 	}
 
 	@SuppressWarnings("unchecked")
-	private <C, B> ChannelMessage<C, B> readMessage(RedisElementReader<C> channelSerializer,
-			RedisElementReader<B> messageSerializer, ChannelMessage<ByteBuffer, ByteBuffer> message) {
+	private <C, B> Message<C, B> readMessage(RedisElementReader<C> channelSerializer,
+			RedisElementReader<B> messageSerializer, Message<ByteBuffer, ByteBuffer> message) {
 
 		if (message instanceof PatternMessage) {
 
@@ -306,7 +317,7 @@ public class ReactiveRedisMessageListenerContainer implements DisposableBean {
 
 	/**
 	 * Object to track subscriber count and to determine the last unsubscribed subscriber.
-	 * 
+	 *
 	 * @author Mark Paluch
 	 */
 	static class Subscribers {

--- a/src/main/java/org/springframework/data/redis/serializer/DefaultRedisElementReader.java
+++ b/src/main/java/org/springframework/data/redis/serializer/DefaultRedisElementReader.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.nio.ByteBuffer;
 
+import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.lang.Nullable;
 
 /**
@@ -44,9 +45,7 @@ class DefaultRedisElementReader<T> implements RedisElementReader<T> {
 			return (T) buffer;
 		}
 
-		byte[] bytes = new byte[buffer.slice().remaining()];
-		buffer.get(bytes);
-
-		return serializer.deserialize(bytes);
+		return serializer.deserialize(ByteUtils.extractBytes(buffer));
 	}
+
 }

--- a/src/main/java/org/springframework/data/redis/util/ByteUtils.java
+++ b/src/main/java/org/springframework/data/redis/util/ByteUtils.java
@@ -16,6 +16,8 @@
 package org.springframework.data.redis.util;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -202,5 +204,32 @@ public final class ByteUtils {
 		}
 
 		return -1;
+	}
+
+	/**
+	 * Convert a {@link String} into a {@link ByteBuffer} using {@link java.nio.charset.StandardCharsets#UTF_8}.
+	 *
+	 * @param theString must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 */
+	public static ByteBuffer getByteBuffer(String theString) {
+		return getByteBuffer(theString, StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Convert a {@link String} into a {@link ByteBuffer} using the given {@link Charset}.
+	 *
+	 * @param theString must not be {@literal null}.
+	 * @param charset must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 */
+	public static ByteBuffer getByteBuffer(String theString, Charset charset) {
+
+		Assert.notNull(theString, "The String must not be null!");
+		Assert.notNull(charset, "The String must not be null!");
+
+		return charset.encode(theString);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/util/ByteUtils.java
+++ b/src/main/java/org/springframework/data/redis/util/ByteUtils.java
@@ -232,4 +232,21 @@ public final class ByteUtils {
 
 		return charset.encode(theString);
 	}
+
+	/**
+	 * Extract/Transfer bytes from the given {@link ByteBuffer} into an array by duplicating the buffer and fetching its
+	 * content.
+	 *
+	 * @param buffer must not be {@literal null}.
+	 * @return the extracted bytes.
+	 * @since 2.1
+	 */
+	public static byte[] extractBytes(ByteBuffer buffer) {
+
+		ByteBuffer duplicate = buffer.duplicate();
+		byte[] bytes = new byte[duplicate.remaining()];
+		duplicate.get(bytes);
+
+		return bytes;
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
@@ -214,7 +214,6 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 
 		MessageListener listener = (message, pattern) -> {
 			messages.add(message);
-			System.out.println("Received message '" + new String(message.getBody()) + "'");
 		};
 
 		Thread t = new Thread() {
@@ -272,7 +271,6 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 		final MessageListener listener = (message, pattern) -> {
 			assertEquals(expectedPattern, new String(pattern));
 			messages.add(message);
-			System.out.println("Received message '" + new String(message.getBody()) + "'");
 		};
 
 		Thread th = new Thread() {

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSubscriptionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSubscriptionUnitTests.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.data.redis.util.ByteUtils.*;
+
+import io.lettuce.core.RedisConnectionException;
+import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
+import reactor.core.Disposable;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CancellationException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
+import org.springframework.data.redis.connection.ReactiveSubscription.PatternMessage;
+
+/**
+ * Unit tests for {@link LettuceReactiveSubscription}.
+ * 
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LettuceReactiveSubscriptionUnitTests {
+
+	LettuceReactiveSubscription subscription;
+
+	@Mock RedisPubSubReactiveCommands<ByteBuffer, ByteBuffer> commandsMock;
+
+	@Before
+	public void before() {
+		subscription = new LettuceReactiveSubscription(commandsMock, e -> new RedisSystemException(e.getMessage(), e));
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldSubscribeChannels() {
+
+		when(commandsMock.subscribe(any())).thenReturn(Mono.empty());
+
+		Mono<Void> subscribe = subscription.subscribe(getByteBuffer("foo"), getByteBuffer("bar"));
+
+		assertThat(subscription.getChannels()).isEmpty();
+
+		StepVerifier.create(subscribe).verifyComplete();
+
+		assertThat(subscription.getChannels()).containsOnly(getByteBuffer("foo"), getByteBuffer("bar"));
+		assertThat(subscription.getPatterns()).isEmpty();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldSubscribeChannelsShouldFail() {
+
+		when(commandsMock.subscribe(any())).thenReturn(Mono.error(new RedisConnectionException("Foo")));
+
+		Mono<Void> subscribe = subscription.subscribe(getByteBuffer("foo"), getByteBuffer("bar"));
+
+		StepVerifier.create(subscribe).expectError(RedisSystemException.class).verify();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldSubscribePatterns() {
+
+		when(commandsMock.psubscribe(any())).thenReturn(Mono.empty());
+
+		Mono<Void> subscribe = subscription.pSubscribe(getByteBuffer("foo"), getByteBuffer("bar"));
+
+		assertThat(subscription.getPatterns()).isEmpty();
+
+		StepVerifier.create(subscribe).verifyComplete();
+
+		assertThat(subscription.getPatterns()).containsOnly(getByteBuffer("foo"), getByteBuffer("bar"));
+		assertThat(subscription.getChannels()).isEmpty();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldUnsubscribeChannels() {
+
+		when(commandsMock.subscribe(any())).thenReturn(Mono.empty());
+		when(commandsMock.unsubscribe(any())).thenReturn(Mono.empty());
+		StepVerifier.create(subscription.subscribe(getByteBuffer("foo"), getByteBuffer("bar"))).verifyComplete();
+
+		StepVerifier.create(subscription.unsubscribe()).verifyComplete();
+
+		assertThat(subscription.getChannels()).isEmpty();
+		verify(commandsMock).unsubscribe(any());
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldUnsubscribePatterns() {
+
+		when(commandsMock.psubscribe(any())).thenReturn(Mono.empty());
+		when(commandsMock.punsubscribe(any())).thenReturn(Mono.empty());
+		StepVerifier.create(subscription.pSubscribe(getByteBuffer("foo"), getByteBuffer("bar"))).verifyComplete();
+
+		StepVerifier.create(subscription.pUnsubscribe()).verifyComplete();
+
+		assertThat(subscription.getPatterns()).isEmpty();
+		verify(commandsMock).punsubscribe(any());
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldEmitChannelMessage() {
+
+		when(commandsMock.subscribe(any())).thenReturn(Mono.empty());
+		StepVerifier.create(subscription.subscribe(getByteBuffer("foo"), getByteBuffer("bar"))).verifyComplete();
+
+		DirectProcessor<io.lettuce.core.pubsub.api.reactive.ChannelMessage<ByteBuffer, ByteBuffer>> emitter = DirectProcessor
+				.create();
+		when(commandsMock.observeChannels()).thenReturn(emitter);
+		when(commandsMock.observePatterns()).thenReturn(Flux.empty());
+
+		StepVerifier.create(subscription.receive()).then(() -> {
+
+			emitter.onNext(createChannelMessage("other", "body"));
+			emitter.onNext(createChannelMessage("foo", "body"));
+		}).assertNext(msg -> {
+			assertThat(msg.getChannel()).isEqualTo(getByteBuffer("foo"));
+		}).thenCancel().verify();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldEmitPatternMessage() {
+
+		when(commandsMock.psubscribe(any())).thenReturn(Mono.empty());
+		StepVerifier.create(subscription.pSubscribe(getByteBuffer("foo*"), getByteBuffer("bar*"))).verifyComplete();
+
+		DirectProcessor<io.lettuce.core.pubsub.api.reactive.PatternMessage<ByteBuffer, ByteBuffer>> emitter = DirectProcessor
+				.create();
+		when(commandsMock.observeChannels()).thenReturn(Flux.empty());
+		when(commandsMock.observePatterns()).thenReturn(emitter);
+
+		StepVerifier.create(subscription.receive()).then(() -> {
+
+			emitter.onNext(createPatternMessage("other*", "channel", "body"));
+			emitter.onNext(createPatternMessage("foo*", "foo", "body"));
+		}).assertNext(msg -> {
+
+			assertThat(((PatternMessage) msg).getPattern()).isEqualTo(getByteBuffer("foo*"));
+			assertThat(msg.getChannel()).isEqualTo(getByteBuffer("foo"));
+		}).thenCancel().verify();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldEmitError() {
+
+		when(commandsMock.subscribe(any())).thenReturn(Mono.empty());
+		StepVerifier.create(subscription.subscribe(getByteBuffer("foo"), getByteBuffer("bar"))).verifyComplete();
+
+		DirectProcessor<io.lettuce.core.pubsub.api.reactive.ChannelMessage<ByteBuffer, ByteBuffer>> emitter = DirectProcessor
+				.create();
+		when(commandsMock.observeChannels()).thenReturn(emitter);
+		when(commandsMock.observePatterns()).thenReturn(Flux.empty());
+
+		StepVerifier.create(subscription.receive()).then(() -> {
+
+			emitter.onError(new RedisConnectionException("foo"));
+		}).expectError(RedisSystemException.class).verify();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldTerminateActiveSubscriptions() {
+
+		when(commandsMock.psubscribe(any())).thenReturn(Mono.empty());
+		when(commandsMock.punsubscribe(any())).thenReturn(Mono.empty());
+		StepVerifier.create(subscription.pSubscribe(getByteBuffer("foo*"))).verifyComplete();
+
+		when(commandsMock.observeChannels()).thenReturn(Flux.never());
+		when(commandsMock.observePatterns()).thenReturn(Flux.never());
+
+		StepVerifier.create(subscription.receive()).then(() -> {
+			subscription.terminate().subscribe();
+		}).expectError(CancellationException.class).verify();
+
+		assertThat(subscription.getPatterns()).isEmpty();
+	}
+
+	@Test // DATAREDIS-612
+	public void cancelledSubscriptionShouldUnregisterDownstream() {
+
+		DirectProcessor<io.lettuce.core.pubsub.api.reactive.PatternMessage<ByteBuffer, ByteBuffer>> emitter = DirectProcessor
+				.create();
+
+		when(commandsMock.psubscribe(any())).thenReturn(Mono.empty());
+		StepVerifier.create(subscription.pSubscribe(getByteBuffer("foo*"))).verifyComplete();
+
+		when(commandsMock.observeChannels()).thenReturn(Flux.never());
+		when(commandsMock.observePatterns()).thenReturn(emitter);
+
+		Flux<ChannelMessage<ByteBuffer, ByteBuffer>> receive = subscription.receive();
+		Disposable subscribe = receive.subscribe();
+
+		assertThat(emitter.downstreamCount()).isEqualTo(1);
+
+		subscribe.dispose();
+		assertThat(emitter.downstreamCount()).isEqualTo(0);
+	}
+
+	private static io.lettuce.core.pubsub.api.reactive.ChannelMessage<ByteBuffer, ByteBuffer> createChannelMessage(
+			String channel, String body) {
+		return new io.lettuce.core.pubsub.api.reactive.ChannelMessage<>(getByteBuffer(channel), getByteBuffer(body));
+	}
+
+	private static io.lettuce.core.pubsub.api.reactive.PatternMessage<ByteBuffer, ByteBuffer> createPatternMessage(
+			String pattern, String channel, String body) {
+		return new io.lettuce.core.pubsub.api.reactive.PatternMessage<>(getByteBuffer(pattern), getByteBuffer(channel),
+				getByteBuffer(body));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSubscriptionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSubscriptionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,13 +37,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.redis.RedisSystemException;
-import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
+import org.springframework.data.redis.connection.ReactiveSubscription.Message;
 import org.springframework.data.redis.connection.ReactiveSubscription.PatternMessage;
 
 /**
  * Unit tests for {@link LettuceReactiveSubscription}.
- * 
+ *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @RunWith(MockitoJUnitRunner.class)
 public class LettuceReactiveSubscriptionUnitTests {
@@ -193,7 +194,7 @@ public class LettuceReactiveSubscriptionUnitTests {
 		when(commandsMock.observePatterns()).thenReturn(Flux.never());
 
 		StepVerifier.create(subscription.receive()).then(() -> {
-			subscription.terminate().subscribe();
+			subscription.cancel().subscribe();
 		}).expectError(CancellationException.class).verify();
 
 		assertThat(subscription.getPatterns()).isEmpty();
@@ -211,7 +212,7 @@ public class LettuceReactiveSubscriptionUnitTests {
 		when(commandsMock.observeChannels()).thenReturn(Flux.never());
 		when(commandsMock.observePatterns()).thenReturn(emitter);
 
-		Flux<ChannelMessage<ByteBuffer, ByteBuffer>> receive = subscription.receive();
+		Flux<Message<ByteBuffer, ByteBuffer>> receive = subscription.receive();
 		Disposable subscribe = receive.subscribe();
 
 		assertThat(emitter.downstreamCount()).isEqualTo(1);
@@ -221,13 +222,15 @@ public class LettuceReactiveSubscriptionUnitTests {
 	}
 
 	private static io.lettuce.core.pubsub.api.reactive.ChannelMessage<ByteBuffer, ByteBuffer> createChannelMessage(
-			String channel, String body) {
-		return new io.lettuce.core.pubsub.api.reactive.ChannelMessage<>(getByteBuffer(channel), getByteBuffer(body));
+			String channel, String message) {
+
+		return new io.lettuce.core.pubsub.api.reactive.ChannelMessage<>(getByteBuffer(channel), getByteBuffer(message));
 	}
 
 	private static io.lettuce.core.pubsub.api.reactive.PatternMessage<ByteBuffer, ByteBuffer> createPatternMessage(
-			String pattern, String channel, String body) {
+			String pattern, String channel, String message) {
+
 		return new io.lettuce.core.pubsub.api.reactive.PatternMessage<>(getByteBuffer(pattern), getByteBuffer(channel),
-				getByteBuffer(body));
+				getByteBuffer(message));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
@@ -39,6 +39,9 @@ import org.springframework.data.redis.Person;
 import org.springframework.data.redis.PersonObjectFactory;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.ReactiveRedisClusterConnection;
+import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
+import org.springframework.data.redis.connection.ReactiveSubscription.Message;
+import org.springframework.data.redis.connection.ReactiveSubscription.PatternMessage;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
@@ -385,5 +388,50 @@ public class ReactiveRedisTemplateIntegrationTests<K, V> {
 		StepVerifier.create(hashOperations.put(key, hashField, hashValue)).expectNext(true).verifyComplete();
 
 		StepVerifier.create(hashOperations.get(key, hashField)).expectNext(hashValue).verifyComplete();
+	}
+
+	@Test // DATAREDIS-612
+	public void listenToChannelShouldReceiveChannelMessagesCorrectly() throws InterruptedException {
+
+		String channel = "my-channel";
+
+		V message = valueFactory.instance();
+
+		StepVerifier.create(redisTemplate.listenToChannel(channel)) //
+				.thenAwait(Duration.ofMillis(500)) // just make sure we the subscription completed
+				.then(() -> redisTemplate.convertAndSend(channel, message).block()) //
+				.assertNext(received -> {
+
+					assertThat(received).isInstanceOf(ChannelMessage.class);
+					assertThat(received.getMessage()).isEqualTo(message);
+					assertThat(received.getChannel()).isEqualTo(channel);
+				}) //
+				.thenAwait(Duration.ofMillis(10)) //
+				.thenCancel() //
+				.verify(Duration.ofSeconds(3));
+	}
+
+	@Test // DATAREDIS-612
+	public void listenToChannelPatternShouldReceiveChannelMessagesCorrectly() throws InterruptedException {
+
+		String channel = "my-channel";
+		String pattern = "my-*";
+
+		V message = valueFactory.instance();
+
+		Flux<? extends Message<String, V>> stream = redisTemplate.listenToPattern(pattern);
+
+		StepVerifier.create(stream) //
+				.thenAwait(Duration.ofMillis(500)) // just make sure we the subscription completed
+				.then(() -> redisTemplate.convertAndSend(channel, message).block()) //
+				.assertNext(received -> {
+
+					assertThat(received).isInstanceOf(PatternMessage.class);
+					assertThat(received.getMessage()).isEqualTo(message);
+					assertThat(received.getChannel()).isEqualTo(channel);
+					assertThat(((PatternMessage) received).getPattern()).isEqualTo(pattern);
+				}) //
+				.thenCancel() //
+				.verify(Duration.ofSeconds(3));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/listener/ReactiveOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/listener/ReactiveOperationsTestParams.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.listener;
+
+import static org.springframework.data.redis.connection.ClusterTestVariables.*;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runners.model.Statement;
+import org.springframework.data.redis.SettingsUtils;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisClusterNode;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
+import org.springframework.data.redis.test.util.RedisClusterRule;
+
+/**
+ * Parameters for testing implementations of {@link ReactiveRedisMessageListenerContainer}
+ *
+ * @author Mark Paluch
+ */
+class ReactiveOperationsTestParams {
+
+	public static Collection<Object[]> testParams() {
+
+		LettuceClientConfiguration clientConfiguration = LettuceClientConfiguration.builder() //
+				.shutdownTimeout(Duration.ZERO) //
+				.clientResources(LettuceTestClientResources.getSharedClientResources()) //
+				.build();
+
+		LettucePoolingClientConfiguration poolingConfiguration = LettucePoolingClientConfiguration.builder() //
+				.shutdownTimeout(Duration.ZERO) //
+				.clientResources(LettuceTestClientResources.getSharedClientResources()) //
+				.build();
+
+		RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration(SettingsUtils.getHost(),
+				SettingsUtils.getPort());
+
+		LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(standaloneConfiguration,
+				clientConfiguration);
+		lettuceConnectionFactory.afterPropertiesSet();
+
+		LettuceConnectionFactory poolingConnectionFactory = new LettuceConnectionFactory(standaloneConfiguration,
+				poolingConfiguration);
+		poolingConnectionFactory.afterPropertiesSet();
+
+		List<Object[]> list = Arrays.asList(new Object[][] { //
+				{ lettuceConnectionFactory, "Standalone" }, //
+				{ poolingConnectionFactory, "Pooled" }, //
+		});
+
+		if (clusterAvailable()) {
+
+			RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration();
+			clusterConfiguration.addClusterNode(new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_1_PORT));
+
+			LettuceConnectionFactory lettuceClusterConnectionFactory = new LettuceConnectionFactory(clusterConfiguration,
+					clientConfiguration);
+			lettuceClusterConnectionFactory.afterPropertiesSet();
+
+			list = new ArrayList<>(list);
+			list.add(new Object[] { lettuceClusterConnectionFactory, "Cluster" });
+		}
+
+		return list;
+	}
+
+	private static boolean clusterAvailable() {
+
+		try {
+			new RedisClusterRule().apply(new Statement() {
+				@Override
+				public void evaluate() {
+
+				}
+			}, null).evaluate();
+		} catch (Throwable throwable) {
+			return false;
+		}
+		return true;
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerIntegrationTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.listener;
+
+import static org.assertj.core.api.Assertions.*;
+
+import reactor.core.Disposable;
+import reactor.test.StepVerifier;
+
+import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.data.redis.ConnectionFactoryTracker;
+import org.springframework.data.redis.connection.ReactiveSubscription;
+import org.springframework.data.redis.connection.ReactiveSubscription.PatternMessage;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.lang.Nullable;
+
+/**
+ * Integration tests for {@link ReactiveRedisMessageListenerContainer} via Lettuce.
+ * 
+ * @author Mark Paluch
+ */
+@RunWith(Parameterized.class)
+public class ReactiveRedisMessageListenerContainerIntegrationTests {
+
+	static final String CHANNEL1 = "my-channel";
+	static final String PATTERN1 = "my-chan*";
+	public static final String MESSAGE = "hello world";
+
+	private final LettuceConnectionFactory connectionFactory;
+	private @Nullable RedisConnection connection;
+
+	@Parameters(name = "{1}")
+	public static Collection<Object[]> testParams() {
+		return ReactiveOperationsTestParams.testParams();
+	}
+
+	@AfterClass
+	public static void cleanUp() {
+		ConnectionFactoryTracker.cleanUp();
+	}
+
+	/**
+	 * @param connectionFactory
+	 * @param label parameterized test label, no further use besides that.
+	 */
+	public ReactiveRedisMessageListenerContainerIntegrationTests(LettuceConnectionFactory connectionFactory,
+			String label) {
+
+		this.connectionFactory = connectionFactory;
+		ConnectionFactoryTracker.add(connectionFactory);
+	}
+
+	@Before
+	public void before() {
+		connection = connectionFactory.getConnection();
+	}
+
+	@After
+	public void tearDown() {
+
+		if (connection != null) {
+			connection.close();
+		}
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldReceiveChannelMessages() {
+
+		ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(connectionFactory);
+
+		StepVerifier.create(container.receive(new ChannelTopic(CHANNEL1))) //
+				.then(awaitSubscription(container::getActiveSubscriptions))
+				.then(() -> connection.publish(CHANNEL1.getBytes(), MESSAGE.getBytes())) //
+				.assertNext(c -> {
+
+					assertThat(c.getChannel()).isEqualTo(CHANNEL1);
+					assertThat(c.getMessage()).isEqualTo(MESSAGE);
+				}) //
+				.thenCancel().verify();
+
+		container.destroy();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldReceivePatternMessages() {
+
+		ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(connectionFactory);
+
+		StepVerifier.create(container.receive(new PatternTopic(PATTERN1))) //
+				.then(awaitSubscription(container::getActiveSubscriptions))
+				.then(() -> connection.publish(CHANNEL1.getBytes(), MESSAGE.getBytes())) //
+				.assertNext(c -> {
+
+					assertThat(c.getPattern()).isEqualTo(PATTERN1);
+					assertThat(c.getChannel()).isEqualTo(CHANNEL1);
+					assertThat(c.getMessage()).isEqualTo(MESSAGE);
+				}) //
+				.thenCancel().verify();
+
+		container.destroy();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldPublishAndReceiveMessage() throws InterruptedException {
+
+		ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(connectionFactory);
+		ReactiveRedisTemplate<String, String> template = new ReactiveRedisTemplate<>(connectionFactory,
+				RedisSerializationContext.string());
+
+		BlockingQueue<PatternMessage<String, String, String>> messages = new LinkedBlockingDeque<>();
+		Disposable subscription = container.receive(new PatternTopic(PATTERN1)).doOnNext(messages::add).subscribe();
+
+		StepVerifier.create(template.convertAndSend(CHANNEL1, MESSAGE), 0) //
+				.then(awaitSubscription(container::getActiveSubscriptions)) //
+				.thenRequest(1).expectNextCount(1) //
+				.verifyComplete();
+
+		PatternMessage<String, String, String> message = messages.poll(1, TimeUnit.SECONDS);
+
+		assertThat(message).isNotNull();
+		assertThat(message.getPattern()).isEqualTo(PATTERN1);
+		assertThat(message.getChannel()).isEqualTo(CHANNEL1);
+		assertThat(message.getMessage()).isEqualTo(MESSAGE);
+
+		subscription.dispose();
+		container.destroy();
+	}
+
+	private static Runnable awaitSubscription(Supplier<Collection<ReactiveSubscription>> activeSubscriptions) {
+
+		return () -> {
+
+			try {
+
+				while (activeSubscriptions.get().isEmpty()) {
+					Thread.sleep(10);
+				}
+
+			} catch (InterruptedException e) {
+				return;
+			}
+		};
+	}
+}

--- a/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerIntegrationTests.java
@@ -96,7 +96,7 @@ public class ReactiveRedisMessageListenerContainerIntegrationTests {
 
 		ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(connectionFactory);
 
-		StepVerifier.create(container.receive(new ChannelTopic(CHANNEL1))) //
+		StepVerifier.create(container.receive(ChannelTopic.of(CHANNEL1))) //
 				.then(awaitSubscription(container::getActiveSubscriptions))
 				.then(() -> connection.publish(CHANNEL1.getBytes(), MESSAGE.getBytes())) //
 				.assertNext(c -> {
@@ -114,7 +114,7 @@ public class ReactiveRedisMessageListenerContainerIntegrationTests {
 
 		ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(connectionFactory);
 
-		StepVerifier.create(container.receive(new PatternTopic(PATTERN1))) //
+		StepVerifier.create(container.receive(PatternTopic.of(PATTERN1))) //
 				.then(awaitSubscription(container::getActiveSubscriptions))
 				.then(() -> connection.publish(CHANNEL1.getBytes(), MESSAGE.getBytes())) //
 				.assertNext(c -> {
@@ -136,7 +136,7 @@ public class ReactiveRedisMessageListenerContainerIntegrationTests {
 				RedisSerializationContext.string());
 
 		BlockingQueue<PatternMessage<String, String, String>> messages = new LinkedBlockingDeque<>();
-		Disposable subscription = container.receive(new PatternTopic(PATTERN1)).doOnNext(messages::add).subscribe();
+		Disposable subscription = container.receive(PatternTopic.of(PATTERN1)).doOnNext(messages::add).subscribe();
 
 		StepVerifier.create(template.convertAndSend(CHANNEL1, MESSAGE), 0) //
 				.then(awaitSubscription(container::getActiveSubscriptions)) //

--- a/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerUnitTests.java
@@ -74,7 +74,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 
 		container = createContainer();
 
-		StepVerifier.create(container.receive(new PatternTopic("foo*"))).thenAwait().thenCancel().verify();
+		StepVerifier.create(container.receive(PatternTopic.of("foo*"))).thenAwait().thenCancel().verify();
 
 		verify(subscriptionMock).pSubscribe(getByteBuffer("foo*"));
 	}
@@ -85,7 +85,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(Flux.never());
 		container = createContainer();
 
-		StepVerifier.create(container.receive(new PatternTopic("foo*"), new PatternTopic("bar*"))).thenRequest(1)
+		StepVerifier.create(container.receive(PatternTopic.of("foo*"), PatternTopic.of("bar*"))).thenRequest(1)
 				.thenAwait().thenCancel().verify();
 
 		verify(subscriptionMock).pSubscribe(getByteBuffer("foo*"), getByteBuffer("bar*"));
@@ -97,7 +97,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(Flux.never());
 		container = createContainer();
 
-		StepVerifier.create(container.receive(new ChannelTopic("foo"))).thenAwait().thenCancel().verify();
+		StepVerifier.create(container.receive(ChannelTopic.of("foo"))).thenAwait().thenCancel().verify();
 
 		verify(subscriptionMock).subscribe(getByteBuffer("foo"));
 	}
@@ -108,7 +108,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(Flux.never());
 		container = createContainer();
 
-		StepVerifier.create(container.receive(new ChannelTopic("foo"), new ChannelTopic("bar"))).thenAwait().thenCancel()
+		StepVerifier.create(container.receive(ChannelTopic.of("foo"), ChannelTopic.of("bar"))).thenAwait().thenCancel()
 				.verify();
 
 		verify(subscriptionMock).subscribe(getByteBuffer("foo"), getByteBuffer("bar"));
@@ -122,7 +122,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(processor);
 		container = createContainer();
 
-		Flux<ChannelMessage<String, String>> messageStream = container.receive(new ChannelTopic("foo"));
+		Flux<ChannelMessage<String, String>> messageStream = container.receive(ChannelTopic.of("foo"));
 
 		StepVerifier.create(messageStream).then(() -> {
 			processor.onNext(createChannelMessage("foo", "message"));
@@ -141,7 +141,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(processor);
 		container = createContainer();
 
-		Flux<PatternMessage<String, String, String>> messageStream = container.receive(new PatternTopic("foo*"));
+		Flux<PatternMessage<String, String, String>> messageStream = container.receive(PatternTopic.of("foo*"));
 
 		StepVerifier.create(messageStream).then(() -> {
 			processor.onNext(createPatternMessage("foo*", "foo", "message"));
@@ -164,7 +164,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(DirectProcessor.create());
 		container = createContainer();
 
-		Flux<ChannelMessage<String, String>> messageStream = container.receive(new ChannelTopic("foo*"));
+		Flux<ChannelMessage<String, String>> messageStream = container.receive(ChannelTopic.of("foo*"));
 
 		Disposable subscription = messageStream.subscribe();
 
@@ -206,7 +206,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(DirectProcessor.create());
 		container = createContainer();
 
-		Flux<PatternMessage<String, String, String>> messageStream = container.receive(new PatternTopic("foo*"));
+		Flux<PatternMessage<String, String, String>> messageStream = container.receive(PatternTopic.of("foo*"));
 
 		StepVerifier.create(messageStream).then(() -> {
 
@@ -230,7 +230,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		}));
 		container = createContainer();
 
-		Flux<PatternMessage<String, String, String>> messageStream = container.receive(new PatternTopic("foo*"));
+		Flux<PatternMessage<String, String, String>> messageStream = container.receive(PatternTopic.of("foo*"));
 
 		StepVerifier.create(messageStream).then(() -> {
 			container.destroy();
@@ -245,7 +245,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(processor);
 		container = createContainer();
 
-		Flux<PatternMessage<String, String, String>> messageStream = container.receive(new PatternTopic("foo*"));
+		Flux<PatternMessage<String, String, String>> messageStream = container.receive(PatternTopic.of("foo*"));
 
 		StepVerifier.create(messageStream).then(() -> {
 			assertThat(processor.hasDownstreams()).isTrue();

--- a/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerUnitTests.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.redis.util.ByteUtils.*;
 
+import org.springframework.data.redis.connection.ReactiveSubscription.Message;
 import reactor.core.Disposable;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
@@ -34,9 +35,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.redis.connection.ReactivePubSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
-import org.springframework.data.redis.connection.ReactiveRedisPubSubCommands;
 import org.springframework.data.redis.connection.ReactiveSubscription;
 import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
 import org.springframework.data.redis.connection.ReactiveSubscription.PatternMessage;
@@ -53,7 +54,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 
 	@Mock ReactiveRedisConnectionFactory connectionFactoryMock;
 	@Mock ReactiveRedisConnection connectionMock;
-	@Mock ReactiveRedisPubSubCommands commandsMock;
+	@Mock ReactivePubSubCommands commandsMock;
 	@Mock ReactiveSubscription subscriptionMock;
 
 	@Before
@@ -61,6 +62,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 
 		when(connectionFactoryMock.getReactiveConnection()).thenReturn(connectionMock);
 		when(connectionMock.pubSubCommands()).thenReturn(commandsMock);
+		when(connectionMock.closeLater()).thenReturn(Mono.empty());
 		when(commandsMock.createSubscription()).thenReturn(Mono.just(subscriptionMock));
 		when(subscriptionMock.subscribe(any())).thenReturn(Mono.empty());
 		when(subscriptionMock.pSubscribe(any())).thenReturn(Mono.empty());
@@ -85,8 +87,8 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(Flux.never());
 		container = createContainer();
 
-		StepVerifier.create(container.receive(PatternTopic.of("foo*"), PatternTopic.of("bar*"))).thenRequest(1)
-				.thenAwait().thenCancel().verify();
+		StepVerifier.create(container.receive(PatternTopic.of("foo*"), PatternTopic.of("bar*"))).thenRequest(1).thenAwait()
+				.thenCancel().verify();
 
 		verify(subscriptionMock).pSubscribe(getByteBuffer("foo*"), getByteBuffer("bar*"));
 	}
@@ -117,12 +119,12 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 	@Test // DATAREDIS-612
 	public void shouldEmitChannelMessage() {
 
-		DirectProcessor<ChannelMessage<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
+		DirectProcessor<Message<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
 
 		when(subscriptionMock.receive()).thenReturn(processor);
 		container = createContainer();
 
-		Flux<ChannelMessage<String, String>> messageStream = container.receive(ChannelTopic.of("foo"));
+		Flux<Message<String, String>> messageStream = container.receive(ChannelTopic.of("foo"));
 
 		StepVerifier.create(messageStream).then(() -> {
 			processor.onNext(createChannelMessage("foo", "message"));
@@ -136,7 +138,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 	@Test // DATAREDIS-612
 	public void shouldEmitPatternMessage() {
 
-		DirectProcessor<ChannelMessage<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
+		DirectProcessor<Message<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
 
 		when(subscriptionMock.receive()).thenReturn(processor);
 		container = createContainer();
@@ -164,7 +166,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(DirectProcessor.create());
 		container = createContainer();
 
-		Flux<ChannelMessage<String, String>> messageStream = container.receive(ChannelTopic.of("foo*"));
+		Flux<Message<String, String>> messageStream = container.receive(ChannelTopic.of("foo*"));
 
 		Disposable subscription = messageStream.subscribe();
 
@@ -184,7 +186,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 		when(subscriptionMock.receive()).thenReturn(DirectProcessor.create());
 		container = createContainer();
 
-		Flux<ChannelMessage<String, String>> messageStream = container.receive(new ChannelTopic("foo*"));
+		Flux<Message<String, String>> messageStream = container.receive(new ChannelTopic("foo*"));
 
 		Disposable first = messageStream.subscribe();
 		Disposable second = messageStream.subscribe();
@@ -220,10 +222,10 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 	@Test // DATAREDIS-612
 	public void shouldTerminateSubscriptionsOnShutdown() {
 
-		DirectProcessor<ChannelMessage<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
+		DirectProcessor<Message<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
 
 		when(subscriptionMock.receive()).thenReturn(processor);
-		when(subscriptionMock.terminate()).thenReturn(Mono.defer(() -> {
+		when(subscriptionMock.cancel()).thenReturn(Mono.defer(() -> {
 
 			processor.onError(new CancellationException());
 			return Mono.empty();
@@ -240,7 +242,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 	@Test // DATAREDIS-612
 	public void shouldCleanupDownstream() {
 
-		DirectProcessor<ChannelMessage<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
+		DirectProcessor<Message<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
 
 		when(subscriptionMock.receive()).thenReturn(processor);
 		container = createContainer();
@@ -265,6 +267,7 @@ public class ReactiveRedisMessageListenerContainerUnitTests {
 
 	private static PatternMessage<ByteBuffer, ByteBuffer, ByteBuffer> createPatternMessage(String pattern, String channel,
 			String body) {
+
 		return new PatternMessage<>(getByteBuffer(pattern), getByteBuffer(channel), getByteBuffer(body));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerUnitTests.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.listener;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.data.redis.util.ByteUtils.*;
+
+import reactor.core.Disposable;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoProcessor;
+import reactor.test.StepVerifier;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CancellationException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.ReactiveRedisPubSubCommands;
+import org.springframework.data.redis.connection.ReactiveSubscription;
+import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
+import org.springframework.data.redis.connection.ReactiveSubscription.PatternMessage;
+
+/**
+ * Unit tests for {@link ReactiveRedisMessageListenerContainer}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ReactiveRedisMessageListenerContainerUnitTests {
+
+	ReactiveRedisMessageListenerContainer container;
+
+	@Mock ReactiveRedisConnectionFactory connectionFactoryMock;
+	@Mock ReactiveRedisConnection connectionMock;
+	@Mock ReactiveRedisPubSubCommands commandsMock;
+	@Mock ReactiveSubscription subscriptionMock;
+
+	@Before
+	public void before() {
+
+		when(connectionFactoryMock.getReactiveConnection()).thenReturn(connectionMock);
+		when(connectionMock.pubSubCommands()).thenReturn(commandsMock);
+		when(commandsMock.createSubscription()).thenReturn(Mono.just(subscriptionMock));
+		when(subscriptionMock.subscribe(any())).thenReturn(Mono.empty());
+		when(subscriptionMock.pSubscribe(any())).thenReturn(Mono.empty());
+		when(subscriptionMock.unsubscribe()).thenReturn(Mono.empty());
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldSubscribeToPattern() {
+
+		when(subscriptionMock.receive()).thenReturn(Flux.never());
+
+		container = createContainer();
+
+		StepVerifier.create(container.receive(new PatternTopic("foo*"))).thenAwait().thenCancel().verify();
+
+		verify(subscriptionMock).pSubscribe(getByteBuffer("foo*"));
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldSubscribeToMultiplePatterns() {
+
+		when(subscriptionMock.receive()).thenReturn(Flux.never());
+		container = createContainer();
+
+		StepVerifier.create(container.receive(new PatternTopic("foo*"), new PatternTopic("bar*"))).thenRequest(1)
+				.thenAwait().thenCancel().verify();
+
+		verify(subscriptionMock).pSubscribe(getByteBuffer("foo*"), getByteBuffer("bar*"));
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldSubscribeToChannel() {
+
+		when(subscriptionMock.receive()).thenReturn(Flux.never());
+		container = createContainer();
+
+		StepVerifier.create(container.receive(new ChannelTopic("foo"))).thenAwait().thenCancel().verify();
+
+		verify(subscriptionMock).subscribe(getByteBuffer("foo"));
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldSubscribeToMultipleChannels() {
+
+		when(subscriptionMock.receive()).thenReturn(Flux.never());
+		container = createContainer();
+
+		StepVerifier.create(container.receive(new ChannelTopic("foo"), new ChannelTopic("bar"))).thenAwait().thenCancel()
+				.verify();
+
+		verify(subscriptionMock).subscribe(getByteBuffer("foo"), getByteBuffer("bar"));
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldEmitChannelMessage() {
+
+		DirectProcessor<ChannelMessage<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
+
+		when(subscriptionMock.receive()).thenReturn(processor);
+		container = createContainer();
+
+		Flux<ChannelMessage<String, String>> messageStream = container.receive(new ChannelTopic("foo"));
+
+		StepVerifier.create(messageStream).then(() -> {
+			processor.onNext(createChannelMessage("foo", "message"));
+		}).assertNext(msg -> {
+
+			assertThat(msg.getChannel()).isEqualTo("foo");
+			assertThat(msg.getMessage()).isEqualTo("message");
+		}).thenCancel().verify();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldEmitPatternMessage() {
+
+		DirectProcessor<ChannelMessage<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
+
+		when(subscriptionMock.receive()).thenReturn(processor);
+		container = createContainer();
+
+		Flux<PatternMessage<String, String, String>> messageStream = container.receive(new PatternTopic("foo*"));
+
+		StepVerifier.create(messageStream).then(() -> {
+			processor.onNext(createPatternMessage("foo*", "foo", "message"));
+		}).assertNext(msg -> {
+
+			assertThat(msg.getPattern()).isEqualTo("foo*");
+			assertThat(msg.getChannel()).isEqualTo("foo");
+			assertThat(msg.getMessage()).isEqualTo("message");
+		}).thenCancel().verify();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldRegisterSubscription() {
+
+		MonoProcessor<Void> subscribeMono = MonoProcessor.create();
+
+		reset(subscriptionMock);
+		when(subscriptionMock.subscribe(any())).thenReturn(subscribeMono);
+		when(subscriptionMock.unsubscribe()).thenReturn(Mono.empty());
+		when(subscriptionMock.receive()).thenReturn(DirectProcessor.create());
+		container = createContainer();
+
+		Flux<ChannelMessage<String, String>> messageStream = container.receive(new ChannelTopic("foo*"));
+
+		Disposable subscription = messageStream.subscribe();
+
+		assertThat(container.getActiveSubscriptions()).isEmpty();
+		subscribeMono.onComplete();
+		assertThat(container.getActiveSubscriptions()).isNotEmpty();
+		subscription.dispose();
+		assertThat(container.getActiveSubscriptions()).isEmpty();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldRegisterSubscriptionMultipleSubscribers() {
+
+		reset(subscriptionMock);
+		when(subscriptionMock.subscribe(any())).thenReturn(Mono.empty());
+		when(subscriptionMock.unsubscribe()).thenReturn(Mono.empty());
+		when(subscriptionMock.receive()).thenReturn(DirectProcessor.create());
+		container = createContainer();
+
+		Flux<ChannelMessage<String, String>> messageStream = container.receive(new ChannelTopic("foo*"));
+
+		Disposable first = messageStream.subscribe();
+		Disposable second = messageStream.subscribe();
+
+		first.dispose();
+
+		verify(subscriptionMock, never()).unsubscribe();
+		assertThat(container.getActiveSubscriptions()).isNotEmpty();
+
+		second.dispose();
+
+		verify(subscriptionMock).unsubscribe();
+		assertThat(container.getActiveSubscriptions()).isEmpty();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldUnsubscribeOnCancel() {
+
+		when(subscriptionMock.receive()).thenReturn(DirectProcessor.create());
+		container = createContainer();
+
+		Flux<PatternMessage<String, String, String>> messageStream = container.receive(new PatternTopic("foo*"));
+
+		StepVerifier.create(messageStream).then(() -> {
+
+			// Then required to trigger cancel.
+
+		}).thenCancel().verify();
+
+		verify(subscriptionMock).unsubscribe();
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldTerminateSubscriptionsOnShutdown() {
+
+		DirectProcessor<ChannelMessage<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
+
+		when(subscriptionMock.receive()).thenReturn(processor);
+		when(subscriptionMock.terminate()).thenReturn(Mono.defer(() -> {
+
+			processor.onError(new CancellationException());
+			return Mono.empty();
+		}));
+		container = createContainer();
+
+		Flux<PatternMessage<String, String, String>> messageStream = container.receive(new PatternTopic("foo*"));
+
+		StepVerifier.create(messageStream).then(() -> {
+			container.destroy();
+		}).verifyError(CancellationException.class);
+	}
+
+	@Test // DATAREDIS-612
+	public void shouldCleanupDownstream() {
+
+		DirectProcessor<ChannelMessage<ByteBuffer, ByteBuffer>> processor = DirectProcessor.create();
+
+		when(subscriptionMock.receive()).thenReturn(processor);
+		container = createContainer();
+
+		Flux<PatternMessage<String, String, String>> messageStream = container.receive(new PatternTopic("foo*"));
+
+		StepVerifier.create(messageStream).then(() -> {
+			assertThat(processor.hasDownstreams()).isTrue();
+			processor.onNext(createPatternMessage("foo*", "foo", "message"));
+		}).expectNextCount(1).thenCancel().verify();
+
+		assertThat(processor.hasDownstreams()).isFalse();
+	}
+
+	private ReactiveRedisMessageListenerContainer createContainer() {
+		return new ReactiveRedisMessageListenerContainer(connectionFactoryMock);
+	}
+
+	private static ChannelMessage<ByteBuffer, ByteBuffer> createChannelMessage(String channel, String body) {
+		return new ChannelMessage<>(getByteBuffer(channel), getByteBuffer(body));
+	}
+
+	private static PatternMessage<ByteBuffer, ByteBuffer, ByteBuffer> createPatternMessage(String pattern, String channel,
+			String body) {
+		return new PatternMessage<>(getByteBuffer(pattern), getByteBuffer(channel), getByteBuffer(body));
+	}
+}


### PR DESCRIPTION
We now provide sending and receiving of Redis Pub/Sub messages with reactive connections. Messages can be sent with `ReactiveRedisTemplate` and received as infinite stream through ReactiveRedisMessageListenerContainer. `ReactiveRedisMessageListenerContainer` uses a single connection to multiplex different subscriptions.

Reactive Pub/Sub supports Standalone, Sentinel and Redis Cluster setups.

```java
ReactiveRedisConnectionFactory factory = …;

ReactiveRedisTemplate<String, String> template = new ReactiveRedisTemplate<>(factory, RedisSerializationContext.string());
Mono<Long> publish = template.convertAndSend("hello!", "world");

ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(factory);
Flux<ChannelMessage<String, String>> channelMessages = container.receive(ChannelTopic.of("foo"));
Flux<PatternMessage<String, String, String>> patternMessages = container.receive(PatternTopic.of("foo"));

//
container.destroy();
```

Also, provide static factory methods for `PatternTopic` and `ChannelTopic`.

---

Related ticket: [DATAREDIS-612](https://jira.spring.io/browse/DATAREDIS-612).