### PR TITLE
DATAREDIS-903 - Delete unused settings from Javadoc.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
@@ -81,9 +81,7 @@ public class RedisClusterConfiguration implements RedisConfiguration, ClusterCon
 	 * <pre>
 	 * <code>
 	 * spring.redis.cluster.nodes=127.0.0.1:23679,127.0.0.1:23680,127.0.0.1:23681
-	 * spring.redis.cluster.timeout=5
 	 * spring.redis.cluster.max-redirects=3
-	 * spring.redis.cluster.password=foobar
 	 * </code>
 	 * </pre>
 	 *


### PR DESCRIPTION
The following configuration keys  which are not used in RedisClusterConfiguration, are removed from the Javadoc.
- spring.redis.cluster.timeout=5
- spring.redis.cluster.password=foobar

Cluster password and timeout are set by [spring.redis.password](https://github.com/spring-projects/spring-boot/blob/ca0de4385c01cbbd120e96ec9f83427fb48c9a15/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java#L56)  and [spring.redis.timeout](https://github.com/spring-projects/spring-boot/blob/ca0de4385c01cbbd120e96ec9f83427fb48c9a15/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java#L71) in Spring Boot.

