### PR TITLE
DATAREDIS-768 - Consider map key type in MappingRedisConverter.readMap…(…).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-768-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -158,6 +158,8 @@ of Complex Type
 addresses.[work].city  = "...
 |===
 
+WARNING: Due to the flat representation structure Map keys need to be simple types such as ``String``s or ``Number``s.
+
 Mapping behavior can be customized by registering the according `Converter` in `RedisCustomConversions`. Those converters can take care of converting from/to a single `byte[]` as well as `Map<String,byte[]>` whereas the first one is suitable for eg. converting one complex type to eg. a binary JSON representation that still uses the default mappings hash structure. The second option offers full control over the resulting hash. Writing objects to a Redis hash will delete the content from the hash and re-create the whole hash, so not mapped data will be lost.
 
 .Sample byte[] Converters

--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.data.redis.core.convert;
 
-import lombok.RequiredArgsConstructor;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.lang.reflect.Array;
 import java.util.*;
@@ -844,9 +844,14 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 				throw new IllegalArgumentException(
 						String.format("Cannot extract map value for key '%s' in path '%s'.", entry.getKey(), path));
 			}
-			String key = matcher.group(2);
+			Object key = matcher.group(2);
 
 			Class<?> typeToUse = getTypeHint(path + ".[" + key + "]", source.getBucket(), valueType);
+
+			if (!keyType.isAssignableFrom(key.getClass())) {
+				key = conversionService.convert(key, keyType);
+			}
+
 			target.put(key, fromBytes(entry.getValue(), typeToUse));
 		}
 
@@ -879,7 +884,7 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 				throw new IllegalArgumentException(
 						String.format("Cannot extract map value for key '%s' in path '%s'.", key, path));
 			}
-			String mapKey = matcher.group(2);
+			Object mapKey = matcher.group(2);
 
 			Bucket partial = source.getBucket().extract(key);
 
@@ -888,8 +893,13 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 				partial.put(TYPE_HINT_ALIAS, typeInfo);
 			}
 
-			Object o = readInternal(key, valueType, new RedisData(partial));
-			target.put(mapKey, o);
+			if (!keyType.isAssignableFrom(mapKey.getClass())) {
+				mapKey = conversionService.convert(mapKey, keyType);
+			}
+
+			Object value = readInternal(key, valueType, new RedisData(partial));
+
+			target.put(mapKey, value);
 		}
 
 		return target.isEmpty() ? null : target;

--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -21,8 +21,17 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -799,7 +808,7 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 				continue;
 			}
 
-			String currentPath = path + ".[" + entry.getKey() + "]";
+			String currentPath = path + ".[" + mapMapKey(entry.getKey()) + "]";
 
 			if (!ClassUtils.isAssignable(mapValueType, entry.getValue().getClass())) {
 				throw new MappingException(
@@ -812,6 +821,15 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 				writeInternal(keyspace, currentPath, entry.getValue(), ClassTypeInformation.from(mapValueType), sink);
 			}
 		}
+	}
+
+	private String mapMapKey(Object key) {
+
+		if (conversionService.canConvert(key.getClass(), byte[].class)) {
+			return new String(conversionService.convert(key, byte[].class));
+		}
+
+		return conversionService.convert(key, String.class);
 	}
 
 	/**
@@ -836,22 +854,8 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 				continue;
 			}
 
-			String regex = "^(" + Pattern.quote(path) + "\\.\\[)(.*?)(\\])";
-			Pattern pattern = Pattern.compile(regex);
-
-			Matcher matcher = pattern.matcher(entry.getKey());
-			if (!matcher.find()) {
-				throw new IllegalArgumentException(
-						String.format("Cannot extract map value for key '%s' in path '%s'.", entry.getKey(), path));
-			}
-			Object key = matcher.group(2);
-
+			Object key = extractMapKeyForPath(path, entry.getKey(), keyType);
 			Class<?> typeToUse = getTypeHint(path + ".[" + key + "]", source.getBucket(), valueType);
-
-			if (!keyType.isAssignableFrom(key.getClass())) {
-				key = conversionService.convert(key, keyType);
-			}
-
 			target.put(key, fromBytes(entry.getValue(), typeToUse));
 		}
 
@@ -876,16 +880,6 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 
 		for (String key : keys) {
 
-			String regex = "^(" + Pattern.quote(path) + "\\.\\[)(.*?)(\\])";
-			Pattern pattern = Pattern.compile(regex);
-
-			Matcher matcher = pattern.matcher(key);
-			if (!matcher.find()) {
-				throw new IllegalArgumentException(
-						String.format("Cannot extract map value for key '%s' in path '%s'.", key, path));
-			}
-			Object mapKey = matcher.group(2);
-
 			Bucket partial = source.getBucket().extract(key);
 
 			byte[] typeInfo = partial.get(key + "." + TYPE_HINT_ALIAS);
@@ -893,16 +887,33 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 				partial.put(TYPE_HINT_ALIAS, typeInfo);
 			}
 
-			if (!keyType.isAssignableFrom(mapKey.getClass())) {
-				mapKey = conversionService.convert(mapKey, keyType);
-			}
-
 			Object value = readInternal(key, valueType, new RedisData(partial));
 
+			Object mapKey = extractMapKeyForPath(path, key, keyType);
 			target.put(mapKey, value);
 		}
 
 		return target.isEmpty() ? null : target;
+	}
+
+	private Object extractMapKeyForPath(String path, String key, Class<?> targetType) {
+
+		String regex = "^(" + Pattern.quote(path) + "\\.\\[)(.*?)(\\])";
+		Pattern pattern = Pattern.compile(regex);
+
+		Matcher matcher = pattern.matcher(key);
+		if (!matcher.find()) {
+			throw new IllegalArgumentException(
+					String.format("Cannot extract map value for key '%s' in path '%s'.", key, path));
+		}
+
+		Object mapKey = matcher.group(2);
+
+		if (ClassUtils.isAssignable(targetType, mapKey.getClass())) {
+			return mapKey;
+		}
+
+		return conversionService.convert(toBytes(mapKey), targetType);
 	}
 
 	private Class<?> getTypeHint(String path, Bucket bucket, Class<?> fallback) {

--- a/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
@@ -74,7 +74,6 @@ public class ConversionTestEntities {
 		Address address;
 
 		Map<String, String> physicalAttributes;
-		Map<Integer, Integer> numberMapping;
 		Map<String, Person> relatives;
 		Map<Integer, Person> favoredRelatives;
 
@@ -181,8 +180,16 @@ public class ConversionTestEntities {
 	}
 
 	static class TypeWithObjectValueTypes {
+
 		Object object;
 		Map<String, Object> map = new HashMap<>();
 		List<Object> list = new ArrayList<>();
+	}
+
+	static class TypeWithMaps {
+
+		Map<Integer, Integer> integerMapKeyMapping;
+		Map<Double, String> decimalMapKeyMapping;
+		Map<Date, String> dateMapKeyMapping;
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
@@ -57,6 +57,7 @@ public class ConversionTestEntities {
 
 		List<String> nicknames;
 		List<Person> coworkers;
+		List<Integer> positions;
 		Integer age;
 		Boolean alive;
 		Date birthdate;
@@ -73,7 +74,9 @@ public class ConversionTestEntities {
 		Address address;
 
 		Map<String, String> physicalAttributes;
+		Map<Integer, Integer> numberMapping;
 		Map<String, Person> relatives;
+		Map<Integer, Person> favoredRelatives;
 
 		@Reference Location location;
 		@Reference List<Location> visited;


### PR DESCRIPTION
We now consider the key type when reading a map from a Redis Hash. Previously, map keys were read as `String` while a map could declare numeric keys.

---

Related ticket: [DATAREDIS-768](https://jira.spring.io/browse/DATAREDIS-768).