### PR TITLE
DATAREDIS-888 - Use Lettuce's read-only Partition view for node conversion.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-888-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -223,7 +223,7 @@ abstract public class LettuceConverters extends Converters {
 					return Collections.emptyList();
 				}
 				List<RedisClusterNode> nodes = new ArrayList<>();
-				for (io.lettuce.core.cluster.models.partitions.RedisClusterNode node : source.getPartitions()) {
+				for (io.lettuce.core.cluster.models.partitions.RedisClusterNode node : source) {
 					nodes.add(CLUSTER_NODE_TO_CLUSTER_NODE_CONVERTER.convert(node));
 				}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
@@ -102,9 +102,9 @@ public class LettuceClusterConnectionUnitTests {
 		partition3.setFlags(Collections.singleton(NodeFlag.MASTER));
 		partition3.setUri(RedisURI.create("redis://" + CLUSTER_HOST + ":" + MASTER_NODE_3_PORT));
 
-		partitions.addPartition(partition1);
-		partitions.addPartition(partition2);
-		partitions.addPartition(partition3);
+		partitions.add(partition1);
+		partitions.add(partition2);
+		partitions.add(partition3);
 
 		when(resourceProvider.getResourceForSpecificNode(CLUSTER_NODE_1)).thenReturn(clusterConnection1Mock);
 		when(resourceProvider.getResourceForSpecificNode(CLUSTER_NODE_2)).thenReturn(clusterConnection2Mock);

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
@@ -88,7 +88,7 @@ public class LettuceConvertersUnitTests {
 		partition.setUri(RedisURI.create("redis://" + CLUSTER_HOST + ":" + MASTER_NODE_1_PORT));
 		partition.setSlots(Arrays.<Integer> asList(1, 2, 3, 4, 5));
 
-		partitions.addPartition(partition);
+		partitions.add(partition);
 
 		List<RedisClusterNode> nodes = LettuceConverters.partitionsToClusterNodes(partitions);
 		assertThat(nodes.size(), is(1));


### PR DESCRIPTION
We now use the read-only view of Lettuce's `Partition` object to convert Lettuce `RedisClusterNode` objects into Spring Data `RedisClusterNode`. The read-only view is atomic and does not require external synchronization

---

Should be backported to 2.0.x and 2.1.x.

Related ticket: [DATAREDIS-888](https://jira.spring.io/browse/DATAREDIS-888).