### PR TITLE
DATAREDIS-849 - Add support for immutable objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-849-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 
@@ -16,7 +16,7 @@
 	</parent>
 
 	<properties>
-		<springdata.keyvalue>2.1.0.BUILD-SNAPSHOT</springdata.keyvalue>
+		<springdata.keyvalue>2.1.0.DATAKV-225-SNAPSHOT</springdata.keyvalue>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>

--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -211,7 +211,11 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 			R instance = (R) conversionService.convert(partial, readType.getType());
 
 			if (entity != null && entity.hasIdProperty()) {
-				entity.getPropertyAccessor(instance).setProperty(entity.getRequiredIdProperty(), source.getId());
+
+				PersistentPropertyAccessor<R> propertyAccessor = entity.getPropertyAccessor(instance);
+
+				propertyAccessor.setProperty(entity.getRequiredIdProperty(), source.getId());
+				instance = propertyAccessor.getBean();
 			}
 			return instance;
 		}
@@ -246,7 +250,7 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 
 		readAssociation(path, source, entity, accessor);
 
-		return (R) instance;
+		return (R) accessor.getBean();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryClusterIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryClusterIntegrationTests.java
@@ -54,7 +54,7 @@ public class RedisRepositoryClusterIntegrationTests extends RedisRepositoryInteg
 	@EnableRedisRepositories(considerNestedRepositories = true, indexConfiguration = MyIndexConfiguration.class,
 			keyspaceConfiguration = MyKeyspaceConfiguration.class,
 			includeFilters = { @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
-					classes = { PersonRepository.class, CityRepository.class }) })
+					classes = { PersonRepository.class, CityRepository.class, ImmutableObjectRepository.class }) })
 	static class Config {
 
 		@Bean

--- a/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/RedisRepositoryIntegrationTests.java
@@ -56,7 +56,7 @@ public class RedisRepositoryIntegrationTests extends RedisRepositoryIntegrationT
 	@EnableRedisRepositories(considerNestedRepositories = true, indexConfiguration = MyIndexConfiguration.class,
 			keyspaceConfiguration = MyKeyspaceConfiguration.class,
 			includeFilters = { @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
-					classes = { PersonRepository.class, CityRepository.class }) })
+					classes = { PersonRepository.class, CityRepository.class, ImmutableObjectRepository.class }) })
 
 	static class Config {
 


### PR DESCRIPTION
We now support immutable objects for saving (e.g. object without a provided Id) and loading (i.e. persistence constructor declares a subset of properties). New instances are created using wither methods/Kotlin `copy(…)` methods if an immutable object requires association with an Id.

Association of the Id to its object moved from `RedisKeyValueAdapter` to `RedisKeyValueTemplate`.

---

Related ticket: [DATAREDIS-849](https://jira.spring.io/browse/DATAREDIS-849).
Depends on: 
* [DATACMNS-1322](https://jira.spring.io/browse/DATACMNS-1322)
* [DATAKV-225](https://jira.spring.io/browse/DATAKV-225)
* https://github.com/spring-projects/spring-data-commons/pull/292
* https://github.com/spring-projects/spring-data-keyvalue/pull/31