### PR TITLE
DATAREDIS-763 - Introduce factory methods for JDK serializer accepting ClassLoader.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-763-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.core.convert.converter.ConverterRegistry;
 import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.format.support.DefaultFormattingConversionService;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -76,9 +77,9 @@ public class RedisCacheConfiguration {
 	 * <dt>default prefix</dt>
 	 * <dd>[the actual cache name]</dd>
 	 * <dt>key serializer</dt>
-	 * <dd>StringRedisSerializer.class</dd>
+	 * <dd>{@link org.springframework.data.redis.serializer.StringRedisSerializer}</dd>
 	 * <dt>value serializer</dt>
-	 * <dd>JdkSerializationRedisSerializer.class</dd>
+	 * <dd>{@link org.springframework.data.redis.serializer.JdkSerializationRedisSerializer}</dd>
 	 * <dt>conversion service</dt>
 	 * <dd>{@link DefaultFormattingConversionService} with {@link #registerDefaultConverters(ConverterRegistry) default}
 	 * cache key converters</dd>
@@ -87,6 +88,33 @@ public class RedisCacheConfiguration {
 	 * @return new {@link RedisCacheConfiguration}.
 	 */
 	public static RedisCacheConfiguration defaultCacheConfig() {
+		return defaultCacheConfig(null);
+	}
+
+	/**
+	 * Create default {@link RedisCacheConfiguration} given {@link ClassLoader} using the following:
+	 * <dl>
+	 * <dt>key expiration</dt>
+	 * <dd>eternal</dd>
+	 * <dt>cache null values</dt>
+	 * <dd>yes</dd>
+	 * <dt>prefix cache keys</dt>
+	 * <dd>yes</dd>
+	 * <dt>default prefix</dt>
+	 * <dd>[the actual cache name]</dd>
+	 * <dt>key serializer</dt>
+	 * <dd>{@link org.springframework.data.redis.serializer.StringRedisSerializer}</dd>
+	 * <dt>value serializer</dt>
+	 * <dd>{@link org.springframework.data.redis.serializer.JdkSerializationRedisSerializer}</dd>
+	 * <dt>conversion service</dt>
+	 * <dd>{@link DefaultFormattingConversionService} with {@link #registerDefaultConverters(ConverterRegistry) default}
+	 * cache key converters</dd>
+	 * </dl>
+	 *
+	 * @return new {@link RedisCacheConfiguration}.
+	 * @since 2.1
+	 */
+	public static RedisCacheConfiguration defaultCacheConfig(@Nullable ClassLoader classLoader) {
 
 		DefaultFormattingConversionService conversionService = new DefaultFormattingConversionService();
 
@@ -94,7 +122,7 @@ public class RedisCacheConfiguration {
 
 		return new RedisCacheConfiguration(Duration.ZERO, true, true, CacheKeyPrefix.simple(),
 				SerializationPair.fromSerializer(RedisSerializer.string()),
-				SerializationPair.fromSerializer(RedisSerializer.java()), conversionService);
+				SerializationPair.fromSerializer(RedisSerializer.java(classLoader)), conversionService);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/serializer/JdkSerializationRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/JdkSerializationRedisSerializer.java
@@ -51,7 +51,7 @@ public class JdkSerializationRedisSerializer implements RedisSerializer<Object> 
 	 * @param classLoader
 	 * @since 1.7
 	 */
-	public JdkSerializationRedisSerializer(ClassLoader classLoader) {
+	public JdkSerializationRedisSerializer(@Nullable ClassLoader classLoader) {
 		this(new SerializingConverter(), new DeserializingConverter(classLoader));
 	}
 

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
@@ -88,6 +88,28 @@ public interface RedisSerializationContext<K, V> {
 	}
 
 	/**
+	 * Creates a new {@link RedisSerializationContext} using {@link JdkSerializationRedisSerializer}.
+	 *
+	 * @return
+	 * @since 2.1
+	 */
+	static RedisSerializationContext<Object, Object> java() {
+		return fromSerializer(RedisSerializer.java());
+	}
+
+	/**
+	 * Creates a new {@link RedisSerializationContext} using {@link JdkSerializationRedisSerializer} given
+	 * {@link ClassLoader}.
+	 *
+	 * @param classLoader the classloader to use.
+	 * @return
+	 * @since 2.1
+	 */
+	static RedisSerializationContext<Object, Object> java(ClassLoader classLoader) {
+		return fromSerializer(RedisSerializer.java(classLoader));
+	}
+
+	/**
 	 * Creates a new {@link RedisSerializationContext} using a {@link StringRedisSerializer}.
 	 *
 	 * @return

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
@@ -54,7 +54,19 @@ public interface RedisSerializer<T> {
 	 * @since 2.1
 	 */
 	static RedisSerializer<Object> java() {
-		return new JdkSerializationRedisSerializer();
+		return java(null);
+	}
+
+	/**
+	 * Obtain a {@link RedisSerializer} using java serialization with the given {@link ClassLoader}.<br />
+	 * <strong>Note:</strong> Ensure that your domain objects are actually {@link java.io.Serializable serializable}.
+	 *
+	 * @param classLoader the classloader to use..
+	 * @return never {@literal null}.
+	 * @since 2.1
+	 */
+	static RedisSerializer<Object> java(@Nullable ClassLoader classLoader) {
+		return new JdkSerializationRedisSerializer(classLoader);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheConfigurationUnitTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.cache;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.instrument.classloading.ShadowingClassLoader;
+
+/**
+ * Unit tests for {@link RedisCacheConfiguration}.
+ *
+ * @author Mark Paluch
+ */
+public class RedisCacheConfigurationUnitTests {
+
+	@Test // DATAREDIS-763
+	public void shouldSetClassLoader() {
+
+		ShadowingClassLoader classLoader = new ShadowingClassLoader(getClass().getClassLoader());
+
+		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig(classLoader);
+
+		Object adapter = new DirectFieldAccessor(config.getValueSerializationPair().getReader())
+				.getPropertyValue("serializer");
+		Object deserializerConverter = new DirectFieldAccessor(adapter).getPropertyValue("deserializer");
+		Object deserializer = new DirectFieldAccessor(deserializerConverter).getPropertyValue("deserializer");
+		Object usedClassLoader = new DirectFieldAccessor(deserializer).getPropertyValue("classLoader");
+
+		assertThat(usedClassLoader).isSameAs(classLoader);
+	}
+}

--- a/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
@@ -97,17 +97,18 @@ abstract public class ReactiveOperationsTestParams {
 				poolingConfiguration);
 		poolingConnectionFactory.afterPropertiesSet();
 
-		JdkSerializationRedisSerializer jdkSerializationRedisSerializer = new JdkSerializationRedisSerializer();
+
 		ReactiveRedisTemplate<Object, Object> objectTemplate = new ReactiveRedisTemplate<>(lettuceConnectionFactory,
-				RedisSerializationContext.fromSerializer(jdkSerializationRedisSerializer));
+				RedisSerializationContext.java(ReactiveOperationsTestParams.class.getClassLoader()));
 
 		ReactiveRedisTemplate<Object, Object> pooledObjectTemplate = new ReactiveRedisTemplate<>(poolingConnectionFactory,
-				RedisSerializationContext.fromSerializer(jdkSerializationRedisSerializer));
+				RedisSerializationContext.java());
 
 		StringRedisSerializer stringRedisSerializer = StringRedisSerializer.UTF_8;
 		ReactiveRedisTemplate<String, String> stringTemplate = new ReactiveRedisTemplate<>(lettuceConnectionFactory,
 				RedisSerializationContext.fromSerializer(stringRedisSerializer));
 
+		JdkSerializationRedisSerializer jdkSerializationRedisSerializer = new JdkSerializationRedisSerializer();
 		GenericToStringSerializer<Long> longToStringSerializer = new GenericToStringSerializer(Long.class);
 		ReactiveRedisTemplate<String, Long> longTemplate = new ReactiveRedisTemplate<>(lettuceConnectionFactory,
 				RedisSerializationContext.<String, Long> newSerializationContext(jdkSerializationRedisSerializer)


### PR DESCRIPTION
We now provide factory methods to create default serializers/deserializers accepting `ClassLoader`.

```java
RedisSerializer.java(ClassLoader)
RedisSerializationContext.java(ClassLoader)
RedisCacheConfiguration.defaultCacheConfig(ClassLoader)
```

---

Related ticket: [DATAREDIS-763](https://jira.spring.io/browse/DATAREDIS-763).