### PR TITLE
DATAREDIS-544 - Read constructor property values through MappingRedisConverter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-544-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -1046,22 +1046,6 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 		}
 	}
 
-	enum ClassNameKeySpaceResolver implements KeySpaceResolver {
-
-		INSTANCE;
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.keyvalue.core.KeySpaceResolver#resolveKeySpace(java.lang.Class)
-		 */
-		@Override
-		public String resolveKeySpace(Class<?> type) {
-
-			Assert.notNull(type, "Type must not be null!");
-			return ClassUtils.getUserClass(type).getName();
-		}
-	}
-
 	private enum NaturalOrderingKeyComparator implements Comparator<String> {
 
 		INSTANCE;

--- a/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.core.convert;
 
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.time.Duration;
@@ -82,6 +83,24 @@ public class ConversionTestEntities {
 		@Reference List<Location> visited;
 
 		Species species;
+	}
+
+	@RedisHash(KEYSPACE_PERSON)
+	@Data
+	public static class RecursiveConstructorPerson {
+
+		final @Id String id;
+		final String firstname;
+		final RecursiveConstructorPerson father;
+		String lastname;
+	}
+
+	@RedisHash(KEYSPACE_PERSON)
+	@Data
+	public static class PersonWithConstructorAndAddress {
+
+		final @Id String id;
+		final Address address;
 	}
 
 	public static class PersonWithAddressReference extends Person {


### PR DESCRIPTION
We now read and convert constructor property values through `MappingRedisConverter.readProperty(…)` to apply proper conversion. This way, constructor properties are read through the same methods as instance properties allowing to read back nested level entities.

Previously, we were only reading simple properties or properties associated with a registered Converter.

---

Related ticket: [DATAREDIS-544](https://jira.spring.io/browse/DATAREDIS-544). 

We should backport the change to `2.0.x`.