### PR TITLE
DATAREDIS-913 - Delete multiple keys through ReactiveRedisTemplate.delete(Publisher) and unlink(Publisher)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-913-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
@@ -213,7 +213,8 @@ public interface ReactiveRedisOperations<K, V> {
 	Mono<Long> delete(K... key);
 
 	/**
-	 * Delete given {@code keys}.
+	 * Delete given {@code keys}. This command buffers keys received from {@link Publisher} into chunks of 128 keys to
+	 * delete to reduce the number of issued {@code DEL} commands.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed.
@@ -234,7 +235,8 @@ public interface ReactiveRedisOperations<K, V> {
 
 	/**
 	 * Unlink the {@code keys} from the keyspace. Unlike with {@link #delete(Publisher)} the actual memory reclaiming here
-	 * happens asynchronously.
+	 * happens asynchronously. This command buffers keys received from {@link Publisher} into chunks of 128 keys to delete
+	 * to reduce the number of issued {@code UNLINK} commands.
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
@@ -28,12 +28,12 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
 import org.springframework.data.redis.connection.ReactiveRedisConnection.CommandResponse;
-import org.springframework.data.redis.connection.ReactiveRedisConnection.KeyCommand;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.ReactiveSubscription.Message;
 import org.springframework.data.redis.core.script.DefaultReactiveScriptExecutor;
@@ -350,9 +350,10 @@ public class ReactiveRedisTemplate<K, V> implements ReactiveRedisOperations<K, V
 
 		Assert.notNull(keys, "Keys must not be null!");
 
-		return createMono(connection -> connection.keyCommands() //
-				.del(Flux.from(keys).map(this::rawKey).map(KeyCommand::new)) //
-				.map(CommandResponse::getOutput));
+		return createFlux(connection -> connection.keyCommands() //
+				.mDel(Flux.from(keys).map(this::rawKey).buffer(128)) //
+				.map(CommandResponse::getOutput)) //
+				.collect(Collectors.summingLong(value -> value));
 	}
 
 	/*
@@ -384,9 +385,10 @@ public class ReactiveRedisTemplate<K, V> implements ReactiveRedisOperations<K, V
 
 		Assert.notNull(keys, "Keys must not be null!");
 
-		return createMono(connection -> connection.keyCommands() //
-				.unlink(Flux.from(keys).map(this::rawKey).map(KeyCommand::new)) //
-				.map(CommandResponse::getOutput));
+		return createFlux(connection -> connection.keyCommands() //
+				.mUnlink(Flux.from(keys).map(this::rawKey).buffer(128)) //
+				.map(CommandResponse::getOutput)) //
+				.collect(Collectors.summingLong(value -> value));
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.core;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assume.*;
 
+import org.springframework.data.redis.StringObjectFactory;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -213,6 +214,44 @@ public class ReactiveRedisTemplateIntegrationTests<K, V> {
 				.verifyComplete();
 
 		StepVerifier.create(redisTemplate.unlink(key1, key2)).expectNext(2L).verifyComplete();
+
+		StepVerifier.create(redisTemplate.hasKey(key1)).expectNext(false).verifyComplete();
+		StepVerifier.create(redisTemplate.hasKey(key2)).expectNext(false).verifyComplete();
+	}
+	
+	@Test // DATAREDIS-913
+	public void unlinkManyPublisher() {
+
+		K key1 = keyFactory.instance();
+		K key2 = keyFactory.instance();
+		
+		assumeTrue(key1 instanceof String && valueFactory instanceof StringObjectFactory);
+
+		StepVerifier.create(redisTemplate.opsForValue().set(key1, valueFactory.instance())).expectNext(true)
+				.verifyComplete();
+		StepVerifier.create(redisTemplate.opsForValue().set(key2, valueFactory.instance())).expectNext(true)
+				.verifyComplete();
+
+		StepVerifier.create(redisTemplate.unlink(redisTemplate.keys((K) "*"))).expectNext(2L).verifyComplete();
+
+		StepVerifier.create(redisTemplate.hasKey(key1)).expectNext(false).verifyComplete();
+		StepVerifier.create(redisTemplate.hasKey(key2)).expectNext(false).verifyComplete();
+	}
+	
+	@Test // DATAREDIS-913
+	public void deleteManyPublisher() {
+
+		K key1 = keyFactory.instance();
+		K key2 = keyFactory.instance();
+		
+		assumeTrue(key1 instanceof String && valueFactory instanceof StringObjectFactory);
+
+		StepVerifier.create(redisTemplate.opsForValue().set(key1, valueFactory.instance())).expectNext(true)
+				.verifyComplete();
+		StepVerifier.create(redisTemplate.opsForValue().set(key2, valueFactory.instance())).expectNext(true)
+				.verifyComplete();
+
+		StepVerifier.create(redisTemplate.delete(redisTemplate.keys((K) "*"))).expectNext(2L).verifyComplete();
 
 		StepVerifier.create(redisTemplate.hasKey(key1)).expectNext(false).verifyComplete();
 		StepVerifier.create(redisTemplate.hasKey(key2)).expectNext(false).verifyComplete();


### PR DESCRIPTION
We now delete all keys that are emitted by the source publisher when invoking `delete(Publisher)` and `unlink(Publisher)`. Both methods split incoming keys into chunks of `128` keys to keep a balance between latency and the issued command count.

Previously, `delete(Publisher)` and `unlink(Publisher)` only deleted the first key.

---

Related ticket: [DATAREDIS-913](https://jira.spring.io/browse/DATAREDIS-913).