### PR TITLE
DATAREDIS-872 - InitialValue is not specified when two threads use the RedisAtomicInteger constructor concurrently, and two threads can cause thread safety issues.

### DIFF
--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -166,7 +166,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 	 * Sets to the given value, only if {@code key} does not exist.
 	 *
 	 * @param newValue the new value.
-	 * @return  true if successful. False return indicates that {@code key} already existed.
+	 * @return true if successful. False return indicates that {@code key} already existed.
 	 */
 	public Boolean setIfAbsent(double newValue) {
 		operations.setIfAbsent(key, newValue);

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -87,9 +87,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -133,9 +131,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -165,6 +161,16 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 		operations.set(key, newValue);
 	}
 
+	/**
+	 * Sets to the given value, only if {@code key} does not exist.
+	 *
+	 * @param newValue the new value.
+	 * @return  true if successful. False return indicates that {@code key} already existed.
+	 */
+	public Boolean setIfAbsent(double newValue) {
+		operations.setIfAbsent(key, newValue);
+	}
+	
 	/**
 	 * Atomically sets to the given value and returns the old value.
 	 *

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Ning Wei
  */
 public class RedisAtomicDouble extends Number implements Serializable, BoundKeyOperations<String> {
 

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -169,7 +169,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 	 * @return true if successful. False return indicates that {@code key} already existed.
 	 */
 	public Boolean setIfAbsent(double newValue) {
-		operations.setIfAbsent(key, newValue);
+		 return operations.setIfAbsent(key, newValue);
 	}
 	
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
- * @author Ning Wei
+ * @author Ning Wei 
  */
 public class RedisAtomicDouble extends Number implements Serializable, BoundKeyOperations<String> {
 

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -169,7 +169,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 	 * @return true if successful. False return indicates that {@code key} already existed.
 	 */
 	public Boolean setIfAbsent(double newValue) {
-		 return operations.setIfAbsent(key, newValue);
+		return operations.setIfAbsent(key, newValue);
 	}
 	
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -110,9 +110,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -131,9 +129,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -163,6 +159,16 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 		operations.set(key, newValue);
 	}
 
+	/**
+	 * Sets to the given value, only if {@code key} does not exist.
+	 *
+	 * @param newValue the new value.
+	 * @return  true if successful. False return indicates that {@code key} already existed.
+	 */
+	public Boolean setIfAbsent(int newValue) {
+		operations.setIfAbsent(key, newValue);
+	}
+	
 	/**
 	 * Set to the give value and return the old value.
 	 *

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -167,7 +167,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	 * @return true if successful. False return indicates that {@code key} already existed.
 	 */
 	public Boolean setIfAbsent(int newValue) {
-		operations.setIfAbsent(key, newValue);
+		return operations.setIfAbsent(key, newValue);
 	}
 	
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -164,7 +164,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	 * Sets to the given value, only if {@code key} does not exist.
 	 *
 	 * @param newValue the new value.
-	 * @return  true if successful. False return indicates that {@code key} already existed.
+	 * @return true if successful. False return indicates that {@code key} already existed.
 	 */
 	public Boolean setIfAbsent(int newValue) {
 		operations.setIfAbsent(key, newValue);

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Ning Wei
  * @see java.util.concurrent.atomic.AtomicInteger
  */
 public class RedisAtomicInteger extends Number implements Serializable, BoundKeyOperations<String> {

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -88,9 +88,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -138,9 +136,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -170,6 +166,16 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 		operations.set(key, newValue);
 	}
 
+	/**
+	 * Sets to the given value, only if {@code key} does not exist.
+	 *
+	 * @param newValue the new value.
+	 * @return  true if successful. False return indicates that {@code key} already existed.
+	 */
+	public Boolean setIfAbsent(long newValue) {
+		operations.setIfAbsent(key, newValue);
+	}
+	
 	/**
 	 * Atomically sets to the given value and returns the old value.
 	 *

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Ning Wei
  * @see java.util.concurrent.atomic.AtomicLong
  */
 public class RedisAtomicLong extends Number implements Serializable, BoundKeyOperations<String> {

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -174,7 +174,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 	 * @return true if successful. False return indicates that {@code key} already existed.
 	 */
 	public Boolean setIfAbsent(long newValue) {
-		operations.setIfAbsent(key, newValue);
+		return operations.setIfAbsent(key, newValue);
 	}
 	
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -171,7 +171,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 	 * Sets to the given value, only if {@code key} does not exist.
 	 *
 	 * @param newValue the new value.
-	 * @return  true if successful. False return indicates that {@code key} already existed.
+	 * @return true if successful. False return indicates that {@code key} already existed.
 	 */
 	public Boolean setIfAbsent(long newValue) {
 		operations.setIfAbsent(key, newValue);


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
