### PR TITLE
DATAREDIS-840 - Catch unsubscribe exceptions when stopping RedisMessageListenerContainer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-840-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -87,7 +87,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 	public static final long DEFAULT_RECOVERY_INTERVAL = 5000;
 
 	/**
-	 * The default subscription wait time: 2000-2018 ms = 2 seconds.
+	 * The default subscription wait time: 2000 ms = 2 seconds.
 	 */
 	public static final long DEFAULT_SUBSCRIPTION_REGISTRATION_WAIT_TIME = 2000L;
 

--- a/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerTests.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.redis.listener;
 
 import static org.hamcrest.core.Is.*;
@@ -33,6 +32,8 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 
 /**
+ * Unit tests for {@link RedisMessageListenerContainer}.
+ *
  * @author Mark Paluch
  * @author Christoph Strobl
  */
@@ -54,7 +55,7 @@ public class RedisMessageListenerContainerTests {
 	private Executor executorMock;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 
 		executorMock = mock(Executor.class);
 		connectionFactoryMock = mock(LettuceConnectionFactory.class);
@@ -72,14 +73,13 @@ public class RedisMessageListenerContainerTests {
 
 	@After
 	public void tearDown() throws Exception {
-
 		container.destroy();
 	}
 
 	@Test // DATAREDIS-415
-	public void interruptAtStart() throws Exception {
+	public void interruptAtStart() {
 
-		final Thread main = Thread.currentThread();
+		Thread main = Thread.currentThread();
 
 		// interrupt thread once Executor.execute is called
 		doAnswer(invocationOnMock -> {
@@ -93,7 +93,6 @@ public class RedisMessageListenerContainerTests {
 
 		// reset the interrupted flag to not destroy the teardown
 		assertThat(Thread.interrupted(), is(true));
-
 		assertThat(container.isRunning(), is(false));
 	}
 


### PR DESCRIPTION
We now catch exceptions that may occur during unsubscription from the subscribed patterns/channels.
Previously, RuntimeExceptions were not caught and prevented a fast shutdown of the ApplicationContext.

---

Related ticket: [DATAREDIS-840](https://jira.spring.io/browse/DATAREDIS-840).