### PR TITLE
DATAREDIS-918 - Enable Lettuce's global timeouts by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-918-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.TimeoutOptions;
 import io.lettuce.core.resource.ClientResources;
 
 import java.time.Duration;
@@ -37,7 +38,7 @@ import org.springframework.util.Assert;
  * <li>Whether to verify peers using SSL</li>
  * <li>Whether to use StartTLS</li>
  * <li>Optional {@link ClientResources}</li>
- * <li>Optional {@link ClientOptions}</li>
+ * <li>Optional {@link ClientOptions}, defaults to {@link ClientOptions} with enabled {@link TimeoutOptions}.</li>
  * <li>Optional client name</li>
  * <li>Optional {@link ReadFrom}. Enables Master/Replica operations if configured.</li>
  * <li>Client {@link Duration timeout}</li>
@@ -132,7 +133,7 @@ public interface LettuceClientConfiguration {
 	 * <dt>Start TLS</dt>
 	 * <dd>no</dd>
 	 * <dt>Client Options</dt>
-	 * <dd>none</dd>
+	 * <dd>{@link ClientOptions} with enabled {@link io.lettuce.core.TimeoutOptions}</dd>
 	 * <dt>Client Resources</dt>
 	 * <dd>none</dd>
 	 * <dt>Client name</dt>
@@ -163,7 +164,7 @@ public interface LettuceClientConfiguration {
 		boolean verifyPeer = true;
 		boolean startTls;
 		@Nullable ClientResources clientResources;
-		@Nullable ClientOptions clientOptions;
+		ClientOptions clientOptions = ClientOptions.builder().timeoutOptions(TimeoutOptions.enabled()).build();
 		@Nullable String clientName;
 		@Nullable ReadFrom readFrom;
 		Duration timeout = Duration.ofSeconds(RedisURI.DEFAULT_TIMEOUT);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfiguration.java
@@ -59,7 +59,7 @@ public interface LettucePoolingClientConfiguration extends LettuceClientConfigur
 	 * <dt>Start TLS</dt>
 	 * <dd>no</dd>
 	 * <dt>Client Options</dt>
-	 * <dd>none</dd>
+	 * <dd>{@link ClientOptions} with enabled {@link io.lettuce.core.TimeoutOptions}</dd>
 	 * <dt>Client Resources</dt>
 	 * <dd>none</dd>
 	 * <dt>Connect Timeout</dt>

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClientConfigurationUnitTests.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  */
 public class LettuceClientConfigurationUnitTests {
 
-	@Test // DATAREDIS-574, DATAREDIS-576, DATAREDIS-667
+	@Test // DATAREDIS-574, DATAREDIS-576, DATAREDIS-667, DATAREDIS-918
 	public void shouldCreateEmptyConfiguration() {
 
 		LettuceClientConfiguration configuration = LettuceClientConfiguration.defaultConfiguration();
@@ -43,7 +43,11 @@ public class LettuceClientConfigurationUnitTests {
 		assertThat(configuration.isUseSsl()).isFalse();
 		assertThat(configuration.isVerifyPeer()).isTrue();
 		assertThat(configuration.isStartTls()).isFalse();
-		assertThat(configuration.getClientOptions()).isEmpty();
+		assertThat(configuration.getClientOptions()).hasValueSatisfying(actual -> {
+
+			TimeoutOptions timeoutOptions = actual.getTimeoutOptions();
+			assertThat(timeoutOptions.isTimeoutCommands()).isTrue();
+		});
 		assertThat(configuration.getClientResources()).isEmpty();
 		assertThat(configuration.getClientName()).isEmpty();
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofSeconds(60));

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettucePoolingClientConfigurationUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.lettuce;
 import static org.assertj.core.api.Assertions.*;
 
 import io.lettuce.core.ClientOptions;
+import io.lettuce.core.TimeoutOptions;
 import io.lettuce.core.resource.ClientResources;
 
 import java.time.Duration;
@@ -33,7 +34,7 @@ import org.junit.Test;
  */
 public class LettucePoolingClientConfigurationUnitTests {
 
-	@Test // DATAREDIS-667
+	@Test // DATAREDIS-667, DATAREDIS-918
 	public void shouldCreateEmptyConfiguration() {
 
 		LettucePoolingClientConfiguration configuration = LettucePoolingClientConfiguration.defaultConfiguration();
@@ -42,7 +43,11 @@ public class LettucePoolingClientConfigurationUnitTests {
 		assertThat(configuration.isUseSsl()).isFalse();
 		assertThat(configuration.isVerifyPeer()).isTrue();
 		assertThat(configuration.isStartTls()).isFalse();
-		assertThat(configuration.getClientOptions()).isEmpty();
+		assertThat(configuration.getClientOptions()).hasValueSatisfying(actual -> {
+
+			TimeoutOptions timeoutOptions = actual.getTimeoutOptions();
+			assertThat(timeoutOptions.isTimeoutCommands()).isTrue();
+		});
 		assertThat(configuration.getClientResources()).isEmpty();
 		assertThat(configuration.getCommandTimeout()).isEqualTo(Duration.ofSeconds(60));
 		assertThat(configuration.getShutdownTimeout()).isEqualTo(Duration.ofMillis(100));


### PR DESCRIPTION
`LettuceClientConfiguration` now enables Lettuce's global timeouts by default to enable timeouts using the reactive API. This change prevents hanging Redis commands due to a blocked connection or when Redis is down. Timeouts are enabled through defaulting so setting `ClientOptions` or `ClusterClientOptions` overrides this behavior.

---

Related ticket: [DATAREDIS-918](https://jira.spring.io/browse/DATAREDIS-918).