### PR TITLE
DATAREDIS-756 - Order results of partitioned multi-key commands by positional keys.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-756-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
@@ -300,8 +300,14 @@ public interface ClusterConnectionTests {
 	// DATAREDIS-315
 	void mGetShouldReturnCorrectlyWhenKeysDoNotMapToSameSlot();
 
+	// DATAREDIS-756
+	void mGetShouldReturnMultipleSameKeysWhenKeysDoNotMapToSameSlot();
+
 	// DATAREDIS-315
 	void mGetShouldReturnCorrectlyWhenKeysMapToSameSlot();
+
+	// DATAREDIS-756
+	void mGetShouldReturnMultipleSameKeysWhenKeysMapToSameSlot();
 
 	// DATAREDIS-315
 	void mSetNXShouldReturnFalseIfNotAllKeysSet();

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -1069,6 +1069,17 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.mGet(KEY_1_BYTES, KEY_2_BYTES), contains(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
+	@Test // DATAREDIS-756
+	public void mGetShouldReturnMultipleSameKeysWhenKeysDoNotMapToSameSlot() {
+
+		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
+		nativeConnection.set(KEY_2_BYTES, VALUE_2_BYTES);
+		nativeConnection.set(KEY_3_BYTES, VALUE_3_BYTES);
+
+		List<byte[]> result = clusterConnection.mGet(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES, KEY_1_BYTES);
+		assertThat(result, contains(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_3_BYTES, VALUE_1_BYTES));
+	}
+
 	@Test // DATAREDIS-315
 	public void mGetShouldReturnCorrectlyWhenKeysMapToSameSlot() {
 
@@ -1077,6 +1088,16 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 
 		assertThat(clusterConnection.mGet(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES),
 				contains(VALUE_1_BYTES, VALUE_2_BYTES));
+	}
+
+	@Test // DATAREDIS-756
+	public void mGetShouldReturnMultipleSameKeysWhenKeysMapToSameSlot() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1_BYTES, VALUE_1_BYTES);
+		nativeConnection.set(SAME_SLOT_KEY_2_BYTES, VALUE_2_BYTES);
+
+		List<byte[]> result = clusterConnection.mGet(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, SAME_SLOT_KEY_1_BYTES);
+		assertThat(result, contains(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_1_BYTES));
 	}
 
 	@Test // DATAREDIS-315

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -1038,6 +1038,16 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.mGet(KEY_1_BYTES, KEY_2_BYTES), contains(VALUE_1_BYTES, VALUE_2_BYTES));
 	}
 
+	@Test // DATAREDIS-756
+	public void mGetShouldReturnMultipleSameKeysWhenKeysDoNotMapToSameSlot() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+		nativeConnection.set(KEY_2, VALUE_2);
+
+		assertThat(clusterConnection.mGet(KEY_1_BYTES, KEY_2_BYTES, KEY_1_BYTES),
+				contains(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_1_BYTES));
+	}
+
 	@Test // DATAREDIS-315
 	public void mGetShouldReturnCorrectlyWhenKeysMapToSameSlot() {
 
@@ -1046,6 +1056,16 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		assertThat(clusterConnection.mGet(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES),
 				contains(VALUE_1_BYTES, VALUE_2_BYTES));
+	}
+
+	@Test // DATAREDIS-756
+	public void mGetShouldReturnMultipleSameKeysWhenKeysMapToSameSlot() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, VALUE_1);
+		nativeConnection.set(SAME_SLOT_KEY_2, VALUE_2);
+
+		assertThat(clusterConnection.mGet(SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES, SAME_SLOT_KEY_1_BYTES),
+				contains(VALUE_1_BYTES, VALUE_2_BYTES, VALUE_1_BYTES));
 	}
 
 	@Test // DATAREDIS-315


### PR DESCRIPTION
We now order and assemble results of multi-key commands (e.g. `MGET` with cross-slot keys) that are executed on different nodes by positional keys to retain duplicate keys in the requested order and retain the server response.

Previously duplicate keys were treated as a set of keys and the response didn't match the requested keys.

---

Related ticket: [DATAREDIS-756](https://jira.spring.io/browse/DATAREDIS-756).