### PR TITLE
DATAREDIS-545, DATAREDIS-731 - Share native Lettuce connection & enable connection pooling using Redis Cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-731-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -138,6 +138,7 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 	 *
 	 * @param connectionProvider must not be {@literal null}.
 	 * @param executor must not be {@literal null}.
+	 * @param timeout must not be {@literal null}.
 	 * @since 2.0
 	 */
 	public LettuceClusterConnection(LettuceConnectionProvider connectionProvider, ClusterCommandExecutor executor,

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -119,7 +119,7 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 		Assert.isTrue(connectionProvider instanceof ClusterConnectionProvider,
 				"LettuceConnectionProvider must be a ClusterConnectionProvider.");
 
-		this.clusterClient = ((ClusterConnectionProvider) connectionProvider).getRedisClient();
+		this.clusterClient = getClient();
 		this.topologyProvider = new LettuceClusterTopologyProvider(this.clusterClient);
 		this.clusterCommandExecutor = new ClusterCommandExecutor(this.topologyProvider,
 				new LettuceClusterNodeResourceProvider(getConnectionProvider()), exceptionConverter);
@@ -156,7 +156,7 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 		Assert.isTrue(connectionProvider instanceof ClusterConnectionProvider,
 				"LettuceConnectionProvider must be a ClusterConnectionProvider.");
 
-		this.clusterClient = ((ClusterConnectionProvider) connectionProvider).getRedisClient();
+		this.clusterClient = getClient();
 		this.topologyProvider = new LettuceClusterTopologyProvider(this.clusterClient);
 		this.clusterCommandExecutor = executor;
 		this.disposeClusterCommandExecutorOnClose = false;
@@ -209,7 +209,6 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 	private Partitions getPartitions() {
 		return clusterClient.getPartitions();
 	}
-
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -153,6 +153,28 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 	}
 
 	/**
+	 * Creates new {@link LettuceClusterConnection} given a shared {@link StatefulRedisClusterConnection}
+	 * and{@link LettuceConnectionProvider} running commands across the cluster via given {@link ClusterCommandExecutor}.
+	 *
+	 * @param sharedConnection must not be {@literal null}.
+	 * @param connectionProvider must not be {@literal null}.
+	 * @param executor must not be {@literal null}.
+	 * @param timeout must not be {@literal null}.
+	 * @since 2.1
+	 */
+	public LettuceClusterConnection(StatefulRedisClusterConnection<byte[], byte[]> sharedConnection,
+			LettuceConnectionProvider connectionProvider, ClusterCommandExecutor executor, Duration timeout) {
+
+		super(sharedConnection, connectionProvider, timeout.toMillis(), 0);
+
+		Assert.notNull(executor, "ClusterCommandExecutor must not be null.");
+
+		this.topologyProvider = new LettuceClusterTopologyProvider(getClient());
+		this.clusterCommandExecutor = executor;
+		this.disposeClusterCommandExecutorOnClose = false;
+	}
+
+	/**
 	 * @return access to {@link RedisClusterClient} for non-connection access.
 	 */
 	private RedisClusterClient getClient() {
@@ -319,7 +341,6 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 
 		clusterCommandExecutor.executeCommandOnSingleNode(
 				(LettuceClusterCommandCallback<String>) client -> client.clusterAddSlots(slots), node);
-
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -255,8 +255,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 	 * @since 2.1
 	 */
 	LettuceConnection(@Nullable StatefulConnection<byte[], byte[]> sharedConnection,
-			LettuceConnectionProvider connectionProvider,
-			long timeout, int defaultDbIndex) {
+			LettuceConnectionProvider connectionProvider, long timeout, int defaultDbIndex) {
 
 		Assert.notNull(connectionProvider, "LettuceConnectionProvider must not be null.");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -243,6 +243,19 @@ public class LettuceConnection extends AbstractRedisConnection {
 	 */
 	public LettuceConnection(StatefulRedisConnection<byte[], byte[]> sharedConnection,
 			LettuceConnectionProvider connectionProvider, long timeout, int defaultDbIndex) {
+		this((StatefulConnection<byte[], byte[]>) sharedConnection, connectionProvider, timeout, defaultDbIndex);
+	}
+
+	/**
+	 * @param sharedConnection A native connection that is shared with other {@link LettuceConnection}s. Should not be
+	 *          used for transactions or blocking operations.
+	 * @param connectionProvider connection provider to obtain and release native connections.
+	 * @param timeout The connection timeout (in milliseconds)
+	 * @param defaultDbIndex The db index to use along with {@link RedisClient} when establishing a dedicated connection.
+	 * @since 2.1
+	 */
+	LettuceConnection(StatefulConnection<byte[], byte[]> sharedConnection, LettuceConnectionProvider connectionProvider,
+			long timeout, int defaultDbIndex) {
 
 		Assert.notNull(connectionProvider, "LettuceConnectionProvider must not be null.");
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -241,7 +241,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 	 * @param defaultDbIndex The db index to use along with {@link RedisClient} when establishing a dedicated connection.
 	 * @since 2.0
 	 */
-	public LettuceConnection(StatefulRedisConnection<byte[], byte[]> sharedConnection,
+	public LettuceConnection(@Nullable StatefulRedisConnection<byte[], byte[]> sharedConnection,
 			LettuceConnectionProvider connectionProvider, long timeout, int defaultDbIndex) {
 		this((StatefulConnection<byte[], byte[]>) sharedConnection, connectionProvider, timeout, defaultDbIndex);
 	}
@@ -254,7 +254,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 	 * @param defaultDbIndex The db index to use along with {@link RedisClient} when establishing a dedicated connection.
 	 * @since 2.1
 	 */
-	LettuceConnection(StatefulConnection<byte[], byte[]> sharedConnection, LettuceConnectionProvider connectionProvider,
+	LettuceConnection(@Nullable StatefulConnection<byte[], byte[]> sharedConnection,
+			LettuceConnectionProvider connectionProvider,
 			long timeout, int defaultDbIndex) {
 
 		Assert.notNull(connectionProvider, "LettuceConnectionProvider must not be null.");

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -345,12 +345,14 @@ public class LettuceConnectionFactory
 			throw new InvalidDataAccessApiUsageException("Cluster is not configured!");
 		}
 
+		RedisClusterClient clusterClient = (RedisClusterClient) client;
+
 		return getShareNativeConnection()
 				? new LettuceClusterConnection(
 						(StatefulRedisClusterConnection<byte[], byte[]>) getOrCreateSharedConnection().getConnection(),
-						connectionProvider, clusterCommandExecutor, clientConfiguration.getCommandTimeout())
-				: new LettuceClusterConnection(connectionProvider, clusterCommandExecutor,
-				clientConfiguration.getCommandTimeout());
+						connectionProvider, clusterClient, clusterCommandExecutor, clientConfiguration.getCommandTimeout())
+				: new LettuceClusterConnection(null, connectionProvider, clusterClient, clusterCommandExecutor,
+						clientConfiguration.getCommandTimeout());
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
@@ -112,9 +112,8 @@ public class LettuceClusterConnectionUnitTests {
 
 		when(clusterMock.getPartitions()).thenReturn(partitions);
 
-		ClusterCommandExecutor executor = new ClusterCommandExecutor(
-				new LettuceClusterTopologyProvider(clusterMock), resourceProvider,
-				LettuceClusterConnection.exceptionConverter);
+		ClusterCommandExecutor executor = new ClusterCommandExecutor(new LettuceClusterTopologyProvider(clusterMock),
+				resourceProvider, LettuceClusterConnection.exceptionConverter);
 
 		connection = new LettuceClusterConnection(clusterMock, executor) {
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -20,6 +20,7 @@ import static org.hamcrest.core.IsEqual.*;
 import static org.hamcrest.core.IsInstanceOf.*;
 import static org.hamcrest.core.IsNull.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.data.redis.connection.ClusterTestVariables.*;
 import static org.springframework.data.redis.connection.lettuce.LettuceTestClientResources.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
@@ -29,6 +30,9 @@ import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.resource.ClientResources;
 
 import java.security.NoSuchAlgorithmException;
@@ -38,6 +42,8 @@ import java.util.Collections;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisClusterConnection;
@@ -552,6 +558,7 @@ public class LettuceConnectionFactoryUnitTests {
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(clusterConfig);
 		connectionFactory.setShutdownTimeout(0);
 		connectionFactory.setTimeout(2000);
+		connectionFactory.setShareNativeConnection(false);
 		connectionFactory.afterPropertiesSet();
 		ConnectionFactoryTracker.add(connectionFactory);
 
@@ -566,6 +573,7 @@ public class LettuceConnectionFactoryUnitTests {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(clusterConfig, LettuceClientConfiguration
 				.builder().commandTimeout(Duration.ofSeconds(2)).shutdownTimeout(Duration.ZERO).build());
+		connectionFactory.setShareNativeConnection(false);
 
 		connectionFactory.afterPropertiesSet();
 		ConnectionFactoryTracker.add(connectionFactory);
@@ -574,5 +582,31 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(ReflectionTestUtils.getField(clusterConnection, "timeout"), is(equalTo(2000L)));
 
 		clusterConnection.close();
+	}
+
+	@Test // DATAREDIS-731
+	public void shouldShareNativeConnectionWithCluster() {
+
+		RedisClusterClient clientMock = mock(RedisClusterClient.class);
+		StatefulRedisClusterConnection<byte[], byte[]> connectionMock = mock(StatefulRedisClusterConnection.class);
+		when(clientMock.connect(ByteArrayCodec.INSTANCE)).thenReturn(connectionMock);
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(clusterConfig,
+				LettuceClientConfiguration.defaultConfiguration()) {
+
+			@Override
+			protected AbstractRedisClient createClient() {
+				return clientMock;
+			}
+		};
+
+		connectionFactory.afterPropertiesSet();
+
+		new DirectFieldAccessor(connectionFactory).setPropertyValue("client", clientMock);
+
+		connectionFactory.getClusterConnection().close();
+		connectionFactory.getClusterConnection().close();
+
+		verify(clientMock).connect(ArgumentMatchers.any(RedisCodec.class));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/RedisClusterTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisClusterTemplateTests.java
@@ -161,8 +161,8 @@ public class RedisClusterTemplateTests<K, V> extends RedisTemplateTests<K, V> {
 		Jackson2JsonRedisSerializer<Person> jackson2JsonSerializer = new Jackson2JsonRedisSerializer<>(Person.class);
 
 		// JEDIS
-		JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory(new RedisClusterConfiguration(
-				CLUSTER_NODES));
+		JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory(
+				new RedisClusterConfiguration(CLUSTER_NODES));
 
 		jedisConnectionFactory.afterPropertiesSet();
 
@@ -198,8 +198,8 @@ public class RedisClusterTemplateTests<K, V> extends RedisTemplateTests<K, V> {
 
 		// LETTUCE
 
-		LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(new RedisClusterConfiguration(
-				CLUSTER_NODES));
+		LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(
+				new RedisClusterConfiguration(CLUSTER_NODES));
 		lettuceConnectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
 
 		lettuceConnectionFactory.afterPropertiesSet();
@@ -247,23 +247,23 @@ public class RedisClusterTemplateTests<K, V> extends RedisTemplateTests<K, V> {
 
 		return Arrays.asList(new Object[][] { //
 
-						// JEDIS
-						{ jedisStringTemplate, stringFactory, stringFactory }, //
-						{ jedisLongTemplate, stringFactory, longFactory }, //
-						{ jedisRawTemplate, rawFactory, rawFactory }, //
-						{ jedisPersonTemplate, stringFactory, personFactory }, //
-						{ jedisXstreamStringTemplate, stringFactory, stringFactory }, //
-						{ jedisJackson2JsonPersonTemplate, stringFactory, personFactory }, //
+				// JEDIS
+				{ jedisStringTemplate, stringFactory, stringFactory }, //
+				{ jedisLongTemplate, stringFactory, longFactory }, //
+				{ jedisRawTemplate, rawFactory, rawFactory }, //
+				{ jedisPersonTemplate, stringFactory, personFactory }, //
+				{ jedisXstreamStringTemplate, stringFactory, stringFactory }, //
+				{ jedisJackson2JsonPersonTemplate, stringFactory, personFactory }, //
 
-						// LETTUCE
-						{ lettuceStringTemplate, stringFactory, stringFactory }, //
-						{ lettuceLongTemplate, stringFactory, longFactory }, //
-						{ lettuceRawTemplate, rawFactory, rawFactory }, //
-						{ lettucePersonTemplate, stringFactory, personFactory }, //
-						{ lettuceXstreamStringTemplate, stringFactory, stringFactory }, //
+				// LETTUCE
+				{ lettuceStringTemplate, stringFactory, stringFactory }, //
+				{ lettuceLongTemplate, stringFactory, longFactory }, //
+				{ lettuceRawTemplate, rawFactory, rawFactory }, //
+				{ lettucePersonTemplate, stringFactory, personFactory }, //
+				{ lettuceXstreamStringTemplate, stringFactory, stringFactory }, //
 				{ lettuceJackson2JsonPersonTemplate, stringFactory, personFactory }, //
 				{ pooledLettuceStringTemplate, stringFactory, stringFactory } //
-				});
+		});
 	}
 
 }

--- a/src/test/java/org/springframework/data/redis/core/RedisClusterTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisClusterTemplateTests.java
@@ -33,6 +33,7 @@ import org.springframework.data.redis.StringObjectFactory;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
@@ -203,6 +204,12 @@ public class RedisClusterTemplateTests<K, V> extends RedisTemplateTests<K, V> {
 
 		lettuceConnectionFactory.afterPropertiesSet();
 
+		LettuceConnectionFactory pooledLettuceConnectionFactory = new LettuceConnectionFactory(
+				new RedisClusterConfiguration(CLUSTER_NODES), LettucePoolingClientConfiguration.builder()
+						.clientResources(LettuceTestClientResources.getSharedClientResources()).build());
+
+		pooledLettuceConnectionFactory.afterPropertiesSet();
+
 		RedisTemplate<String, String> lettuceStringTemplate = new RedisTemplate<>();
 		lettuceStringTemplate.setDefaultSerializer(StringRedisSerializer.UTF_8);
 		lettuceStringTemplate.setConnectionFactory(lettuceConnectionFactory);
@@ -233,6 +240,11 @@ public class RedisClusterTemplateTests<K, V> extends RedisTemplateTests<K, V> {
 		lettuceJackson2JsonPersonTemplate.setValueSerializer(jackson2JsonSerializer);
 		lettuceJackson2JsonPersonTemplate.afterPropertiesSet();
 
+		RedisTemplate<String, String> pooledLettuceStringTemplate = new RedisTemplate<>();
+		pooledLettuceStringTemplate.setDefaultSerializer(StringRedisSerializer.UTF_8);
+		pooledLettuceStringTemplate.setConnectionFactory(pooledLettuceConnectionFactory);
+		pooledLettuceStringTemplate.afterPropertiesSet();
+
 		return Arrays.asList(new Object[][] { //
 
 						// JEDIS
@@ -249,7 +261,8 @@ public class RedisClusterTemplateTests<K, V> extends RedisTemplateTests<K, V> {
 						{ lettuceRawTemplate, rawFactory, rawFactory }, //
 						{ lettucePersonTemplate, stringFactory, personFactory }, //
 						{ lettuceXstreamStringTemplate, stringFactory, stringFactory }, //
-						{ lettuceJackson2JsonPersonTemplate, stringFactory, personFactory } //
+				{ lettuceJackson2JsonPersonTemplate, stringFactory, personFactory }, //
+				{ pooledLettuceStringTemplate, stringFactory, stringFactory } //
 				});
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/RedisClusterTemplateTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisClusterTemplateTests.java
@@ -54,7 +54,7 @@ public class RedisClusterTemplateTests<K, V> extends RedisTemplateTests<K, V> {
 		super(redisTemplate, keyFactory, valueFactory);
 	}
 
-	public static @ClassRule RedisClusterRule clusterAvaialbale = new RedisClusterRule();
+	public static @ClassRule RedisClusterRule clusterAvailable = new RedisClusterRule();
 
 	@Test(expected = InvalidDataAccessApiUsageException.class)
 	@Ignore("Pipeline not supported in cluster mode")


### PR DESCRIPTION
* We now share Lettuce Cluster connections if configured on `LettuceConnectionFactory` (enabled by default) across multiple `LettuceClusterConnection`s. Connection sharing prevents creation and disposal of cluster connections per template command execution which improves overall performance.
* We now support connection pooling for Cluster connections using Lettuce.

--- 

Related tickets: [DATAREDIS-545](https://jira.spring.io/browse/DATAREDIS-545),  [DATAREDIS-731](https://jira.spring.io/browse/DATAREDIS-731).