### PR TITLE
DATAREDIS-872 - InitialValue is not specified when two threads use the RedisAtomicInteger constructor concurrently, and two threads can cause thread safety issues. 

### DIFF
--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -42,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Graham MacMaster
+ * @author Ning Wei
  */
 public class RedisAtomicDouble extends Number implements Serializable, BoundKeyOperations<String> {
 
@@ -90,9 +91,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -136,9 +135,7 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -166,6 +163,16 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 	 */
 	public void set(double newValue) {
 		operations.set(key, newValue);
+	}
+
+	/**
+	 * Sets to the given value, only if {@code key} does not exist.
+	 *
+	 * @param newValue the new value.
+	 * @return true if successful. False return indicates that {@code key} already existed.
+	 */
+	public Boolean setIfAbsent(double newValue) {
+		return operations.setIfAbsent(key, newValue);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -42,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Graham MacMaster
+ * @author Ning Wei
  * @see java.util.concurrent.atomic.AtomicInteger
  */
 public class RedisAtomicInteger extends Number implements Serializable, BoundKeyOperations<String> {
@@ -113,9 +114,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -134,9 +133,7 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -164,6 +161,16 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	 */
 	public void set(int newValue) {
 		operations.set(key, newValue);
+	}
+
+	/**
+	 * Sets to the given value, only if {@code key} does not exist.
+	 *
+	 * @param newValue the new value.
+	 * @return true if successful. False return indicates that {@code key} already existed.
+	 */
+	public Boolean setIfAbsent(int newValue) {
+		return operations.setIfAbsent(key, newValue);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Graham MacMaster
+ * @author Ning Wei
  * @see java.util.concurrent.atomic.AtomicLong
  */
 public class RedisAtomicLong extends Number implements Serializable, BoundKeyOperations<String> {
@@ -91,9 +92,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -141,9 +140,7 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 		this.operations = generalOps.opsForValue();
 
 		if (initialValue == null) {
-			if (this.operations.get(redisCounter) == null) {
-				set(0);
-			}
+			setIfAbsent(0);
 		} else {
 			set(initialValue);
 		}
@@ -171,6 +168,16 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 	 */
 	public void set(long newValue) {
 		operations.set(key, newValue);
+	}
+
+	/**
+	 * Sets to the given value, only if {@code key} does not exist.
+	 *
+	 * @param newValue the new value.
+	 * @return true if successful. False return indicates that {@code key} already existed.
+	 */
+	public Boolean setIfAbsent(long newValue) {
+		return operations.setIfAbsent(key, newValue);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleTests.java
@@ -47,6 +47,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Graham MacMaster
+ * @author Ning Wei
  */
 @RunWith(Parameterized.class)
 public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
@@ -402,5 +403,23 @@ public class RedisAtomicDoubleTests extends AbstractRedisAtomicsTests {
 		doubleCounter.getAndAccumulate(15, accumulatorFunction);
 
 		assertThat(operatorHasBeenApplied).isTrue();
+	}
+
+	@Test // DATAREDIS-872
+	public void testUseSetIfAbsentRedisAtomicDoubleForTemplate() {
+ 		RedisAtomicDouble ral = new RedisAtomicDouble("DATAREDIS-872.atomicDouble", template);
+		assertThat(ral.get()).isEqualTo(0);
+		ral.set(32.13);
+ 		RedisAtomicDouble ral1 = new RedisAtomicDouble("DATAREDIS-872.atomicDouble", template);
+		assertThat(ral1.get()).isEqualTo(32.13);
+	}
+
+	@Test // DATAREDIS-872
+	public void testUseSetIfAbsentRedisAtomicDoubleForFactory() {
+ 		RedisAtomicDouble ral = new RedisAtomicDouble("DATAREDIS-872.atomicDouble", factory);
+		assertThat(ral.get()).isEqualTo(0);
+		ral.set(32.13);
+ 		RedisAtomicDouble ral1 = new RedisAtomicDouble("DATAREDIS-872.atomicDouble", factory);
+		assertThat(ral1.get()).isEqualTo(32.13);
 	}
 }

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicIntegerTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicIntegerTests.java
@@ -46,6 +46,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Graham MacMaster
+ * @author Ning Wei
  */
 @RunWith(Parameterized.class)
 public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
@@ -409,5 +410,23 @@ public class RedisAtomicIntegerTests extends AbstractRedisAtomicsTests {
 		intCounter.getAndAccumulate(15, accumulatorFunction);
 
 		assertThat(operatorHasBeenApplied).isTrue();
+	}
+
+	@Test // DATAREDIS-872
+	public void testUseSetIfAbsentRedisAtomicIntegerForTemplate() {
+ 		RedisAtomicInteger ral = new RedisAtomicInteger("DATAREDIS-872.atomicInteger", template);
+		assertThat(ral.get()).isEqualTo(0);
+		ral.set(31);
+ 		RedisAtomicInteger ral1 = new RedisAtomicInteger("DATAREDIS-872.atomicInteger", template);
+		assertThat(ral1.get()).isEqualTo(31);
+	}
+
+	@Test // DATAREDIS-872
+	public void testUseSetIfAbsentRedisAtomicIntegerForFactory() {
+ 		RedisAtomicInteger ral = new RedisAtomicInteger("DATAREDIS-872.atomicInteger", factory);
+		assertThat(ral.get()).isEqualTo(0);
+		ral.set(31);
+ 		RedisAtomicInteger ral1 = new RedisAtomicInteger("DATAREDIS-872.atomicInteger", factory);
+		assertThat(ral1.get()).isEqualTo(31);
 	}
 }

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicLongTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicLongTests.java
@@ -45,6 +45,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Graham MacMaster
+ * @author Ning Wei
  */
 @RunWith(Parameterized.class)
 public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
@@ -391,5 +392,23 @@ public class RedisAtomicLongTests extends AbstractRedisAtomicsTests {
 		longCounter.getAndAccumulate(15L, accumulatorFunction);
 
 		assertThat(operatorHasBeenApplied).isTrue();
+	}
+
+	@Test // DATAREDIS-872
+	public void testUseSetIfAbsentRedisAtomicLongForTemplate() {
+ 		RedisAtomicLong ral = new RedisAtomicLong("DATAREDIS-872.atomicLong", template);
+		assertThat(ral.get()).isEqualTo(0);
+		ral.set(32L);
+ 		RedisAtomicLong ral1 = new RedisAtomicLong("DATAREDIS-872.atomicLong", template);
+		assertThat(ral1.get()).isEqualTo(32L);
+	}
+
+	@Test // DATAREDIS-872
+	public void testUseSetIfAbsentRedisAtomicLongForFactory() {
+ 		RedisAtomicLong ral = new RedisAtomicLong("DATAREDIS-872.atomicLong", factory);
+		assertThat(ral.get()).isEqualTo(0);
+		ral.set(32L);
+ 		RedisAtomicLong ral1 = new RedisAtomicLong("DATAREDIS-872.atomicLong", factory);
+		assertThat(ral1.get()).isEqualTo(32L);
 	}
 }


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
