### PR TITLE
 DATAREDIS-635 - Add keyspace scanning using Redis Cluster.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-635-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -8,6 +8,7 @@ New and noteworthy in the latest releases.
 
 * Unix domain socket connections using <<redis:connectors:lettuce,Lettuce>>.
 * <<redis:write-to-master-read-from-slave, Write to Master read from Slave>> support using Lettuce.
+* Cluster-wide `SCAN` using Lettuce and `SCAN` execution on a selected node supported by both drivers.
 
 [[new-in-2.0.0]]
 == New in Spring Data Redis 2.0

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConnection.java
@@ -18,6 +18,8 @@ package org.springframework.data.redis.connection;
 import java.util.Collection;
 import java.util.Set;
 
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.lang.Nullable;
 
 /**
@@ -48,6 +50,17 @@ public interface RedisClusterConnection extends RedisConnection, RedisClusterCom
 	 */
 	@Nullable
 	Set<byte[]> keys(RedisClusterNode node, byte[] pattern);
+
+	/**
+	 * Use a {@link Cursor} to iterate over keys.
+	 *
+	 * @param node must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 */
+	Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options);
 
 	/**
 	 * @param node must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -48,6 +48,8 @@ import org.springframework.data.redis.connection.ClusterCommandExecutor.MultiKey
 import org.springframework.data.redis.connection.ClusterCommandExecutor.NodeResult;
 import org.springframework.data.redis.connection.RedisClusterNode.SlotRange;
 import org.springframework.data.redis.connection.convert.Converters;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.util.DirectFieldAccessFallbackBeanWrapper;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -304,9 +306,22 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 		return new JedisClusterKeyCommands(this);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisClusterConnection#keys(org.springframework.data.redis.connection.RedisClusterNode, byte[])
+	 */
 	@Override
 	public Set<byte[]> keys(RedisClusterNode node, byte[] pattern) {
 		return doGetKeyCommands().keys(node, pattern);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisClusterConnection#scan(org.springframework.data.redis.connection.RedisClusterNode, org.springframework.data.redis.core.ScanOptions)
+	 */
+	@Override
+	public Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options) {
+		return doGetKeyCommands().scan(node, options);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -46,6 +46,8 @@ import org.springframework.data.redis.connection.ClusterCommandExecutor.MultiKey
 import org.springframework.data.redis.connection.ClusterCommandExecutor.NodeResult;
 import org.springframework.data.redis.connection.RedisClusterNode.SlotRange;
 import org.springframework.data.redis.connection.convert.Converters;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -483,6 +485,19 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 		return doGetClusterKeyCommands().keys(node, pattern);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisClusterConnection#scan(org.springframework.data.redis.connection.RedisClusterNode, org.springframework.data.redis.core.ScanOptions)
+	 */
+	@Override
+	public Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options) {
+		return doGetClusterKeyCommands().scan(node, options);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisClusterConnection#randomKey(org.springframework.data.redis.connection.RedisClusterNode)
+	 */
 	public byte[] randomKey(RedisClusterNode node) {
 		return doGetClusterKeyCommands().randomKey(node);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceScanCursor.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceScanCursor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.util.Collection;
+
+import org.springframework.data.redis.core.ScanCursor;
+import org.springframework.data.redis.core.ScanIteration;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.lang.Nullable;
+
+/**
+ * Lettuce-specific {@link ScanCursor} extension that maintains the cursor state that is required for stateful-scanning
+ * across a Redis Cluster.
+ * <p/>
+ * The cursor state uses Lettuce's stateful {@link io.lettuce.core.ScanCursor} to keep track of scanning progress.
+ * Lettuce's cursor stores scanning progress inside its cursor so using a primitive {@code long} is not sufficient.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+abstract class LettuceScanCursor<T> extends ScanCursor<T> {
+
+	@Nullable private io.lettuce.core.ScanCursor state;
+
+	/**
+	 * Creates a new {@link LettuceScanCursor} given {@link ScanOptions}.
+	 *
+	 * @param options must not be {@literal null}.
+	 */
+	LettuceScanCursor(ScanOptions options) {
+		super(options);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ScanCursor#doScan(long, org.springframework.data.redis.core.ScanOptions)
+	 */
+	@Override
+	protected ScanIteration<T> doScan(long cursorId, ScanOptions options) {
+
+		if (state == null && cursorId == 0) {
+			return scanAndProcessState(io.lettuce.core.ScanCursor.INITIAL, options);
+		}
+
+		if (state != null) {
+
+			if (isMatchingCursor(cursorId)) {
+				return scanAndProcessState(state, options);
+			}
+		}
+
+		throw new IllegalArgumentException(String.format("Current scan %s state and cursor %d do not match!",
+				state != null ? state.getCursor() : "(none)", cursorId));
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ScanCursor#isFinished(long)
+	 */
+	@Override
+	protected boolean isFinished(long cursorId) {
+		return state != null && isMatchingCursor(cursorId) ? state.isFinished() : super.isFinished(cursorId);
+	}
+
+	private ScanIteration<T> scanAndProcessState(io.lettuce.core.ScanCursor scanCursor, ScanOptions options) {
+
+		LettuceScanIteration<T> iteration = doScan(scanCursor, options);
+		state = iteration.cursor;
+
+		return iteration;
+	}
+
+	private boolean isMatchingCursor(long cursorId) {
+		return state != null && state.getCursor().equals(Long.toString(cursorId));
+	}
+
+	/**
+	 * Perform the actual scan operation given {@link io.lettuce.core.ScanCursor} and {@link ScanOptions}.
+	 *
+	 * @param cursor must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return
+	 */
+	protected abstract LettuceScanIteration<T> doScan(io.lettuce.core.ScanCursor cursor, ScanOptions options);
+
+	/**
+	 * Lettuce-specific extension to {@link ScanIteration} keeping track of the original
+	 * {@link io.lettuce.core.ScanCursor} object.
+	 */
+	static class LettuceScanIteration<T> extends ScanIteration<T> {
+
+		private final io.lettuce.core.ScanCursor cursor;
+
+		LettuceScanIteration(io.lettuce.core.ScanCursor cursor, Collection<T> items) {
+			super(Long.parseLong(cursor.getCursor()), items);
+			this.cursor = cursor;
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/ScanCursor.java
+++ b/src/main/java/org/springframework/data/redis/core/ScanCursor.java
@@ -134,7 +134,7 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 
 		cursorId = Long.valueOf(result.getCursorId());
 
-		if (cursorId == 0) {
+		if (isFinished(cursorId)) {
 			state = CursorState.FINISHED;
 		}
 
@@ -143,6 +143,17 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 		} else {
 			resetDelegate();
 		}
+	}
+
+	/**
+	 * Check whether {@code cursorId} is finished.
+	 *
+	 * @param cursorId the cursor Id
+	 * @return {@literal true} if the cursor is considered finished, {@literal false} otherwise.s
+	 * @since 2.1
+	 */
+	protected boolean isFinished(long cursorId) {
+		return cursorId == 0;
 	}
 
 	private void resetDelegate() {

--- a/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
@@ -267,6 +267,12 @@ public interface ClusterConnectionTests {
 	// DATAREDIS-315
 	void keysShouldReturnAllKeysForSpecificNode();
 
+	// DATAREDIS-635
+	void scanShouldReturnAllKeys();
+
+	// DATAREDIS-635
+	void scanShouldReturnAllKeysForSpecificNode();
+
 	// DATAREDIS-315
 	void lIndexShouldGetElementAtIndexCorrectly();
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -941,6 +941,34 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(keysOnNode, not(hasItems(KEY_1_BYTES)));
 	}
 
+	@Test // DATAREDIS-635
+	public void scanShouldReturnAllKeys() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+		nativeConnection.set(KEY_2, VALUE_2);
+
+		Cursor<byte[]> scan = clusterConnection.scan(ScanOptions.NONE);
+		List<byte[]> keys = new ArrayList<>();
+		scan.forEachRemaining(keys::add);
+
+		assertThat(keys, hasItems(KEY_1_BYTES, KEY_2_BYTES));
+	}
+
+	@Test // DATAREDIS-635
+	public void scanShouldReturnAllKeysForSpecificNode() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+		nativeConnection.set(KEY_2, VALUE_2);
+
+		Cursor<byte[]> scan = clusterConnection.scan(new RedisClusterNode("127.0.0.1", 7379, SlotRange.empty()),
+				ScanOptions.NONE);
+		List<byte[]> keysOnNode = new ArrayList<>();
+		scan.forEachRemaining(keysOnNode::add);
+
+		assertThat(keysOnNode, hasItems(KEY_2_BYTES));
+		assertThat(keysOnNode, not(hasItems(KEY_1_BYTES)));
+	}
+
 	@Test // DATAREDIS-315
 	public void lIndexShouldGetElementAtIndexCorrectly() {
 


### PR DESCRIPTION
We now support SCAN commands with Redis Cluster. Cluster-wide scanning is supported with Lettuce only and SCAN on a selected node works with both clients.

```java
// Lettuce only
Cursor<byte[]> scan = clusterConnection.scan(ScanOptions.NONE);

// Jedis and Lettuce
Cursor<byte[]> scan = clusterConnection.scan(new RedisClusterNode("127.0.0.1", 7379, SlotRange.empty()), ScanOptions.NONE);
```

---

Related ticket: [DATAREDIS-635](https://jira.spring.io/browse/DATAREDIS-635).