### PR TITLE
DATAREDIS-875 - Fix MappingRedisConvert adding superfluous type hint for primitive type properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-875-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -298,6 +298,10 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 
 		byte[] sourceBytes = source.getBucket().get(currentPath);
 
+		if(typeInformation.getType().isPrimitive() && sourceBytes == null) {
+			return null;
+		}
+
 		if (persistentProperty.isIdProperty() && StringUtils.isEmpty(path.isEmpty())) {
 			return sourceBytes == null ? fromBytes(sourceBytes, typeInformation.getActualType().getType()) : source.getId();
 		}
@@ -739,7 +743,7 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 
 			Optional<Class<?>> targetType = customConversions.getCustomWriteTarget(value.getClass());
 
-			if (!targetType.filter(it -> ClassUtils.isAssignable(Map.class, it)).isPresent()
+			if (!propertyType.isPrimitive() && !targetType.filter(it -> ClassUtils.isAssignable(Map.class, it)).isPresent()
 					&& customConversions.isSimpleType(value.getClass()) && value.getClass() != propertyType) {
 				typeMapper.writeType(value.getClass(), sink.getBucket().getPropertyPath(path));
 			}

--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -1814,6 +1814,24 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(update).getBucket().get("_class"), is(nullValue()));
 	}
 
+	@Test // DATAREDIS-875
+	public void shouldNotWriteTypeHintForPrimitveTypes() {
+
+		Size source = new Size();
+		source.height = 1;
+
+		assertThat(write(source).getBucket().get("height._class"), is(nullValue()));
+	}
+
+	@Test // DATAREDIS-875
+	public void shouldReadPrimitveTypes() {
+
+		Map<String, String> source = new LinkedHashMap<>();
+		source.put("height", "1000");
+
+		assertThat(read(Size.class, source).height, is(equalTo(1000)));
+	}
+
 	private RedisData write(Object source) {
 
 		RedisData rdo = new RedisData();


### PR DESCRIPTION
We now additionally check if the target property is a primitive type and do no longer add the type hint if so.