### PR TITLE
DATAREDIS-771 - Add support for IsTrue and IsFalse keywords in repository query methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-771-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -14,6 +14,7 @@ This section briefly covers items that are new and noteworthy in the latest rele
 * <<redis:reactive:pubsub,Reactive Pub/Sub>> to send and receive a message stream.
 * `BITFIELD`, `BITPOS`, and `OBJECT` command support.
 * Align return types of `BoundZSetOperations` with `ZSetOperations`.
+* Usage of `IsTrue` and `IsFalse` keywords in repository query methods.
 
 [[new-in-2.0.0]]
 == New in Spring Data Redis 2.0

--- a/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
+++ b/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
@@ -70,7 +70,7 @@ public class RedisQueryCreator extends AbstractQueryCreator<KeyValueQuery<RedisO
 				sink.near(getNearPath(part, iterator));
 				break;
 			default:
-				throw new IllegalArgumentException(part.getType() + "is not supported for redis query derivation");
+				throw new IllegalArgumentException(String.format("%s is not supported for Redis query derivation!", part.getType()));
 		}
 
 		return sink;

--- a/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
+++ b/src/main/java/org/springframework/data/redis/repository/query/RedisQueryCreator.java
@@ -59,6 +59,12 @@ public class RedisQueryCreator extends AbstractQueryCreator<KeyValueQuery<RedisO
 			case SIMPLE_PROPERTY:
 				sink.sismember(part.getProperty().toDotPath(), iterator.next());
 				break;
+			case TRUE:
+				sink.sismember(part.getProperty().toDotPath(), true);
+				break;
+			case FALSE:
+				sink.sismember(part.getProperty().toDotPath(), false);
+				break;
 			case WITHIN:
 			case NEAR:
 				sink.near(getNearPath(part, iterator));

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTestBase.java
@@ -224,6 +224,24 @@ public abstract class RedisRepositoryIntegrationTestBase {
 		assertThat(repo.findBy(firstPage.nextPageable()).getContent(), hasSize(1));
 	}
 
+	@Test // DATAREDIS-771
+	public void shouldFindByBooleanIsTrue() {
+
+		Person eddard = new Person("eddard", "stark");
+		eddard.setAlive(true);
+
+		Person robb = new Person("robb", "stark");
+		robb.setAlive(false);
+		Person jon = new Person("jon", "snow");
+
+		repo.saveAll(Arrays.asList(eddard, robb, jon));
+
+		List<Person> result = repo.findPersonByAliveIsTrue();
+
+		assertThat(result, hasSize(1));
+		assertThat(result, contains(eddard));
+	}
+
 	@Test // DATAREDIS-547
 	public void shouldReturnEmptyListWhenPageableOutOfBoundsUsingFindAll() {
 
@@ -374,6 +392,8 @@ public abstract class RedisRepositoryIntegrationTestBase {
 
 		Page<Person> findPersonByLastname(String lastname, Pageable page);
 
+		List<Person> findPersonByAliveIsTrue();
+
 		List<Person> findByFirstnameAndLastname(String firstname, String lastname);
 
 		List<Person> findByFirstnameOrLastname(String firstname, String lastname);
@@ -429,6 +449,7 @@ public abstract class RedisRepositoryIntegrationTestBase {
 
 		@Id String id;
 		@Indexed String firstname;
+		@Indexed Boolean alive;
 		String lastname;
 		@Reference City city;
 		City hometown;

--- a/src/test/java/org/springframework/data/redis/repository/query/RedisQueryCreatorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/query/RedisQueryCreatorUnitTests.java
@@ -173,6 +173,30 @@ public class RedisQueryCreatorUnitTests {
 		creator.createQuery();
 	}
 
+	@Test // DATAREDIS-771
+	public void findByBooleanIsTrue() throws SecurityException, NoSuchMethodException {
+
+		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
+				SampleRepository.class.getMethod("findByAliveIsTrue"), new Object[0]);
+
+		KeyValueQuery<RedisOperationChain> query = creator.createQuery();
+
+		assertThat(query.getCriteria().getSismember(), hasSize(1));
+		assertThat(query.getCriteria().getSismember(), hasItem(new PathAndValue("alive", true)));
+	}
+
+	@Test // DATAREDIS-771
+	public void findByBooleanIsFalse() throws SecurityException, NoSuchMethodException {
+
+		RedisQueryCreator creator = createQueryCreatorForMethodWithArgs(
+				SampleRepository.class.getMethod("findByAliveIsFalse"), new Object[0]);
+
+		KeyValueQuery<RedisOperationChain> query = creator.createQuery();
+
+		assertThat(query.getCriteria().getSismember(), hasSize(1));
+		assertThat(query.getCriteria().getSismember(), hasItem(new PathAndValue("alive", false)));
+	}
+
 	private RedisQueryCreator createQueryCreatorForMethodWithArgs(Method method, Object[] args) {
 
 		PartTree partTree = new PartTree(method.getName(), method.getReturnType());
@@ -189,6 +213,10 @@ public class RedisQueryCreatorUnitTests {
 		Person findByFirstnameAndAge(String firstname, Integer age);
 
 		Person findByAgeOrFirstname(Integer age, String firstname);
+
+		Person findByAliveIsTrue();
+
+		Person findByAliveIsFalse();
 
 		Person findByLocationWithin(Circle circle);
 

--- a/src/test/java/org/springframework/data/redis/repository/query/RedisQueryCreatorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/query/RedisQueryCreatorUnitTests.java
@@ -44,6 +44,8 @@ import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.parser.PartTree;
 
 /**
+ * Unit tests for {@link RedisQueryCreator}.
+ *
  * @author Christoph Strobl
  * @author Mark Paluch
  */


### PR DESCRIPTION
We now support `IsTrue` and `IsFalse` keywords usage in repository query methods to create queries with predicates for boolean fields values without requiring to pass a boolean argument.

```java
class Person {

    @Id String id;

    @Indexed Boolean alive;
}

interface PersonRepository extends Repository<Person, String> {

    Person findByAliveIsTrue();

    Person findByAliveIsFalse();
}
```

---

Related ticket: [DATAREDIS-771](https://jira.spring.io/browse/DATAREDIS-771).