### PR TITLE
DATAREDIS-843 - Adapt compare-and-set to changed transaction rollback response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-843-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/support/atomic/CompareAndSet.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/CompareAndSet.java
@@ -44,7 +44,7 @@ class CompareAndSet<T> implements SessionCallback<Boolean> {
 
 	private final Supplier<T> getter;
 	private final Consumer<T> setter;
-	private final String key;
+	private final Object key;
 	private final T expect;
 	private final T update;
 
@@ -56,13 +56,11 @@ class CompareAndSet<T> implements SessionCallback<Boolean> {
 	@SuppressWarnings("unchecked")
 	public <K, V> Boolean execute(RedisOperations<K, V> operations) throws DataAccessException {
 
-		RedisOperations<String, T> ops = (RedisOperations<String, T>) operations;
-
-		ops.watch(key);
+		operations.watch((K) key);
 
 		if (expect.equals(getter.get())) {
 
-			ops.multi();
+			operations.multi();
 			setter.accept(update);
 
 			if (updateSuccessful(operations.exec())) {
@@ -70,7 +68,7 @@ class CompareAndSet<T> implements SessionCallback<Boolean> {
 			}
 		}
 
-		ops.unwatch();
+		operations.unwatch();
 		return false;
 	}
 

--- a/src/main/java/org/springframework/data/redis/support/atomic/CompareAndSet.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/CompareAndSet.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.support.atomic;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Compare-and-set (CAS) operation using Redis Transactions ({@literal WATCH} and {@literal MULTI}) to atomically update
+ * the value at {@code key}.
+ * <p>
+ * The CAS block registers a {@literal WATCH} on the key holding the expected value which guarantees that changes after
+ * watching and comparing the key will rollback the transaction. The {@literal WATCH} is reset if the comparison fails.
+ *
+ * @author Mark Paluch
+ * @since 2.0.8
+ * @see RedisAtomicDouble
+ * @see RedisAtomicInteger
+ * @see RedisAtomicLong
+ */
+@RequiredArgsConstructor
+class CompareAndSet<T> implements SessionCallback<Boolean> {
+
+	private final Supplier<T> getter;
+	private final Consumer<T> setter;
+	private final String key;
+	private final T expect;
+	private final T update;
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.SessionCallback#execute(org.springframework.data.redis.core.RedisOperations)
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public <K, V> Boolean execute(RedisOperations<K, V> operations) throws DataAccessException {
+
+		RedisOperations<String, T> ops = (RedisOperations<String, T>) operations;
+
+		ops.watch(key);
+
+		if (expect.equals(getter.get())) {
+
+			ops.multi();
+			setter.accept(update);
+
+			if (updateSuccessful(operations.exec())) {
+				return true;
+			}
+		}
+
+		ops.unwatch();
+		return false;
+	}
+
+	private static boolean updateSuccessful(Collection<?> exec) {
+		return !CollectionUtils.isEmpty(exec);
+	}
+}

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -150,7 +150,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 		Double value = operations.get(key);
 		if (value != null) {
-			return value.doubleValue();
+			return value;
 		}
 
 		throw new DataRetrievalFailureException(String.format("The key '%s' seems to no longer exist.", key));
@@ -175,7 +175,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 
 		Double value = operations.getAndSet(key, newValue);
 
-		return value != null ? value.doubleValue() : 0;
+		return value != null ? value : 0;
 	}
 
 	/**
@@ -186,7 +186,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 	 * @return {@literal true} if successful. {@literal false} indicates that the actual value was not equal to the
 	 *         expected value.
 	 */
-	public boolean compareAndSet(final double expect, final double update) {
+	public boolean compareAndSet(double expect, double update) {
 		return generalOps.execute(new CompareAndSet<>(this::get, this::set, key, expect, update));
 	}
 
@@ -214,7 +214,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 	 * @param delta the value to add
 	 * @return the previous value
 	 */
-	public double getAndAdd(final double delta) {
+	public double getAndAdd(double delta) {
 		return addAndGet(delta) - delta;
 	}
 

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -16,7 +16,6 @@
 package org.springframework.data.redis.support.atomic;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -26,7 +25,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.BoundKeyOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -187,27 +185,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	 *         expected value.
 	 */
 	public boolean compareAndSet(int expect, int update) {
-
-		return generalOps.execute(new SessionCallback<Boolean>() {
-
-			@Override
-			@SuppressWarnings("unchecked")
-			public Boolean execute(RedisOperations operations) {
-				for (;;) {
-					operations.watch(Collections.singleton(key));
-					if (expect == get()) {
-						generalOps.multi();
-						set(update);
-						if (operations.exec() != null) {
-							return true;
-						}
-					}
-					{
-						return false;
-					}
-				}
-			}
-		});
+		return generalOps.execute(new CompareAndSet<>(this::get, this::set, key, expect, update));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -148,7 +148,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 		Integer value = operations.get(key);
 		if (value != null) {
-			return value.intValue();
+			return value;
 		}
 
 		throw new DataRetrievalFailureException(String.format("The key '%s' seems to no longer exist.", key));
@@ -173,7 +173,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 
 		Integer value = operations.getAndSet(key, newValue);
 
-		return value != null ? value.intValue() : 0;
+		return value != null ? value : 0;
 	}
 
 	/**
@@ -212,7 +212,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	 * @param delta the value to add.
 	 * @return the previous value.
 	 */
-	public int getAndAdd(final int delta) {
+	public int getAndAdd(int delta) {
 		return addAndGet(delta) - delta;
 	}
 

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -155,7 +155,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 		Long value = operations.get(key);
 		if (value != null) {
-			return value.longValue();
+			return value;
 		}
 
 		throw new DataRetrievalFailureException(String.format("The key '%s' seems to no longer exist.", key));
@@ -180,7 +180,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 
 		Long value = operations.getAndSet(key, newValue);
 
-		return value != null ? value.longValue() : 0;
+		return value != null ? value : 0;
 	}
 
 	/**
@@ -219,7 +219,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 	 * @param delta the value to add.
 	 * @return the previous value.
 	 */
-	public long getAndAdd(final long delta) {
+	public long getAndAdd(long delta) {
 		return addAndGet(delta) - delta;
 	}
 

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -16,7 +16,6 @@
 package org.springframework.data.redis.support.atomic;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -26,7 +25,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.BoundKeyOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -194,27 +192,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 	 *         expected value.
 	 */
 	public boolean compareAndSet(long expect, long update) {
-
-		return generalOps.execute(new SessionCallback<Boolean>() {
-
-			@Override
-			@SuppressWarnings("unchecked")
-			public Boolean execute(RedisOperations operations) {
-				for (;;) {
-					operations.watch(Collections.singleton(key));
-					if (expect == get()) {
-						generalOps.multi();
-						set(update);
-						if (operations.exec() != null) {
-							return true;
-						}
-					}
-					{
-						return false;
-					}
-				}
-			}
-		});
+		return generalOps.execute(new CompareAndSet<>(this::get, this::set, key, expect, update));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/support/atomic/AtomicCountersParam.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/AtomicCountersParam.java
@@ -18,8 +18,9 @@ package org.springframework.data.redis.support.atomic;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.springframework.data.redis.SettingsUtils;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
 
@@ -27,22 +28,20 @@ import org.springframework.data.redis.connection.lettuce.LettuceTestClientResour
  * @author Costin Leau
  * @author Jennifer Hickey
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
-public abstract class AtomicCountersParam {
+abstract class AtomicCountersParam {
 
-	public static Collection<Object[]> testParams() {
+	static Collection<Object[]> testParams() {
+
 		// Jedis
-		JedisConnectionFactory jedisConnFactory = new JedisConnectionFactory();
-		jedisConnFactory.setPort(SettingsUtils.getPort());
-		jedisConnFactory.setHostName(SettingsUtils.getHost());
-		jedisConnFactory.setUsePool(true);
+		JedisConnectionFactory jedisConnFactory = new JedisConnectionFactory(new RedisStandaloneConfiguration());
 		jedisConnFactory.afterPropertiesSet();
 
 		// Lettuce
-		LettuceConnectionFactory lettuceConnFactory = new LettuceConnectionFactory();
-		lettuceConnFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
-		lettuceConnFactory.setPort(SettingsUtils.getPort());
-		lettuceConnFactory.setHostName(SettingsUtils.getHost());
+		LettuceConnectionFactory lettuceConnFactory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(),
+				LettuceClientConfiguration.builder().clientResources(LettuceTestClientResources.getSharedClientResources())
+						.build());
 		lettuceConnFactory.afterPropertiesSet();
 
 		return Arrays.asList(new Object[][] { { jedisConnFactory }, { lettuceConnFactory } });

--- a/src/test/java/org/springframework/data/redis/support/atomic/CompareAndSetIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/CompareAndSetIntegrationTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.support.atomic;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.data.redis.ConnectionFactoryTracker;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Integration tests for {@link CompareAndSet}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(Parameterized.class)
+public class CompareAndSetIntegrationTests {
+
+	private static final String KEY = "key";
+
+	private final RedisConnectionFactory factory;
+	private final RedisTemplate<String, Long> template;
+	private final ValueOperations<String, Long> valueOps;
+
+	public CompareAndSetIntegrationTests(RedisConnectionFactory factory) {
+
+		this.factory = factory;
+
+		this.template = new RedisTemplate<>();
+		this.template.setConnectionFactory(factory);
+		this.template.setKeySerializer(StringRedisSerializer.UTF_8);
+		this.template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+		this.template.afterPropertiesSet();
+
+		this.valueOps = this.template.opsForValue();
+
+		ConnectionFactoryTracker.add(factory);
+	}
+
+	@After
+	public void stop() {
+		RedisConnection connection = factory.getConnection();
+		connection.flushDb();
+		connection.close();
+	}
+
+	@AfterClass
+	public static void cleanUp() {
+		ConnectionFactoryTracker.cleanUp();
+	}
+
+	@Parameters
+	public static Collection<Object[]> testParams() {
+		return AtomicCountersParam.testParams();
+	}
+
+	@Test // DATAREDIS-843
+	public void shouldUpdateCounter() {
+
+		long expected = 5;
+		long actual = 5;
+		long update = 6;
+
+		CompareAndSet<Long> cas = new CompareAndSet<>(() -> actual, newValue -> valueOps.set(KEY, newValue), KEY, expected,
+				update);
+
+		Boolean executed = this.template.execute(cas);
+
+		assertThat(executed).isTrue();
+		assertThat(valueOps.get(KEY)).isEqualTo(update);
+	}
+
+	@Test // DATAREDIS-843
+	public void expectationNotMet() {
+
+		long expected = 5;
+		long actual = 7;
+		long update = 6;
+
+		CompareAndSet<Long> cas = new CompareAndSet<>(() -> actual, newValue -> valueOps.set(KEY, newValue), KEY, expected,
+				update);
+
+		Boolean executed = this.template.execute(cas);
+
+		assertThat(executed).isFalse();
+		assertThat(valueOps.get(KEY)).isNull();
+	}
+
+	@Test // DATAREDIS-843
+	public void concurrentUpdate() {
+
+		long expected = 5;
+		long actual = 5;
+		long update = 6;
+		long concurrentlyUpdated = 7;
+
+		CompareAndSet<Long> cas = new CompareAndSet<>(() -> actual, newValue -> {
+
+			RedisConnection connection = this.factory.getConnection();
+			connection.set(KEY.getBytes(), Long.toString(concurrentlyUpdated).getBytes());
+			connection.close();
+
+			valueOps.set(KEY, newValue);
+		}, KEY, expected, update);
+
+		Boolean executed = this.template.execute(cas);
+
+		assertThat(executed).isFalse();
+		assertThat(valueOps.get(KEY)).isEqualTo(concurrentlyUpdated);
+	}
+}

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleTests.java
@@ -69,12 +69,6 @@ public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
 		ConnectionFactoryTracker.add(factory);
 	}
 
-	@Before
-	public void setUp() {
-		// Most atomic Double ops involve incrByFloat, which is new as of 2.6
-		assumeTrue(RedisTestProfileValueSource.matches("redisVersion", "2.6"));
-	}
-
 	@After
 	public void stop() {
 		RedisConnection connection = factory.getConnection();

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicLongTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicLongTests.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.data.redis.support.atomic;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.Collection;
 
@@ -64,11 +63,9 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		ConnectionFactoryTracker.add(factory);
 	}
 
-	@After
-	public void stop() {
-		RedisConnection connection = factory.getConnection();
-		connection.flushDb();
-		connection.close();
+	@Parameters
+	public static Collection<Object[]> testParams() {
+		return AtomicCountersParam.testParams();
 	}
 
 	@AfterClass
@@ -76,77 +73,83 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		ConnectionFactoryTracker.cleanUp();
 	}
 
-	@Parameters
-	public static Collection<Object[]> testParams() {
-		return AtomicCountersParam.testParams();
+	@After
+	public void tearDown() {
+
+		RedisConnection connection = factory.getConnection();
+		connection.flushDb();
+		connection.close();
 	}
 
 	@Test
-	public void testCheckAndSet() throws Exception {
+	public void testCheckAndSet() {
 
 		longCounter.set(0);
-		assertFalse(longCounter.compareAndSet(1, 10));
-		assertTrue(longCounter.compareAndSet(0, 10));
-		assertTrue(longCounter.compareAndSet(10, 0));
+		assertThat(longCounter.compareAndSet(1, 10)).isFalse();
+		assertThat(longCounter.compareAndSet(0, 10)).isTrue();
+		assertThat(longCounter.compareAndSet(10, 0)).isTrue();
 	}
 
 	@Test
-	public void testIncrementAndGet() throws Exception {
+	public void testIncrementAndGet() {
+
 		longCounter.set(0);
-		assertEquals(1, longCounter.incrementAndGet());
+		assertThat(longCounter.incrementAndGet()).isOne();
 	}
 
 	@Test
-	public void testAddAndGet() throws Exception {
+	public void testAddAndGet() {
+
 		longCounter.set(0);
 		long delta = 5;
-		assertEquals(delta, longCounter.addAndGet(delta));
+		assertThat(longCounter.addAndGet(delta)).isEqualTo(delta);
 	}
 
 	@Test
-	public void testDecrementAndGet() throws Exception {
+	public void testDecrementAndGet() {
+
 		longCounter.set(1);
-		assertEquals(0, longCounter.decrementAndGet());
+		assertThat(longCounter.decrementAndGet()).isZero();
 	}
 
 	@Test // DATAREDIS-469
 	public void testGetAndIncrement() {
 
 		longCounter.set(1);
-		assertEquals(1, longCounter.getAndIncrement());
-		assertEquals(2, longCounter.get());
+		assertThat(longCounter.getAndIncrement()).isOne();
+		assertThat(longCounter.get()).isEqualTo(2);
 	}
 
 	@Test // DATAREDIS-469
 	public void testGetAndAdd() {
 
 		longCounter.set(1);
-		assertEquals(1, longCounter.getAndAdd(5));
-		assertEquals(6, longCounter.get());
+		assertThat(longCounter.getAndAdd(5)).isOne();
+		assertThat(longCounter.get()).isEqualTo(6);
 	}
 
 	@Test // DATAREDIS-469
 	public void testGetAndDecrement() {
 
 		longCounter.set(1);
-		assertEquals(1, longCounter.getAndDecrement());
-		assertEquals(0, longCounter.get());
+		assertThat(longCounter.getAndDecrement()).isOne();
+		assertThat(longCounter.get()).isZero();
 	}
 
 	@Test // DATAREDIS-469
 	public void testGetAndSet() {
 
 		longCounter.set(1);
-		assertEquals(1, longCounter.getAndSet(5));
-		assertEquals(5, longCounter.get());
+		assertThat(longCounter.getAndSet(5)).isOne();
+		assertThat(longCounter.get()).isEqualTo(5);
 	}
 
 	@Test
-	public void testGetExistingValue() throws Exception {
+	public void testGetExistingValue() {
 
 		longCounter.set(5);
 		RedisAtomicLong keyCopy = new RedisAtomicLong(longCounter.getKey(), factory);
-		assertEquals(longCounter.get(), keyCopy.get());
+		assertThat(longCounter.get()).isEqualTo(keyCopy.get());
 	}
 
 	@Test // DATAREDIS-317
@@ -182,7 +185,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		RedisAtomicLong ral = new RedisAtomicLong("DATAREDIS-317.atomicLong", template);
 		ral.set(32L);
 
-		assertThat(ral.get(), is(32L));
+		assertThat(ral.get()).isEqualTo(32L);
 	}
 
 	@Test // DATAREDIS-469
@@ -193,7 +196,7 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 
 		// setup long
 		RedisAtomicLong test = new RedisAtomicLong("test", factory, 1);
-		assertThat(test.get(), equalTo(1L)); // this passes
+		assertThat(test.get()).isOne();
 
 		template.delete("test");
 
@@ -205,10 +208,10 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 
 		// setup long
 		RedisAtomicLong test = new RedisAtomicLong("test", factory, 1);
-		assertThat(test.get(), equalTo(1L)); // this passes
+		assertThat(test.get()).isOne();
 
 		template.delete("test");
 
-		assertThat(test.getAndSet(2), is(0L));
+		assertThat(test.getAndSet(2)).isZero();
 	}
 }


### PR DESCRIPTION
We now consider a transactional rollback that returns an empty `EXEC` result as rollback for the CAS (compare-and-set) operation. Previously, we checked only that the response of `EXEC` is not `null`. A rollback returns an empty list which was previously considered a successful CAS operation.

The code for CAS is now extracted to `CompareAndSet` and is reused from `RedisAtomic…` implementations.

---

Related ticket: [DATAREDIS-843](https://jira.spring.io/browse/DATAREDIS-843).

Should be backported to `2.0.x`.