### PR TITLE
DATAREDIS-721 - Switch to non-blocking connect methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,12 +114,14 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
+			<version>${jackson}</version>
 			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
+			<version>${jackson}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-721-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,13 @@
 
 	<repositories>
 		<repository>
+			<id>sonatype-nexus-snapshots</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<repository>
 			<id>spring-libs-snapshot</id>
 			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -49,6 +49,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -1253,11 +1254,28 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 		private final LettucePool pool;
 
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnection(java.lang.Class)
+		 */
 		@Override
 		public <T extends StatefulConnection<?, ?>> T getConnection(Class<T> connectionType) {
 			return connectionType.cast(pool.getResource());
 		}
 
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnectionAsync(java.lang.Class)
+		 */
+		@Override
+		public <T extends StatefulConnection<?, ?>> CompletionStage<T> getConnectionAsync(Class<T> connectionType) {
+			throw new UnsupportedOperationException("Async operations not supported!");
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#release(io.lettuce.core.api.StatefulConnection)
+		 */
 		@Override
 		@SuppressWarnings("unchecked")
 		public void release(StatefulConnection<?, ?> connection) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -101,6 +101,7 @@ public class LettuceConnectionFactory
 	private @Nullable LettuceConnectionProvider reactiveConnectionProvider;
 	private boolean validateConnection = false;
 	private boolean shareNativeConnection = true;
+	private boolean eagerInitialization = false;
 	private @Nullable SharedConnection<byte[]> connection;
 	private @Nullable SharedConnection<ByteBuffer> reactiveConnection;
 	private @Nullable LettucePool pool;
@@ -279,6 +280,10 @@ public class LettuceConnectionFactory
 					new LettuceClusterTopologyProvider((RedisClusterClient) client),
 					new LettuceClusterConnection.LettuceClusterNodeResourceProvider(this.connectionProvider),
 					EXCEPTION_TRANSLATION);
+		}
+
+		if (getEagerInitialization() && getShareNativeConnection()) {
+			initConnection();
 		}
 	}
 
@@ -627,6 +632,30 @@ public class LettuceConnectionFactory
 	 */
 	public void setShareNativeConnection(boolean shareNativeConnection) {
 		this.shareNativeConnection = shareNativeConnection;
+	}
+
+	/**
+	 * Indicates {@link #setShareNativeConnection(boolean) shared connections} should be eagerly initialized. Eager
+	 * initialization requires a running Redis instance during application startup to allow early validation of connection
+	 * factory configuration. Eager initialization also prevents blocking connect while using reactive API and is
+	 * recommended for reactive API usage.
+	 *
+	 * @return {@link true} if the shared connection is initialized upon {@link #afterPropertiesSet()}.
+	 * @since 2.2
+	 */
+	public boolean getEagerInitialization() {
+		return eagerInitialization;
+	}
+
+	/**
+	 * Enables eager initialization of {@link #setShareNativeConnection(boolean) shared connections}.
+	 *
+	 * @param eagerInitialization enable eager connection shared connection initialization upon
+	 *          {@link #afterPropertiesSet()}.
+	 * @since 2.2
+	 */
+	public void setEagerInitialization(boolean eagerInitialization) {
+		this.eagerInitialization = eagerInitialization;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceFutureUtils.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceFutureUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Utility methods to interact with {@link CompletableFuture} and {@link CompletionStage}.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+class LettuceFutureUtils {
+
+	/**
+	 * Creates a {@link CompletableFuture} that is completed {@link CompletableFuture#exceptionally(Function)
+	 * exceptionally} given {@link Throwable}. This utility method allows exceptionally future creation with a single
+	 * invocation.
+	 *
+	 * @param t must not be {@literal null}.
+	 * @return the completed {@link CompletableFuture future}.
+	 */
+	static <T> CompletableFuture<T> failed(Throwable t) {
+
+		Assert.notNull(t, "Throwable must not be null!");
+
+		CompletableFuture<T> future = new CompletableFuture<>();
+		future.completeExceptionally(t);
+
+		return future;
+	}
+
+	/**
+	 * Synchronizes a {@link CompletableFuture} result by {@link CompletableFuture#join() waiting until the future is
+	 * complete}. This method preserves {@link RuntimeException}s that may get thrown as result of future completion.
+	 * Checked exceptions are thrown encapsulated within {@link java.util.concurrent.CompletionException}.
+	 *
+	 * @param future must not be {@literal null}.
+	 * @throws RuntimeException thrown if the future is completed with a {@link RuntimeException}.
+	 * @throws CompletionException thrown if the future is completed with a checked exception.
+	 * @return the future result if completed normally.
+	 */
+	@Nullable
+	static <T> T join(CompletionStage<T> future) throws RuntimeException, CompletionException {
+
+		Assert.notNull(future, "CompletableFuture must not be null!");
+
+		try {
+			return future.toCompletableFuture().join();
+		} catch (Exception e) {
+
+			Throwable exceptionToUse = e;
+
+			if (e instanceof CompletionException) {
+				exceptionToUse = new LettuceExceptionConverter().convert((Exception) e.getCause());
+				if (exceptionToUse == null) {
+					exceptionToUse = e.getCause();
+				}
+			}
+
+			if (exceptionToUse instanceof RuntimeException) {
+				throw (RuntimeException) exceptionToUse;
+			}
+
+			throw new CompletionException(exceptionToUse);
+		}
+	}
+
+	/**
+	 * Returns a {@link Function} that ignores {@link CompletionStage#exceptionally(Function) exceptional completion} by
+	 * recovering to {@code null}. This allows to progress with a previously failed {@link CompletionStage} without regard
+	 * to the actual success/exception state.
+	 *
+	 * @return
+	 */
+	static <T> Function<Throwable, T> ignoreErrors() {
+		return ignored -> null;
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.reactive.BaseRedisReactiveCommands;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.cluster.RedisClusterClient;
@@ -240,7 +241,7 @@ class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisConnecti
 					.map(it -> it.getConnection(node.getId()).reactive());
 		}
 
-		return getConnection().cast(StatefulRedisClusterConnection.class)
-				.map(it -> it.getConnection(node.getHost(), node.getPort()).reactive());
+		return getConnection().flatMap(it -> Mono.fromCompletionStage(it.getConnectionAsync(node.getHost(), node.getPort()))
+				.map(StatefulRedisConnection::reactive));
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
@@ -362,9 +362,8 @@ class LettuceReactiveRedisConnection implements ReactiveRedisConnection {
 
 			this.connectionProvider = connectionProvider;
 
-			Mono<StatefulConnection<ByteBuffer, ByteBuffer>> defer = Mono
-					.defer(() -> Mono.fromCompletionStage(connectionProvider.getConnectionAsync(connectionType)))
-					.map(it -> (StatefulConnection<ByteBuffer, ByteBuffer>) it);
+			Mono<StatefulConnection> defer = Mono
+					.defer(() -> Mono.fromCompletionStage(connectionProvider.getConnectionAsync(connectionType)));
 
 			this.connectionPublisher = defer.doOnNext(it -> {
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -29,6 +29,8 @@ import io.lettuce.core.AbstractRedisClient;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.codec.ByteArrayCodec;
@@ -38,6 +40,7 @@ import io.lettuce.core.resource.ClientResources;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.After;
 import org.junit.Before;
@@ -590,7 +593,7 @@ public class LettuceConnectionFactoryUnitTests {
 
 		RedisClusterClient clientMock = mock(RedisClusterClient.class);
 		StatefulRedisClusterConnection<byte[], byte[]> connectionMock = mock(StatefulRedisClusterConnection.class);
-		when(clientMock.connect(ByteArrayCodec.INSTANCE)).thenReturn(connectionMock);
+		when(clientMock.connectAsync(ByteArrayCodec.INSTANCE)).thenReturn(CompletableFuture.completedFuture(connectionMock));
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(clusterConfig,
 				LettuceClientConfiguration.defaultConfiguration()) {
@@ -608,7 +611,31 @@ public class LettuceConnectionFactoryUnitTests {
 		connectionFactory.getClusterConnection().close();
 		connectionFactory.getClusterConnection().close();
 
-		verify(clientMock).connect(ArgumentMatchers.any(RedisCodec.class));
+		verify(clientMock).connectAsync(ArgumentMatchers.any(RedisCodec.class));
+	}
+
+	@Test // DATAREDIS-721
+	@SuppressWarnings("unchecked")
+	public void shouldEagerlyInitializeSharedConnection() {
+
+		LettuceConnectionProvider connectionProviderMock = mock(LettuceConnectionProvider.class);
+		StatefulRedisConnection connectionMock = mock(StatefulRedisConnection.class);
+
+		when(connectionProviderMock.getConnectionAsync(any()))
+				.thenReturn(CompletableFuture.completedFuture(connectionMock));
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory() {
+			@Override
+			protected LettuceConnectionProvider doCreateConnectionProvider(AbstractRedisClient client,
+																		   RedisCodec<?, ?> codec) {
+				return connectionProviderMock;
+			}
+		};
+		connectionFactory.setEagerInitialization(true);
+
+		connectionFactory.afterPropertiesSet();
+
+		verify(connectionProviderMock, times(2)).getConnection(StatefulConnection.class);
 	}
 
 	@Test // DATAREDIS-842

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnectionUnitTests.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.springframework.data.redis.connection.ClusterTestVariables.*;
 
+import io.lettuce.core.ConnectionFuture;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.cluster.RedisClusterClient;
@@ -30,6 +31,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -60,8 +62,8 @@ public class LettuceReactiveRedisClusterConnectionUnitTests {
 	@Before
 	public void before() {
 
-		when(connectionProvider.getConnection(any())).thenReturn(sharedConnection);
-		when(sharedConnection.getConnection(anyString(), anyInt())).thenReturn(nodeConnection);
+		when(connectionProvider.getConnectionAsync(any())).thenReturn(CompletableFuture.completedFuture(sharedConnection));
+		when(sharedConnection.getConnectionAsync(anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(nodeConnection));
 		when(nodeConnection.reactive()).thenReturn(reactiveNodeCommands);
 	}
 


### PR DESCRIPTION
We now connect asynchronously to expose non-blocking connection behavior for reactive API usage. We also use a non-blocking, asynchronous pool implementation for connections that are used through a reactive API. Shared connection usage, which is blocking on the very first access can be pre-initialized during connection factory initialization instead of initialization on first access:

```java
LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory();
connectionFactory.setEagerInitialization(true);
connectionFactory.afterPropertiesSet();

```
We no longer require offloading of blocking connects to a dedicated scheduler which makes reactive API usage fully non-blocking.

---

Related ticket: [DATAREDIS-721](https://jira.spring.io/browse/DATAREDIS-721).