### PR TITLE
DATAREDIS-890 - Randomly send node command to redis cluster.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -24,7 +24,9 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisClusterConnectionHandler;
 import redis.clients.jedis.JedisPool;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -64,6 +66,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Ninad Divadkar
+ * @author Tao Chen
  * @since 1.7
  */
 public class JedisClusterConnection implements DefaultedRedisClusterConnection {
@@ -982,7 +985,9 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 
 			Map<String, Exception> errors = new LinkedHashMap<>();
 
-			for (Entry<String, JedisPool> entry : cluster.getClusterNodes().entrySet()) {
+			List<Entry<String, JedisPool>> list = new ArrayList<>(cluster.getClusterNodes().entrySet());
+			Collections.shuffle(list);
+			for (Entry<String, JedisPool> entry : list) {
 
 				Jedis jedis = null;
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionUnitTests.java
@@ -103,6 +103,8 @@ public class JedisClusterConnectionUnitTests {
 		when(node3PoolMock.getResource()).thenReturn(con3Mock);
 
 		when(con1Mock.clusterNodes()).thenReturn(CLUSTER_NODES_RESPONSE);
+		when(con2Mock.clusterNodes()).thenReturn(CLUSTER_NODES_RESPONSE);
+		when(con3Mock.clusterNodes()).thenReturn(CLUSTER_NODES_RESPONSE);
 		clusterMock.setConnectionHandler(connectionHandlerMock);
 
 		connection = new JedisClusterConnection(clusterMock);
@@ -140,7 +142,6 @@ public class JedisClusterConnectionUnitTests {
 		connection.clusterForget(CLUSTER_NODE_2);
 
 		verify(con1Mock, times(1)).clusterForget(CLUSTER_NODE_2.getId());
-		verifyZeroInteractions(con2Mock);
 		verify(con3Mock, times(1)).clusterForget(CLUSTER_NODE_2.getId());
 	}
 
@@ -150,8 +151,8 @@ public class JedisClusterConnectionUnitTests {
 		connection.clusterReplicate(CLUSTER_NODE_1, CLUSTER_NODE_2);
 
 		verify(con2Mock, times(1)).clusterReplicate(CLUSTER_NODE_1.getId());
-		verify(con1Mock, times(1)).clusterNodes();
-		verify(con1Mock, times(1)).close();
+		verify(con1Mock, atMost(1)).clusterNodes();
+		verify(con1Mock, atMost(1)).close();
 		verifyZeroInteractions(con1Mock);
 	}
 
@@ -312,10 +313,10 @@ public class JedisClusterConnectionUnitTests {
 		connection.time(CLUSTER_NODE_2);
 
 		verify(con2Mock, times(1)).time();
-		verify(con2Mock, times(1)).close();
-		verify(con1Mock, times(1)).clusterNodes();
-		verify(con1Mock, times(1)).close();
-		verifyZeroInteractions(con1Mock, con3Mock);
+		verify(con2Mock, atLeast(1)).close();
+		verify(con1Mock, atMost(1)).clusterNodes();
+		verify(con1Mock, atMost(1)).close();
+
 	}
 
 	@Test // DATAREDIS-315
@@ -334,7 +335,7 @@ public class JedisClusterConnectionUnitTests {
 		connection.resetConfigStats(CLUSTER_NODE_2);
 
 		verify(con2Mock, times(1)).configResetStat();
-		verify(con2Mock, times(1)).close();
+		verify(con2Mock, atLeast(1)).close();
 		verify(con1Mock, never()).configResetStat();
 		verify(con3Mock, never()).configResetStat();
 	}


### PR DESCRIPTION
Randomly send 'node' command to redis cluster instead of selecting the first one always.

Jira ticket : [ refrence](https://jira.spring.io/projects/DATAREDIS/issues/DATAREDIS-890?filter=allopenissues)