### PR TITLE
DATAREDIS-803 - Work around Redis parameter limitation

### DIFF
--- a/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisMap.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisMap.java
@@ -38,6 +38,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Costin Leau
  * @author Christoph Strobl
+ * @author Christian Bühler
  */
 public class DefaultRedisMap<K, V> implements RedisMap<K, V> {
 
@@ -156,19 +157,9 @@ public class DefaultRedisMap<K, V> implements RedisMap<K, V> {
 	@Override
 	public Set<java.util.Map.Entry<K, V>> entrySet() {
 
-		Set<K> keySet = keySet();
-		checkResult(keySet);
-		Collection<V> multiGet = hashOps.multiGet(keySet);
-
-		Iterator<K> keys = keySet.iterator();
-		Iterator<V> values = multiGet.iterator();
-
-		Set<Map.Entry<K, V>> entries = new LinkedHashSet<>();
-		while (keys.hasNext()) {
-			entries.add(new DefaultRedisMapEntry(keys.next(), values.next()));
-		}
-
-		return entries;
+		Map<K, V> entries = hashOps.entries();
+		checkResult(entries);
+		return entries.entrySet();
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisMapTests.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisMapTests.java
@@ -25,6 +25,7 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -62,6 +63,7 @@ import org.springframework.test.annotation.IfProfileValue;
  * @author Jennifer Hickey
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Christian Bühler
  */
 @RunWith(Parameterized.class)
 public abstract class AbstractRedisMapTests<K, V> {
@@ -394,6 +396,27 @@ public abstract class AbstractRedisMapTests<K, V> {
 		assertThat(keys, hasItems(k1, k2));
 		assertThat(values, hasItem(v1));
 		assertThat(values, not(hasItem(v2)));
+	}
+
+	@Test // DATAREDIS-803
+	@IfProfileValue(name = "runLongTests", value = "true")
+	public void testBigEntrySet() {
+
+		Set<Entry<K, V>> entries = map.entrySet();
+		assertTrue(entries.isEmpty());
+
+		for (int j = 0; j < 2; j++) {
+			Map<K, V> m = new HashMap<>();
+			for (int i = 0; i < 1024 * 1024 / 2 - 1; i++) {
+				m.put(getKey(), getValue());
+			}
+			map.putAll(m);
+		}
+		map.put(getKey(), getValue());
+
+		entries = map.entrySet();
+
+		assertEquals(1024 * 1024 - 1, entries.size());
 	}
 
 	@Test


### PR DESCRIPTION
Redis has a [limitation of 1024 * 1024 parameters](https://github.com/antirez/redis/blob/4.0.9/src/networking.c#L1200) for bulk operations.

To insert more than 1024 * 1024 / 2 - 1 entries with putAll(), they need to be split up in multiple HMSET commands.

To reveive more than 1024 * 1024 - 1 entries with entrySet(), we can directly use the HGETALL command instead of first fetching the keys with HKEYS and then fetching the values with HMGET.