### PR TITLE
DATAREDIS-767 - Add flag to disable in flight Cache creation. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.4.BUILD-SNAPSHOT</version>
+	<version>2.0.4.DATAREDIS-767-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
@@ -91,4 +91,23 @@ public class RedisCacheManagerUnitTests {
 		assertThat(cache).isInstanceOfAny(TransactionAwareCacheDecorator.class);
 		assertThat(ReflectionTestUtils.getField(cache, "targetCache")).isInstanceOf(RedisCache.class);
 	}
+
+	@Test // DATAREDIS-767
+	public void lockingCacheShouldPreventInFlightCacheCreation() {
+
+		RedisCacheManager cacheManager = RedisCacheManager.builder(cacheWriter).disableCreateOnMissingCache().build();
+		cacheManager.afterPropertiesSet();
+
+		assertThat(cacheManager.getCache("not-configured")).isNull();
+	}
+
+	@Test // DATAREDIS-767
+	public void lockingCacheShouldStillReturnPreconfiguredCaches() {
+
+		RedisCacheManager cacheManager = RedisCacheManager.builder(cacheWriter)
+				.initialCacheNames(Collections.singleton("configured")).disableCreateOnMissingCache().build();
+		cacheManager.afterPropertiesSet();
+
+		assertThat(cacheManager.getCache("configured")).isNotNull();
+	}
 }


### PR DESCRIPTION
We now provide a flag to disable the in flight cache creation for missing caches. This gives eg. a `CompositeCacheManager` the possibility to chime in.