### PR TITLE
DATAREDIS-673 - Prevent false positive cache hits while Redis keys expire.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.11.BUILD-SNAPSHOT</version>
+	<version>1.8.11.DATAREDIS-673-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 


### PR DESCRIPTION
We now prevent false positive cache hits after checking for key presence and the Redis key gets removed before fetching its value.
This can happen if we check positively for presence but the key expires (TTL) or gets removed before the `GET` call is able to fetch the value.

Previously, we returned a `RedisCacheElement` wrapping null without regard to whether the cache is able to store/return null values. We now inspect the returned value for presence to eagerly return a negative cache hit and to preserve cached `null` values.

---

Related ticket: [DATAREDIS-673](https://jira.spring.io/browse/DATAREDIS-673).
Related pull request: #261.