### PR TITLE
DATAREDIS-715 - Allow computation of cache key prefix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.0.4.BUILD-SNAPSHOT</version>
+	<version>2.0.4.DATAREDIS-715-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/reference/redis.adoc
+++ b/src/main/asciidoc/reference/redis.adoc
@@ -527,6 +527,18 @@ RedisCacheManager cm = RedisCacheManager.build(RedisCacheWriter.lockingRedisCach
 	...
 ----
 
+By default any `key` for a cache entry gets prefixed with the actual cache name followed by 2 colons.
+This behavior can be changed to a static as well as a computed prefix.
+
+[source,java]
+----
+// static key prefix
+RedisCacheConfiguration.defaultCacheConfig().prefixKeysWith("( ͡° ᴥ ͡°)");
+
+// computed key prefix
+RedisCacheConfiguration.defaultCacheConfig().computePrefixWith(cacheName -> "¯\_(ツ)_/¯" + cacheName);
+----
+
 .RedisCacheManager defaults
 [width="80%",cols="<1,<2",options="header"]
 |====

--- a/src/main/java/org/springframework/data/redis/cache/CacheKeyPrefix.java
+++ b/src/main/java/org/springframework/data/redis/cache/CacheKeyPrefix.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.cache;
+
+/**
+ * {@link CacheKeyPrefix} provides a hook for creating custom prefixes prepended to the actual {@literal key} stored in
+ * Redis.
+ *
+ * @author Christoph Strobl
+ * @since 2.0.4
+ */
+@FunctionalInterface
+public interface CacheKeyPrefix {
+
+	/**
+	 * Compute the prefix for the actual {@literal key} stored in Redis.
+	 *
+	 * @param cacheName will never be {@literal null}.
+	 * @return never {@literal null}.
+	 */
+	String compute(String cacheName);
+}

--- a/src/main/java/org/springframework/data/redis/cache/CacheKeyPrefix.java
+++ b/src/main/java/org/springframework/data/redis/cache/CacheKeyPrefix.java
@@ -20,6 +20,7 @@ package org.springframework.data.redis.cache;
  * Redis.
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 2.0.4
  */
 @FunctionalInterface
@@ -32,4 +33,14 @@ public interface CacheKeyPrefix {
 	 * @return never {@literal null}.
 	 */
 	String compute(String cacheName);
+
+	/**
+	 * Creates a default {@link CacheKeyPrefix} scheme that prefixes cache keys with {@code cacheName} followed by double
+	 * colons. A cache named {@code myCache} will prefix all cache keys with {@code myCache::}.
+	 *
+	 * @return the default {@link CacheKeyPrefix} scheme.
+	 */
+	static CacheKeyPrefix simple() {
+		return name -> name + "::";
+	}
 }

--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -300,7 +300,7 @@ public class RedisCache extends AbstractValueAdaptingCache {
 	}
 
 	private String prefixCacheKey(String key) {
-		return cacheConfig.getKeyPrefix().orElseGet(() -> name + "::") + key;
+		return cacheConfig.getKeyPrefixFor(name).orElseGet(() -> name + "::") + key;
 	}
 
 	private static <T> T valueFromLoader(Object key, Callable<T> valueLoader) {

--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -300,7 +300,9 @@ public class RedisCache extends AbstractValueAdaptingCache {
 	}
 
 	private String prefixCacheKey(String key) {
-		return cacheConfig.getKeyPrefixFor(name).orElseGet(() -> name + "::") + key;
+
+		// allow contextual cache names by computing the key prefix on every call.
+		return cacheConfig.getKeyPrefixFor(name) + key;
 	}
 
 	private static <T> T valueFromLoader(Object key, Callable<T> valueLoader) {


### PR DESCRIPTION
We now allow, in addition to a static key prefix, the computation of prefixes based on the cache name. This change introduces an alternative to the in 2.x removed `org.springframework.data.redis.cache.RedisCacheKey`, and gives users more control over cache key generation.

```java
// static key prefix
RedisCacheConfiguration.defaultCacheConfig()
    .prefixKeysWith("( ͡° ᴥ ͡°)");

// computed key prefix
RedisCacheConfiguration.defaultCacheConfig()
    .computePrefixWith(cacheName -> "¯\_(ツ)_/¯" + cacheName);
```