### PR TITLE
DATAREDIS-791 - Disable ifValueNotExists() flag in ReactiveHashCommands.hMSet.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-791-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -195,8 +195,7 @@ public interface ReactiveHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(fieldValueMap, "Field must not be null!");
 
-		return hSet(Mono.just(HSetCommand.fieldValues(fieldValueMap).forKey(key).ifValueNotExists())).next()
-				.map(BooleanResponse::getOutput);
+		return hSet(Mono.just(HSetCommand.fieldValues(fieldValueMap).forKey(key))).next().map(it -> true);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
@@ -34,7 +34,6 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyComm
 import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
 
 /**
  * @author Christoph Strobl
@@ -74,7 +73,7 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 
 				Entry<ByteBuffer, ByteBuffer> entry = command.getFieldValueMap().entrySet().iterator().next();
 
-				result = ObjectUtils.nullSafeEquals(command.isUpsert(), Boolean.TRUE)
+				result = command.isUpsert()
 						? cmd.hset(command.getKey(), entry.getKey(), entry.getValue())
 						: cmd.hsetnx(command.getKey(), entry.getKey(), entry.getValue());
 			} else {

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
@@ -120,6 +120,21 @@ public class LettuceReactiveHashCommandsTests extends LettuceReactiveCommandsTes
 		assertThat(nativeCommands.hget(KEY_1, FIELD_2), is(equalTo(VALUE_2)));
 	}
 
+	@Test // DATAREDIS-791
+	public void hMSetShouldOverwriteValuesCorrectly() {
+
+		Map<ByteBuffer, ByteBuffer> fieldValues = new LinkedHashMap<>();
+		fieldValues.put(FIELD_1_BBUFFER, VALUE_1_BBUFFER);
+
+		connection.hashCommands().hMSet(KEY_1_BBUFFER, fieldValues).block();
+
+		Map<ByteBuffer, ByteBuffer> overwriteFieldValues = new LinkedHashMap<>();
+		overwriteFieldValues.put(FIELD_1_BBUFFER, VALUE_2_BBUFFER);
+
+		connection.hashCommands().hMSet(KEY_1_BBUFFER, overwriteFieldValues).block();
+		assertThat(nativeCommands.hget(KEY_1, FIELD_1), is(equalTo(VALUE_2)));
+	}
+
 	@Test // DATAREDIS-525
 	public void hExistsShouldReturnTrueForExistingField() {
 


### PR DESCRIPTION
We now no longer set `ifValueNotExists()` in `ReactiveHashCommands.hMSet` to always upsert hash entries. Previously, we called `HSETNX` if `hMSet` was called with a single tuple which did not overwrite existing entries.

Align return value of `hMSet` to return always true as calling internally `HSET` returns 1 only on newly set hash fields and setting an existing field resulted previously in `false`.

---

Related ticket: [DATAREDIS-791](https://jira.spring.io/browse/DATAREDIS-791).

We should backport both fixes to `2.0.x`.
