### PR TITLE
DATAREDIS-708 - Move BGREWRITEAOF and BGSAVE tests to unit tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-708-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterServerCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterServerCommandsTests.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.redis.connection.ClusterTestVariables.*;
 import static org.springframework.data.redis.connection.lettuce.LettuceReactiveCommandsTestsBase.*;
 
-import org.junit.Ignore;
 import reactor.test.StepVerifier;
 
 import org.junit.Test;
@@ -38,18 +37,6 @@ public class LettuceReactiveClusterServerCommandsTests extends LettuceReactiveCl
 	@Test // DATAREDIS-659
 	public void pingShouldRespondCorrectly() {
 		StepVerifier.create(connection.ping(NODE1)).expectNext("PONG").verifyComplete();
-	}
-
-	@Test // DATAREDIS-659
-	@Ignore("DATAREDIS-708, Causes ERR Background append only file rewriting already")
-	public void bgReWriteAofShouldRespondCorrectly() {
-		StepVerifier.create(connection.serverCommands().bgReWriteAof(NODE1)).expectNextCount(1).verifyComplete();
-	}
-
-	@Test // DATAREDIS-659
-	@Ignore("DATAREDIS-708, Causes ERR Background append only file rewriting already")
-	public void bgSaveShouldRespondCorrectly() {
-		StepVerifier.create(connection.serverCommands().bgSave(NODE1)).expectNextCount(1).verifyComplete();
 	}
 
 	@Test // DATAREDIS-659

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnectionUnitTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.springframework.data.redis.connection.ClusterTestVariables.*;
+
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.redis.connection.RedisClusterNode;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider.TargetAware;
+
+/**
+ * Unit tests for {@link LettuceReactiveRedisClusterConnection}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LettuceReactiveRedisClusterConnectionUnitTests {
+
+	static final RedisClusterNode NODE1 = new RedisClusterNode(CLUSTER_HOST, MASTER_NODE_1_PORT);
+
+	@Mock StatefulRedisClusterConnection<ByteBuffer, ByteBuffer> sharedConnection;
+	@Mock StatefulRedisConnection<ByteBuffer, ByteBuffer> nodeConnection;
+
+	@Mock RedisClusterClient clusterClient;
+	@Mock RedisAdvancedClusterReactiveCommands<ByteBuffer, ByteBuffer> reactiveCommands;
+	@Mock RedisReactiveCommands<ByteBuffer, ByteBuffer> reactiveNodeCommands;
+	@Mock(extraInterfaces = TargetAware.class) LettuceConnectionProvider connectionProvider;
+
+	@Before
+	public void before() {
+
+		when(connectionProvider.getConnection(any())).thenReturn(sharedConnection);
+		when(sharedConnection.getConnection(anyString(), anyInt())).thenReturn(nodeConnection);
+		when(nodeConnection.reactive()).thenReturn(reactiveNodeCommands);
+	}
+
+	@Test // DATAREDIS-659, DATAREDIS-708
+	public void bgReWriteAofShouldRespondCorrectly() {
+
+		LettuceReactiveRedisClusterConnection connection = new LettuceReactiveRedisClusterConnection(connectionProvider,
+				clusterClient);
+
+		when(reactiveNodeCommands.bgrewriteaof()).thenReturn(Mono.just("OK"));
+
+		StepVerifier.create(connection.serverCommands().bgReWriteAof(NODE1)).expectNextCount(1).verifyComplete();
+	}
+
+	@Test // DATAREDIS-659, DATAREDIS-708
+	public void bgSaveShouldRespondCorrectly() {
+
+		LettuceReactiveRedisClusterConnection connection = new LettuceReactiveRedisClusterConnection(connectionProvider,
+				clusterClient);
+
+		when(reactiveNodeCommands.bgsave()).thenReturn(Mono.just("OK"));
+
+		StepVerifier.create(connection.serverCommands().bgSave(NODE1)).expectNextCount(1).verifyComplete();
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveServerCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveServerCommandsTests.java
@@ -18,7 +18,6 @@ package org.springframework.data.redis.connection.lettuce;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assume.*;
 
-import org.junit.Ignore;
 import reactor.test.StepVerifier;
 
 import org.junit.Test;
@@ -32,21 +31,6 @@ public class LettuceReactiveServerCommandsTests extends LettuceReactiveCommandsT
 	@Test // DATAREDIS-659
 	public void pingShouldRespondCorrectly() {
 		StepVerifier.create(connection.ping()).expectNext("PONG").verifyComplete();
-	}
-
-	@Test // DATAREDIS-659
-	@Ignore("DATAREDIS-708, Causes ERR Background append only file rewriting already")
-	public void bgReWriteAofShouldRespondCorrectly() {
-		StepVerifier.create(connection.serverCommands().bgReWriteAof()).expectNextCount(1).verifyComplete();
-	}
-
-	@Test // DATAREDIS-659, DATAREDIS-667
-	@Ignore("DATAREDIS-708, Causes ERR Background append only file rewriting already")
-	public void bgSaveShouldRespondCorrectly() {
-
-		assumeTrue(connectionProvider instanceof StandaloneConnectionProvider);
-
-		StepVerifier.create(connection.serverCommands().bgSave()).expectNextCount(1).verifyComplete();
 	}
 
 	@Test // DATAREDIS-659


### PR DESCRIPTION
Run tests against Lettuce connection mocks to not interfere with running Redis background processes.

---

Related ticket: [DATAREDIS-708](https://jira.spring.io/browse/DATAREDIS-708).