### PR TITLE
DATAREDIS-673 - redis cache return null store value when ttl reached during get

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -181,7 +181,8 @@ public class RedisCache extends AbstractValueAdaptingCache {
 			return null;
 		}
 
-		return new RedisCacheElement(cacheKey, fromStoreValue(lookup(cacheKey)));
+		Object storeValue = lookup(cacheKey);
+		return (storeValue != null ? new RedisCacheElement(cacheKey,fromStoreValue(storeValue)) : null);
 	}
 
 	/*


### PR DESCRIPTION

based on https://github.com/spring-projects/spring-data-redis/pull/261

I just rebased.