### PR TITLE
DATAREDIS-775 - Expose Lettuce RedisClient through RedisClientProvider.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-775-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.AbstractRedisClient;
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.cluster.RedisClusterClient;
@@ -34,7 +35,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @since 2.0
  */
-class ClusterConnectionProvider implements LettuceConnectionProvider {
+class ClusterConnectionProvider implements LettuceConnectionProvider, RedisClientProvider {
 
 	private final RedisClusterClient client;
 	private final RedisCodec<?, ?> codec;
@@ -91,7 +92,12 @@ class ClusterConnectionProvider implements LettuceConnectionProvider {
 		throw new UnsupportedOperationException("Connection type " + connectionType + " not supported!");
 	}
 
-	public RedisClusterClient getClient() {
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.RedisClientProvider#getRedisClient()
+	 */
+	@Override
+	public AbstractRedisClient getRedisClient() {
 		return client;
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -154,7 +154,15 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 	 * @return access to {@link RedisClusterClient} for non-connection access.
 	 */
 	private RedisClusterClient getClient() {
-		return ((ClusterConnectionProvider) getConnectionProvider()).getClient();
+
+		LettuceConnectionProvider connectionProvider = getConnectionProvider();
+
+		if (connectionProvider instanceof RedisClientProvider) {
+			return (RedisClusterClient) ((RedisClientProvider) getConnectionProvider()).getRedisClient();
+		}
+
+		throw new IllegalStateException(String.format("Connection provider %s does not implement RedisClientProvider!",
+				connectionProvider.getClass().getName()));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingConnectionProvider.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.AbstractRedisClient;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.support.ConnectionPoolSupport;
 
@@ -42,7 +43,7 @@ import org.springframework.util.Assert;
  * @since 2.0
  * @see #getConnection(Class)
  */
-class LettucePoolingConnectionProvider implements LettuceConnectionProvider, DisposableBean {
+class LettucePoolingConnectionProvider implements LettuceConnectionProvider, RedisClientProvider,  DisposableBean {
 
 	private final static Log log = LogFactory.getLog(LettucePoolingConnectionProvider.class);
 
@@ -84,6 +85,22 @@ class LettucePoolingConnectionProvider implements LettuceConnectionProvider, Dis
 		} catch (Exception e) {
 			throw new PoolException("Could not get a resource from the pool", e);
 		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.RedisClientProvider#getRedisClient()
+	 */
+	@Override
+	public AbstractRedisClient getRedisClient() {
+
+		if (connectionProvider instanceof RedisClientProvider) {
+			return ((RedisClientProvider) connectionProvider).getRedisClient();
+		}
+
+		throw new IllegalStateException(
+				String.format("Undyerlying connection provider %s does not implement RedisClientProvider!",
+						connectionProvider.getClass().getName()));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/RedisClientProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/RedisClientProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.AbstractRedisClient;
+
+/**
+ * Extension to {@link LettuceConnectionProvider} for providers exposing {@link io.lettuce.core.RedisClient}.
+ *
+ * @author Mark Paluch
+ * @since 2.0.5
+ */
+interface RedisClientProvider {
+
+	/**
+	 * Returns the underlying Redis Client.
+	 *
+	 * @return the {@link AbstractRedisClient}.
+	 */
+	AbstractRedisClient getRedisClient();
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestsBase.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
@@ -122,7 +123,7 @@ public abstract class LettuceReactiveCommandsTestsBase {
 			ClusterConnectionProvider clusterConnectionProvider = (ClusterConnectionProvider) nativeConnectionProvider;
 			nativeCommands = nativeConnectionProvider.getConnection(StatefulRedisClusterConnection.class).sync();
 			this.connection = new LettuceReactiveRedisClusterConnection(connectionProvider,
-					clusterConnectionProvider.getClient());
+					(RedisClusterClient) clusterConnectionProvider.getRedisClient());
 		}
 	}
 


### PR DESCRIPTION
We now expose the underlying Redis Client instance via `RedisClientProvider.getRedisClient()` to components that require direct client interaction. The client is exposed through ClusterConnectionProvider and now also through `LettucePoolingConnectionProvider`.

Exposing the client via `LettucePoolingConnectionProvider` allows Redis Cluster usage with connection pooling.

---

Requires backporting to `2.0.x`.

Related ticket: [DATAREDIS-775](https://jira.spring.io/browse/DATAREDIS-775).