### PR TITLE
DATAREDIS-881 - Add config parameter shutdownQuietPeriod beside of shutdownTimeout

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettuceClientConfiguration.java
@@ -42,11 +42,13 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 	private final Optional<ReadFrom> readFrom;
 	private final Duration timeout;
 	private final Duration shutdownTimeout;
+	private final Duration shutdownQuietPeriod;
 
 	DefaultLettuceClientConfiguration(boolean useSsl, boolean verifyPeer, boolean startTls,
 			@Nullable ClientResources clientResources, @Nullable ClientOptions clientOptions, @Nullable String clientName,
 			@Nullable ReadFrom readFrom,
-			Duration timeout, Duration shutdownTimeout) {
+			Duration timeout, Duration shutdownTimeout,
+			@Nullable Duration shutdownQuietPeriod) {
 
 		this.useSsl = useSsl;
 		this.verifyPeer = verifyPeer;
@@ -57,6 +59,7 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 		this.readFrom = Optional.ofNullable(readFrom);
 		this.timeout = timeout;
 		this.shutdownTimeout = shutdownTimeout;
+		this.shutdownQuietPeriod = shutdownQuietPeriod != null ? shutdownQuietPeriod : shutdownTimeout;
 	}
 
 	/*
@@ -138,5 +141,14 @@ class DefaultLettuceClientConfiguration implements LettuceClientConfiguration {
 	@Override
 	public Duration getShutdownTimeout() {
 		return shutdownTimeout;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getShutdownQuietPeriod()
+	 */
+	@Override
+	public Duration getShutdownQuietPeriod() {
+		return shutdownQuietPeriod;
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolingClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolingClientConfiguration.java
@@ -126,6 +126,15 @@ class DefaultLettucePoolingClientConfiguration implements LettucePoolingClientCo
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getShutdownQuietPeriod()
+	 */
+	@Override
+	public Duration getShutdownQuietPeriod() {
+		return clientConfiguration.getShutdownQuietPeriod();
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettucePoolingClientConfiguration#getPoolConfig()
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -104,6 +104,13 @@ public interface LettuceClientConfiguration {
 	Duration getShutdownTimeout();
 
 	/**
+	 * @return the shutdown quiet period used to close the client.
+	 * @since 2.2
+	 * @see io.lettuce.core.AbstractRedisClient#shutdown(long, long, TimeUnit)
+	 */
+	Duration getShutdownQuietPeriod();
+
+	/**
 	 * Creates a new {@link LettuceClientConfigurationBuilder} to build {@link LettuceClientConfiguration} to be used with
 	 * the Lettuce client.
 	 *
@@ -157,6 +164,7 @@ public interface LettuceClientConfiguration {
 		@Nullable ReadFrom readFrom;
 		Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);
 		Duration shutdownTimeout = Duration.ofMillis(100);
+		@Nullable Duration shutdownQuietPeriod;
 
 		LettuceClientConfigurationBuilder() {}
 
@@ -258,9 +266,25 @@ public interface LettuceClientConfiguration {
 		 */
 		public LettuceClientConfigurationBuilder shutdownTimeout(Duration shutdownTimeout) {
 
-			Assert.notNull(timeout, "Duration must not be null!");
+			Assert.notNull(shutdownTimeout, "Duration must not be null!");
 
 			this.shutdownTimeout = shutdownTimeout;
+			return this;
+		}
+
+		/**
+		 * Configure a shutdown timeout.
+		 *
+		 * @param shutdownQuietPeriod must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 * @throws IllegalArgumentException if shutdownQuietPeriod is {@literal null}.
+		 * @since 2.2
+		 */
+		public LettuceClientConfigurationBuilder shutdownQuietPeriod(Duration shutdownQuietPeriod) {
+
+			Assert.notNull(shutdownQuietPeriod, "Duration must not be null!");
+
+			this.shutdownQuietPeriod = shutdownQuietPeriod;
 			return this;
 		}
 
@@ -272,7 +296,7 @@ public interface LettuceClientConfiguration {
 		public LettuceClientConfiguration build() {
 
 			return new DefaultLettuceClientConfiguration(useSsl, verifyPeer, startTls, clientResources, clientOptions,
-					clientName, readFrom, timeout, shutdownTimeout);
+					clientName, readFrom, timeout, shutdownTimeout, shutdownQuietPeriod);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -302,8 +302,9 @@ public class LettuceConnectionFactory
 		}
 
 		try {
+			Duration quietPeriod = clientConfiguration.getShutdownQuietPeriod();
 			Duration timeout = clientConfiguration.getShutdownTimeout();
-			client.shutdown(timeout.toMillis(), timeout.toMillis(), TimeUnit.MILLISECONDS);
+			client.shutdown(quietPeriod.toMillis(), timeout.toMillis(), TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
 
 			if (log.isWarnEnabled()) {
@@ -1275,6 +1276,15 @@ public class LettuceConnectionFactory
 
 		void setShutdownTimeout(Duration shutdownTimeout) {
 			this.shutdownTimeout = shutdownTimeout;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration#getShutdownQuietPeriod()
+		 */
+		@Override
+		public Duration getShutdownQuietPeriod() {
+			return shutdownTimeout;
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfiguration.java
@@ -142,6 +142,17 @@ public interface LettucePoolingClientConfiguration extends LettuceClientConfigur
 			return this;
 		}
 
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder#shutdownQuietPeriod(java.time.Duration)
+		 */
+		@Override
+		public LettucePoolingClientConfigurationBuilder shutdownQuietPeriod(Duration shutdownQuietPeriod) {
+
+			super.shutdownQuietPeriod(shutdownQuietPeriod);
+			return this;
+		}
+
 		/**
 		 * Set the {@link GenericObjectPoolConfig} used by the driver.
 		 *

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
@@ -45,6 +45,7 @@ public class LettuceClientConfigurationUnitTests {
 		assertThat(configuration.getClientName()).isEmpty();
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofSeconds(60));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofMillis(100));
+		assertThat(configuration.getShutdownQuietPeriod()).isEqualTo(Duration.ofMillis(100));
 	}
 
 	@Test // DATAREDIS-574, DATAREDIS-576, DATAREDIS-667
@@ -62,6 +63,7 @@ public class LettuceClientConfigurationUnitTests {
 				.clientName("foo") //
 				.commandTimeout(Duration.ofMinutes(5)) //
 				.shutdownTimeout(Duration.ofHours(2)) //
+				.shutdownQuietPeriod(Duration.ofMinutes(5)) //
 				.build();
 
 		assertThat(configuration.isUseSsl()).isTrue();
@@ -72,6 +74,7 @@ public class LettuceClientConfigurationUnitTests {
 		assertThat(configuration.getClientName()).contains("foo");
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofMinutes(5));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofHours(2));
+		assertThat(configuration.getShutdownQuietPeriod()).isEqualTo(Duration.ofMinutes(5));
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAREDIS-576

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfigurationUnitTests.java
@@ -46,6 +46,7 @@ public class LettucePoolingClientConfigurationUnitTests {
 		assertThat(configuration.getClientResources()).isEmpty();
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofSeconds(60));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofMillis(100));
+		assertThat(configuration.getShutdownQuietPeriod()).isEqualTo(Duration.ofMillis(100));
 	}
 
 	@Test // DATAREDIS-667
@@ -64,6 +65,7 @@ public class LettucePoolingClientConfigurationUnitTests {
 				.clientResources(sharedClientResources) //
 				.commandTimeout(Duration.ofMinutes(5)) //
 				.shutdownTimeout(Duration.ofHours(2)) //
+				.shutdownQuietPeriod(Duration.ofMinutes(5)) //
 				.build();
 
 		assertThat(configuration.getPoolConfig()).isEqualTo(poolConfig);
@@ -74,5 +76,6 @@ public class LettucePoolingClientConfigurationUnitTests {
 		assertThat(configuration.getClientResources()).contains(sharedClientResources);
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofMinutes(5));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofHours(2));
+		assertThat(configuration.getShutdownQuietPeriod()).isEqualTo(Duration.ofMinutes(5));
 	}
 }


### PR DESCRIPTION
Refer to https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java#L52 , shutdownQuietPeriod should be extra option separated from shutdownTimeout.