### PR TITLE
DATAREDIS-905 - Fix race condition in StreamMessageListenerContainer subscription activation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-905-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/stream/StreamPollTask.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamPollTask.java
@@ -115,11 +115,11 @@ class StreamPollTask<K, V extends Record<K, ?>> implements Task {
 	public void run() {
 
 		pollState.starting();
-		pollState.running();
 
 		try {
 
 			isInEventLoop = true;
+			pollState.running();
 			doLoop(request.getStreamOffset().getKey());
 		} finally {
 			isInEventLoop = false;
@@ -144,8 +144,7 @@ class StreamPollTask<K, V extends Record<K, ?>> implements Task {
 				}
 			} catch (InterruptedException e) {
 
-				pollState.cancel();
-
+				cancel();
 				Thread.currentThread().interrupt();
 			} catch (RuntimeException e) {
 

--- a/src/test/java/org/springframework/data/redis/stream/StreamMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/StreamMessageListenerContainerIntegrationTests.java
@@ -53,7 +53,7 @@ import org.springframework.data.redis.stream.StreamMessageListenerContainer.Stre
 
 /**
  * Integration tests for {@link StreamMessageListenerContainer}.
- * 
+ *
  * @author Mark Paluch
  */
 public class StreamMessageListenerContainerIntegrationTests {


### PR DESCRIPTION
Stream subscriptions now report reliably their state reflecting regarding activation, cancellation and while being active.

Previously, registering a subscription with immediate cancel could report an inactive subscription although `StreamMessageListenerContainer` could perform a stream read.

When activating a subscription in StreamMessageListenerContainer, awaiting activation (`awaitStart(…)`), immediately canceling the subscription, and reading active state via `Subscription.isActive()`, `Subscription.isActive()` could report in this case `false`. This was because we checked that the status was either running or the stream read has reached event looping. The state was `CANCELLED` and the task thread had not yet reached the event loop and so there was a gap.

---

Related ticket: [DATAREDIS-905](https://jira.spring.io/browse/DATAREDIS-905).