### PR TITLE
DATAREDIS-743 - Add Reactive SCAN, HSCAN, SSCAN, and ZSCAN support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-743-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -14,6 +14,7 @@ This section briefly covers items that are new and noteworthy in the latest rele
 * <<redis:reactive:pubsub,Reactive Pub/Sub>> to send and receive a message stream.
 * `BITFIELD`, `BITPOS`, and `OBJECT` command support.
 * Align return types of `BoundZSetOperations` with `ZSetOperations`.
+* Reactive `SCAN`, `HSCAN`, `SSCAN`, and `ZSCAN` support.
 
 [[new-in-2.0.0]]
 == New in Spring Data Redis 2.0

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -31,8 +31,10 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.Boolean
 import org.springframework.data.redis.connection.ReactiveRedisConnection.Command;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyScanCommand;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -577,6 +579,45 @@ public interface ReactiveHashCommands {
 	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<Map.Entry<ByteBuffer, ByteBuffer>>>> hGetAll(Publisher<KeyCommand> commands);
+
+	/**
+	 * Use a {@link Flux} to iterate over entries in the hash at {@code key}. The resulting {@link Flux} acts as a cursor
+	 * and issues {@code HSCAN} commands itself as long as the subscriber signals demand .
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @since 2.1
+	 */
+	default Flux<Map.Entry<ByteBuffer, ByteBuffer>> hScan(ByteBuffer key) {
+		return hScan(key, ScanOptions.NONE);
+	}
+
+	/**
+	 * Use a {@link Flux} to iterate over entries in the hash at {@code key} given {@link ScanOptions}. The resulting
+	 * {@link Flux} acts as a cursor and issues {@code HSCAN} commands itself as long as the subscriber signals demand.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @since 2.1
+	 */
+	default Flux<Map.Entry<ByteBuffer, ByteBuffer>> hScan(ByteBuffer key, ScanOptions options) {
+		return hScan(Mono.just(KeyScanCommand.key(key).withOptions(options))).map(CommandResponse::getOutput)
+				.flatMap(it -> it);
+	}
+
+	/**
+	 * Use a {@link Flux} to iterate over entries in the hash at {@code key}. The resulting {@link Flux} acts as a cursor
+	 * and issues {@code HSCAN} commands itself as long as the subscriber signals demand.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @since 2.1
+	 */
+	Flux<CommandResponse<KeyCommand, Flux<Map.Entry<ByteBuffer, ByteBuffer>>>> hScan(Publisher<KeyScanCommand> commands);
 
 	/**
 	 * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
@@ -30,6 +30,7 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.Command
 import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -132,6 +133,29 @@ public interface ReactiveKeyCommands {
 	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
 	 */
 	Flux<MultiValueResponse<ByteBuffer, ByteBuffer>> keys(Publisher<ByteBuffer> patterns);
+
+	/**
+	 * Use a {@link Flux} to iterate over keys. The resulting {@link Flux} acts as a cursor and issues {@code SCAN}
+	 * commands itself as long as the subscriber signals demand.
+	 *
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @since 2.1
+	 */
+	default Flux<ByteBuffer> scan() {
+		return scan(ScanOptions.NONE);
+	}
+
+	/**
+	 * Use a {@link Flux} to iterate over keys. The resulting {@link Flux} acts as a cursor and issues {@code SCAN}
+	 * commands itself as long as the subscriber signals demand.
+	 *
+	 * @param options must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @since 2.1
+	 */
+	Flux<ByteBuffer> scan(ScanOptions options);
 
 	/**
 	 * Return a random key from the keyspace.

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.domain.Range.Bound;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -206,6 +207,49 @@ public interface ReactiveRedisConnection extends Closeable {
 		@Override
 		public ByteBuffer getKey() {
 			return key;
+		}
+	}
+
+	/**
+	 * {@link Command} for key-bound scan operations like {@code HSCAN}, {@code SSCAN}, and {@code ZSCAN}, .
+	 *
+	 * @author Mark Paluch
+	 * @since 2.1
+	 */
+	class KeyScanCommand extends KeyCommand {
+
+		private ScanOptions options;
+
+		private KeyScanCommand(@Nullable ByteBuffer key, ScanOptions options) {
+
+			super(key);
+
+			Assert.notNull(options, "ScanOptions must not be null!");
+			this.options = options;
+		}
+
+		/**
+		 * Creates a new {@link KeyScanCommand} given a {@code key}.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @return a new {@link KeyScanCommand} for {@code key}.
+		 */
+		public static KeyScanCommand key(ByteBuffer key) {
+			return new KeyScanCommand(key, ScanOptions.NONE);
+		}
+
+		/**
+		 * Applies {@link ScanOptions}. Constructs a new command instance with all previously configured properties.
+		 *
+		 * @param options must not be {@literal null}.
+		 * @return a new {@link KeyScanCommand} with {@link ScanOptions} applied.
+		 */
+		public KeyScanCommand withOptions(ScanOptions options) {
+			return new KeyScanCommand(getKey(), options);
+		}
+
+		public ScanOptions getOptions() {
+			return options;
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
@@ -31,7 +31,9 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.ByteBuf
 import org.springframework.data.redis.connection.ReactiveRedisConnection.Command;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyScanCommand;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -1012,6 +1014,45 @@ public interface ReactiveSetCommands {
 	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> sMembers(Publisher<KeyCommand> commands);
+
+	/**
+	 * Use a {@link Flux} to iterate over members in the set at {@code key}. The resulting {@link Flux} acts as a cursor
+	 * and issues {@code SSCAN} commands itself as long as the subscriber signals demand.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @since 2.1
+	 */
+	default Flux<ByteBuffer> sScan(ByteBuffer key) {
+		return sScan(key, ScanOptions.NONE);
+	}
+
+	/**
+	 * Use a {@link Flux} to iterate over members in the set at {@code key} given {@link ScanOptions}. The resulting
+	 * {@link Flux} acts as a cursor and issues {@code SSCAN} commands itself as long as the subscriber signals demand.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @since 2.1
+	 */
+	default Flux<ByteBuffer> sScan(ByteBuffer key, ScanOptions options) {
+		return sScan(Mono.just(KeyScanCommand.key(key).withOptions(options))).map(CommandResponse::getOutput)
+				.flatMap(it -> it);
+	}
+
+	/**
+	 * Use a {@link Flux} to iterate over members in the set at {@code key}. The resulting {@link Flux} acts as a cursor
+	 * and issues {@code SSCAN} commands itself as long as the subscriber signals demand.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @since 2.1
+	 */
+	Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> sScan(Publisher<KeyScanCommand> commands);
 
 	/**
 	 * {@code SRANDMEMBER} command parameters.

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyCommands.java
@@ -204,7 +204,7 @@ class LettuceClusterKeyCommands extends LettuceKeyCommands {
 						@Override
 						protected LettuceScanIteration<byte[]> doScan(io.lettuce.core.ScanCursor cursor, ScanOptions options) {
 
-							ScanArgs scanArgs = connection.getScanArgs(options);
+							ScanArgs scanArgs = LettuceConverters.toScanArgs(options);
 
 							KeyScanCursor<byte[]> keyScanCursor = client.scan(cursor, scanArgs);
 							return new LettuceScanIteration<>(keyScanCursor, keyScanCursor.getKeys());

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -23,7 +23,6 @@ import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
-import io.lettuce.core.ScanArgs;
 import io.lettuce.core.TransactionResult;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -68,7 +67,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionProvid
 import org.springframework.data.redis.connection.lettuce.LettuceResult.LettuceResultBuilder;
 import org.springframework.data.redis.connection.lettuce.LettuceResult.LettuceStatusResult;
 import org.springframework.data.redis.core.RedisCommand;
-import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -920,26 +918,6 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	io.lettuce.core.ScanCursor getScanCursor(long cursorId) {
 		return io.lettuce.core.ScanCursor.of(Long.toString(cursorId));
-	}
-
-	@Nullable
-	ScanArgs getScanArgs(@Nullable ScanOptions options) {
-
-		if (options == null) {
-			return null;
-		}
-
-		ScanArgs scanArgs = new ScanArgs();
-
-		if (options.getPattern() != null) {
-			scanArgs.match(options.getPattern());
-		}
-
-		if (options.getCount() != null) {
-			scanArgs.limit(options.getCount());
-		}
-
-		return scanArgs;
 	}
 
 	private void validateCommandIfRunningInTransactionMode(CommandType cmd, byte[]... args) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -63,6 +63,7 @@ import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.connection.convert.ListConverter;
 import org.springframework.data.redis.connection.convert.LongToBooleanConverter;
 import org.springframework.data.redis.connection.convert.StringToRedisClientInfoConverter;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.data.redis.util.ByteUtils;
@@ -876,6 +877,33 @@ abstract public class LettuceConverters extends Converters {
 		}
 
 		return args;
+	}
+
+	/**
+	 * Convert {@link ScanOptions} to {@link ScanArgs}.
+	 *
+	 * @param options the {@link ScanOptions} to convert, may be {@literal null}.
+	 * @return the converted {@link ScanArgs}. Returns {@literal null} if {@link ScanOptions} is {@literal null}.
+	 * @see 2.1
+	 */
+	@Nullable
+	static ScanArgs toScanArgs(@Nullable ScanOptions options) {
+
+		if (options == null) {
+			return null;
+		}
+
+		ScanArgs scanArgs = new ScanArgs();
+
+		if (options.getPattern() != null) {
+			scanArgs.match(options.getPattern());
+		}
+
+		if (options.getCount() != null) {
+			scanArgs.limit(options.getCount());
+		}
+
+		return scanArgs;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
@@ -401,7 +401,7 @@ class LettuceHashCommands implements RedisHashCommands {
 				}
 
 				io.lettuce.core.ScanCursor scanCursor = connection.getScanCursor(cursorId);
-				ScanArgs scanArgs = connection.getScanArgs(options);
+				ScanArgs scanArgs = LettuceConverters.toScanArgs(options);
 
 				MapScanCursor<byte[], byte[]> mapScanCursor = getConnection().hscan(key, scanCursor, scanArgs);
 				String nextCursorId = mapScanCursor.getCursor();

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
@@ -259,7 +259,7 @@ class LettuceKeyCommands implements RedisKeyCommands {
 					throw new UnsupportedOperationException("'SCAN' cannot be called in pipeline / transaction mode.");
 				}
 
-				ScanArgs scanArgs = connection.getScanArgs(options);
+				ScanArgs scanArgs = LettuceConverters.toScanArgs(options);
 
 				KeyScanCursor<byte[]> keyScanCursor = getConnection().scan(cursor, scanArgs);
 				List<byte[]> keys = keyScanCursor.getKeys();

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.KeyValue;
+import io.lettuce.core.ScanStream;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -31,6 +32,7 @@ import org.springframework.data.redis.connection.ReactiveHashCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.BooleanResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
+import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyScanCommand;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiValueResponse;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.util.Assert;
@@ -211,6 +213,44 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 			Mono<Map<ByteBuffer, ByteBuffer>> result = cmd.hgetall(command.getKey());
 
 			return Mono.just(new CommandResponse<>(command, result.flatMapMany(v -> Flux.fromStream(v.entrySet().stream()))));
+		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveHashCommands#hScan(org.reactivestreams.Publisher)
+	 */
+	@Override
+	public Flux<CommandResponse<KeyCommand, Flux<Map.Entry<ByteBuffer, ByteBuffer>>>> hScan(
+			Publisher<KeyScanCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null!");
+			Assert.notNull(command.getOptions(), "ScanOptions must not be null!");
+
+			Flux<KeyValue<ByteBuffer, ByteBuffer>> result = ScanStream.hscan(cmd, command.getKey(),
+					LettuceConverters.toScanArgs(command.getOptions()));
+
+			Flux<Entry<ByteBuffer, ByteBuffer>> entryFlux = result.map(it -> new Entry<ByteBuffer, ByteBuffer>() {
+
+				@Override
+				public ByteBuffer getKey() {
+					return it.getKey();
+				}
+
+				@Override
+				public ByteBuffer getValue() {
+					return it.getValue();
+				}
+
+				@Override
+				public ByteBuffer setValue(ByteBuffer value) {
+					throw new UnsupportedOperationException("Cannot set value for entry in cursor");
+				}
+			});
+
+			return Mono.just(new CommandResponse<>(command, entryFlux));
 		}));
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.ScanStream;
 import io.lettuce.core.api.reactive.RedisKeyReactiveCommands;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -34,6 +35,7 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection.MultiVa
 import org.springframework.data.redis.connection.ReactiveRedisConnection.NumericResponse;
 import org.springframework.data.redis.connection.ValueEncoding;
 import org.springframework.data.redis.connection.ValueEncoding.RedisValueEncoding;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.util.Assert;
 
 /**
@@ -117,6 +119,18 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 			// TODO: stream elements instead of collection
 			return cmd.keys(pattern).collectList().map(value -> new MultiValueResponse<>(pattern, value));
 		}));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisConnection.ReactiveKeyCommands#scan(org.springframework.data.redis.core.ScanOptions)
+	 */
+	@Override
+	public Flux<ByteBuffer> scan(ScanOptions options) {
+
+		Assert.notNull(options, "ScanOptions must not be null!");
+
+		return connection.execute(cmd -> ScanStream.scan(cmd, LettuceConverters.toScanArgs(options)));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSetCommands.java
@@ -476,7 +476,7 @@ class LettuceSetCommands implements RedisSetCommands {
 				}
 
 				io.lettuce.core.ScanCursor scanCursor = connection.getScanCursor(cursorId);
-				ScanArgs scanArgs = connection.getScanArgs(options);
+				ScanArgs scanArgs = LettuceConverters.toScanArgs(options);
 
 				ValueScanCursor<byte[]> valueScanCursor = getConnection().sscan(key, scanCursor, scanArgs);
 				String nextCursorId = valueScanCursor.getCursor();

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceZSetCommands.java
@@ -711,7 +711,7 @@ class LettuceZSetCommands implements RedisZSetCommands {
 				}
 
 				io.lettuce.core.ScanCursor scanCursor = connection.getScanCursor(cursorId);
-				ScanArgs scanArgs = connection.getScanArgs(options);
+				ScanArgs scanArgs = LettuceConverters.toScanArgs(options);
 
 				ScoredValueScanCursor<byte[]> scoredValueScanCursor = getConnection().zscan(key, scanCursor, scanArgs);
 				String nextCursorId = scoredValueScanCursor.getCursor();

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
@@ -222,6 +222,19 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 	}
 
 	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveHashOperations#scan(java.lang.Object, org.springframework.data.redis.core.ScanOptions)
+	 */
+	@Override
+	public Flux<Map.Entry<HK, HV>> scan(H key, ScanOptions options) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(key, "ScanOptions must not be null!");
+
+		return createFlux(connection -> connection.hScan(rawKey(key), options) //
+				.map(this::deserializeHashEntry));
+	}
+
+	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveHashOperations#delete(java.lang.Object)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveSetOperations.java
@@ -323,6 +323,18 @@ class DefaultReactiveSetOperations<K, V> implements ReactiveSetOperations<K, V> 
 	}
 
 	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveSetOperations#scan(java.lang.Object, org.springframework.data.redis.core.ScanOptions)
+	 */
+	@Override
+	public Flux<V> scan(K key, ScanOptions options) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(options, "ScanOptions must not be null!");
+
+		return createFlux(connection -> connection.sScan(rawKey(key)).map(this::readValue));
+	}
+
+	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveSetOperations#randomMember(java.lang.Object)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveZSetOperations.java
@@ -284,6 +284,18 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 	}
 
 	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#scan(java.lang.Object, org.springframework.data.redis.core.ScanOptions)
+	 */
+	@Override
+	public Flux<TypedTuple<V>> scan(K key, ScanOptions options) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(options, "ScanOptions must not be null!");
+
+		return createFlux(connection -> connection.zScan(rawKey(key), options).map(this::readTypedTuple));
+	}
+
+	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#count(java.lang.Object, org.springframework.data.domain.Range)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
@@ -147,6 +147,31 @@ public interface ReactiveHashOperations<H, HK, HV> {
 	Flux<Map.Entry<HK, HV>> entries(H key);
 
 	/**
+	 * Use a {@link Flux} to iterate over entries in the hash at {@code key} given {@link ScanOptions}. The resulting
+	 * {@link Flux} acts as a cursor and issues {@code HSCAN} commands itself as long as the subscriber signals demand.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @since 2.1
+	 */
+	default Flux<Map.Entry<HK, HV>> scan(H key) {
+		return scan(key, ScanOptions.NONE);
+	}
+
+	/**
+	 * Use a {@link Flux} to iterate over entries in the hash at {@code key} given {@link ScanOptions}. The resulting
+	 * {@link Flux} acts as a cursor and issues {@code HSCAN} commands itself as long as the subscriber signals demand.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @since 2.1
+	 */
+	Flux<Map.Entry<HK, HV>> scan(H key, ScanOptions options);
+
+	/**
 	 * Removes the given {@literal key}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
@@ -143,8 +143,34 @@ public interface ReactiveRedisOperations<K, V> {
 	 * @param pattern must not be {@literal null}.
 	 * @return
 	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
+	 * @deprecated Since 2.1. Use {@link #scan()} to iterate over the keyspace as {@link #keys(Object)} is a
+	 *             non-interruptible and expensive Redis operation.
 	 */
+	@Deprecated
 	Flux<K> keys(K pattern);
+
+	/**
+	 * Use a {@link Flux} to iterate over keys. The resulting {@link Flux} acts as a cursor and issues {@code SCAN}
+	 * commands itself as long as the subscriber signals demand.
+	 *
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @since 2.1
+	 */
+	default Flux<K> scan() {
+		return scan(ScanOptions.NONE);
+	}
+
+	/**
+	 * Use a {@link Flux} to iterate over keys. The resulting {@link Flux} acts as a cursor and issues {@code SCAN}
+	 * commands itself as long as the subscriber signals demand.
+	 *
+	 * @param options must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @since 2.1
+	 */
+	Flux<K> scan(ScanOptions options);
 
 	/**
 	 * Return a random key from the keyspace.

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
@@ -272,6 +272,19 @@ public class ReactiveRedisTemplate<K, V> implements ReactiveRedisOperations<K, V
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveRedisOperations#scan(org.springframework.data.redis.core.ScanOptions)
+	 */
+	@Override
+	public Flux<K> scan(ScanOptions options) {
+
+		Assert.notNull(options, "ScanOptions must not be null!");
+
+		return createFlux(connection -> connection.keyCommands().scan(options)) //
+				.map(this::readKey);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveRedisOperations#randomKey()
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/ReactiveSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveSetOperations.java
@@ -235,6 +235,31 @@ public interface ReactiveSetOperations<K, V> {
 	Flux<V> members(K key);
 
 	/**
+	 * Use a {@link Flux} to iterate over entries in the set at {@code key} given {@link ScanOptions}. The resulting
+	 * {@link Flux} acts as a cursor and issues {@code SSCAN} commands itself as long as the subscriber signals demand.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @since 2.1
+	 */
+	default Flux<V> scan(K key) {
+		return scan(key, ScanOptions.NONE);
+	}
+
+	/**
+	 * Use a {@link Flux} to iterate over entries in the set at {@code key} given {@link ScanOptions}. The resulting
+	 * {@link Flux} acts as a cursor and issues {@code SSCAN} commands itself as long as the subscriber signals demand.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @since 2.1
+	 */
+	Flux<V> scan(K key, ScanOptions options);
+
+	/**
 	 * Get random element from set at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
@@ -229,6 +229,33 @@ public interface ReactiveZSetOperations<K, V> {
 	Flux<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range, Limit limit);
 
 	/**
+	 * Use a {@link Flux} to iterate over entries in the sorted set at {@code key} given {@link ScanOptions}. The
+	 * resulting {@link Flux} acts as a cursor and issues {@code ZSCAN} commands itself as long as the subscriber signals
+	 * demand.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @since 2.1
+	 */
+	default Flux<TypedTuple<V>> scan(K key) {
+		return scan(key, ScanOptions.NONE);
+	}
+
+	/**
+	 * Use a {@link Flux} to iterate over entries in the sorted set at {@code key} given {@link ScanOptions}. The
+	 * resulting {@link Flux} acts as a cursor and issues {@code ZSCAN} commands itself as long as the subscriber signals
+	 * demand.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @since 2.1
+	 */
+	Flux<TypedTuple<V>> scan(K key, ScanOptions options);
+
+	/**
 	 * Count number of elements within sorted set with scores between {@code min} and {@code max}.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/core/ScanOptions.java
+++ b/src/main/java/org/springframework/data/redis/core/ScanOptions.java
@@ -19,20 +19,27 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
- * Options to be used for with {@literal SCAN} command.
+ * Options to be used for with {@literal SCAN} commands.
  *
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Mark Paluch
  * @since 1.4
  */
 public class ScanOptions {
 
-	public static ScanOptions NONE = new ScanOptions();
+	/**
+	 * Constant to apply default {@link ScanOptions} without setting a limit or matching a pattern.
+	 */
+	public static ScanOptions NONE = new ScanOptions(null, null);
 
-	private @Nullable Long count;
-	private @Nullable String pattern;
+	private final @Nullable Long count;
+	private final @Nullable String pattern;
 
-	private ScanOptions() {}
+	private ScanOptions(@Nullable Long count, @Nullable String pattern) {
+		this.count = count;
+		this.pattern = pattern;
+	}
 
 	/**
 	 * Static factory method that returns a new {@link ScanOptionsBuilder}.
@@ -73,15 +80,14 @@ public class ScanOptions {
 
 	/**
 	 * @author Christoph Strobl
+	 * @author Mark Paluch
 	 * @since 1.4
 	 */
 	public static class ScanOptionsBuilder {
 
-		ScanOptions options;
+		private @Nullable Long count;
+		private @Nullable String pattern;
 
-		public ScanOptionsBuilder() {
-			options = new ScanOptions();
-		}
 
 		/**
 		 * Returns the current {@link ScanOptionsBuilder} configured with the given {@code count}.
@@ -90,7 +96,7 @@ public class ScanOptions {
 		 * @return
 		 */
 		public ScanOptionsBuilder count(long count) {
-			options.count = count;
+			this.count = count;
 			return this;
 		}
 
@@ -101,14 +107,17 @@ public class ScanOptions {
 		 * @return
 		 */
 		public ScanOptionsBuilder match(String pattern) {
-			options.pattern = pattern;
+			this.pattern = pattern;
 			return this;
 		}
 
+		/**
+		 * Builds a new {@link ScanOptions} objects.
+		 *
+		 * @return a new {@link ScanOptions} objects.
+		 */
 		public ScanOptions build() {
-			return options;
+			return new ScanOptions(count, pattern);
 		}
-
 	}
-
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.Test;
+import org.springframework.data.redis.core.ScanOptions;
 
 /**
  * @author Christoph Strobl
@@ -230,6 +231,18 @@ public class LettuceReactiveHashCommandsTests extends LettuceReactiveCommandsTes
 				.consumeNextWith(list -> {
 					assertTrue(list.containsAll(expected.entrySet()));
 				}) //
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-743
+	public void hScanShouldIterateOverHash() {
+
+		nativeCommands.hset(KEY_1, FIELD_1, VALUE_1);
+		nativeCommands.hset(KEY_1, FIELD_2, VALUE_2);
+		nativeCommands.hset(KEY_1, FIELD_3, VALUE_3);
+
+		StepVerifier.create(connection.hashCommands().hScan(KEY_1_BBUFFER, ScanOptions.scanOptions().count(1).build())) //
+				.expectNextCount(3) //
 				.verifyComplete();
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommandsTests.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import org.springframework.data.redis.core.ScanOptions;
 
 /**
+ * Integration tests for {@link LettuceReactiveHashCommands}.
+ *
  * @author Christoph Strobl
  * @author Mark Paluch
  */

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommandsTests.java
@@ -29,6 +29,12 @@ import java.util.Arrays;
 import org.junit.Test;
 import org.springframework.data.redis.core.ScanOptions;
 
+/**
+ * Integration tests for {@link LettuceReactiveSetCommands}.
+ *
+ * @author Christoph Strobl
+ * @author Mark Paluch
+ */
 public class LettuceReactiveSetCommandsTests extends LettuceReactiveCommandsTestsBase {
 
 	@Test // DATAREDIS-525

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommandsTests.java
@@ -27,6 +27,7 @@ import reactor.test.StepVerifier;
 import java.util.Arrays;
 
 import org.junit.Test;
+import org.springframework.data.redis.core.ScanOptions;
 
 public class LettuceReactiveSetCommandsTests extends LettuceReactiveCommandsTestsBase {
 
@@ -217,6 +218,21 @@ public class LettuceReactiveSetCommandsTests extends LettuceReactiveCommandsTest
 		StepVerifier.create(connection.setCommands().sMembers(KEY_1_BBUFFER).buffer(3)) //
 				.consumeNextWith(
 						list -> assertThat(list, containsInAnyOrder(VALUE_1_BBUFFER, VALUE_2_BBUFFER, VALUE_3_BBUFFER))) //
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-743
+	public void sScanShouldIterateOverSet() {
+
+		nativeCommands.sadd(KEY_1, VALUE_1, VALUE_2, VALUE_3);
+
+		StepVerifier.create(connection.setCommands().sScan(KEY_1_BBUFFER)) //
+				.expectNextCount(3) //
+				.verifyComplete();
+
+		StepVerifier
+				.create(connection.setCommands().sScan(KEY_1_BBUFFER, ScanOptions.scanOptions().match("value-3").build())) //
+				.expectNext(VALUE_3_BBUFFER) //
 				.verifyComplete();
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
@@ -28,7 +28,7 @@ import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.DefaultTuple;
-import org.springframework.data.redis.test.util.LettuceRedisClientProvider;
+import org.springframework.data.redis.core.ScanOptions;
 
 /**
  * @author Christoph Strobl
@@ -272,6 +272,22 @@ public class LettuceReactiveZSetCommandsTests extends LettuceReactiveCommandsTes
 
 		StepVerifier
 				.create(connection.zSetCommands().zRevRangeByScoreWithScores(KEY_1_BBUFFER, new Range<>(2D, 3D, true, false))) //
+				.expectNext(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)) //
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-743
+	public void zScanShouldIterateOverSortedSet() {
+
+		nativeCommands.zadd(KEY_1, 1D, VALUE_1);
+		nativeCommands.zadd(KEY_1, 2D, VALUE_2);
+		nativeCommands.zadd(KEY_1, 3D, VALUE_3);
+
+		StepVerifier.create(connection.zSetCommands().zScan(KEY_1_BBUFFER, ScanOptions.scanOptions().count(1).build())) //
+				.expectNextCount(3).verifyComplete();
+
+		StepVerifier
+				.create(connection.zSetCommands().zScan(KEY_1_BBUFFER, ScanOptions.scanOptions().match(VALUE_2).build())) //
 				.expectNext(new DefaultTuple(VALUE_2_BBUFFER.array(), 2D)) //
 				.verifyComplete();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveZSetCommandsTests.java
@@ -31,6 +31,8 @@ import org.springframework.data.redis.connection.DefaultTuple;
 import org.springframework.data.redis.core.ScanOptions;
 
 /**
+ * Integration tests for {@link LettuceReactiveZSetCommands}.
+ *
  * @author Christoph Strobl
  * @author Mark Paluch
  */

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
@@ -382,6 +382,31 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 				.verifyComplete();
 	}
 
+	@Test // DATAREDIS-743
+	public void scan() {
+
+		assumeTrue(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory);
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+
+		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
+
+		StepVerifier.create(hashOperations.scan(key).buffer(2)) //
+				.consumeNextWith(list -> {
+
+					Entry<HK, HV> entry1 = Collections.singletonMap(hashkey1, hashvalue1).entrySet().iterator().next();
+					Entry<HK, HV> entry2 = Collections.singletonMap(hashkey2, hashvalue2).entrySet().iterator().next();
+
+					assertThat(list).containsExactlyInAnyOrder(entry1, entry2);
+				}) //
+				.verifyComplete();
+	}
+
 	@Test // DATAREDIS-602
 	public void delete() {
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveSetOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveSetOperationsIntegrationTests.java
@@ -310,6 +310,25 @@ public class DefaultReactiveSetOperationsIntegrationTests<K, V> {
 				.consumeNextWith(actual -> assertThat(actual).isIn(value1, value2)).expectNextCount(1).verifyComplete();
 	}
 
+	@Test // DATAREDIS-743
+	public void scan() {
+
+		assumeFalse(valueFactory instanceof ByteBufferObjectFactory);
+
+		K key = keyFactory.instance();
+		V value1 = valueFactory.instance();
+		V value2 = valueFactory.instance();
+
+		StepVerifier.create(setOperations.add(key, value1, value2)) //
+				.expectNext(2L) //
+				.verifyComplete();
+
+		StepVerifier.create(setOperations.scan(key)) //
+				.consumeNextWith(actual -> assertThat(actual).isIn(value1, value2)) //
+				.expectNextCount(1) //
+				.verifyComplete();
+	}
+
 	@Test // DATAREDIS-602
 	public void randomMember() {
 

--- a/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
@@ -25,6 +25,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -114,6 +116,23 @@ public class ReactiveRedisTemplateIntegrationTests<K, V> {
 				.verifyComplete();
 
 		StepVerifier.create(redisTemplate.hasKey(key)).expectNext(true).verifyComplete();
+	}
+
+	@Test // DATAREDIS-743
+	public void scan() {
+
+		assumeFalse(valueFactory.instance() instanceof Person);
+
+		Map<K, V> tuples = new HashMap<>();
+		tuples.put(keyFactory.instance(), valueFactory.instance());
+		tuples.put(keyFactory.instance(), valueFactory.instance());
+		tuples.put(keyFactory.instance(), valueFactory.instance());
+
+		StepVerifier.create(redisTemplate.opsForValue().multiSet(tuples)).expectNext(true).verifyComplete();
+
+		StepVerifier.create(redisTemplate.scan().collectList()) //
+				.consumeNextWith(actual -> assertThat(actual).containsAll(tuples.keySet())) //
+				.verifyComplete();
 	}
 
 	@Test // DATAREDIS-602


### PR DESCRIPTION
We now provide reactive `SCAN` support for keys, hashes, sets, and sorted sets. Scanning uses a cursor-based Flux and takes subscriber demand into account to issue the according scan commands once a batch of keys/values/entries was emitted. Specifying a `SCAN` limit controls the batch (page) size and can be used to optimize the number of roundtrips between the application and Redis.

---

Related ticket: [DATAREDIS-743](https://jira.spring.io/browse/DATAREDIS-743).