### PR TITLE
DATAREDIS-848 - Use Lettuce's RestoreArgs to restore a key with replace option.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-848-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 


### PR DESCRIPTION
We now use `RestoreArgs` instead of constructing a custom command.

---

Should be backported to _2.1.x._.

Related ticket: [DATAREDIS-848](https://jira.spring.io/browse/DATAREDIS-848).