### PR TITLE
DATAREDIS-830 - Release Pub/Sub connection when closing LettuceSubscription

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-830-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -426,6 +426,10 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.AbstractRedisConnection#close()
+	 */
 	@Override
 	public void close() throws DataAccessException {
 
@@ -455,26 +459,48 @@ public class LettuceConnection extends AbstractRedisConnection {
 		this.dbIndex = defaultDbIndex;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConnection#isClosed()
+	 */
 	@Override
 	public boolean isClosed() {
 		return isClosed && !isSubscribed();
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConnection#getNativeConnection()
+	 */
 	@Override
 	public RedisClusterAsyncCommands<byte[], byte[]> getNativeConnection() {
-		return (subscription != null ? subscription.pubsub.async() : getAsyncConnection());
+
+		LettuceSubscription subscription = this.subscription;
+		return (subscription != null ? subscription.getNativeConnection().async() : getAsyncConnection());
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConnection#isQueueing()
+	 */
 	@Override
 	public boolean isQueueing() {
 		return isMulti;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConnection#isPipelined()
+	 */
 	@Override
 	public boolean isPipelined() {
 		return isPipelined;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConnection#openPipeline()
+	 */
 	@Override
 	public void openPipeline() {
 		if (!isPipelined) {
@@ -483,6 +509,10 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConnection#closePipeline()
+	 */
 	@Override
 	public List<Object> closePipeline() {
 
@@ -549,7 +579,6 @@ public class LettuceConnection extends AbstractRedisConnection {
 	 * @see org.springframework.data.redis.connection.RedisServerCommands#shutdown(org.springframework.data.redis.connection.RedisServerCommands.ShutdownOption)
 	 */
 	@Override
-
 	public byte[] echo(byte[] message) {
 		try {
 			if (isPipelined()) {
@@ -716,43 +745,62 @@ public class LettuceConnection extends AbstractRedisConnection {
 	// Pub/Sub functionality
 	//
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPubSubCommands#publish(byte[], byte[])
+	 */
 	@Override
 	public Long publish(byte[] channel, byte[] message) {
+
 		try {
+
 			if (isPipelined()) {
 				pipeline(newLettuceResult(getAsyncConnection().publish(channel, message)));
 				return null;
 			}
+
 			if (isQueueing()) {
 				transaction(newLettuceResult(getAsyncConnection().publish(channel, message)));
 				return null;
 			}
+
 			return getConnection().publish(channel, message);
 		} catch (Exception ex) {
 			throw convertLettuceAccessException(ex);
 		}
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPubSubCommands#getSubscription()
+	 */
 	@Override
 	public Subscription getSubscription() {
 		return subscription;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPubSubCommands#isSubscribed()
+	 */
 	@Override
 	public boolean isSubscribed() {
 		return (subscription != null && subscription.isAlive());
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPubSubCommands#pSubscribe(org.springframework.data.redis.connection.MessageListener, byte[][])
+	 */
 	@Override
 	public void pSubscribe(MessageListener listener, byte[]... patterns) {
+
 		checkSubscription();
 
-		if (isQueueing()) {
-			throw new UnsupportedOperationException();
+		if (isQueueing() || isPipelined()) {
+			throw new UnsupportedOperationException("Transaction/Pipelining is not supported for Pub/Sub subscriptions!");
 		}
-		if (isPipelined()) {
-			throw new UnsupportedOperationException();
-		}
+
 		try {
 			subscription = new LettuceSubscription(listener, switchToPubSub(), connectionProvider);
 			subscription.pSubscribe(patterns);
@@ -761,17 +809,22 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisPubSubCommands#subscribe(org.springframework.data.redis.connection.MessageListener, byte[][])
+	 */
 	@Override
 	public void subscribe(MessageListener listener, byte[]... channels) {
+
 		checkSubscription();
 
-		if (isPipelined()) {
-			throw new UnsupportedOperationException();
+		if (isQueueing() || isPipelined()) {
+			throw new UnsupportedOperationException("Transaction/Pipelining is not supported for Pub/Sub subscriptions!");
 		}
+
 		try {
 			subscription = new LettuceSubscription(listener, switchToPubSub(), connectionProvider);
 			subscription.subscribe(channels);
-
 		} catch (Exception ex) {
 			throw convertLettuceAccessException(ex);
 		}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -754,7 +754,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 			throw new UnsupportedOperationException();
 		}
 		try {
-			subscription = new LettuceSubscription(listener, switchToPubSub());
+			subscription = new LettuceSubscription(listener, switchToPubSub(), connectionProvider);
 			subscription.pSubscribe(patterns);
 		} catch (Exception ex) {
 			throw convertLettuceAccessException(ex);
@@ -769,7 +769,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 			throw new UnsupportedOperationException();
 		}
 		try {
-			subscription = new LettuceSubscription(listener, switchToPubSub());
+			subscription = new LettuceSubscription(listener, switchToPubSub(), connectionProvider);
 			subscription.subscribe(channels);
 
 		} catch (Exception ex) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.pubsub.RedisPubSubListener;
@@ -32,23 +31,47 @@ class LettuceMessageListener implements RedisPubSubListener<byte[], byte[]> {
 	private final MessageListener listener;
 
 	LettuceMessageListener(MessageListener listener) {
-		Assert.notNull(listener, "message listener is required");
+		Assert.notNull(listener, "MessageListener must not be null!");
 		this.listener = listener;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see io.lettuce.core.pubsub.RedisPubSubListener#message(java.lang.Object, java.lang.Object)
+	 */
 	public void message(byte[] channel, byte[] message) {
 		listener.onMessage(new DefaultMessage(channel, message), null);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see io.lettuce.core.pubsub.RedisPubSubListener#message(java.lang.Object, java.lang.Object, java.lang.Object)
+	 */
 	public void message(byte[] pattern, byte[] channel, byte[] message) {
 		listener.onMessage(new DefaultMessage(channel, message), pattern);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see io.lettuce.core.pubsub.RedisPubSubListener#subscribed(java.lang.Object, long)
+	 */
 	public void subscribed(byte[] channel, long count) {}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see io.lettuce.core.pubsub.RedisPubSubListener#psubscribed(java.lang.Object, long)
+	 */
 	public void psubscribed(byte[] pattern, long count) {}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see io.lettuce.core.pubsub.RedisPubSubListener#unsubscribed(java.lang.Object, long)
+	 */
 	public void unsubscribed(byte[] channel, long count) {}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see io.lettuce.core.pubsub.RedisPubSubListener#punsubscribed(java.lang.Object, long)
+	 */
 	public void punsubscribed(byte[] pattern, long count) {}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingConnectionProvider.java
@@ -99,7 +99,7 @@ class LettucePoolingConnectionProvider implements LettuceConnectionProvider, Red
 		}
 
 		throw new IllegalStateException(
-				String.format("Undyerlying connection provider %s does not implement RedisClientProvider!",
+				String.format("Underlying connection provider %s does not implement RedisClientProvider!",
 						connectionProvider.getClass().getName()));
 	}
 


### PR DESCRIPTION
We now release the native connection back to the connection provider when `LettuceSubscription` is closed. Previously, we just closed the connection which interfered with pooling as pooling connection providers still had a reference to the connection.

---

We should backport this one to _2.0.x_.
Related ticket: [DATAREDIS-830](https://jira.spring.io/browse/DATAREDIS-830).