### PR TITLE
DATAREDIS-697 - Add support for BITPOS.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-697-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -1162,6 +1162,16 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#bitPos(byte[], boolean, org.springframework.data.domain.Range)
+	 */
+	@Nullable
+	@Override
+	public Long bitPos(byte[] key, boolean bit, org.springframework.data.domain.Range<Long> range) {
+ 		return convertAndReturn(delegate.bitPos(key, bit, range), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisPubSubCommands#subscribe(org.springframework.data.redis.connection.MessageListener, byte[][])
 	 */
 	@Override
@@ -2468,6 +2478,16 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	@Override
 	public Long bitOp(BitOperation op, String destination, String... keys) {
 		return bitOp(op, serialize(destination), serializeMulti(keys));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#bitPos(java.lang.String, boolean, org.springframework.data.domain.Range)
+	 */
+	@Nullable
+	@Override
+	public Long bitPos(String key, boolean bit, org.springframework.data.domain.Range<Long> range) {
+		return bitPos(serialize(key), bit, range);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResults;
@@ -383,6 +384,13 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	@Deprecated
 	default Long bitOp(BitOperation op, byte[] destination, byte[]... keys) {
 		return stringCommands().bitOp(op, destination, keys);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#stringCommands()}}. */
+	@Override
+	@Deprecated
+	default Long bitPos(byte[] key, boolean bit, org.springframework.data.domain.Range<Long> range) {
+		return stringCommands().bitPos(key, bit, range);
 	}
 
 	/** @deprecated in favor of {@link RedisConnection#stringCommands()}}. */

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
@@ -1015,6 +1015,80 @@ public interface ReactiveStringCommands {
 	Flux<NumericResponse<BitOpCommand, Long>> bitOp(Publisher<BitOpCommand> commands);
 
 	/**
+	 * @author Christoph Strobl
+	 * @since 2.1
+	 */
+	class BitPosCommand extends KeyCommand {
+
+		private boolean bit;
+		private Range<Long> range;
+
+		private BitPosCommand(@Nullable ByteBuffer key, boolean bit, Range<Long> range) {
+			super(key);
+			this.bit = bit;
+			this.range = range;
+		}
+
+		static BitPosCommand positionOf(boolean bit) {
+			return new BitPosCommand(null, bit, Range.unbounded());
+		}
+
+		public BitPosCommand in(ByteBuffer key) {
+			return new BitPosCommand(key, bit, range);
+		}
+
+		public BitPosCommand within(Range<Long> range) {
+			return new BitPosCommand(getKey(), bit, range);
+		}
+
+		public boolean getBit() {
+			return bit;
+		}
+
+		public Range<Long> getRange() {
+			return range;
+		}
+	}
+
+	/**
+	 * Return the position of the first bit set to given {@code bit} in a string.
+	 *
+	 * @param key the key holding the actual String.
+	 * @param bit the bit value to look for.
+	 * @return {@link Mono} emitting result when ready.
+	 * @since 2.1
+	 */
+	default Mono<Long> bitPos(ByteBuffer key, boolean bit) {
+		return bitPos(key, bit, Range.unbounded());
+	}
+
+	/**
+	 * Return the position of the first bit set to given {@code bit} in a string. {@link Range} start and end can contain
+	 * negative values in order to index <strong>bytes</strong> starting from the end of the string, where {@literal -1}
+	 * is the last byte, {@literal -2} is the penultimate.
+	 *
+	 * @param key the key holding the actual String.
+	 * @param bit the bit value to look for.
+	 * @param range must not be {@literal null}. Use {@link Range#unbounded()} to not limit search.
+	 * @return {@link Mono} emitting result when ready.
+	 * @since 2.1
+	 */
+	default Mono<Long> bitPos(ByteBuffer key, boolean bit, Range<Long> range) {
+		return bitPos(Mono.just(BitPosCommand.positionOf(bit).in(key).within(range))).next()
+				.map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Emmit the the position of the first bit set to given {@code bit} in a string. Get the length of the value stored at
+	 * {@literal key}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return {@link Flux} emitting results when ready.
+	 * @since 2.1
+	 */
+	Flux<NumericResponse<BitPosCommand, Long>> bitPos(Publisher<BitPosCommand> commands);
+
+	/**
 	 * Get the length of the value stored at {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.lang.Nullable;
 
@@ -291,6 +292,37 @@ public interface RedisStringCommands {
 	 */
 	@Nullable
 	Long bitOp(BitOperation op, byte[] destination, byte[]... keys);
+
+	/**
+	 * Return the position of the first bit set to given {@code bit} in a string.
+	 *
+	 * @param key the key holding the actual String.
+	 * @param bit the bit value to look for.
+	 * @return {@literal null} when used in pipeline / transaction. The position of the first bit set to 1 or 0 according
+	 *         to the request.
+	 * @see <a href="http://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
+	 * @since 2.1
+	 */
+	@Nullable
+	default Long bitPos(byte[] key, boolean bit) {
+		return bitPos(key, bit, Range.unbounded());
+	}
+
+	/**
+	 * Return the position of the first bit set to given {@code bit} in a string. {@link Range} start and end can contain
+	 * negative values in order to index <strong>bytes</strong> starting from the end of the string, where {@literal -1}
+	 * is the last byte, {@literal -2} is the penultimate.
+	 * 
+	 * @param key the key holding the actual String.
+	 * @param bit the bit value to look for.
+	 * @param range must not be {@literal null}. Use {@link Range#unbounded()} to not limit search.
+	 * @return {@literal null} when used in pipeline / transaction. The position of the first bit set to 1 or 0 according
+	 *         to the request.
+	 * @see <a href="http://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
+	 * @since 2.1
+	 */
+	@Nullable
+	Long bitPos(byte[] key, boolean bit, Range<Long> range);
 
 	/**
 	 * Get the length of the value stored at {@code key}.

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -581,6 +581,37 @@ public interface StringRedisConnection extends RedisConnection {
 	Long bitOp(BitOperation op, String destination, String... keys);
 
 	/**
+	 * Return the position of the first bit set to given {@code bit} in a string.
+	 *
+	 * @param key the key holding the actual String.
+	 * @param bit the bit value to look for.
+	 * @return {@literal null} when used in pipeline / transaction. The position of the first bit set to 1 or 0 according
+	 *         to the request.
+	 * @see <a href="http://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
+	 * @since 2.1
+	 */
+	default Long bitPos(String key, boolean bit) {
+		return bitPos(key, bit, org.springframework.data.domain.Range.unbounded());
+	}
+
+	/**
+	 * Return the position of the first bit set to given {@code bit} in a string.
+	 * {@link org.springframework.data.domain.Range} start and end can contain negative values in order to index
+	 * <strong>bytes</strong> starting from the end of the string, where {@literal -1} is the last byte, {@literal -2} is
+	 * the penultimate.
+	 *
+	 * @param key the key holding the actual String.
+	 * @param bit the bit value to look for.
+	 * @param range must not be {@literal null}. Use {@link Range#unbounded()} to not limit search.
+	 * @return {@literal null} when used in pipeline / transaction. The position of the first bit set to 1 or 0 according
+	 *         to the request.
+	 * @see <a href="http://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
+	 * @since 2.1
+	 */
+	@Nullable
+	Long bitPos(String key, boolean bit, org.springframework.data.domain.Range<Long> range);
+
+	/**
 	 * Get the length of the value stored at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -1019,6 +1019,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 			// INTEGER
 			COMMAND_OUTPUT_TYPE_MAPPING.put(BITCOUNT, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(BITOP, IntegerOutput.class);
+			COMMAND_OUTPUT_TYPE_MAPPING.put(BITPOS, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(DBSIZE, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(DECR, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(DECRBY, IntegerOutput.class);

--- a/src/main/java/org/springframework/data/redis/core/RedisCommand.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisCommand.java
@@ -41,7 +41,7 @@ public enum RedisCommand {
 	BGSAVE("r", 0, 0), //
 	BITCOUNT("r", 1, 3), //
 	BITOP("rw", 3), //
-	BITPOS("r", 2), //
+	BITPOS("r", 2, 4), //
 	BLPOP("rw", 2), //
 	BRPOP("rw", 2), //
 	BRPOPLPUSH("rw", 3), //

--- a/src/main/java/org/springframework/data/redis/core/RedisCommand.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisCommand.java
@@ -28,6 +28,7 @@ import org.springframework.util.StringUtils;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Ninad Divadkar
+ * @author Mark Paluch
  * @since 1.3
  * @see Redis command list:
  *      https://github.com/antirez/redis/blob/93e7a130fc9594e41ccfc996b5eca7626ae5356a/src/redis.c#L119
@@ -279,10 +280,10 @@ public enum RedisCommand {
 	}
 
 	/**
-	 * @return {@literal true} if an exact number of arguments is expected
+	 * @return {@literal true} if an exact number of arguments is expected.
 	 */
 	public boolean requiresExactNumberOfArguments() {
-		return maxArgs >= 0;
+		return maxArgs == 0 || minArgs == maxArgs;
 	}
 
 	/**
@@ -344,6 +345,11 @@ public enum RedisCommand {
 			if (nrArguments < minArgs) {
 				throw new IllegalArgumentException(
 						String.format("%s command requires at least %s arguments.", this.name(), this.minArgs));
+			}
+
+			if (maxArgs != 0 && nrArguments > maxArgs) {
+				throw new IllegalArgumentException(
+						String.format("%s command requires at most %s arguments.", this.name(), this.maxArgs));
 			}
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/core/RedisCommand.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisCommand.java
@@ -41,7 +41,7 @@ public enum RedisCommand {
 	BGSAVE("r", 0, 0), //
 	BITCOUNT("r", 1, 3), //
 	BITOP("rw", 3), //
-	BITPOS("r", 2, 4), //
+	BITPOS("r", 2), //
 	BLPOP("rw", 2), //
 	BRPOP("rw", 2), //
 	BRPOPLPUSH("rw", 3), //

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -38,6 +38,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.domain.Range.Bound;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResults;
@@ -59,6 +60,7 @@ import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.types.Expiration;
+import org.springframework.data.redis.test.util.HexStringUtils;
 import org.springframework.data.redis.test.util.MinimumRedisVersionRule;
 import org.springframework.data.redis.test.util.RedisClusterRule;
 import org.springframework.test.annotation.IfProfileValue;
@@ -2269,6 +2271,25 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 	@Test // DATAREDIS-693
 	public void unlinkReturnsZeroIfNoKeysTouched() {
 		assertThat(clusterConnection.keyCommands().unlink(KEY_1_BYTES), is(0L));
+	}
+
+	@Test // DATAREDIS-697
+	@IfProfileValue(name = "redisVersion", value = "2.8.7+")
+	public void bitPosShouldReturnPositionCorrectly() {
+
+		nativeConnection.set(KEY_1_BYTES, HexStringUtils.hexToBytes("fff000"));
+
+		assertThat(clusterConnection.stringCommands().bitPos(KEY_1_BYTES, false), is(12L));
+	}
+
+	@Test // DATAREDIS-697
+	@IfProfileValue(name = "redisVersion", value = "2.8.7+")
+	public void bitPosShouldReturnPositionInRangeCorrectly() {
+
+		nativeConnection.set(KEY_1_BYTES, HexStringUtils.hexToBytes("fff0f0"));
+
+		assertThat(clusterConnection.stringCommands().bitPos(KEY_1_BYTES, true,
+				org.springframework.data.domain.Range.of(Bound.inclusive(2L), Bound.unbounded())), is(16L));
 	}
 
 }

--- a/src/test/java/org/springframework/data/redis/core/RedisCommandUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisCommandUnitTests.java
@@ -23,8 +23,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 /**
+ * Unit tests for {@link RedisCommand}.
+ *
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class RedisCommandUnitTests {
 
@@ -65,8 +68,25 @@ public class RedisCommandUnitTests {
 		RedisCommand.AUTH.validateArgumentCount(1);
 	}
 
+	@Test // DATAREDIS-822
+	public void shouldConsiderMinMaxArguments() {
+
+		RedisCommand.BITPOS.validateArgumentCount(2);
+		RedisCommand.BITPOS.validateArgumentCount(3);
+		RedisCommand.BITPOS.validateArgumentCount(4);
+	}
+
+	@Test // DATAREDIS-822
+	public void shouldReportArgumentMismatchIfMaxArgumentsExceeded() {
+
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("BITPOS command requires at most 4 arguments");
+
+		RedisCommand.BITPOS.validateArgumentCount(5);
+	}
+
 	@Test // DATAREDIS-73
-	public void shouldThrowExceptionOnInvalidArgumentCountWhenExpectedExcatMatch() {
+	public void shouldThrowExceptionOnInvalidArgumentCountWhenExpectedExactMatch() {
 
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage("AUTH command requires 1 arguments");

--- a/src/test/java/org/springframework/data/redis/test/util/HexStringUtils.java
+++ b/src/test/java/org/springframework/data/redis/test/util/HexStringUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.test.util;
+
+import org.springframework.util.Assert;
+
+/**
+ * Utils for working with Hex Stings.
+ *
+ * @author Christoph Strobl
+ * @currentRead Beyong the Shadows - Brent Weeks
+ */
+public class HexStringUtils {
+
+	/**
+	 * Convert a given HEX {@link String} to its byte representation.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @return
+	 */
+	public static byte[] hexToBytes(String source) {
+
+		Assert.notNull(source, "Source must not be null!");
+		int len = source.length();
+
+		byte[] data = new byte[len / 2];
+		for (int i = 0; i < len; i += 2) {
+			data[i / 2] = (byte) ((Character.digit(source.charAt(i), 16) << 4) + Character.digit(source.charAt(i + 1), 16));
+		}
+		return data;
+	}
+}


### PR DESCRIPTION
We now support the `BITPOS` command throughout the sync and reactive api.