### PR TITLE
DATAREDIS-543 - Allow customized type aliasing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-543-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -252,6 +252,61 @@ ciudad = "emond's field"
 
 NOTE: Custom conversions have no effect on index resolution. <<redis.repositories.indexes>> will still be created even for custom converted types.
 
+=== Customizing type mapping
+
+In case you want to avoid writing the entire Java class name as type information but rather like to use some key you can use the `@TypeAlias` annotation at the entity class being persisted. If you need to customize the mapping even more have a look at the `TypeInformationMapper` interface. An instance of that interface can be configured at the `DefaultRedisTypeMapper` which can be configured on `MappingRedisConverter`.
+
+.Defining `@TypeAlias` for an Entity
+====
+[source,java]
+----
+@TypeAlias("pers")
+class Person {
+
+}
+----
+====
+
+Note that the resulting document will contain `pers` as the value in a `_class` field.
+
+==== Configuring custom type mapping
+
+The following example demonstrates how to configure a custom `RedisTypeMapper` in `MappingRedisConverter`.
+
+.Configuring a custom `RedisTypeMapper` via Spring Java Config
+====
+[source,java]
+----
+class CustomRedisTypeMapper extends DefaultRedisTypeMapper {
+  //implement custom type mapping here
+}
+----
+====
+
+[source,java]
+----
+@Configuration
+class SampleRedisConfiguration {
+
+  @Bean
+  public MappingRedisConverter redisConverter(RedisMappingContext mappingContext,
+        RedisCustomConversions customConversions, ReferenceResolver referenceResolver) {
+
+    MappingRedisConverter mappingRedisConverter = new MappingRedisConverter(mappingContext, null, referenceResolver,
+            customTypeMapper());
+
+    mappingRedisConverter.setCustomConversions(customConversions);
+
+    return mappingRedisConverter;
+  }
+
+  @Bean
+  public RedisTypeMapper customTypeMapper() {
+    return new CustomRedisTypeMapper();
+  }
+}
+----
+
 [[redis.repositories.keyspaces]]
 == Keyspaces
 Keyspaces define prefixes used to create the actual _key_ for the Redis Hash.

--- a/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
@@ -389,7 +389,7 @@ public interface RedisGeoCommands {
 
 		/*
 		 * (non-Javadoc)
-		 * @see org.springframework.data.mongodb.core.geo.Metric#getMultiplier()
+		 * @see org.springframework.data.geo.Metric#getMultiplier()
 		 */
 		public double getMultiplier() {
 			return multiplier;

--- a/src/main/java/org/springframework/data/redis/core/convert/BucketPropertyPath.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/BucketPropertyPath.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.convert;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+/**
+ * Value object representing a path within a {@link Bucket}. Paths can be either top-level (if the {@code prefix} is
+ * {@literal null} or empty) or nested with a given {@code prefix}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class BucketPropertyPath {
+
+	private final @NonNull Bucket bucket;
+	private final @Nullable String prefix;
+
+	/**
+	 * Creates a top-level {@link BucketPropertyPath} given {@link Bucket}.
+	 *
+	 * @param bucket the bucket, must not be {@literal null}.
+	 * @return {@link BucketPropertyPath} within the given {@link Bucket}.
+	 */
+	public static BucketPropertyPath from(Bucket bucket) {
+		return new BucketPropertyPath(bucket, null);
+	}
+
+	/**
+	 * Creates a {@link BucketPropertyPath} given {@link Bucket} and {@code prefix}. The resulting path is top-level if
+	 * {@code prefix} is empty or nested, if {@code prefix} is not empty.
+	 *
+	 * @param bucket the bucket, must not be {@literal null}.
+	 * @param prefix the prefix. Property path is top-level if {@code prefix} is {@literal null} or empty.
+	 * @return {@link BucketPropertyPath} within the given {@link Bucket} using {@code prefix}.
+	 */
+	public static BucketPropertyPath from(Bucket bucket, @Nullable String prefix) {
+		return new BucketPropertyPath(bucket, prefix);
+	}
+
+	/**
+	 * Retrieve a value at {@code key} considering top-level/nesting.
+	 *
+	 * @param key must not be {@literal null} or empty.
+	 * @return the resulting value, may be {@literal null}.
+	 */
+	@Nullable
+	public byte[] get(String key) {
+		return bucket.get(getPath(key));
+	}
+
+	/**
+	 * Write a {@code value} at {@code key} considering top-level/nesting.
+	 *
+	 * @param key must not be {@literal null} or empty.
+	 * @param value the value.
+	 */
+	public void put(String key, byte[] value) {
+		bucket.put(getPath(key), value);
+	}
+
+	private String getPath(String key) {
+		return StringUtils.hasText(prefix) ? prefix + "." + key : key;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/convert/DefaultRedisTypeMapper.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/DefaultRedisTypeMapper.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.convert;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.convert.DefaultTypeMapper;
+import org.springframework.data.convert.SimpleTypeInformationMapper;
+import org.springframework.data.convert.TypeAliasAccessor;
+import org.springframework.data.convert.TypeInformationMapper;
+import org.springframework.data.mapping.Alias;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Default implementation of {@link RedisTypeMapper} allowing configuration of the key to lookup and store type
+ * information via {@link BucketPropertyPath} in buckets. The key defaults to {@link #DEFAULT_TYPE_KEY}. Actual
+ * type-to-{@code byte[]} conversion and back is done in {@link BucketTypeAliasAccessor}.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ */
+public class DefaultRedisTypeMapper extends DefaultTypeMapper<BucketPropertyPath> implements RedisTypeMapper {
+
+	public static final String DEFAULT_TYPE_KEY = "_class";
+
+	private final @Nullable String typeKey;
+
+	/**
+	 * Create a new {@link DefaultRedisTypeMapper} using {@link #DEFAULT_TYPE_KEY} to exchange type hints.
+	 */
+	public DefaultRedisTypeMapper() {
+		this(DEFAULT_TYPE_KEY);
+	}
+
+	/**
+	 * Create a new {@link DefaultRedisTypeMapper} given {@code typeKey} to exchange type hints. Does not consider type
+	 * hints if {@code typeKey} is {@literal null}.
+	 *
+	 * @param typeKey the type key can be {@literal null} to skip type hinting.
+	 */
+	public DefaultRedisTypeMapper(@Nullable String typeKey) {
+		this(typeKey, Collections.singletonList(new SimpleTypeInformationMapper()));
+	}
+
+	/**
+	 * Create a new {@link DefaultRedisTypeMapper} given {@code typeKey} to exchange type hints and
+	 * {@link MappingContext}. Does not consider type hints if {@code typeKey} is {@literal null}. {@link MappingContext}
+	 * is used to obtain entity-based aliases
+	 *
+	 * @param typeKey the type key can be {@literal null} to skip type hinting.
+	 * @param mappingContext must not be {@literal null}.
+	 * @see org.springframework.data.annotation.TypeAlias
+	 */
+	public DefaultRedisTypeMapper(@Nullable String typeKey,
+			MappingContext<? extends PersistentEntity<?, ?>, ?> mappingContext) {
+		this(typeKey, new BucketTypeAliasAccessor(typeKey, getConversionService()), mappingContext,
+				Collections.singletonList(new SimpleTypeInformationMapper()));
+	}
+
+	/**
+	 * Create a new {@link DefaultRedisTypeMapper} given {@code typeKey} to exchange type hints and {@link List} of
+	 * {@link TypeInformationMapper}. Does not consider type hints if {@code typeKey} is {@literal null}.
+	 * {@link MappingContext} is used to obtain entity-based aliases
+	 *
+	 * @param typeKey the type key can be {@literal null} to skip type hinting.
+	 * @param mappers must not be {@literal null}.
+	 */
+	public DefaultRedisTypeMapper(@Nullable String typeKey, List<? extends TypeInformationMapper> mappers) {
+		this(typeKey, new BucketTypeAliasAccessor(typeKey, getConversionService()), null, mappers);
+	}
+
+	private DefaultRedisTypeMapper(@Nullable String typeKey, TypeAliasAccessor<BucketPropertyPath> accessor,
+			@Nullable MappingContext<? extends PersistentEntity<?, ?>, ?> mappingContext,
+			List<? extends TypeInformationMapper> mappers) {
+
+		super(accessor, mappingContext, mappers);
+
+		this.typeKey = typeKey;
+	}
+
+	private static GenericConversionService getConversionService() {
+
+		GenericConversionService conversionService = new GenericConversionService();
+		new RedisCustomConversions().registerConvertersIn(conversionService);
+
+		return conversionService;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.convert.RedisTypeMapper#isTypeKey(java.lang.String)
+	 */
+	public boolean isTypeKey(@Nullable String key) {
+		return key != null && typeKey != null && key.endsWith(typeKey);
+	}
+
+	/**
+	 * {@link TypeAliasAccessor} to store aliases in a {@link Bucket}.
+	 *
+	 * @author Mark Paluch
+	 */
+	static final class BucketTypeAliasAccessor implements TypeAliasAccessor<BucketPropertyPath> {
+
+		private final @Nullable String typeKey;
+
+		private final ConversionService conversionService;
+
+		BucketTypeAliasAccessor(@Nullable String typeKey, ConversionService conversionService) {
+
+			Assert.notNull(conversionService, "ConversionService must not be null!");
+
+			this.typeKey = typeKey;
+			this.conversionService = conversionService;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.convert.TypeAliasAccessor#readAliasFrom(java.lang.Object)
+		 */
+		public Alias readAliasFrom(BucketPropertyPath source) {
+
+			if (typeKey == null || source instanceof List) {
+				return Alias.NONE;
+			}
+
+			byte[] bytes = source.get(typeKey);
+
+			if (bytes != null) {
+				return Alias.ofNullable(conversionService.convert(bytes, String.class));
+			}
+
+			return Alias.NONE;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.convert.TypeAliasAccessor#writeTypeTo(java.lang.Object, java.lang.Object)
+		 */
+		public void writeTypeTo(BucketPropertyPath sink, Object alias) {
+
+			if (typeKey != null) {
+
+				if (alias instanceof byte[]) {
+					sink.put(typeKey, (byte[]) alias);
+				} else {
+					sink.put(typeKey, conversionService.convert(alias, byte[].class));
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/convert/RedisTypeMapper.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/RedisTypeMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.convert;
+
+import org.springframework.data.convert.TypeMapper;
+
+/**
+ * Redis-specific {@link TypeMapper} exposing that {@link BucketPropertyPath}s might contain a type key.
+ *
+ * @author Mark Paluch
+ * @since 2.1
+ * @see BucketPropertyPath
+ */
+public interface RedisTypeMapper extends TypeMapper<BucketPropertyPath> {
+
+	/**
+	 * Returns whether the given {@code key} is the type key.
+	 *
+	 * @return {@literal true} if the given {@code key} is the type key.
+	 */
+	boolean isTypeKey(String key);
+}

--- a/src/main/java/org/springframework/data/redis/repository/cdi/RedisRepositoryExtension.java
+++ b/src/main/java/org/springframework/data/redis/repository/cdi/RedisRepositoryExtension.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.repository.cdi;
 
 import java.lang.annotation.Annotation;
@@ -183,7 +182,7 @@ public class RedisRepositoryExtension extends CdiRepositoryExtensionSupport {
 	private <T> CdiRepositoryBean<T> createRepositoryBean(Class<T> repositoryType, Set<Annotation> qualifiers,
 			BeanManager beanManager) {
 
-		// Determine the MongoOperations bean which matches the qualifiers of the repository.
+		// Determine the KeyValueOperations bean which matches the qualifiers of the repository.
 		Bean<KeyValueOperations> redisKeyValueTemplate = this.redisKeyValueTemplates.get(qualifiers);
 
 		if (redisKeyValueTemplate == null) {
@@ -205,7 +204,7 @@ public class RedisRepositoryExtension extends CdiRepositoryExtensionSupport {
 	 */
 	private RedisKeyValueAdapterBean createRedisKeyValueAdapterBean(Set<Annotation> qualifiers, BeanManager beanManager) {
 
-		// Determine the MongoOperations bean which matches the qualifiers of the repository.
+		// Determine the RedisOperations bean which matches the qualifiers of the repository.
 		Bean<RedisOperations<?, ?>> redisOperationsBean = this.redisOperations.get(qualifiers);
 
 		if (redisOperationsBean == null) {
@@ -227,7 +226,7 @@ public class RedisRepositoryExtension extends CdiRepositoryExtensionSupport {
 	private RedisKeyValueTemplateBean createRedisKeyValueTemplateBean(Set<Annotation> qualifiers,
 			BeanManager beanManager) {
 
-		// Determine the MongoOperations bean which matches the qualifiers of the repository.
+		// Determine the RedisKeyValueAdapter bean which matches the qualifiers of the repository.
 		Bean<RedisKeyValueAdapter> redisKeyValueAdapterBean = this.redisKeyValueAdapters.get(qualifiers);
 
 		if (redisKeyValueAdapterBean == null) {

--- a/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Reference;
+import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
@@ -107,6 +108,7 @@ public class ConversionTestEntities {
 		}
 	}
 
+	@TypeAlias("with-post-code")
 	public static class AddressWithPostcode extends Address {
 
 		String postcode;

--- a/src/test/java/org/springframework/data/redis/core/convert/DefaultRedisTypeMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/DefaultRedisTypeMapperUnitTests.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.convert;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.convert.ConfigurableTypeInformationMapper;
+import org.springframework.data.convert.SimpleTypeInformationMapper;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
+
+/**
+ * Unit tests for {@link DefaultRedisTypeMapper}.
+ *
+ * @author Mark Paluch
+ */
+public class DefaultRedisTypeMapperUnitTests {
+
+	GenericConversionService conversionService;
+	ConfigurableTypeInformationMapper configurableTypeInformationMapper;
+	SimpleTypeInformationMapper simpleTypeInformationMapper;
+	DefaultRedisTypeMapper typeMapper;
+
+	@Before
+	public void setUp() {
+
+		conversionService = new GenericConversionService();
+		new RedisCustomConversions().registerConvertersIn(conversionService);
+
+		configurableTypeInformationMapper = new ConfigurableTypeInformationMapper(singletonMap(String.class, "1"));
+		simpleTypeInformationMapper = new SimpleTypeInformationMapper();
+
+		typeMapper = new DefaultRedisTypeMapper(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY);
+	}
+
+	@Test // DATAREDIS-543
+	public void defaultInstanceWritesClasses() {
+		writesTypeToField(new Bucket(), String.class, String.class.getName());
+	}
+
+	@Test // DATAREDIS-543
+	public void defaultInstanceReadsClasses() {
+
+		Bucket bucket = Bucket
+				.newBucketFromStringMap(singletonMap(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, String.class.getName()));
+		readsTypeFromField(bucket, String.class);
+	}
+
+	@Test // DATAREDIS-543
+	public void writesMapKeyForType() {
+
+		typeMapper = new DefaultRedisTypeMapper(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY,
+				Collections.singletonList(configurableTypeInformationMapper));
+
+		writesTypeToField(new Bucket(), String.class, "1");
+		writesTypeToField(new Bucket(), Object.class, null);
+	}
+
+	@Test // DATAREDIS-543
+	public void writesClassNamesForUnmappedValuesIfConfigured() {
+
+		typeMapper = new DefaultRedisTypeMapper(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY,
+				Arrays.asList(configurableTypeInformationMapper, simpleTypeInformationMapper));
+
+		writesTypeToField(new Bucket(), String.class, "1");
+		writesTypeToField(new Bucket(), Object.class, Object.class.getName());
+	}
+
+	@Test // DATAREDIS-543
+	public void readsTypeForMapKey() {
+
+		typeMapper = new DefaultRedisTypeMapper(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY,
+				Collections.singletonList(configurableTypeInformationMapper));
+
+		readsTypeFromField(Bucket.newBucketFromStringMap(singletonMap(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, "1")),
+				String.class);
+		readsTypeFromField(Bucket.newBucketFromStringMap(singletonMap(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, "unmapped")),
+				null);
+	}
+
+	@Test // DATAREDIS-543
+	public void readsTypeLoadingClassesForUnmappedTypesIfConfigured() {
+
+		typeMapper = new DefaultRedisTypeMapper(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY,
+				Arrays.asList(configurableTypeInformationMapper, simpleTypeInformationMapper));
+
+		readsTypeFromField(new Bucket(singletonMap(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, "1".getBytes())), String.class);
+		readsTypeFromField(
+				new Bucket(singletonMap(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, Object.class.getName().getBytes())),
+				Object.class);
+	}
+
+	@Test // DATAREDIS-543
+	public void addsFullyQualifiedClassNameUnderDefaultKeyByDefault() {
+		writesTypeToField(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, new Bucket(), String.class);
+	}
+
+	@Test // DATAREDIS-543
+	public void writesTypeToCustomFieldIfConfigured() {
+		typeMapper = new DefaultRedisTypeMapper("_custom");
+		writesTypeToField("_custom", new Bucket(), String.class);
+	}
+
+	@Test // DATAREDIS-543
+	public void doesNotWriteTypeInformationInCaseKeyIsSetToNull() {
+		typeMapper = new DefaultRedisTypeMapper(null);
+		writesTypeToField(null, new Bucket(), String.class);
+	}
+
+	@Test // DATAREDIS-543
+	public void readsTypeFromDefaultKeyByDefault() {
+		readsTypeFromField(
+				Bucket.newBucketFromStringMap(singletonMap(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, String.class.getName())),
+				String.class);
+	}
+
+	@Test // DATAREDIS-543
+	public void readsTypeFromCustomFieldConfigured() {
+
+		typeMapper = new DefaultRedisTypeMapper("_custom");
+		readsTypeFromField(Bucket.newBucketFromStringMap(singletonMap("_custom", String.class.getName())), String.class);
+	}
+
+	@Test // DATAREDIS-543
+	public void returnsListForBasicDBLists() {
+		readsTypeFromField(new Bucket(), null);
+	}
+
+	@Test // DATAREDIS-543
+	public void returnsNullIfNoTypeInfoInBucket() {
+
+		readsTypeFromField(new Bucket(), null);
+		readsTypeFromField(Bucket.newBucketFromStringMap(singletonMap(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, "")), null);
+	}
+
+	@Test // DATAREDIS-543
+	public void returnsNullIfClassCannotBeLoaded() {
+
+		readsTypeFromField(Bucket.newBucketFromStringMap(singletonMap(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, "fooBar")),
+				null);
+	}
+
+	@Test // DATAREDIS-543
+	public void returnsNullIfTypeKeySetToNull() {
+
+		typeMapper = new DefaultRedisTypeMapper(null);
+		readsTypeFromField(
+				Bucket.newBucketFromStringMap(singletonMap(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, String.class.getName())),
+				null);
+	}
+
+	@Test // DATAREDIS-543
+	public void returnsCorrectTypeKey() {
+
+		assertThat(typeMapper.isTypeKey(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY)).isTrue();
+
+		typeMapper = new DefaultRedisTypeMapper("_custom");
+		assertThat(typeMapper.isTypeKey("_custom")).isTrue();
+		assertThat(typeMapper.isTypeKey(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY)).isFalse();
+
+		typeMapper = new DefaultRedisTypeMapper(null);
+		assertThat(typeMapper.isTypeKey("_custom")).isFalse();
+		assertThat(typeMapper.isTypeKey(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY)).isFalse();
+	}
+
+	private void readsTypeFromField(Bucket bucket, @Nullable Class<?> type) {
+
+		TypeInformation<?> typeInfo = typeMapper.readType(BucketPropertyPath.from(bucket));
+
+		if (type != null) {
+			assertThat(typeInfo).isNotNull();
+			assertThat(typeInfo.getType()).isAssignableFrom(type);
+		} else {
+			assertThat(typeInfo).isNull();
+		}
+	}
+
+	private void writesTypeToField(@Nullable String field, Bucket bucket, Class<?> type) {
+
+		typeMapper.writeType(type, BucketPropertyPath.from(bucket));
+
+		if (field == null) {
+			assertThat(bucket.keySet()).isEmpty();
+		} else {
+			assertThat(bucket.asMap()).containsKey(field);
+			assertThat(bucket.get(field)).isEqualTo(type.getName().getBytes());
+		}
+	}
+
+	private void writesTypeToField(Bucket bucket, Class<?> type, @Nullable Object value) {
+
+		typeMapper.writeType(type, BucketPropertyPath.from(bucket));
+
+		if (value == null) {
+			assertThat(bucket.keySet()).isEmpty();
+		} else {
+
+			byte[] expected = value instanceof Class ? ((Class) value).getName().getBytes() : value.toString().getBytes();
+
+			assertThat(bucket.asMap()).containsKey(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY);
+			assertThat(bucket.get(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY)).isEqualTo(expected);
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -32,16 +32,7 @@ import java.time.LocalTime;
 import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import org.hamcrest.core.IsEqual;
 import org.junit.Before;
@@ -91,6 +82,15 @@ public class MappingRedisConverterUnitTests {
 
 	@Test // DATAREDIS-425
 	public void writeAppendsTypeHintForRootCorrectly() {
+		assertThat(write(rand).getBucket(), isBucket().containingTypeHint("_class", Person.class));
+	}
+
+	@Test // DATAREDIS-543
+	public void writeSkipsTypeHintIfConfigured() {
+
+		converter = new MappingRedisConverter(new RedisMappingContext(), null, resolverMock);
+		converter.afterPropertiesSet();
+
 		assertThat(write(rand).getBucket(), isBucket().containingTypeHint("_class", Person.class));
 	}
 
@@ -205,7 +205,7 @@ public class MappingRedisConverterUnitTests {
 		assertThat(target.getBucket(), isBucket().without("address._class"));
 	}
 
-	@Test // DATAREDIS-425
+	@Test // DATAREDIS-425, DATAREDIS-543
 	public void writeAddsClassTypeInformationCorrectlyForNonMatchingTypes() {
 
 		AddressWithPostcode address = new AddressWithPostcode();
@@ -216,7 +216,7 @@ public class MappingRedisConverterUnitTests {
 
 		RedisData target = write(rand);
 
-		assertThat(target.getBucket(), isBucket().containingTypeHint("address._class", AddressWithPostcode.class));
+		assertThat(target.getBucket(), isBucket().containingUtf8String("address._class", "with-post-code"));
 	}
 
 	@Test // DATAREDIS-425

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,38 @@
  */
 package org.springframework.data.redis.repository;
 
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.data.convert.ConfigurableTypeInformationMapper;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.convert.DefaultRedisTypeMapper;
+import org.springframework.data.redis.core.convert.MappingRedisConverter;
+import org.springframework.data.redis.core.convert.RedisCustomConversions;
+import org.springframework.data.redis.core.convert.RedisTypeMapper;
+import org.springframework.data.redis.core.convert.ReferenceResolver;
+import org.springframework.data.redis.core.mapping.RedisMappingContext;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -45,10 +64,52 @@ public class RedisRepositoryIntegrationTests extends RedisRepositoryIntegrationT
 			JedisConnectionFactory connectionFactory = new JedisConnectionFactory();
 			connectionFactory.afterPropertiesSet();
 
-			RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+			RedisTemplate<String, String> template = new RedisTemplate<>();
+			template.setDefaultSerializer(StringRedisSerializer.UTF_8);
 			template.setConnectionFactory(connectionFactory);
 
 			return template;
 		}
+
+		@Bean
+		public MappingRedisConverter redisConverter(RedisMappingContext mappingContext,
+				RedisCustomConversions customConversions, ReferenceResolver referenceResolver) {
+
+			MappingRedisConverter mappingRedisConverter = new MappingRedisConverter(mappingContext, null, referenceResolver,
+					customTypeMapper());
+
+			mappingRedisConverter.setCustomConversions(customConversions);
+
+			return mappingRedisConverter;
+		}
+
+		private RedisTypeMapper customTypeMapper() {
+
+			Map<Class<?>, String> mapping = new HashMap<>();
+
+			mapping.put(Person.class, "person");
+			mapping.put(City.class, "city");
+
+			ConfigurableTypeInformationMapper mapper = new ConfigurableTypeInformationMapper(mapping);
+
+			return new DefaultRedisTypeMapper(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, Collections.singletonList(mapper));
+		}
+	}
+
+	@Autowired RedisOperations<String, String> operations;
+
+	@Test // DATAREDIS-543
+	public void shouldConsiderCustomTypeMapper() {
+
+		Person rand = new Person();
+		rand.id = "rand";
+		rand.firstname = "rand";
+		rand.lastname = "al'thor";
+
+		repo.save(rand);
+
+		Map<String, String> entries = operations.<String, String> opsForHash().entries("persons:rand");
+
+		assertThat(entries.get("_class"), is(equalTo("person")));
 	}
 }


### PR DESCRIPTION
We now support customization of type aliasing for types using through Redis Repositories. Type aliasing can be customized by either annotating types with `@TypeAlias` or by providing a `RedisTypeMapper` to `MappingRedisConverter`.

```java
Map<Class<?>, String> mapping = new HashMap<>();

mapping.put(Person.class, "person");

ConfigurableTypeInformationMapper mapper = new ConfigurableTypeInformationMapper(mapping);
RedisTypeMapper typeMapper = new DefaultRedisTypeMapper(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY, Collections.singletonList(mapper))
```

alternatively:

```java
@RedisHash
@TypeAlias("person")
class Person {
  // …
}
```

---

Related ticket: [DATAREDIS-543](https://jira.spring.io/browse/DATAREDIS-543).