### PR TITLE
DATAREDIS-746 - Add ZSet union/intersect operation aggregation/weights support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-746-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -1295,15 +1295,6 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 		return convertAndReturn(delegate.zIncrBy(key, increment, value), identityConverter);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zInterStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, int[], byte[][])
-	 */
-	@Override
-	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
-		return convertAndReturn(delegate.zInterStore(destKey, aggregate, weights, sets), identityConverter);
-	}
-
 	/* 
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zInterStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
@@ -1563,14 +1554,6 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	@Override
 	public Double zScore(byte[] key, byte[] value) {
 		return convertAndReturn(delegate.zScore(key, value), identityConverter);
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, int[], byte[][])
-	 */
-	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
-		return convertAndReturn(delegate.zUnionStore(destKey, aggregate, weights, sets), identityConverter);
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -15,17 +15,8 @@
  */
 package org.springframework.data.redis.connection;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
@@ -1313,6 +1304,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 		return convertAndReturn(delegate.zInterStore(destKey, aggregate, weights, sets), identityConverter);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zInterStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
+	 */
+	@Override
+	public Long zInterStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
+		return convertAndReturn(delegate.zInterStore(destKey, aggregate, weights, sets), identityConverter);
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zInterStore(byte[], byte[][])
@@ -1570,6 +1570,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, int[], byte[][])
 	 */
 	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+		return convertAndReturn(delegate.zUnionStore(destKey, aggregate, weights, sets), identityConverter);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
+	 */
+	@Override
+	public Long zUnionStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
 		return convertAndReturn(delegate.zUnionStore(destKey, aggregate, weights, sets), identityConverter);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -688,6 +688,13 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	/** @deprecated in favor of {@link RedisConnection#zSetCommands()}}. */
 	@Override
 	@Deprecated
+	default Long zInterStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
+		return zSetCommands().zInterStore(destKey, aggregate, weights, sets);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#zSetCommands()}}. */
+	@Override
+	@Deprecated
 	default Long zInterStore(byte[] destKey, byte[]... sets) {
 		return zSetCommands().zInterStore(destKey, sets);
 	}
@@ -808,6 +815,13 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	@Override
 	@Deprecated
 	default Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+		return zSetCommands().zUnionStore(destKey, aggregate, weights, sets);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#zSetCommands()}}. */
+	@Override
+	@Deprecated
+	default Long zUnionStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
 		return zSetCommands().zUnionStore(destKey, aggregate, weights, sets);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
@@ -34,6 +34,7 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.Numeric
 import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
+import org.springframework.data.redis.connection.RedisZSetCommands.Weights;
 import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -1367,6 +1368,17 @@ public interface ReactiveZSetCommands {
 		}
 
 		/**
+		 * Applies the {@link Weights}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param weights must not be {@literal null}.
+		 * @return a new {@link ZUnionStoreCommand} with {@literal weights} applied.
+		 * @since 2.1
+		 */
+		public ZUnionStoreCommand applyWeights(Weights weights) {
+			return new ZUnionStoreCommand(getKey(), sourceKeys, weights.toList(), aggregateFunction);
+		}
+
+		/**
 		 * Applies a specific {@link Aggregate} function. Constructs a new command instance with all previously configured
 		 * properties.
 		 *
@@ -1441,6 +1453,21 @@ public interface ReactiveZSetCommands {
 	}
 
 	/**
+	 * Union sorted {@literal sets} and store result in destination {@literal destinationKey} and apply weights to
+	 * individual sets.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets, Weights weights) {
+		return zUnionStore(destinationKey, sets, weights, null);
+	}
+
+	/**
 	 * Union sorted {@literal sets} by applying {@literal aggregateFunction} and store result in destination
 	 * {@literal destinationKey} and apply weights to individual sets.
 	 *
@@ -1452,6 +1479,29 @@ public interface ReactiveZSetCommands {
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights,
+			@Nullable Aggregate aggregateFunction) {
+
+		Assert.notNull(destinationKey, "DestinationKey must not be null!");
+		Assert.notNull(sets, "Sets must not be null!");
+
+		return zUnionStore(Mono.just(
+				ZUnionStoreCommand.sets(sets).aggregateUsing(aggregateFunction).applyWeights(weights).storeAs(destinationKey)))
+						.next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Union sorted {@literal sets} by applying {@literal aggregateFunction} and store result in destination
+	 * {@literal destinationKey} and apply weights to individual sets.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @param weights can be {@literal null}.
+	 * @param aggregateFunction can be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets, Weights weights,
 			@Nullable Aggregate aggregateFunction) {
 
 		Assert.notNull(destinationKey, "DestinationKey must not be null!");
@@ -1515,6 +1565,17 @@ public interface ReactiveZSetCommands {
 		 */
 		public ZInterStoreCommand applyWeights(List<Double> weights) {
 			return new ZInterStoreCommand(getKey(), sourceKeys, weights, aggregateFunction);
+		}
+
+		/**
+		 * Applies the {@link Weights}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param weights must not be {@literal null}.
+		 * @return a new {@link ZInterStoreCommand} with {@literal weights} applied.
+		 * @since 2.1
+		 */
+		public ZInterStoreCommand applyWeights(Weights weights) {
+			return new ZInterStoreCommand(getKey(), sourceKeys, weights.toList(), aggregateFunction);
 		}
 
 		/**
@@ -1592,6 +1653,21 @@ public interface ReactiveZSetCommands {
 	}
 
 	/**
+	 * Intersect sorted {@literal sets} and store result in destination {@literal destinationKey} and apply weights to
+	 * individual sets.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets, Weights weights) {
+		return zInterStore(destinationKey, sets, weights, null);
+	}
+
+	/**
 	 * Intersect sorted {@literal sets} by applying {@literal aggregateFunction} and store result in destination
 	 * {@literal destinationKey} and apply weights to individual sets.
 	 *
@@ -1603,6 +1679,29 @@ public interface ReactiveZSetCommands {
 	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights,
+			@Nullable Aggregate aggregateFunction) {
+
+		Assert.notNull(destinationKey, "DestinationKey must not be null!");
+		Assert.notNull(sets, "Sets must not be null!");
+
+		return zInterStore(Mono.just(
+				ZInterStoreCommand.sets(sets).aggregateUsing(aggregateFunction).applyWeights(weights).storeAs(destinationKey)))
+						.next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Intersect sorted {@literal sets} by applying {@literal aggregateFunction} and store result in destination
+	 * {@literal destinationKey} and apply weights to individual sets.
+	 *
+	 * @param destinationKey must not be {@literal null}.
+	 * @param sets must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
+	 * @param aggregateFunction can be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets, Weights weights,
 			@Nullable Aggregate aggregateFunction) {
 
 		Assert.notNull(destinationKey, "DestinationKey must not be null!");

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
@@ -1375,7 +1375,7 @@ public interface ReactiveZSetCommands {
 		 * @since 2.1
 		 */
 		public ZUnionStoreCommand applyWeights(Weights weights) {
-			return new ZUnionStoreCommand(getKey(), sourceKeys, weights.toList(), aggregateFunction);
+			return applyWeights(weights.toList());
 		}
 
 		/**
@@ -1575,7 +1575,7 @@ public interface ReactiveZSetCommands {
 		 * @since 2.1
 		 */
 		public ZInterStoreCommand applyWeights(Weights weights) {
-			return new ZInterStoreCommand(getKey(), sourceKeys, weights.toList(), aggregateFunction);
+			return applyWeights(weights.toList());
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
@@ -631,16 +631,28 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 	 */
 	@Override
 	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+		return zUnionStore(destKey, aggregate, Weights.of(weights), sets);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
+	 */
+	@Override
+	public Long zUnionStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
 
 		Assert.notNull(destKey, "Destination key must not be null!");
 		Assert.notNull(sets, "Source sets must not be null!");
 		Assert.noNullElements(sets, "Source sets must not contain null elements!");
+		Assert.isTrue(weights.size() == sets.length, () -> String
+				.format("The number of weights (%d) must match the number of source sets (%d)!", weights.size(), sets.length));
 
 		byte[][] allKeys = ByteUtils.mergeArrays(destKey, sets);
 
 		if (ClusterSlotHashUtil.isSameSlotForAllKeys(allKeys)) {
 
-			ZParams zparams = new ZParams().weights(weights).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
+			ZParams zparams = new ZParams().weightsByDouble(weights.toArray())
+					.aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
 
 			try {
 				return connection.getCluster().zunionstore(destKey, zparams, sets);
@@ -683,16 +695,28 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 	 */
 	@Override
 	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+		return zInterStore(destKey, aggregate, Weights.of(weights), sets);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zInterStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
+	 */
+	@Override
+	public Long zInterStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
 
 		Assert.notNull(destKey, "Destination key must not be null!");
 		Assert.notNull(sets, "Source sets must not be null!");
 		Assert.noNullElements(sets, "Source sets must not contain null elements!");
+		Assert.isTrue(weights.size() == sets.length, () -> String
+				.format("The number of weights (%d) must match the number of source sets (%d)!", weights.size(), sets.length));
 
 		byte[][] allKeys = ByteUtils.mergeArrays(destKey, sets);
 
 		if (ClusterSlotHashUtil.isSameSlotForAllKeys(allKeys)) {
 
-			ZParams zparams = new ZParams().weights(weights).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
+			ZParams zparams = new ZParams().weightsByDouble(weights.toArray())
+					.aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
 
 			try {
 				return connection.getCluster().zinterstore(destKey, zparams, sets);

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
@@ -627,15 +627,6 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, int[], byte[][])
-	 */
-	@Override
-	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
-		return zUnionStore(destKey, aggregate, Weights.of(weights), sets);
-	}
-
-	/*
-	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
 	 */
 	@Override
@@ -689,14 +680,6 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 		throw new InvalidDataAccessApiUsageException("ZINTERSTORE can only be executed when all keys map to the same slot");
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zInterStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, int[], byte[][])
-	 */
-	@Override
-	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
-		return zInterStore(destKey, aggregate, Weights.of(weights), sets);
-	}
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
@@ -585,13 +585,26 @@ class JedisZSetCommands implements RedisZSetCommands {
 	 */
 	@Override
 	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+		return zUnionStore(destKey, aggregate, Weights.of(weights), sets);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
+	 */
+	@Override
+	public Long zUnionStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
 
 		Assert.notNull(destKey, "Destination key must not be null!");
 		Assert.notNull(sets, "Source sets must not be null!");
+		Assert.notNull(weights, "Weights must not be null!");
 		Assert.noNullElements(sets, "Source sets must not contain null elements!");
+		Assert.isTrue(weights.size() == sets.length, () -> String
+				.format("The number of weights (%d) must match the number of source sets (%d)!", weights.size(), sets.length));
 
 		try {
-			ZParams zparams = new ZParams().weights(weights).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
+			ZParams zparams = new ZParams().weightsByDouble(weights.toArray())
+					.aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
 
 			if (isPipelined()) {
 				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zunionstore(destKey, zparams, sets)));
@@ -639,13 +652,25 @@ class JedisZSetCommands implements RedisZSetCommands {
 	 */
 	@Override
 	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+		return zInterStore(destKey, aggregate, Weights.of(weights), sets);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zInterStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
+	 */
+	@Override
+	public Long zInterStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
 
 		Assert.notNull(destKey, "Destination key must not be null!");
 		Assert.notNull(sets, "Source sets must not be null!");
 		Assert.noNullElements(sets, "Source sets must not contain null elements!");
+		Assert.isTrue(weights.size() == sets.length, () -> String
+				.format("The number of weights (%d) must match the number of source sets (%d)!", weights.size(), sets.length));
 
 		try {
-			ZParams zparams = new ZParams().weights(weights).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
+			ZParams zparams = new ZParams().weightsByDouble(weights.toArray())
+					.aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
 
 			if (isPipelined()) {
 				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zinterstore(destKey, zparams, sets)));

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
@@ -579,15 +579,6 @@ class JedisZSetCommands implements RedisZSetCommands {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, int[], byte[][])
-	 */
-	@Override
-	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
-		return zUnionStore(destKey, aggregate, Weights.of(weights), sets);
-	}
-
 	/* 
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
@@ -644,15 +635,6 @@ class JedisZSetCommands implements RedisZSetCommands {
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zInterStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, int[], byte[][])
-	 */
-	@Override
-	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
-		return zInterStore(destKey, aggregate, Weights.of(weights), sets);
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommands.java
@@ -39,6 +39,7 @@ import org.springframework.data.redis.connection.ReactiveZSetCommands;
 import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 import org.springframework.data.redis.util.ByteUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -466,7 +467,7 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 		}));
 	}
 
-	private ZStoreArgs zStoreArgs(Aggregate aggregate, List<Double> weights) {
+	private static ZStoreArgs zStoreArgs(@Nullable Aggregate aggregate, @Nullable List<Double> weights) {
 
 		ZStoreArgs args = new ZStoreArgs();
 		if (aggregate != null) {
@@ -484,12 +485,9 @@ class LettuceReactiveZSetCommands implements ReactiveZSetCommands {
 		}
 
 		if (weights != null) {
-			double[] lg = new double[weights.size()];
-			for (int i = 0; i < lg.length; i++) {
-				lg[i] = weights.get(i).longValue();
-			}
-			args.weights(lg);
+			args.weights(weights.stream().mapToDouble(it -> it).toArray());
 		}
+
 		return args;
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceZSetCommands.java
@@ -571,15 +571,6 @@ class LettuceZSetCommands implements RedisZSetCommands {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, int[], byte[][])
-	 */
-	@Override
-	public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
-		return zUnionStore(destKey, aggregate, Weights.of(weights), sets);
-	}
-
-	/*
-	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zUnionStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights, byte[][])
 	 */
 	@Override
@@ -632,15 +623,6 @@ class LettuceZSetCommands implements RedisZSetCommands {
 		} catch (Exception ex) {
 			throw convertLettuceAccessException(ex);
 		}
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisZSetCommands#zInterStore(byte[], org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, int[], byte[][])
-	 */
-	@Override
-	public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
-		return zInterStore(destKey, aggregate, Weights.of(weights), sets);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.core;
 import java.util.Collection;
 import java.util.Set;
 
+import org.springframework.data.redis.connection.RedisZSetCommands;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
@@ -30,6 +31,7 @@ import org.springframework.lang.Nullable;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author wongoo
  */
 public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 
@@ -260,6 +262,27 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	void unionAndStore(Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Union sorted sets at the bound key and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	void unionAndStore(Collection<K> otherKeys, K destKey, RedisZSetCommands.Aggregate aggregate);
+
+	/**
+	 * Union sorted sets at the bound key and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param otherKeys must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	void unionAndStore(Collection<K> otherKeys, int[] weights, K destKey, RedisZSetCommands.Aggregate aggregate);
 
 	/**
 	 * Intersect sorted sets at the bound key and {@code otherKey} and store result in destination {@code destKey}.

--- a/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
@@ -22,6 +22,7 @@ import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
+import org.springframework.data.redis.connection.RedisZSetCommands.Weights;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.lang.Nullable;
 
@@ -278,13 +279,13 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * Union sorted sets at the bound key and {@code otherKeys} and store result in destination {@code destKey}.
 	 *
 	 * @param otherKeys must not be {@literal null}.
-	 * @param weights must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @param aggregate must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
 	 * @since 2.1
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
-	void unionAndStore(Collection<K> otherKeys, int[] weights, K destKey, Aggregate aggregate);
+	void unionAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
 
 	/**
 	 * Intersect sorted sets at the bound key and {@code otherKey} and store result in destination {@code destKey}.
@@ -303,6 +304,29 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	void intersectAndStore(Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Intersect sorted sets at the bound key and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	void intersectAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate);
+
+	/**
+	 * Intersect sorted sets at the bound key and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	void intersectAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
 
 	/**
 	 * Iterate over elements in zset at the bound key. <br />

--- a/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
@@ -18,7 +18,7 @@ package org.springframework.data.redis.core;
 import java.util.Collection;
 import java.util.Set;
 
-import org.springframework.data.redis.connection.RedisZSetCommands;
+import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
@@ -31,7 +31,7 @@ import org.springframework.lang.Nullable;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Mark Paluch
- * @author wongoo
+ * @author Wongoo
  */
 public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 
@@ -269,9 +269,10 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @param aggregate must not be {@literal null}.
+	 * @since 2.1
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
-	void unionAndStore(Collection<K> otherKeys, K destKey, RedisZSetCommands.Aggregate aggregate);
+	void unionAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate);
 
 	/**
 	 * Union sorted sets at the bound key and {@code otherKeys} and store result in destination {@code destKey}.
@@ -280,9 +281,10 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param weights must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @param aggregate must not be {@literal null}.
+	 * @since 2.1
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
-	void unionAndStore(Collection<K> otherKeys, int[] weights, K destKey, RedisZSetCommands.Aggregate aggregate);
+	void unionAndStore(Collection<K> otherKeys, int[] weights, K destKey, Aggregate aggregate);
 
 	/**
 	 * Intersect sorted sets at the bound key and {@code otherKey} and store result in destination {@code destKey}.

--- a/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
@@ -32,7 +32,7 @@ import org.springframework.lang.Nullable;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Mark Paluch
- * @author Wongoo
+ * @author Wongoo (望哥)
  */
 public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultBoundZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultBoundZSetOperations.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.springframework.data.redis.connection.DataType;
+import org.springframework.data.redis.connection.RedisZSetCommands;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
@@ -30,6 +31,7 @@ import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author wongoo
  */
 class DefaultBoundZSetOperations<K, V> extends DefaultBoundKeyOperations<K> implements BoundZSetOperations<K, V> {
 
@@ -288,6 +290,24 @@ class DefaultBoundZSetOperations<K, V> extends DefaultBoundKeyOperations<K> impl
 	@Override
 	public void unionAndStore(Collection<K> otherKeys, K destKey) {
 		ops.unionAndStore(getKey(), otherKeys, destKey);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.BoundZSetOperations#unionAndStore(Collection, Object, RedisZSetCommands.Aggregate)
+	 */
+	@Override
+	public void unionAndStore(Collection<K> otherKeys, K destKey, RedisZSetCommands.Aggregate aggregate) {
+		ops.unionAndStore(getKey(), otherKeys, destKey, aggregate);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.BoundZSetOperations#unionAndStore(Collection, int[], Object, RedisZSetCommands.Aggregate)
+	 */
+	@Override
+	public void unionAndStore(Collection<K> otherKeys, int[] weights, K destKey, RedisZSetCommands.Aggregate aggregate) {
+		ops.unionAndStore(getKey(), otherKeys, weights, destKey, aggregate);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultBoundZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultBoundZSetOperations.java
@@ -32,7 +32,7 @@ import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Mark Paluch
- * @author wongoo
+ * @author Wongoo (望哥)
  */
 class DefaultBoundZSetOperations<K, V> extends DefaultBoundKeyOperations<K> implements BoundZSetOperations<K, V> {
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultBoundZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultBoundZSetOperations.java
@@ -20,9 +20,10 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.springframework.data.redis.connection.DataType;
-import org.springframework.data.redis.connection.RedisZSetCommands;
+import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
+import org.springframework.data.redis.connection.RedisZSetCommands.Weights;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
 /**
@@ -101,6 +102,24 @@ class DefaultBoundZSetOperations<K, V> extends DefaultBoundKeyOperations<K> impl
 	@Override
 	public void intersectAndStore(Collection<K> otherKeys, K destKey) {
 		ops.intersectAndStore(getKey(), otherKeys, destKey);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.BoundZSetOperations#intersectAndStore(java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate)
+	 */
+	@Override
+	public void intersectAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate) {
+		ops.intersectAndStore(getKey(), otherKeys, destKey, aggregate);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.BoundZSetOperations#intersectAndStore(java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights)
+	 */
+	@Override
+	public void intersectAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights) {
+		ops.intersectAndStore(getKey(), otherKeys, destKey, aggregate, weights);
 	}
 
 	/*
@@ -292,22 +311,22 @@ class DefaultBoundZSetOperations<K, V> extends DefaultBoundKeyOperations<K> impl
 		ops.unionAndStore(getKey(), otherKeys, destKey);
 	}
 
-	/*
+	/* 
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundZSetOperations#unionAndStore(Collection, Object, RedisZSetCommands.Aggregate)
+	 * @see org.springframework.data.redis.core.BoundZSetOperations#unionAndStore(java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate)
 	 */
 	@Override
-	public void unionAndStore(Collection<K> otherKeys, K destKey, RedisZSetCommands.Aggregate aggregate) {
+	public void unionAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate) {
 		ops.unionAndStore(getKey(), otherKeys, destKey, aggregate);
 	}
 
-	/*
+	/* 
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.BoundZSetOperations#unionAndStore(Collection, int[], Object, RedisZSetCommands.Aggregate)
+	 * @see org.springframework.data.redis.core.BoundZSetOperations#unionAndStore(java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights)
 	 */
 	@Override
-	public void unionAndStore(Collection<K> otherKeys, int[] weights, K destKey, RedisZSetCommands.Aggregate aggregate) {
-		ops.unionAndStore(getKey(), otherKeys, weights, destKey, aggregate);
+	public void unionAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights) {
+		ops.unionAndStore(getKey(), otherKeys, destKey, aggregate, weights);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveZSetOperations.java
@@ -375,18 +375,6 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#unionAndStore(java.lang.Object, java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate)
-	 */
-	@Override
-	public Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
-
-		Assert.notNull(otherKeys, "Other keys must not be null!");
-
-		return unionAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
-	}
-
-	/*
-	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#unionAndStore(java.lang.Object, java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate, org.springframework.data.redis.connection.RedisZSetCommands.Weights)
 	 */
 	@Override
@@ -433,18 +421,6 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 				.map(this::rawKey) //
 				.collectList() //
 				.flatMap(serialized -> connection.zInterStore(rawKey(destKey), serialized)));
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#intersectAndStore(java.lang.Object, java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate)
-	 */
-	@Override
-	public Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
-
-		Assert.notNull(otherKeys, "Other keys must not be null!");
-
-		return intersectAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
@@ -33,7 +33,7 @@ import org.springframework.data.redis.connection.RedisZSetCommands.Weights;
  * @author Thomas Darimont
  * @author David Liu
  * @author Mark Paluch
- * @author wongoo
+ * @author Wongoo (望哥)
  */
 class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZSetOperations<K, V> {
 
@@ -97,15 +97,6 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		byte[] rawDestKey = rawKey(destKey);
 
 		return execute(connection -> connection.zInterStore(rawDestKey, rawKeys), true);
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ZSetOperations#intersectAndStore(java.lang.Object, java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate)
-	 */
-	@Override
-	public Long intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
-		return intersectAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
 	}
 
 	/*
@@ -431,15 +422,6 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		byte[] rawDestKey = rawKey(destKey);
 
 		return execute(connection -> connection.zUnionStore(rawDestKey, rawKeys), true);
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.core.ZSetOperations#unionAndStore(java.lang.Object, java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate)
-	 */
-	@Override
-	public Long unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
-		return unionAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
+import org.springframework.data.redis.connection.RedisZSetCommands;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
@@ -31,6 +32,7 @@ import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
  * @author Thomas Darimont
  * @author David Liu
  * @author Mark Paluch
+ * @author wongoo
  */
 class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZSetOperations<K, V> {
 
@@ -400,10 +402,33 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	 */
 	@Override
 	public Long unionAndStore(K key, Collection<K> otherKeys, K destKey) {
-
 		byte[][] rawKeys = rawKeys(key, otherKeys);
 		byte[] rawDestKey = rawKey(destKey);
 		return execute(connection -> connection.zUnionStore(rawDestKey, rawKeys), true);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ZSetOperations#unionAndStore(java.lang.Object, java.util.Collection, java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate)
+	 */
+	@Override
+	public Long unionAndStore(K key, Collection<K> otherKeys, K destKey, RedisZSetCommands.Aggregate aggregate) {
+		int weights[] = new int[otherKeys.size() + (key != null ? 1 : 0)];
+		for (int i = 0; i < weights.length; i++) {
+			weights[i] = 1;
+		}
+		return unionAndStore(key, otherKeys, weights, destKey, aggregate);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ZSetOperations#unionAndStore(java.lang.Object, java.util.Collection, int[], java.lang.Object, org.springframework.data.redis.connection.RedisZSetCommands.Aggregate)
+	 */
+	@Override
+	public Long unionAndStore(K key, Collection<K> otherKeys, int[] weights, K destKey, RedisZSetCommands.Aggregate aggregate) {
+		byte[][] rawKeys = rawKeys(key, otherKeys);
+		byte[] rawDestKey = rawKey(destKey);
+		return execute(connection -> connection.zUnionStore(rawDestKey, aggregate, weights, rawKeys), true);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
@@ -21,8 +21,10 @@ import reactor.core.publisher.Mono;
 import java.util.Collection;
 
 import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
+import org.springframework.data.redis.connection.RedisZSetCommands.Weights;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
 /**
@@ -298,6 +300,33 @@ public interface ReactiveZSetOperations<K, V> {
 	Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey);
 
 	/**
+	 * Union sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate);
+
+	/**
+	 * Union sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
+
+	/**
 	 * Intersect sorted sets at {@code key} and {@code otherKey} and store result in destination {@code destKey}.
 	 *
 	 * @param key must not be {@literal null}.
@@ -318,6 +347,33 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Intersect sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate);
+
+	/**
+	 * Intersect sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
+	 * @return
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
 
 	/**
 	 * Get all elements with lexicographical ordering from {@literal ZSET} at {@code key} with a value between

--- a/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
@@ -310,7 +310,9 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @since 2.1
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
-	Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate);
+	default Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
+		return unionAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
+	}
 
 	/**
 	 * Union sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
@@ -359,7 +361,9 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @since 2.1
 	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
-	Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate);
+	default Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
+		return intersectAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
+	}
 
 	/**
 	 * Intersect sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.

--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -22,6 +22,7 @@ import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
+import org.springframework.data.redis.connection.RedisZSetCommands.Weights;
 import org.springframework.lang.Nullable;
 
 /**
@@ -384,15 +385,15 @@ public interface ZSetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param otherKeys must not be {@literal null}.
-	 * @param weights must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @param aggregate must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
-	Long unionAndStore(K key, Collection<K> otherKeys, int[] weights, K destKey, Aggregate aggregate);
+	Long unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
 
 	/**
 	 * Intersect sorted sets at {@code key} and {@code otherKey} and store result in destination {@code destKey}.
@@ -417,6 +418,35 @@ public interface ZSetOperations<K, V> {
 	 */
 	@Nullable
 	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Intersect sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	@Nullable
+	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate);
+
+	/**
+	 * Intersect sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @since 2.1
+	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 */
+	@Nullable
+	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
 
 	/**
 	 * Iterate over elements in zset at {@code key}. <br />

--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -32,7 +32,7 @@ import org.springframework.lang.Nullable;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Rosty Kerei
- * @author wongoo
+ * @author Wongoo (望哥)
  */
 public interface ZSetOperations<K, V> {
 
@@ -378,7 +378,9 @@ public interface ZSetOperations<K, V> {
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
-	Long unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate);
+	default Long unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
+		return unionAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
+	}
 
 	/**
 	 * Union sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
@@ -431,7 +433,9 @@ public interface ZSetOperations<K, V> {
 	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
-	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate);
+	default Long intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
+		return intersectAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
+	}
 
 	/**
 	 * Intersect sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.

--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -18,7 +18,7 @@ package org.springframework.data.redis.core;
 import java.util.Collection;
 import java.util.Set;
 
-import org.springframework.data.redis.connection.RedisZSetCommands;
+import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
@@ -373,10 +373,11 @@ public interface ZSetOperations<K, V> {
 	 * @param destKey must not be {@literal null}.
 	 * @param aggregate must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
+	 * @since 2.1
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
-	Long unionAndStore(K key, Collection<K> otherKeys, K destKey, RedisZSetCommands.Aggregate aggregate);
+	Long unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate);
 
 	/**
 	 * Union sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
@@ -387,10 +388,11 @@ public interface ZSetOperations<K, V> {
 	 * @param destKey must not be {@literal null}.
 	 * @param aggregate must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
+	 * @since 2.1
 	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
-	Long unionAndStore(K key, Collection<K> otherKeys, int[] weights, K destKey, RedisZSetCommands.Aggregate aggregate);
+	Long unionAndStore(K key, Collection<K> otherKeys, int[] weights, K destKey, Aggregate aggregate);
 
 	/**
 	 * Intersect sorted sets at {@code key} and {@code otherKey} and store result in destination {@code destKey}.

--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.core;
 import java.util.Collection;
 import java.util.Set;
 
+import org.springframework.data.redis.connection.RedisZSetCommands;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
@@ -30,6 +31,7 @@ import org.springframework.lang.Nullable;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Rosty Kerei
+ * @author wongoo
  */
 public interface ZSetOperations<K, V> {
 
@@ -362,6 +364,33 @@ public interface ZSetOperations<K, V> {
 	 */
 	@Nullable
 	Long unionAndStore(K key, Collection<K> otherKeys, K destKey);
+
+	/**
+	 * Union sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	@Nullable
+	Long unionAndStore(K key, Collection<K> otherKeys, K destKey, RedisZSetCommands.Aggregate aggregate);
+
+	/**
+	 * Union sorted sets at {@code key} and {@code otherKeys} and store result in destination {@code destKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @param weights must not be {@literal null}.
+	 * @param destKey must not be {@literal null}.
+	 * @param aggregate must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 */
+	@Nullable
+	Long unionAndStore(K key, Collection<K> otherKeys, int[] weights, K destKey, RedisZSetCommands.Aggregate aggregate);
 
 	/**
 	 * Intersect sorted sets at {@code key} and {@code otherKey} and store result in destination {@code destKey}.

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
@@ -18,7 +18,16 @@ package org.springframework.data.redis.connection;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
@@ -38,6 +47,7 @@ import org.springframework.data.redis.connection.RedisServerCommands.ShutdownOpt
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
+import org.springframework.data.redis.connection.RedisZSetCommands.Weights;
 import org.springframework.data.redis.connection.StringRedisConnection.StringTuple;
 import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -1286,14 +1296,14 @@ public class DefaultStringRedisConnectionTests {
 
 	@Test
 	public void testZInterStoreAggWeightsBytes() {
-		doReturn(5l).when(nativeConnection).zInterStore(fooBytes, Aggregate.MAX, new int[0], fooBytes);
+		doReturn(5l).when(nativeConnection).zInterStore(eq(fooBytes), eq(Aggregate.MAX), any(Weights.class), eq(fooBytes));
 		actual.add(connection.zInterStore(fooBytes, Aggregate.MAX, new int[0], fooBytes));
 		verifyResults(Arrays.asList(new Object[] { 5l }));
 	}
 
 	@Test
 	public void testZInterStoreAggWeights() {
-		doReturn(5l).when(nativeConnection).zInterStore(fooBytes, Aggregate.MAX, new int[0], fooBytes);
+		doReturn(5l).when(nativeConnection).zInterStore(eq(fooBytes), eq(Aggregate.MAX), any(Weights.class), eq(fooBytes));
 		actual.add(connection.zInterStore(foo, Aggregate.MAX, new int[0], foo));
 		verifyResults(Arrays.asList(new Object[] { 5l }));
 	}
@@ -1566,14 +1576,14 @@ public class DefaultStringRedisConnectionTests {
 
 	@Test
 	public void testZUnionStoreAggWeightsBytes() {
-		doReturn(5l).when(nativeConnection).zUnionStore(fooBytes, Aggregate.MAX, new int[0], fooBytes);
+		doReturn(5l).when(nativeConnection).zUnionStore(eq(fooBytes), eq(Aggregate.MAX), any(Weights.class), eq(fooBytes));
 		actual.add(connection.zUnionStore(fooBytes, Aggregate.MAX, new int[0], fooBytes));
 		verifyResults(Arrays.asList(new Object[] { 5l }));
 	}
 
 	@Test
 	public void testZUnionStoreAggWeights() {
-		doReturn(5l).when(nativeConnection).zUnionStore(fooBytes, Aggregate.MAX, new int[0], fooBytes);
+		doReturn(5l).when(nativeConnection).zUnionStore(eq(fooBytes), eq(Aggregate.MAX), any(Weights.class), eq(fooBytes));
 		actual.add(connection.zUnionStore(foo, Aggregate.MAX, new int[0], foo));
 		verifyResults(Arrays.asList(new Object[] { 5l }));
 	}
@@ -1785,8 +1795,7 @@ public class DefaultStringRedisConnectionTests {
 	@Test // DATAREDIS-438
 	public void testGeoAddWithGeoLocationBytes() {
 
-		doReturn(1l).when(nativeConnection).geoAdd(fooBytes,
-				new GeoLocation<>(barBytes, new Point(1.23232, 34.2342434)));
+		doReturn(1l).when(nativeConnection).geoAdd(fooBytes, new GeoLocation<>(barBytes, new Point(1.23232, 34.2342434)));
 
 		actual.add(connection.geoAdd(fooBytes, new GeoLocation<>(barBytes, new Point(1.23232, 34.2342434))));
 		verifyResults(Collections.singletonList(1L));

--- a/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
@@ -840,10 +840,6 @@ public class RedisConnectionUnitTests {
 			return delegate.zUnionStore(destKey, sets);
 		}
 
-		public Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
-			return delegate.zUnionStore(destKey, aggregate, weights, sets);
-		}
-
 		public Long zUnionStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
 			return delegate.zUnionStore(destKey, aggregate, weights, sets);
 		}

--- a/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
@@ -844,11 +844,19 @@ public class RedisConnectionUnitTests {
 			return delegate.zUnionStore(destKey, aggregate, weights, sets);
 		}
 
+		public Long zUnionStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
+			return delegate.zUnionStore(destKey, aggregate, weights, sets);
+		}
+
 		public Long zInterStore(byte[] destKey, byte[]... sets) {
 			return delegate.zInterStore(destKey, sets);
 		}
 
 		public Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
+			return delegate.zInterStore(destKey, aggregate, weights, sets);
+		}
+
+		public Long zInterStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets) {
 			return delegate.zInterStore(destKey, aggregate, weights, sets);
 		}
 

--- a/src/test/java/org/springframework/data/redis/connection/WeightsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/WeightsUnitTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.springframework.data.redis.connection.RedisZSetCommands.Weights;
+
+/**
+ * Unit tests for {@link org.springframework.data.redis.connection.RedisZSetCommands.Weights}.
+ *
+ * @author Mark Paluch
+ */
+public class WeightsUnitTests {
+
+	@Test // DATAREDIS-746
+	public void shouldCreateWeights() {
+
+		assertThat(Weights.of(1, 2, 3).toArray()).contains(1, 2, 3);
+		assertThat(Weights.of(1, 2d, 3).toArray()).contains(1d, 2d, 3d);
+	}
+
+	@Test // DATAREDIS-746
+	public void shouldRejectCreationWithNull() {
+
+		assertThatThrownBy(() -> Weights.of((int[]) null)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> Weights.of((double[]) null)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test // DATAREDIS-746
+	public void shouldCreateEqualWeights() {
+
+		Weights weights = Weights.fromSetCount(3);
+		assertThat(weights.getWeight(0)).isOne();
+		assertThat(weights.getWeight(1)).isOne();
+		assertThat(weights.getWeight(2)).isOne();
+	}
+
+	@Test // DATAREDIS-746
+	public void getShouldThrowIndexOutOfBoundsException() {
+
+		assertThatThrownBy(() -> Weights.fromSetCount(1).getWeight(1)).isInstanceOf(IndexOutOfBoundsException.class);
+		assertThatThrownBy(() -> Weights.fromSetCount(1).getWeight(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+	}
+
+	@Test // DATAREDIS-746
+	public void shouldMultiplyDouble() {
+
+		Weights weights = Weights.of(1, 2, 3).multiply(2.5);
+		assertThat(weights.getWeight(0)).isEqualTo(2.5);
+		assertThat(weights.getWeight(2)).isEqualTo(7.5);
+	}
+
+	@Test // DATAREDIS-746
+	public void shouldMultiplyInt() {
+
+		Weights weights = Weights.of(1, 2, 3).multiply(2);
+		assertThat(weights.getWeight(0)).isEqualTo(2);
+		assertThat(weights.getWeight(2)).isEqualTo(6);
+	}
+}

--- a/src/test/java/org/springframework/data/redis/core/DefaultZSetOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultZSetOperationsTests.java
@@ -53,7 +53,7 @@ import org.springframework.test.annotation.IfProfileValue;
  * @author Jennifer Hickey
  * @author Christoph Strobl
  * @author Mark Paluch
- * @author wongoo
+ * @author Wongoo (望哥)
  * @param <K> Key type
  * @param <V> Value type
  */
@@ -378,7 +378,6 @@ public class DefaultZSetOperationsTests<K, V> {
 		zSetOps.add(key1, value1, 1.0);
 		zSetOps.add(key1, value2, 2.0);
 		zSetOps.add(key2, value2, 3.0);
-
 
 		zSetOps.unionAndStore(key1, Collections.singletonList(key2), key1, RedisZSetCommands.Aggregate.MIN);
 


### PR DESCRIPTION
We now support aggregation and weight options for `ZUNIONSTORE` and `ZINTERSTORE`. We also encapsulate weights used for `ZUNIONSTORE` and `ZINTERSTORE` within a `Weights` value object.

```
zSetOps.intersectAndStore(set1, Arrays.asList(set2, set3), out, Aggregate.MAX,
				Weights.of(1, 2, 1));
```

---

Original pull request: #300.
Related pull request: #98.
Related tickets: [DATAREDIS-515](https://jira.spring.io/browse/DATAREDIS-515), [DATAREDIS-746](https://jira.spring.io/browse/DATAREDIS-746).