### PR TITLE
DATAREDIS-781 - Change select() to jedis.select() in JedisConnection's constructor

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -15,6 +15,22 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.BinaryJedisPubSub;
+import redis.clients.jedis.Client;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.Response;
+import redis.clients.jedis.Transaction;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.util.Pool;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.Supplier;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -30,12 +46,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
-import redis.clients.jedis.*;
-import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.util.Pool;
-
-import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * {@code RedisConnection} implementation on top of <a href="http://github.com/xetorthio/jedis">Jedis</a> library.
@@ -50,6 +60,7 @@ import java.util.function.Supplier;
  * @author Milan Agatonovic
  * @author Mark Paluch
  * @author Ninad Divadkar
+ * @author Binglei Yu
  */
 public class JedisConnection extends AbstractRedisConnection {
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -15,22 +15,6 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
-import redis.clients.jedis.BinaryJedisPubSub;
-import redis.clients.jedis.Client;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.Response;
-import redis.clients.jedis.Transaction;
-import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.util.Pool;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-import java.util.function.Supplier;
-
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -46,6 +30,12 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import redis.clients.jedis.*;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.util.Pool;
+
+import java.util.*;
+import java.util.function.Supplier;
 
 /**
  * {@code RedisConnection} implementation on top of <a href="http://github.com/xetorthio/jedis">Jedis</a> library.
@@ -122,7 +112,7 @@ public class JedisConnection extends AbstractRedisConnection {
 		// as we're inside the constructor
 		if (dbIndex != jedis.getDB()) {
 			try {
-				select(dbIndex);
+				jedis.select(dbIndex);
 			} catch (DataAccessException ex) {
 				close();
 				throw ex;


### PR DESCRIPTION
JedisConnection's constructor(line 125) calls a public method, the select(dbIndex). Method call inside constructor can be dangerous, because a bad subclass may hurt super class by overriding that method. And consider that when we construct a JedisConnection, it won't be in transaction or piplined, so change to use jedis.select directly
