### PR TITLE
DATAREDIS-869 - Adapt to nomenclature change about Master/Replica.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ cluster-start: work/cluster-7379.pid work/cluster-7380.pid work/cluster-7381.pid
 work/meet-%:
 	-work/redis/bin/redis-cli -p $* cluster meet 127.0.0.1 7379
 
-# Handled separately because this node is a slave
+# Handled separately because this node is a replica
 work/meet-7382:
 	-work/redis/bin/redis-cli -p 7382 cluster meet 127.0.0.1 7379
 	sleep 2

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REDIS_VERSION:=4.0.9
+REDIS_VERSION:=4.0.11
 SPRING_PROFILE?=ci
 
 #######

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Running the tests requires you to have a RedisServer running at its default port
 You can alternatively use the provided `Makefile` which runs the build plus downloads and spins up the following environment:
 
 * 1 Single Node
-* HA Redis (1 Master, 2 Slaves, 3 Sentinels).
-* Redis Cluster (3 Masters, 1 Slave) 
+* HA Redis (1 Master, 2 Replicas, 3 Sentinels).
+* Redis Cluster (3 Masters, 1 Replica) 
 
 ```bash
     make test

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAREDIS-869-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -7,7 +7,7 @@ This section briefly covers items that are new and noteworthy in the latest rele
 == New in Spring Data Redis 2.1
 
 * Unix domain socket connections using <<redis:connectors:lettuce,Lettuce>>.
-* <<redis:write-to-master-read-from-slave, Write to Master, read from Slave>> support using Lettuce.
+* <<redis:write-to-master-read-from-replica, Write to Master, read from Replica>> support using Lettuce.
 * <<query-by-example,Query by Example>> integration.
 * `@TypeAlias` Support for Redis repositories.
 * Cluster-wide `SCAN` using Lettuce and `SCAN` execution on a selected node supported by both drivers.

--- a/src/main/asciidoc/reference/redis-cluster.adoc
+++ b/src/main/asciidoc/reference/redis-cluster.adoc
@@ -67,7 +67,7 @@ NOTE: The initial configuration points driver libraries to an initial set of clu
 
 == Working With Redis Cluster Connection
 
-As mentioned earlier, Redis Cluster behaves differently from single-node Redis or even a Sentinel-monitored master-slave environment. This is because the automatic sharding maps a key to one of 16384 slots, which are distributed across the nodes. Therefore, commands that involve more than one key must assert all keys map to the exact same slot to avoid cross-slot execution errors.
+As mentioned earlier, Redis Cluster behaves differently from single-node Redis or even a Sentinel-monitored master-replica environment. This is because the automatic sharding maps a key to one of 16384 slots, which are distributed across the nodes. Therefore, commands that involve more than one key must assert all keys map to the exact same slot to avoid cross-slot execution errors.
 A single cluster node serves only a dedicated set of keys. Commands issued against one particular server return results only for those keys served by that server. As a simple example, consider the `KEYS` command. When issued to a server in a cluster environment, it returns only the keys served by the node the request is sent to and not necessarily all keys within the cluster. So, to get all keys in a cluster environment, you must read the keys from all the known master nodes.
 
 While redirects for specific keys to the corresponding slot-serving node are handled by the driver libraries, higher-level functions, such as collecting information across nodes or sending commands to all nodes in the cluster, are covered by `RedisClusterConnection`. Picking up the keys example from earlier, this means that the `keys(pattern)` method picks up every master node in the cluster and simultaneously executes the `KEYS` command on every master node while picking up the results and returning the cumulated set of keys. To just request the keys of a single node `RedisClusterConnection` provides overloads for those methods (for example, `keys(node, pattern)`).
@@ -102,10 +102,10 @@ connection.keys(NODE_7380, "*");                                               <
 connection.keys(NODE_7381, "*");                                               <10>
 connection.keys(NODE_7382, "*");                                               <11>
 ----
-<1> Master node serving slots 0 to 5460 replicated to slave at 7382
+<1> Master node serving slots 0 to 5460 replicated to replica at 7382
 <2> Master node serving slots 5461 to 10922
 <3> Master node serving slots 10923 to 16383
-<4> Slave node holding replicants of the master at 7379
+<4> Replica node holding replicants of the master at 7379
 <5> Request routed to node at 7381 serving slot 12182
 <6> Request routed to node at 7379 serving slot 5061
 <7> Request routed to nodes at 7379, 7380, 7381 -> [thing1, thing2]
@@ -166,5 +166,5 @@ The following example shows how to access `RedisClusterConnection` with `RedisTe
 ClusterOperations clusterOps = redisTemplate.opsForCluster();
 clusterOps.shutdown(NODE_7379);                                              <1>
 ----
-<1> Shut down node at 7379 and cross fingers there is a slave in place that can take over.
+<1> Shut down node at 7379 and cross fingers there is a replica in place that can take over.
 ====

--- a/src/main/asciidoc/reference/redis.adoc
+++ b/src/main/asciidoc/reference/redis.adoc
@@ -109,15 +109,15 @@ class RedisConfiguration {
 }
 ----
 
-[[redis:write-to-master-read-from-slave]]
-=== Write to Master, Read from Slave
+[[redis:write-to-master-read-from-replica]]
+=== Write to Master, Read from Replica
 
-The Redis Master/Slave setup -- without automatic failover (for automatic failover see: <<redis:sentinel, Sentinel>>) -- not only allows data to be safely stored at more nodes. It also allows, by using <<redis:connectors:lettuce, Lettuce>>, reading data from slaves while pushing writes to the master. You can set the read/write strategy to be used by using `LettuceClientConfiguration`, as shown in the following example:
+The Redis Master/Replica setup -- without automatic failover (for automatic failover see: <<redis:sentinel, Sentinel>>) -- not only allows data to be safely stored at more nodes. It also allows, by using <<redis:connectors:lettuce, Lettuce>>, reading data from replicas while pushing writes to the master. You can set the read/write strategy to be used by using `LettuceClientConfiguration`, as shown in the following example:
 
 [source,java]
 ----
 @Configuration
-class WriteToMasterReadFromSlaveConfiguration {
+class WriteToMasterReadFromReplicaConfiguration {
 
   @Bean
   public LettuceConnectionFactory redisConnectionFactory() {
@@ -133,7 +133,7 @@ class WriteToMasterReadFromSlaveConfiguration {
 }
 ----
 
-TIP: For environments reporting non-public addresses through the `INFO` command (for example, when using AWS), use `RedisStaticMasterSlaveConfiguration` instead of `RedisStandaloneConfiguration`.
+TIP: For environments reporting non-public addresses through the `INFO` command (for example, when using AWS), use `RedisStaticMasterReplicaConfiguration` instead of `RedisStandaloneConfiguration`.
 
 [[redis:sentinel]]
 == Redis Sentinel Support

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterCommands.java
@@ -174,10 +174,10 @@ public interface RedisClusterCommands {
 	 * Assign a {@literal slave} to given {@literal master}.
 	 *
 	 * @param master must not be {@literal null}.
-	 * @param slave must not be {@literal null}.
+	 * @param replica must not be {@literal null}.
 	 * @see <a href="https://redis.io/commands/cluster-replicate">Redis Documentation: CLUSTER REPLICATE</a>
 	 */
-	void clusterReplicate(RedisClusterNode master, RedisClusterNode slave);
+	void clusterReplicate(RedisClusterNode master, RedisClusterNode replica);
 
 	enum AddSlots {
 		MIGRATING, IMPORTING, STABLE, NODE

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterNode.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterNode.java
@@ -326,6 +326,16 @@ public class RedisClusterNode extends RedisNode {
 			return this;
 		}
 
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.RedisNode.RedisNodeBuilder#replicaOf(java.lang.String)
+		 */
+		@Override
+		public RedisClusterNodeBuilder replicaOf(String masterId) {
+			super.replicaOf(masterId);
+			return this;
+		}
+
 		/**
 		 * Set flags for node.
 		 *

--- a/src/main/java/org/springframework/data/redis/connection/RedisConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisConfiguration.java
@@ -95,10 +95,10 @@ public interface RedisConfiguration {
 
 	/**
 	 * @param configuration can be {@literal null}.
-	 * @return {@code true} if given {@link RedisConfiguration} is instance of {@link StaticMasterSlaveConfiguration}.
+	 * @return {@code true} if given {@link RedisConfiguration} is instance of {@link StaticMasterReplicaConfiguration}.
 	 */
-	static boolean isStaticMasterSlaveConfiguration(@Nullable RedisConfiguration configuration) {
-		return configuration instanceof StaticMasterSlaveConfiguration;
+	static boolean isStaticMasterReplicaConfiguration(@Nullable RedisConfiguration configuration) {
+		return configuration instanceof StaticMasterReplicaConfiguration;
 	}
 
 	/**
@@ -323,12 +323,14 @@ public interface RedisConfiguration {
 	}
 
 	/**
-	 * Configuration interface suitable for Redis master/slave environments with fixed hosts.
+	 * Configuration interface suitable for Redis master/slave environments with fixed hosts. <br/>
+	 * Redis is undergoing a nomenclature change where the term replica is used synonymously to slave.
 	 *
 	 * @author Christoph Strobl
+	 * @author Mark Paluch
 	 * @since 2.1
 	 */
-	interface StaticMasterSlaveConfiguration extends WithDatabaseIndex, WithPassword {
+	interface StaticMasterReplicaConfiguration extends WithDatabaseIndex, WithPassword {
 
 		/**
 		 * @return unmodifiable {@link List} of {@link RedisStandaloneConfiguration nodes}.

--- a/src/main/java/org/springframework/data/redis/connection/RedisNode.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisNode.java
@@ -128,6 +128,14 @@ public class RedisNode implements NamedNode {
 	 * @since 1.7
 	 */
 	public boolean isSlave() {
+		return isReplica();
+	}
+
+	/**
+	 * @return
+	 * @since 2.1
+	 */
+	public boolean isReplica() {
 		return ObjectUtils.nullSafeEquals(NodeType.SLAVE, getType());
 	}
 
@@ -242,7 +250,7 @@ public class RedisNode implements NamedNode {
 		/**
 		 * Set server role.
 		 *
-		 * @param nodeType
+		 * @param type
 		 * @return
 		 * @since 1.7
 		 */
@@ -260,6 +268,17 @@ public class RedisNode implements NamedNode {
 		 * @since 1.7
 		 */
 		public RedisNodeBuilder slaveOf(String masterId) {
+			return replicaOf(masterId);
+		}
+
+		/**
+		 * Set the id of the master node.
+		 *
+		 * @param masterId
+		 * @return this.
+		 * @since 2.1
+		 */
+		public RedisNodeBuilder replicaOf(String masterId) {
 
 			node.masterId = masterId;
 			return this;

--- a/src/main/java/org/springframework/data/redis/connection/RedisServer.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisServer.java
@@ -166,6 +166,16 @@ public class RedisServer extends RedisNode {
 	}
 
 	public Long getNumberSlaves() {
+		return getNumberReplicas();
+	}
+
+	/**
+	 * Get the number of connected replicas.
+	 *
+	 * @return
+	 * @since 2.1
+	 */
+	public Long getNumberReplicas() {
 		return getLongValueOf(INFO.NUMBER_SLAVES);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisStaticMasterReplicaConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStaticMasterReplicaConfiguration.java
@@ -19,19 +19,20 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.springframework.data.redis.connection.RedisConfiguration.StaticMasterSlaveConfiguration;
+import org.springframework.data.redis.connection.RedisConfiguration.StaticMasterReplicaConfiguration;
 import org.springframework.util.Assert;
 
 /**
  * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} using the provided
- * Master / Slave configuration to nodes know to not change address. Eg. when connecting to
- * <a href="https://aws.amazon.com/documentation/elasticache/">AWS ElastiCache with Read Replicas</a> .
+ * Master / Replica configuration to nodes know to not change address. Eg. when connecting to
+ * <a href="https://aws.amazon.com/documentation/elasticache/">AWS ElastiCache with Read Replicas</a>. <br/>
+ * Note: Redis is undergoing a nomenclature change where the term replica is used synonymously to slave.
  *
  * @author Mark Paluch
  * @author Christoph Strobl
  * @since 2.1
  */
-public class RedisStaticMasterSlaveConfiguration implements RedisConfiguration, StaticMasterSlaveConfiguration {
+public class RedisStaticMasterReplicaConfiguration implements RedisConfiguration, StaticMasterReplicaConfiguration {
 
 	private static final int DEFAULT_PORT = 6379;
 
@@ -40,21 +41,21 @@ public class RedisStaticMasterSlaveConfiguration implements RedisConfiguration, 
 	private RedisPassword password = RedisPassword.none();
 
 	/**
-	 * Create a new {@link StaticMasterSlaveConfiguration} given {@code hostName}.
+	 * Create a new {@link StaticMasterReplicaConfiguration} given {@code hostName}.
 	 *
 	 * @param hostName must not be {@literal null} or empty.
 	 */
-	public RedisStaticMasterSlaveConfiguration(String hostName) {
+	public RedisStaticMasterReplicaConfiguration(String hostName) {
 		this(hostName, DEFAULT_PORT);
 	}
 
 	/**
-	 * Create a new {@link StaticMasterSlaveConfiguration} given {@code hostName} and {@code port}.
+	 * Create a new {@link StaticMasterReplicaConfiguration} given {@code hostName} and {@code port}.
 	 *
 	 * @param hostName must not be {@literal null} or empty.
 	 * @param port a valid TCP port (1-65535).
 	 */
-	public RedisStaticMasterSlaveConfiguration(String hostName, int port) {
+	public RedisStaticMasterReplicaConfiguration(String hostName, int port) {
 		addNode(hostName, port);
 	}
 
@@ -86,9 +87,9 @@ public class RedisStaticMasterSlaveConfiguration implements RedisConfiguration, 
 	 * Add a {@link RedisStandaloneConfiguration node} to the list of nodes given {@code hostName}.
 	 *
 	 * @param hostName must not be {@literal null} or empty.
-	 * @return {@code this} {@link StaticMasterSlaveConfiguration}.
+	 * @return {@code this} {@link StaticMasterReplicaConfiguration}.
 	 */
-	public StaticMasterSlaveConfiguration node(String hostName) {
+	public StaticMasterReplicaConfiguration node(String hostName) {
 		return node(hostName, DEFAULT_PORT);
 	}
 
@@ -97,9 +98,9 @@ public class RedisStaticMasterSlaveConfiguration implements RedisConfiguration, 
 	 *
 	 * @param hostName must not be {@literal null} or empty.
 	 * @param port a valid TCP port (1-65535).
-	 * @return {@code this} {@link StaticMasterSlaveConfiguration}.
+	 * @return {@code this} {@link StaticMasterReplicaConfiguration}.
 	 */
-	public RedisStaticMasterSlaveConfiguration node(String hostName, int port) {
+	public RedisStaticMasterReplicaConfiguration node(String hostName, int port) {
 
 		addNode(hostName, port);
 		return this;
@@ -151,7 +152,7 @@ public class RedisStaticMasterSlaveConfiguration implements RedisConfiguration, 
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisConfiguration.StaticMasterSlaveConfiguration#getNodes()
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.StaticMasterReplicaConfiguration#getNodes()
 	 */
 	@Override
 	public List<RedisStandaloneConfiguration> getNodes() {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -641,12 +641,12 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 	 * @see org.springframework.data.redis.connection.RedisClusterCommands#clusterReplicate(org.springframework.data.redis.connection.RedisClusterNode, org.springframework.data.redis.connection.RedisClusterNode)
 	 */
 	@Override
-	public void clusterReplicate(RedisClusterNode master, RedisClusterNode slave) {
+	public void clusterReplicate(RedisClusterNode master, RedisClusterNode replica) {
 
 		RedisClusterNode masterNode = topologyProvider.getTopology().lookup(master);
 
 		clusterCommandExecutor.executeCommandOnSingleNode(
-				(JedisClusterCommandCallback<String>) client -> client.clusterReplicate(masterNode.getId()), slave);
+				(JedisClusterCommandCallback<String>) client -> client.clusterReplicate(masterNode.getId()), replica);
 
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  * <li>Optional {@link ClientResources}</li>
  * <li>Optional {@link ClientOptions}</li>
  * <li>Optional client name</li>
- * <li>Optional {@link ReadFrom}. Enables Master/Slave operations if configured.</li>
+ * <li>Optional {@link ReadFrom}. Enables Master/Replica operations if configured.</li>
  * <li>Client {@link Duration timeout}</li>
  * <li>Shutdown {@link Duration timeout}</li>
  * </ul>
@@ -85,6 +85,8 @@ public interface LettuceClientConfiguration {
 	Optional<String> getClientName();
 
 	/**
+	 * Note: Redis is undergoing a nomenclature change where the term replica is used synonymously to slave.
+	 *
 	 * @return the optional {@link io.lettuce.core.ReadFrom} setting.
 	 * @since 2.1
 	 */
@@ -200,7 +202,8 @@ public interface LettuceClientConfiguration {
 		}
 
 		/**
-		 * Configure {@link ReadFrom}. Enables Master/Slave operations if configured.
+		 * Configure {@link ReadFrom}. Enables Master/Replica operations if configured. <br/>
+		 * Note: Redis is undergoing a nomenclature change where the term replica is used synonymously to slave.
 		 *
 		 * @param readFrom must not be {@literal null}.
 		 * @return {@literal this} builder.

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -490,11 +490,11 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 	 * @see org.springframework.data.redis.connection.RedisClusterCommands#clusterReplicate(org.springframework.data.redis.connection.RedisClusterNode, org.springframework.data.redis.connection.RedisClusterNode)
 	 */
 	@Override
-	public void clusterReplicate(RedisClusterNode master, RedisClusterNode slave) {
+	public void clusterReplicate(RedisClusterNode master, RedisClusterNode replica) {
 
 		RedisClusterNode masterNode = topologyProvider.getTopology().lookup(master);
 		clusterCommandExecutor.executeCommandOnSingleNode(
-				(LettuceClusterCommandCallback<String>) client -> client.clusterReplicate(masterNode.getId()), slave);
+				(LettuceClusterCommandCallback<String>) client -> client.clusterReplicate(masterNode.getId()), replica);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -73,7 +73,7 @@ import org.springframework.util.ClassUtils;
  * {@link LettuceConnectionFactory client configuration}. Lettuce supports the following environmental configurations:
  * <ul>
  * <li>{@link RedisStandaloneConfiguration}</li>
- * <li>{@link RedisStaticMasterSlaveConfiguration}</li>
+ * <li>{@link RedisStaticMasterReplicaConfiguration}</li>
  * <li>{@link RedisSocketConfiguration}</li>
  * <li>{@link RedisSentinelConfiguration}</li>
  * <li>{@link RedisClusterConfiguration}</li>
@@ -212,7 +212,7 @@ public class LettuceConnectionFactory
 
 	/**
 	 * Constructs a new {@link LettuceConnectionFactory} instance using the given
-	 * {@link RedisStaticMasterSlaveConfiguration} and {@link LettuceClientConfiguration}.
+	 * {@link RedisStaticMasterReplicaConfiguration} and {@link LettuceClientConfiguration}.
 	 *
 	 * @param redisConfiguration must not be {@literal null}.
 	 * @param clientConfig must not be {@literal null}.
@@ -825,11 +825,11 @@ public class LettuceConnectionFactory
 	}
 
 	/**
-	 * @return true when {@link RedisStaticMasterSlaveConfiguration} is present.
+	 * @return true when {@link RedisStaticMasterReplicaConfiguration} is present.
 	 * @since 2.1
 	 */
-	private boolean isStaticMasterSlaveAware() {
-		return RedisConfiguration.isStaticMasterSlaveConfiguration(configuration);
+	private boolean isStaticMasterReplicaAware() {
+		return RedisConfiguration.isStaticMasterReplicaConfiguration(configuration);
 	}
 
 	/**
@@ -903,14 +903,14 @@ public class LettuceConnectionFactory
 
 		ReadFrom readFrom = getClientConfiguration().getReadFrom().orElse(null);
 
-		if (isStaticMasterSlaveAware()) {
+		if (isStaticMasterReplicaAware()) {
 
-			List<RedisURI> nodes = ((RedisStaticMasterSlaveConfiguration) configuration).getNodes().stream() //
+			List<RedisURI> nodes = ((RedisStaticMasterReplicaConfiguration) configuration).getNodes().stream() //
 					.map(it -> createRedisURIAndApplySettings(it.getHostName(), it.getPort())) //
 					.peek(it -> it.setDatabase(getDatabase())) //
 					.collect(Collectors.toList());
 
-			return new StaticMasterSlaveConnectionProvider((RedisClient) client, codec, nodes, readFrom);
+			return new StaticMasterReplicaConnectionProvider((RedisClient) client, codec, nodes, readFrom);
 		}
 
 		if (isClusterAware()) {
@@ -922,7 +922,7 @@ public class LettuceConnectionFactory
 
 	protected AbstractRedisClient createClient() {
 
-		if (isStaticMasterSlaveAware()) {
+		if (isStaticMasterReplicaAware()) {
 
 			RedisClient redisClient = clientConfiguration.getClientResources() //
 					.map(RedisClient::create) //

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StandaloneConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StandaloneConnectionProvider.java
@@ -109,7 +109,7 @@ class StandaloneConnectionProvider implements LettuceConnectionProvider, TargetA
 
 		if (StatefulConnection.class.isAssignableFrom(connectionType)) {
 
-			return connectionType.cast(readFrom.map(it -> this.masterSlaveConnection(redisURISupplier.get(), it))
+			return connectionType.cast(readFrom.map(it -> this.masterReplicaConnection(redisURISupplier.get(), it))
 					.orElseGet(() -> client.connect(codec)));
 		}
 
@@ -135,14 +135,15 @@ class StandaloneConnectionProvider implements LettuceConnectionProvider, TargetA
 		if (StatefulConnection.class.isAssignableFrom(connectionType)) {
 
 			return connectionType
-					.cast(readFrom.map(it -> this.masterSlaveConnection(redisURI, it)).orElseGet(() -> client.connect(codec)));
+					.cast(readFrom.map(it -> this.masterReplicaConnection(redisURI, it)).orElseGet(() -> client.connect(codec)));
 		}
 
 		throw new UnsupportedOperationException("Connection type " + connectionType + " not supported!");
 	}
 
-	private StatefulRedisConnection masterSlaveConnection(RedisURI redisUri, ReadFrom readFrom) {
+	private StatefulRedisConnection masterReplicaConnection(RedisURI redisUri, ReadFrom readFrom) {
 
+		// See https://github.com/lettuce-io/lettuce-core/issues/845 for MasterSlave -> MasterReplica change.
 		StatefulRedisMasterSlaveConnection<?, ?> connection = MasterSlave.connect(client, codec, redisUri);
 		connection.setReadFrom(readFrom);
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StaticMasterReplicaConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StaticMasterReplicaConnectionProvider.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import org.springframework.lang.Nullable;
 
 /**
- * {@link LettuceConnectionProvider} implementation for a static Master/Slave connection suitable for eg. AWS
+ * {@link LettuceConnectionProvider} implementation for a static Master/Replica connection suitable for eg. AWS
  * ElastiCache with replicas setup.<br/>
  * Lettuce auto-discovers node roles from the static {@link RedisURI} collection.
  *
@@ -37,7 +37,7 @@ import org.springframework.lang.Nullable;
  * @author Christoph Strobl
  * @since 2.1
  */
-class StaticMasterSlaveConnectionProvider implements LettuceConnectionProvider {
+class StaticMasterReplicaConnectionProvider implements LettuceConnectionProvider {
 
 	private final RedisClient client;
 	private final RedisCodec<?, ?> codec;
@@ -45,14 +45,14 @@ class StaticMasterSlaveConnectionProvider implements LettuceConnectionProvider {
 	private final Collection<RedisURI> nodes;
 
 	/**
-	 * Create new {@link StaticMasterSlaveConnectionProvider}.
+	 * Create new {@link StaticMasterReplicaConnectionProvider}.
 	 *
 	 * @param client must not be {@literal null}.
 	 * @param codec must not be {@literal null}.
 	 * @param nodes must not be {@literal null}.
 	 * @param readFrom can be {@literal null}.
 	 */
-	StaticMasterSlaveConnectionProvider(RedisClient client, RedisCodec<?, ?> codec, Collection<RedisURI> nodes,
+	StaticMasterReplicaConnectionProvider(RedisClient client, RedisCodec<?, ?> codec, Collection<RedisURI> nodes,
 			@Nullable ReadFrom readFrom) {
 
 		this.client = client;
@@ -70,6 +70,7 @@ class StaticMasterSlaveConnectionProvider implements LettuceConnectionProvider {
 
 		if (StatefulConnection.class.isAssignableFrom(connectionType)) {
 
+			// See https://github.com/lettuce-io/lettuce-core/issues/845 for MasterSlave -> MasterReplica change.
 			StatefulRedisMasterSlaveConnection<?, ?> connection = MasterSlave.connect(client, codec, nodes);
 			readFrom.ifPresent(connection::setReadFrom);
 

--- a/src/test/java/org/springframework/data/redis/connection/RedisElastiCacheConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisElastiCacheConfigurationUnitTests.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link RedisStaticMasterSlaveConfiguration}.
+ * Unit tests for {@link RedisStaticMasterReplicaConfiguration}.
  *
  * @author Mark Paluch
  */
@@ -29,7 +29,7 @@ public class RedisElastiCacheConfigurationUnitTests {
 	@Test // DATAREDIS-762
 	public void shouldCreateSingleHostConfiguration() {
 
-		RedisStaticMasterSlaveConfiguration singleHost = new RedisStaticMasterSlaveConfiguration("localhost");
+		RedisStaticMasterReplicaConfiguration singleHost = new RedisStaticMasterReplicaConfiguration("localhost");
 
 		assertThat(singleHost.getNodes()).hasSize(1);
 
@@ -42,7 +42,7 @@ public class RedisElastiCacheConfigurationUnitTests {
 	@Test // DATAREDIS-762
 	public void shouldCreateMultiHostConfiguration() {
 
-		RedisStaticMasterSlaveConfiguration multiHost = new RedisStaticMasterSlaveConfiguration("localhost");
+		RedisStaticMasterReplicaConfiguration multiHost = new RedisStaticMasterReplicaConfiguration("localhost");
 		multiHost.node("other-host", 6479);
 
 		assertThat(multiHost.getNodes()).hasSize(2);
@@ -61,7 +61,7 @@ public class RedisElastiCacheConfigurationUnitTests {
 	@Test // DATAREDIS-762
 	public void shouldApplyPasswordToNodes() {
 
-		RedisStaticMasterSlaveConfiguration multiHost = new RedisStaticMasterSlaveConfiguration("localhost").node("other-host", 6479);
+		RedisStaticMasterReplicaConfiguration multiHost = new RedisStaticMasterReplicaConfiguration("localhost").node("other-host", 6479);
 
 		multiHost.setPassword(RedisPassword.of("foobar"));
 		multiHost.node("third", 1234);
@@ -73,7 +73,7 @@ public class RedisElastiCacheConfigurationUnitTests {
 	@Test // DATAREDIS-762
 	public void shouldApplyDatabaseToNodes() {
 
-		RedisStaticMasterSlaveConfiguration multiHost = new RedisStaticMasterSlaveConfiguration("localhost").node("other-host", 6479);
+		RedisStaticMasterReplicaConfiguration multiHost = new RedisStaticMasterReplicaConfiguration("localhost").node("other-host", 6479);
 
 		multiHost.setDatabase(4);
 		multiHost.node("third", 1234);

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -41,7 +41,7 @@ import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.connection.DefaultStringRedisConnection;
 import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.RedisStaticMasterSlaveConfiguration;
+import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.StringRedisConnection;
 
@@ -385,8 +385,8 @@ public class LettuceConnectionFactoryTests {
 		factory.destroy();
 	}
 
-	@Test // DATAREDIS-762
-	public void factoryUsesElastiCacheMasterSlaveConnections() {
+	@Test // DATAREDIS-762, DATAREDIS-869
+	public void factoryUsesElastiCacheMasterReplicaConnections() {
 
 		assumeThat(String.format("No slaves connected to %s:%s.", SettingsUtils.getHost(), SettingsUtils.getPort()),
 				connection.info("replication").getProperty("connected_slaves", "0").compareTo("0") > 0, is(true));
@@ -394,7 +394,7 @@ public class LettuceConnectionFactoryTests {
 		LettuceClientConfiguration configuration = LettuceTestClientConfiguration.builder().readFrom(ReadFrom.SLAVE)
 				.build();
 
-		RedisStaticMasterSlaveConfiguration elastiCache = new RedisStaticMasterSlaveConfiguration(SettingsUtils.getHost())
+		RedisStaticMasterReplicaConfiguration elastiCache = new RedisStaticMasterReplicaConfiguration(SettingsUtils.getHost())
 				.node(SettingsUtils.getHost(), SettingsUtils.getPort() + 1);
 
 		LettuceConnectionFactory factory = new LettuceConnectionFactory(elastiCache,
@@ -413,16 +413,16 @@ public class LettuceConnectionFactoryTests {
 		factory.destroy();
 	}
 
-	@Test // DATAREDIS-762
+	@Test // DATAREDIS-762, DATAREDIS-869
 	public void factoryUsesElastiCacheMasterWithoutMaster() {
 
-		assumeThat(String.format("No slaves connected to %s:%s.", SettingsUtils.getHost(), SettingsUtils.getPort()),
+		assumeThat(String.format("No replicas connected to %s:%s.", SettingsUtils.getHost(), SettingsUtils.getPort()),
 				connection.info("replication").getProperty("connected_slaves", "0").compareTo("0") > 0, is(true));
 
 		LettuceClientConfiguration configuration = LettuceTestClientConfiguration.builder().readFrom(ReadFrom.MASTER)
 				.build();
 
-		RedisStaticMasterSlaveConfiguration elastiCache = new RedisStaticMasterSlaveConfiguration(SettingsUtils.getHost(),
+		RedisStaticMasterReplicaConfiguration elastiCache = new RedisStaticMasterReplicaConfiguration(SettingsUtils.getHost(),
 				SettingsUtils.getPort() + 1);
 
 		LettuceConnectionFactory factory = new LettuceConnectionFactory(elastiCache, configuration);
@@ -444,10 +444,10 @@ public class LettuceConnectionFactoryTests {
 		factory.destroy();
 	}
 
-	@Test // DATAREDIS-580
-	public void factoryUsesMasterSlaveConnections() {
+	@Test // DATAREDIS-580, DATAREDIS-869
+	public void factoryUsesMasterReplicaConnections() {
 
-		assumeThat(String.format("No slaves connected to %s:%s.", SettingsUtils.getHost(), SettingsUtils.getPort()),
+		assumeThat(String.format("No replicas connected to %s:%s.", SettingsUtils.getHost(), SettingsUtils.getPort()),
 				connection.info("replication").getProperty("connected_slaves", "0").compareTo("0") > 0, is(true));
 
 		LettuceClientConfiguration configuration = LettuceTestClientConfiguration.builder().readFrom(ReadFrom.SLAVE)


### PR DESCRIPTION
Adapt documentation and non-released public API to changed nomenclature regarding Master/Replica (previously: Master/Slave).

---

Related ticket: [DATAREDIS-869](https://jira.spring.io/browse/DATAREDIS-869).