### PR TITLE
DATAREDIS-766 - Configure SSL usage in JedisConnectionFactory depending on JedisShardInfo.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.11.BUILD-SNAPSHOT</version>
+	<version>1.8.11.DATAREDIS-766-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 
@@ -31,26 +31,26 @@
 
 	<dependencyManagement>
 		<dependencies>
-		
+
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-pool2</artifactId>
 				<version>${pool}</version>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>${guava}</version>
 			</dependency>
-			
+
 		</dependencies>
 	</dependencyManagement>
 
 	<dependencies>
 
 		<!-- Spring -->
-		
+
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-keyvalue</artifactId>
@@ -78,35 +78,35 @@
 		</dependency>
 
 		<!-- REDIS Drivers -->
-		
+
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
 			<version>${jedis}</version>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.jredis</groupId>
 			<artifactId>jredis-core-api</artifactId>
 			<version>${jredis}</version>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.jredis</groupId>
 			<artifactId>jredis-core-ri</artifactId>
 			<version>${jredis}</version>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>com.github.spullara.redis</groupId>
 			<artifactId>client</artifactId>
 			<version>${srp}</version>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>biz.paluch.redis</groupId>
 			<artifactId>lettuce</artifactId>
@@ -221,7 +221,7 @@
 
 	<build>
 		<plugins>
-		
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -242,12 +242,12 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>wagon-maven-plugin</artifactId>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>
@@ -261,13 +261,13 @@
 			<id>release</id>
 			<build>
 				<plugins>
-				
+
 					<plugin>
 						<groupId>org.jfrog.buildinfo</groupId>
 						<artifactId>artifactory-maven-plugin</artifactId>
 						<inherited>false</inherited>
 					</plugin>
-					
+
 				</plugins>
 			</build>
 		</profile>

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 the original author or authors.
+ * Copyright 2011-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	 * @param shardInfo shard information
 	 */
 	public JedisConnectionFactory(JedisShardInfo shardInfo) {
-		this.shardInfo = shardInfo;
+		setShardInfo(shardInfo);
 	}
 
 	/**
@@ -457,12 +457,17 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 	}
 
 	/**
-	 * Sets the shard info for this factory.
+	 * Sets the shard info for this factory and apply SSL settings.
 	 *
 	 * @param shardInfo the shardInfo to set.
 	 */
 	public void setShardInfo(JedisShardInfo shardInfo) {
+
 		this.shardInfo = shardInfo;
+
+		if(shardInfo != null) {
+			setUseSsl(shardInfo.getSsl());
+		}
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -28,9 +30,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.JedisShardInfo;
 
 /**
+ * Unit tests for {@link JedisConnectionFactory}.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class JedisConnectionFactoryUnitTests {
 
@@ -74,7 +80,7 @@ public class JedisConnectionFactoryUnitTests {
 	}
 
 	@Test // DATAREDIS-315
-	public void shouldClostClusterCorrectlyOnFactoryDestruction() throws IOException {
+	public void shouldCloseClusterCorrectlyOnFactoryDestruction() throws IOException {
 
 		JedisCluster clusterMock = mock(JedisCluster.class);
 		JedisConnectionFactory factory = new JedisConnectionFactory();
@@ -83,6 +89,15 @@ public class JedisConnectionFactoryUnitTests {
 		factory.destroy();
 
 		verify(clusterMock, times(1)).close();
+	}
+
+	@Test // DATAREDIS-766
+	public void shardInfoShouldConfigureSslFlag() {
+
+		JedisShardInfo shardInfo = new JedisShardInfo("host", 6379, true);
+		JedisConnectionFactory factory = new JedisConnectionFactory(shardInfo);
+
+		assertThat(factory.isUseSsl(), is(true));
 	}
 
 	private JedisConnectionFactory initSpyedConnectionFactory(RedisSentinelConfiguration sentinelConfig,


### PR DESCRIPTION
We now enable/disable SSL usage when configuring `JedisConnectionFactory` with `JedisShardInfo` based on the configured SSL use in `JedisShardInfo`.

---

Related ticket: [DATAREDIS-766](https://jira.spring.io/browse/DATAREDIS-766).