### PR TITLE
DATAREDIS-937 - Add ReactiveRedisOperations Coroutines extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-937-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,40 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Kotlin extension -->
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-core</artifactId>
+			<version>${kotlin-coroutines}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-reactor</artifactId>
+			<version>${kotlin-coroutines}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>io.mockk</groupId>
+			<artifactId>mockk</artifactId>
+			<version>${mockk}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- Test -->
 
 		<dependency>

--- a/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.DoubleUnaryOperator;
 import java.util.function.Function;
@@ -163,6 +164,21 @@ public interface RedisZSetCommands {
 		 */
 		public List<Double> toList() {
 			return Collections.unmodifiableList(weights);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (!(o instanceof Weights))
+				return false;
+			Weights weights1 = (Weights) o;
+			return Objects.equals(weights, weights1.weights);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(weights);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
@@ -18,7 +18,6 @@ package org.springframework.data.redis.connection;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.DoubleUnaryOperator;
 import java.util.function.Function;
@@ -30,6 +29,7 @@ import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * ZSet(SortedSet)-specific commands supported by Redis.
@@ -166,19 +166,32 @@ public interface RedisZSetCommands {
 			return Collections.unmodifiableList(weights);
 		}
 
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#equals(java.lang.Object)
+		 */
 		@Override
 		public boolean equals(Object o) {
-			if (this == o)
+
+			if (this == o) {
 				return true;
-			if (!(o instanceof Weights))
+			}
+
+			if (!(o instanceof Weights)) {
 				return false;
-			Weights weights1 = (Weights) o;
-			return Objects.equals(weights, weights1.weights);
+			}
+
+			Weights that = (Weights) o;
+			return ObjectUtils.nullSafeEquals(this.weights, that.weights);
 		}
 
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#hashCode()
+		 */
 		@Override
 		public int hashCode() {
-			return Objects.hash(weights);
+			return ObjectUtils.nullSafeHashCode(weights);
 		}
 	}
 

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensions.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.data.geo.Distance
+import org.springframework.data.geo.Metric
+import org.springframework.data.geo.Point
+import org.springframework.data.redis.connection.RedisGeoCommands
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.add].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, point: Point, member: M): Long =
+		add(key, point, member).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.add].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, location: RedisGeoCommands.GeoLocation<M>): Long =
+		add(key, location).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.add].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, memberCoordinateMap: Map<M, Point>): Long =
+		add(key, memberCoordinateMap).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.add].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, locations: Iterable<RedisGeoCommands.GeoLocation<M>>): Long =
+		add(key, locations).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.distance].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M): Distance =
+		distance(key, member1, member2).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.distance].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M, metric: Metric): Distance =
+		distance(key, member1, member2, metric).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.hash].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.hashAndAwait(key: K, member: M): String =
+		hash(key, member).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.hash].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.hashAndAwait(key: K, vararg member: M): List<String> =
+		hash(key, *member).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.position].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.positionAndAwait(key: K, member: M): Point? =
+		position(key, member).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.position].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.positionAndAwait(key: K, vararg members: M): List<Point> =
+		position(key, *members).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.remove].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.removeAndAwait(key: K, vararg member: M): Long =
+		remove(key, *member).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveGeoOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.deleteAndAwait(key: K): Boolean =
+		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensions.kt
@@ -62,28 +62,31 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * Coroutines variant of [ReactiveGeoOperations.distance].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M): Distance =
-		distance(key, member1, member2).awaitSingle()
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M): Distance? =
+		distance(key, member1, member2).awaitFirstOrNull()
 
 /**
  * Coroutines variant of [ReactiveGeoOperations.distance].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M, metric: Metric): Distance =
-		distance(key, member1, member2, metric).awaitSingle()
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M, metric: Metric): Distance? =
+		distance(key, member1, member2, metric).awaitFirstOrNull()
 
 /**
  * Coroutines variant of [ReactiveGeoOperations.hash].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.hashAndAwait(key: K, member: M): String =
-		hash(key, member).awaitSingle()
+suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.hashAndAwait(key: K, member: M): String? =
+		hash(key, member).awaitFirstOrNull()
 
 /**
  * Coroutines variant of [ReactiveGeoOperations.hash].

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensions.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import kotlinx.coroutines.reactive.awaitSingle
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.hasKey].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.hasKeyAndAwait(key: H, hashKey: HK): Boolean =
+		hasKey(key, hashKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.get].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.getAndAwait(key: H, hashKey: HK): HV =
+		get(key, hashKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.multiGet].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.multiGetAndAwait(key: H, vararg hashKeys: HK): List<HV?> =
+		multiGet(key, hashKeys.toCollection(ArrayList())).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.increment].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.incrementAndAwait(key: H, hashKey: HK, delta: Long): Long =
+		increment(key, hashKey, delta).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.increment].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.incrementAndAwait(key: H, hashKey: HK, delta: Double): Double =
+		increment(key, hashKey, delta).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.size].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.sizeAndAwait(key: H): Long =
+		size(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.putAll].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.putAllAndAwait(key: H, map: Map<HK, HV>): Boolean =
+		putAll(key, map).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.put].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.putAndAwait(key: H, hashKey: HK, hashValue: HV): Boolean =
+		put(key, hashKey, hashValue).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.putIfAbsent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.putIfAbsentAndAwait(key: H, hashKey: HK, hashValue: HV): Boolean =
+		putIfAbsent(key, hashKey, hashValue).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.remove].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.removeAndAwait(key: H, vararg hashKeys: Any): Long =
+		remove(key, *hashKeys).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensions.kt
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.core
 
+import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 
 /**
@@ -30,10 +31,11 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * Coroutines variant of [ReactiveHashOperations.get].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.getAndAwait(key: H, hashKey: HK): HV =
-		get(key, hashKey).awaitSingle()
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.getAndAwait(key: H, hashKey: HK): HV? =
+		get(key, hashKey).awaitFirstOrNull()
 
 /**
  * Coroutines variant of [ReactiveHashOperations.multiGet].
@@ -106,3 +108,12 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  */
 suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.removeAndAwait(key: H, vararg hashKeys: Any): Long =
 		remove(key, *hashKeys).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.delete].
+ *
+ * @author Christoph Strobl
+ * @since 2.2
+ */
+suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.deleteAndAwait(key: H): Boolean =
+		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveHyperLogLogOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveHyperLogLogOperationsExtensions.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import kotlinx.coroutines.reactive.awaitSingle
+
+/**
+ * Coroutines variant of [ReactiveHyperLogLogOperations.add].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperations<K, V>.addAndAwait(key: K, vararg values: V): Long =
+		add(key, *values).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHyperLogLogOperations.size].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperations<K, V>.sizeAndAwait(vararg keys: K): Long =
+		size(*keys).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHyperLogLogOperations.union].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperations<K, V>.unionAndAwait(destination: K, vararg sourceKeys: K): Boolean =
+		union(destination, *sourceKeys).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHyperLogLogOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperations<K, V>.deleteAndAwait(key: K): Boolean =
+		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensions.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
+import java.time.Duration
+
+/**
+ * Coroutines variant of [ReactiveListOperations.trim].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.trimAndAwait(key: K, start: Long, end: Long): Boolean =
+		trim(key, start, end).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.size].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.sizeAndAwait(key: K): Long =
+		size(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.leftPush].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushAndAwait(key: K, value: V): Long =
+		leftPush(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.leftPushAll].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushAllAndAwait(key: K, vararg values: V): Long =
+		leftPushAll(key, *values).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.leftPushAll].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushAllAndAwait(key: K, values: Collection<V>): Long =
+		leftPushAll(key, values).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.leftPushIfPresent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushIfPresentAndAwait(key: K, value: V): Long =
+		leftPushIfPresent(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.leftPushIfPresent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushAndAwait(key: K, pivot: V, value: V): Long =
+		leftPush(key, pivot, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.rightPush].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushAndAwait(key: K, value: V): Long =
+		rightPush(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.rightPushAll].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushAllAndAwait(key: K, vararg values: V): Long =
+		rightPushAll(key, *values).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.rightPushAll].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushAllAndAwait(key: K, values: Collection<V>): Long =
+		rightPushAll(key, values).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.rightPushIfPresent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushIfPresentAndAwait(key: K, value: V): Long =
+		rightPushIfPresent(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.rightPushIfPresent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushAndAwait(key: K, pivot: V, value: V): Long =
+		rightPush(key, pivot, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.set].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.setAndAwait(key: K, index: Long, value: V): Boolean =
+		set(key, index, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.remove].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.removeAndAwait(key: K, count: Long, value: V): Long =
+		remove(key, count, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.index].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.indexAndAwait(key: K, index: Long): V? =
+		index(key, index).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.leftPop].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPopAndAwait(key: K): V? =
+		leftPop(key).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.leftPop].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPopAndAwait(key: K, timeout: Duration): V? =
+		leftPop(key, timeout).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.rightPop].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPopAndAwait(key: K): V? =
+		rightPop(key).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.rightPop].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPopAndAwait(key: K, timeout: Duration): V? =
+		rightPop(key, timeout).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveListOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.deleteAndAwait(key: K): Boolean =
+		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensions.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.data.redis.connection.DataType
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.convertAndSend].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.sendAndAwait(destination: String, message: V): Long =
+		convertAndSend(destination, message).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.hasKey].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.hasKeyAndAwait(key: K): Boolean =
+		hasKey(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.type].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.typeAndAwait(key: K): DataType =
+		type(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.randomKey].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.randomKeyAndAwait(): K? =
+		randomKey().awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.rename].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.renameAndAwait(oldKey: K, newKey: K): Boolean =
+		rename(oldKey, newKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.renameIfAbsent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.renameIfAbsentAndAwait(oldKey: K, newKey: K): Boolean =
+		renameIfAbsent(oldKey, newKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.deleteAndAwait(vararg key: K): Long =
+		delete(*key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.unlink].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.unlinkAndAwait(vararg key: K): Long =
+		unlink(*key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.expire].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.expireAndAwait(key: K, timeout: Duration): Boolean =
+		expire(key, timeout).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.expireAt].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.expireAtAndAwait(key: K, expireAt: Instant): Boolean = expireAt(key, expireAt).awaitSingle()
+
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.persist].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.persistAndAwait(key: K): Boolean =
+		persist(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.move].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.moveAndAwait(key: K, dbIndex: Int): Boolean = move(key, dbIndex).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.getExpire].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.getExpireAndAwait(key: K): Duration? = getExpire(key).awaitFirstOrNull()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensions.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.add].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.addAndAwait(key: K, vararg values: V): Long =
+		add(key, *values).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.remove].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.removeAndAwait(key: K, vararg values: V): Long =
+		remove(key, *values).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.pop].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.popAndAwait(key: K): V? =
+		pop(key).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.move].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.moveAndAwait(sourceKey: K, value: V, destKey: K): Boolean =
+		move(sourceKey, value, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.size].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.sizeAndAwait(key: K): Long =
+		size(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.isMember].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.isMemberAndAwait(key: K, value: V): Boolean =
+		isMember(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.intersectAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+		intersectAndStore(key, otherKey, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.intersectAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.intersectAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
+		intersectAndStore(keys, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.unionAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+		unionAndStore(key, otherKey, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.unionAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.unionAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
+		unionAndStore(keys, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.differenceAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.differenceAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+		differenceAndStore(key, otherKey, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.differenceAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.differenceAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
+		differenceAndStore(keys, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.randomMember].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.randomMemberAndAwait(key: K): V? =
+		randomMember(key).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.deleteAndAwait(key: K): Boolean =
+		delete(key).awaitSingle()
+
+

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.data.redis.connection.stream.*
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.acknowledge].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(key: K, group: String, vararg recordIds: String): Long =
+		acknowledge(key, group, *recordIds).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.acknowledge].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(key: K, group: String, vararg recordIds: RecordId): Long =
+		acknowledge(key, group, *recordIds).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.acknowledge].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(group: String, record: Record<K, *>): Long =
+		acknowledge(group, record).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.add].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.addAndAwait(record: MapRecord<K, HK, HV>): RecordId =
+		add(record).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.add].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.addAndAwait(record: Record<K, *>): RecordId =
+		add(record).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteAndAwait(key: K, vararg recordIds: String): Long =
+		delete(key, *recordIds).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteAndAwait(record: Record<K, *>): Long =
+		delete(record).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteAndAwait(key: K, vararg recordIds: RecordId): Long =
+		delete(key, *recordIds).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.createGroup].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.createGroupAndAwait(key: K, group: String): String =
+		createGroup(key, group).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.createGroup].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.createGroupAndAwait(key: K, readOffset: ReadOffset, group: String): String =
+		createGroup(key, readOffset, group).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.deleteConsumer].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteConsumerAndAwait(key: K, consumer: Consumer): String =
+		deleteConsumer(key, consumer).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.destroyGroup].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.destroyGroupAndAwait(key: K, group: String): String =
+		destroyGroup(key, group).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.size].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.sizeAndAwait(key: K): Long =
+		size(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.trim].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.trimAndAwait(key: K, count: Long): Long =
+		trim(key, count).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensions.kt
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.data.redis.connection.BitFieldSubCommands
+import java.time.Duration
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.set].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setAndAwait(key: K, value: V): Boolean =
+		set(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.set].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setAndAwait(key: K, value: V, timeout: Duration): Boolean =
+		set(key, value, timeout).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.setIfAbsent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setIfAbsentAndAwait(key: K, value: V): Boolean =
+		setIfAbsent(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.setIfAbsent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setIfAbsentAndAwait(key: K, value: V, timeout: Duration): Boolean =
+		setIfAbsent(key, value, timeout).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.setIfPresent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setIfPresentAndAwait(key: K, value: V): Boolean =
+		setIfPresent(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.setIfPresent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setIfPresentAndAwait(key: K, value: V, timeout: Duration): Boolean =
+		setIfPresent(key, value, timeout).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.multiSet].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.multiSetAndAwait(map: Map<K, V>): Boolean =
+		multiSet(map).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.multiSetIfAbsent].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.multiSetIfAbsentAndAwait(map: Map<K, V>): Boolean =
+		multiSetIfAbsent(map).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.get].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.getAndAwait(key: K): V? =
+		get(key).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.getAndSet].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.getAndSetAndAwait(key: K, value: V): V? =
+		getAndSet(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.multiGet].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.multiGetAndAwait(vararg keys: K): List<V?> =
+		multiGet(keys.toCollection(ArrayList())).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.multiGet].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.multiGetAndAwait(keys: Collection<K>): List<V?> =
+		multiGet(keys).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.increment].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.incrementAndAwait(key: K): Long =
+		increment(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.increment].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.incrementAndAwait(key: K, delta: Long): Long =
+		increment(key, delta).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.increment].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.incrementAndAwait(key: K, delta: Double): Double =
+		increment(key, delta).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.decrement].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.decrementAndAwait(key: K): Long =
+		decrement(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.decrement].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.decrementAndAwait(key: K, delta: Long): Long =
+		decrement(key, delta).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.append].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.appendAndAwait(key: K, value: String): Long =
+		append(key, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.get].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.getAndAwait(key: K, start: Long, end: Long): String? =
+		get(key, start, end).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.set].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setAndAwait(key: K, value: V, offset: Long): Long =
+		set(key, value, offset).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.size].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.sizeAndAwait(key: K): Long? =
+		size(key).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.setBit].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setBitAndAwait(key: K, offset: Long, value: Boolean): Boolean =
+		setBit(key, offset, value).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.getBit].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.getBitAndAwait(key: K, offset: Long): Boolean =
+		getBit(key, offset).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.bitField].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.bitFieldAndAwait(key: K, commands: BitFieldSubCommands): List<Long?> =
+		bitField(key, commands).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveValueOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.deleteAndAwait(key: K): Boolean =
+		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensions.kt
@@ -105,10 +105,11 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * Coroutines variant of [ReactiveValueOperations.getAndSet].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.2
  */
 suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.getAndSetAndAwait(key: K, value: V): V? =
-		getAndSet(key, value).awaitSingle()
+		getAndSet(key, value).awaitFirstOrNull()
 
 /**
  * Coroutines variant of [ReactiveValueOperations.multiGet].
@@ -204,10 +205,11 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * Coroutines variant of [ReactiveValueOperations.size].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.sizeAndAwait(key: K): Long? =
-		size(key).awaitFirstOrNull()
+suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.sizeAndAwait(key: K): Long =
+		size(key).awaitSingle()
 
 /**
  * Coroutines variant of [ReactiveValueOperations.setBit].

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensions.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.data.domain.Range
+import org.springframework.data.redis.connection.RedisZSetCommands
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.add].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.addAndAwait(key: K, value: V, score: Double): Boolean =
+		add(key, value, score).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.addAll].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.addAllAndAwait(key: K, values: Collection<ZSetOperations.TypedTuple<V>>): Long =
+		addAll(key, values).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.remove].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.removeAndAwait(key: K, vararg values: Any): Long =
+		remove(key, *values).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.incrementScore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.incrementScoreAndAwait(key: K, value: V, score: Double): Double =
+		incrementScore(key, value, score).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.rank].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.rankAndAwait(key: K, value: V): Long? =
+		rank(key, value).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.reverseRank].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.reverseRankAndAwait(key: K, value: V): Long? =
+		reverseRank(key, value).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.count].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.countAndAwait(key: K, range: Range<Double>): Long =
+		count(key, range).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.score].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.scoreAndAwait(key: K, value: V): Double? =
+		score(key, value).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.removeRange].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.removeRangeAndAwait(key: K, range: Range<Long>): Long =
+		removeRange(key, range).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.removeRangeByScore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.removeRangeByScoreAndAwait(key: K, range: Range<Double>): Long =
+		removeRangeByScore(key, range).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.unionAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+		unionAndStore(key, otherKey, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.unionAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K): Long =
+		unionAndStore(key, otherKeys, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.unionAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate): Long =
+		unionAndStore(key, otherKeys, destKey, aggregate).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.unionAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate, weights: RedisZSetCommands.Weights): Long =
+		unionAndStore(key, otherKeys, destKey, aggregate, weights).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.intersectAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+		intersectAndStore(key, otherKey, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.intersectAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K): Long =
+		intersectAndStore(key, otherKeys, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.intersectAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate): Long =
+		intersectAndStore(key, otherKeys, destKey, aggregate).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.intersectAndStore].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate, weights: RedisZSetCommands.Weights): Long =
+		intersectAndStore(key, otherKeys, destKey, aggregate, weights).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.delete].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.deleteAndAwait(key: K): Boolean =
+		delete(key).awaitSingle()

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensionsUnitTests.kt
@@ -31,6 +31,7 @@ import reactor.core.publisher.Mono
  * Unit tests for [ReactiveGeoOperationsExtensions].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 class ReactiveGeoOperationsExtensionsUnitTests {
 
@@ -110,6 +111,21 @@ class ReactiveGeoOperationsExtensionsUnitTests {
 	}
 
 	@Test // DATAREDIS-937
+	fun `distance returning an empty Mono`() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.distance(any(), any(), any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.distanceAndAwait("foo", "from", "to")).isNull()
+		}
+
+		verify {
+			operations.distance("foo", "from", "to")
+		}
+	}
+
+	@Test // DATAREDIS-937
 	fun distanceWithMetric() {
 
 		val operations = mockk<ReactiveGeoOperations<String, String>>()
@@ -125,6 +141,21 @@ class ReactiveGeoOperationsExtensionsUnitTests {
 	}
 
 	@Test // DATAREDIS-937
+	fun `distance with Metric returning an empty Mono`() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.distance(any(), any(), any(), any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.distanceAndAwait("foo", "from", "to", Metrics.KILOMETERS)).isNull()
+		}
+
+		verify {
+			operations.distance("foo", "from", "to", Metrics.KILOMETERS)
+		}
+	}
+
+	@Test // DATAREDIS-937
 	fun hash() {
 
 		val operations = mockk<ReactiveGeoOperations<String, String>>()
@@ -132,6 +163,21 @@ class ReactiveGeoOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.hashAndAwait("foo", "bar")).isEqualTo("baz")
+		}
+
+		verify {
+			operations.hash("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `hash returning an empty Mono`() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.hash(any(), any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.hashAndAwait("foo", "bar")).isNull()
 		}
 
 		verify {
@@ -163,6 +209,21 @@ class ReactiveGeoOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.positionAndAwait("foo", "bar")).isEqualTo(Point(1.0, 2.0))
+		}
+
+		verify {
+			operations.position("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `position returning an empty Mono`() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.position(any(), any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.positionAndAwait("foo", "bar")).isNull()
 		}
 
 		verify {

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensionsUnitTests.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.data.geo.Distance
+import org.springframework.data.geo.Metrics
+import org.springframework.data.geo.Point
+import org.springframework.data.redis.connection.RedisGeoCommands
+import reactor.core.publisher.Mono
+
+/**
+ * Unit tests for [ReactiveGeoOperationsExtensions].
+ *
+ * @author Mark Paluch
+ */
+class ReactiveGeoOperationsExtensionsUnitTests {
+
+	@Test // DATAREDIS-937
+	fun addPoint() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.add(any(), any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.addAndAwait("foo", Point(1.0, 2.0), "bar")).isEqualTo(1)
+		}
+
+		verify {
+			operations.add("foo", Point(1.0, 2.0), "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun addGeoLocation() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.add(any(), any<RedisGeoCommands.GeoLocation<String>>()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.addAndAwait("foo", RedisGeoCommands.GeoLocation("bar", Point(1.0, 2.0)))).isEqualTo(1)
+		}
+
+		verify {
+			operations.add("foo", RedisGeoCommands.GeoLocation("bar", Point(1.0, 2.0)))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun addLocationMap() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.add(any(), any<Map<String, Point>>()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.addAndAwait("foo", mapOf("foo" to Point(1.0, 2.0)))).isEqualTo(1)
+		}
+
+		verify {
+			operations.add("foo", mapOf("foo" to Point(1.0, 2.0)))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun addGeoLocationList() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.add(any(), any<List<RedisGeoCommands.GeoLocation<String>>>()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.addAndAwait("foo", listOf(RedisGeoCommands.GeoLocation("bar", Point(1.0, 2.0))))).isEqualTo(1)
+		}
+
+		verify {
+			operations.add("foo", listOf(RedisGeoCommands.GeoLocation("bar", Point(1.0, 2.0))))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun distance() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.distance(any(), any(), any()) } returns Mono.just(Distance(2.0))
+
+		runBlocking {
+			assertThat(operations.distanceAndAwait("foo", "from", "to")).isEqualTo(Distance(2.0))
+		}
+
+		verify {
+			operations.distance("foo", "from", "to")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun distanceWithMetric() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.distance(any(), any(), any(), any()) } returns Mono.just(Distance(2.0))
+
+		runBlocking {
+			assertThat(operations.distanceAndAwait("foo", "from", "to", Metrics.KILOMETERS)).isEqualTo(Distance(2.0))
+		}
+
+		verify {
+			operations.distance("foo", "from", "to", Metrics.KILOMETERS)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun hash() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.hash(any(), any()) } returns Mono.just("baz")
+
+		runBlocking {
+			assertThat(operations.hashAndAwait("foo", "bar")).isEqualTo("baz")
+		}
+
+		verify {
+			operations.hash("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun hashVararg() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.hash(any(), any(), any()) } returns Mono.just(listOf("baz1", "baz2"))
+
+		runBlocking {
+			assertThat(operations.hashAndAwait("foo", "bar", "baz")).isEqualTo(listOf("baz1", "baz2"))
+		}
+
+		verify {
+			operations.hash("foo", "bar", "baz")
+		}
+	}
+
+
+	@Test // DATAREDIS-937
+	fun position() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.position(any(), any()) } returns Mono.just(Point(1.0, 2.0))
+
+		runBlocking {
+			assertThat(operations.positionAndAwait("foo", "bar")).isEqualTo(Point(1.0, 2.0))
+		}
+
+		verify {
+			operations.position("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun positionVararg() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.position(any(), any(), any()) } returns Mono.just(listOf(Point(1.0, 2.0), Point(2.0, 3.0)))
+
+		runBlocking {
+			assertThat(operations.positionAndAwait("foo", "bar", "baz")).isEqualTo(listOf(Point(1.0, 2.0), Point(2.0, 3.0)))
+		}
+
+		verify {
+			operations.position("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun remove() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.remove(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.removeAndAwait("foo", "bar")).isEqualTo(1)
+		}
+
+		verify {
+			operations.remove("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun delete() {
+
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.delete(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait("foo")).isTrue()
+		}
+
+		verify {
+			operations.delete("foo")
+		}
+	}
+}

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensionsUnitTests.kt
@@ -27,6 +27,7 @@ import reactor.core.publisher.Mono
  * Unit tests for [ReactiveHashOperationsExtensions].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 class ReactiveHashOperationsExtensionsUnitTests {
 
@@ -53,6 +54,21 @@ class ReactiveHashOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.getAndAwait("foo", "bar")).isEqualTo("baz")
+		}
+
+		verify {
+			operations.get("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `get returning an empty Mono`() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.get(any(), any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.getAndAwait("foo", "bar")).isNull()
 		}
 
 		verify {
@@ -177,6 +193,21 @@ class ReactiveHashOperationsExtensionsUnitTests {
 
 		verify {
 			operations.remove("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun delete() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.delete(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait("foo")).isTrue()
+		}
+
+		verify {
+			operations.delete("foo")
 		}
 	}
 }

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensionsUnitTests.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import reactor.core.publisher.Mono
+
+/**
+ * Unit tests for [ReactiveHashOperationsExtensions].
+ *
+ * @author Mark Paluch
+ */
+class ReactiveHashOperationsExtensionsUnitTests {
+
+	@Test // DATAREDIS-937
+	fun hasKey() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.hasKey(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.hasKeyAndAwait("foo", "bar")).isTrue()
+		}
+
+		verify {
+			operations.hasKey("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun get() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.get(any(), any()) } returns Mono.just("baz")
+
+		runBlocking {
+			assertThat(operations.getAndAwait("foo", "bar")).isEqualTo("baz")
+		}
+
+		verify {
+			operations.get("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun multiGet() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.multiGet(any(), any()) } returns Mono.just(listOf("baz1", "baz2"))
+
+		runBlocking {
+			assertThat(operations.multiGetAndAwait("foo", "bar", "joe")).isEqualTo(listOf("baz1", "baz2"))
+		}
+
+		verify {
+			operations.multiGet("foo", listOf("bar", "joe"))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun increment() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.increment(any(), any(), 1) } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.incrementAndAwait("foo", "bar", 1)).isEqualTo(2)
+		}
+
+		verify {
+			operations.increment("foo", "bar", 1)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun incrementDouble() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.increment(any(), any(), 1.0) } returns Mono.just(2.0)
+
+		runBlocking {
+			assertThat(operations.incrementAndAwait("foo", "bar", 1.0)).isEqualTo(2.0)
+		}
+
+		verify {
+			operations.increment("foo", "bar", 1.0)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun size() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.size(any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.sizeAndAwait("foo")).isEqualTo(1)
+		}
+
+		verify {
+			operations.size("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun put() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.put(any(), any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.putAndAwait("foo", "bar", "baz")).isTrue()
+		}
+
+		verify {
+			operations.put("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun putAll() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.putAll(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.putAllAndAwait("foo", mapOf("bar" to "baz"))).isTrue()
+		}
+
+		verify {
+			operations.putAll("foo", mapOf("bar" to "baz"))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun putIfAbsent() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.putIfAbsent(any(), any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.putIfAbsentAndAwait("foo", "bar", "baz")).isTrue()
+		}
+
+		verify {
+			operations.putIfAbsent("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun remove() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.remove(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.removeAndAwait("foo", "bar")).isEqualTo(1)
+		}
+
+		verify {
+			operations.remove("foo", "bar")
+		}
+	}
+}

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveHyperLogLogOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveHyperLogLogOperationsExtensionsUnitTests.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import reactor.core.publisher.Mono
+
+/**
+ * Unit tests for [ReactiveHyperLogLogOperationsExtensions]
+ *
+ * @author Mark Paluch
+ */
+class ReactiveHyperLogLogOperationsExtensionsUnitTests {
+
+	@Test // DATAREDIS-937
+	fun add() {
+
+		val operations = mockk<ReactiveHyperLogLogOperations<String, String>>()
+		every { operations.add(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.addAndAwait("foo", "bar")).isEqualTo(1)
+		}
+
+		verify {
+			operations.add("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun size() {
+
+		val operations = mockk<ReactiveHyperLogLogOperations<String, String>>()
+		every { operations.size("foo") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.sizeAndAwait("foo")).isEqualTo(1)
+		}
+
+		verify {
+			operations.size("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun union() {
+
+		val operations = mockk<ReactiveHyperLogLogOperations<String, String>>()
+		every { operations.union("foo", "bar", "baz") } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.unionAndAwait("foo", "bar", "baz")).isTrue()
+		}
+
+		verify {
+			operations.union("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun remove() {
+
+		val operations = mockk<ReactiveHyperLogLogOperations<String, String>>()
+		every { operations.delete(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait("foo")).isTrue()
+		}
+
+		verify {
+			operations.delete("foo")
+		}
+	}
+}

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensionsUnitTests.kt
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono
 import java.time.Duration
 
 /**
- * Unit tests for [ReactiveHyperLogLogOperationsExtensions]
+ * Unit tests for [ReactiveListOperationsExtensions]
  *
  * @author Mark Paluch
  */

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensionsUnitTests.kt
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * Unit tests for [ReactiveHyperLogLogOperationsExtensions]
+ *
+ * @author Mark Paluch
+ */
+class ReactiveListOperationsExtensionsUnitTests {
+
+	@Test // DATAREDIS-937
+	fun trim() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.trim(any(), any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.trimAndAwait("foo", 2, 3)).isTrue()
+		}
+
+		verify {
+			operations.trim("foo", 2, 3)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun size() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.size(any()) } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.sizeAndAwait("foo")).isEqualTo(2)
+		}
+
+		verify {
+			operations.size("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun leftPush() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.leftPush(any(), any()) } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.leftPushAndAwait("foo", "bar")).isEqualTo(2)
+		}
+
+		verify {
+			operations.leftPush("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun leftPushAll() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.leftPushAll("foo", "bar", "baz") } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.leftPushAllAndAwait("foo", "bar", "baz")).isEqualTo(2)
+		}
+
+		verify {
+			operations.leftPushAll("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun leftPushAllCollection() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.leftPushAll("foo", listOf("bar", "baz")) } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.leftPushAllAndAwait("foo", listOf("bar", "baz"))).isEqualTo(2)
+		}
+
+		verify {
+			operations.leftPushAll("foo", listOf("bar", "baz"))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun leftPushIfPresent() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.leftPushIfPresent(any(), any()) } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.leftPushIfPresentAndAwait("foo", "bar")).isEqualTo(2)
+		}
+
+		verify {
+			operations.leftPushIfPresent("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun leftPushPivot() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.leftPush("foo", "bar", "baz") } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.leftPushAndAwait("foo", "bar", "baz")).isEqualTo(2)
+		}
+
+		verify {
+			operations.leftPush("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun rightPush() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.rightPush(any(), any()) } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.rightPushAndAwait("foo", "bar")).isEqualTo(2)
+		}
+
+		verify {
+			operations.rightPush("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun rightPushAll() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.rightPushAll("foo", "bar", "baz") } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.rightPushAllAndAwait("foo", "bar", "baz")).isEqualTo(2)
+		}
+
+		verify {
+			operations.rightPushAll("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun rightPushAllCollection() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.rightPushAll("foo", listOf("bar", "baz")) } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.rightPushAllAndAwait("foo", listOf("bar", "baz"))).isEqualTo(2)
+		}
+
+		verify {
+			operations.rightPushAll("foo", listOf("bar", "baz"))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun rightPushIfPresent() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.rightPushIfPresent(any(), any()) } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.rightPushIfPresentAndAwait("foo", "bar")).isEqualTo(2)
+		}
+
+		verify {
+			operations.rightPushIfPresent("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun rightPushPivot() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.rightPush("foo", "bar", "baz") } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.rightPushAndAwait("foo", "bar", "baz")).isEqualTo(2)
+		}
+
+		verify {
+			operations.rightPush("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun set() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.set(any(), any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.setAndAwait("foo", 1, "baz")).isTrue()
+		}
+
+		verify {
+			operations.set("foo", 1, "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun remove() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.remove(any(), any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.removeAndAwait("foo", 1, "baz")).isEqualTo(1)
+		}
+
+		verify {
+			operations.remove("foo", 1, "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun index() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.index(any(), any()) } returns Mono.just("foo")
+
+		runBlocking {
+			assertThat(operations.indexAndAwait("foo", 1)).isEqualTo("foo")
+		}
+
+		verify {
+			operations.index("foo", 1)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun leftPop() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.leftPop(any()) } returns Mono.just("foo")
+
+		runBlocking {
+			assertThat(operations.leftPopAndAwait("foo")).isEqualTo("foo")
+		}
+
+		verify {
+			operations.leftPop("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun blockingLeftPop() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.leftPop(any(), any()) } returns Mono.just("foo")
+
+		runBlocking {
+			assertThat(operations.leftPopAndAwait("foo", Duration.ofDays(1))).isEqualTo("foo")
+		}
+
+		verify {
+			operations.leftPop("foo", Duration.ofDays(1))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun rightPop() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.rightPop(any()) } returns Mono.just("foo")
+
+		runBlocking {
+			assertThat(operations.rightPopAndAwait("foo")).isEqualTo("foo")
+		}
+
+		verify {
+			operations.rightPop("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun blockingRightPop() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.rightPop(any(), any()) } returns Mono.just("foo")
+
+		runBlocking {
+			assertThat(operations.rightPopAndAwait("foo", Duration.ofDays(1))).isEqualTo("foo")
+		}
+
+		verify {
+			operations.rightPop("foo", Duration.ofDays(1))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun delete() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.delete(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait("foo")).isTrue()
+		}
+
+		verify {
+			operations.delete("foo")
+		}
+	}
+
+}

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensionsUnitTests.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.data.redis.connection.DataType
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Unit tests for [ReactiveRedisOperationsExtensions].
+ *
+ * @author Mark Paluch
+ */
+class ReactiveRedisOperationsExtensionsUnitTests {
+
+	@Test // DATAREDIS-937
+	fun convertAndSend() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.convertAndSend(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.sendAndAwait("foo", "bar")).isEqualTo(1)
+		}
+
+		verify {
+			operations.convertAndSend("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun hasKey() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.hasKey(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.hasKeyAndAwait("foo")).isTrue()
+		}
+
+		verify {
+			operations.hasKey("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun type() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.type(any()) } returns Mono.just(DataType.HASH)
+
+		runBlocking {
+			assertThat(operations.typeAndAwait("foo")).isEqualTo(DataType.HASH)
+		}
+
+		verify {
+			operations.type("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun randomKey() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.randomKey() } returns Mono.just("foo")
+
+		runBlocking {
+			assertThat(operations.randomKeyAndAwait()).isEqualTo("foo")
+		}
+
+		verify {
+			operations.randomKey()
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun rename() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.rename(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.renameAndAwait("foo", "bar")).isTrue()
+		}
+
+		verify {
+			operations.rename("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun renameIfAbsent() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.renameIfAbsent(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.renameIfAbsentAndAwait("foo", "bar")).isTrue()
+		}
+
+		verify {
+			operations.renameIfAbsent("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun delete() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.delete("foo", "bar") } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait("foo", "bar")).isEqualTo(2)
+		}
+
+		verify {
+			operations.delete("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun unlink() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.unlink("foo", "bar") } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.unlinkAndAwait("foo", "bar")).isEqualTo(2)
+		}
+
+		verify {
+			operations.unlink("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun expire() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.expire(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.expireAndAwait("foo", Duration.ofDays(1))).isTrue()
+		}
+
+		verify {
+			operations.expire("foo", Duration.ofDays(1))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun expireAt() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.expireAt(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.expireAtAndAwait("foo", Instant.ofEpochSecond(2))).isTrue()
+		}
+
+		verify {
+			operations.expireAt("foo", Instant.ofEpochSecond(2))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun persist() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.persist(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.persistAndAwait("foo")).isTrue()
+		}
+
+		verify {
+			operations.persist("foo")
+		}
+	}
+
+
+	@Test // DATAREDIS-937
+	fun move() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.move(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.moveAndAwait("foo", 2)).isTrue()
+		}
+
+		verify {
+			operations.move("foo", 2)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun getExpire() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.getExpire(any()) } returns Mono.just(Duration.ofDays(1))
+
+		runBlocking {
+			assertThat(operations.getExpireAndAwait("foo")).isEqualTo(Duration.ofDays(1))
+		}
+
+		verify {
+			operations.getExpire("foo")
+		}
+	}
+}

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensionsUnitTests.kt
@@ -30,6 +30,7 @@ import java.time.Instant
  * Unit tests for [ReactiveRedisOperationsExtensions].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 class ReactiveRedisOperationsExtensionsUnitTests {
 
@@ -86,6 +87,21 @@ class ReactiveRedisOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.randomKeyAndAwait()).isEqualTo("foo")
+		}
+
+		verify {
+			operations.randomKey()
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `randomKey returning an empty Mono`() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.randomKey() } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.randomKeyAndAwait()).isNull();
 		}
 
 		verify {

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensionsUnitTests.kt
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import reactor.core.publisher.Mono
+
+/**
+ * Unit tests for [ReactiveSetOperationsExtensions].
+ *
+ * @author Mark Paluch
+ */
+class ReactiveSetOperationsExtensionsUnitTests {
+
+	@Test // DATAREDIS-937
+	fun add() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.add("foo", "bar", "baz") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.addAndAwait("foo", "bar", "baz")).isEqualTo(1)
+		}
+
+		verify {
+			operations.add("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun remove() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.remove("foo", "bar", "baz") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.removeAndAwait("foo", "bar", "baz")).isEqualTo(1)
+		}
+
+		verify {
+			operations.remove("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun pop() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.pop(any()) } returns Mono.just("bar")
+
+		runBlocking {
+			assertThat(operations.popAndAwait("foo")).isEqualTo("bar")
+		}
+
+		verify {
+			operations.pop("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun move() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.move(any(), any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.moveAndAwait("foo", "from", "to")).isTrue()
+		}
+
+		verify {
+			operations.move("foo", "from", "to")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun size() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.size(any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.sizeAndAwait("foo")).isEqualTo(1)
+		}
+
+		verify {
+			operations.size("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun isMember() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.isMember("foo", "bar") } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.isMemberAndAwait("foo", "bar")).isTrue()
+		}
+
+		verify {
+			operations.isMember("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun intersectAndStore() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.intersectAndStore("foo", "bar", "baz") } returns Mono.just(3)
+
+		runBlocking {
+			assertThat(operations.intersectAndStoreAndAwait("foo", "bar", "baz")).isEqualTo(3)
+		}
+
+		verify {
+			operations.intersectAndStore("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun intersectAndStoreCollection() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.intersectAndStore(listOf("foo", "bar"), "baz") } returns Mono.just(3)
+
+		runBlocking {
+			assertThat(operations.intersectAndStoreAndAwait(listOf("foo", "bar"), "baz")).isEqualTo(3)
+		}
+
+		verify {
+			operations.intersectAndStore(listOf("foo", "bar"), "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun unionAndStore() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.unionAndStore("foo", "bar", "baz") } returns Mono.just(3)
+
+		runBlocking {
+			assertThat(operations.unionAndStoreAndAwait("foo", "bar", "baz")).isEqualTo(3)
+		}
+
+		verify {
+			operations.unionAndStore("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun unionAndStoreCollection() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.unionAndStore(listOf("foo", "bar"), "baz") } returns Mono.just(3)
+
+		runBlocking {
+			assertThat(operations.unionAndStoreAndAwait(listOf("foo", "bar"), "baz")).isEqualTo(3)
+		}
+
+		verify {
+			operations.unionAndStore(listOf("foo", "bar"), "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun differenceAndStore() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.differenceAndStore("foo", "bar", "baz") } returns Mono.just(3)
+
+		runBlocking {
+			assertThat(operations.differenceAndStoreAndAwait("foo", "bar", "baz")).isEqualTo(3)
+		}
+
+		verify {
+			operations.differenceAndStore("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun differenceAndStoreCollection() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.differenceAndStore(listOf("foo", "bar"), "baz") } returns Mono.just(3)
+
+		runBlocking {
+			assertThat(operations.differenceAndStoreAndAwait(listOf("foo", "bar"), "baz")).isEqualTo(3)
+		}
+
+		verify {
+			operations.differenceAndStore(listOf("foo", "bar"), "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun randomMember() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.randomMember(any()) } returns Mono.just("bar")
+
+		runBlocking {
+			assertThat(operations.randomMemberAndAwait("foo")).isEqualTo("bar")
+		}
+
+		verify {
+			operations.randomMember("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun delete() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.delete(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait("foo")).isTrue()
+		}
+
+		verify {
+			operations.delete("foo")
+		}
+	}
+}

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensionsUnitTests.kt
@@ -27,6 +27,7 @@ import reactor.core.publisher.Mono
  * Unit tests for [ReactiveSetOperationsExtensions].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 class ReactiveSetOperationsExtensionsUnitTests {
 
@@ -68,6 +69,21 @@ class ReactiveSetOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.popAndAwait("foo")).isEqualTo("bar")
+		}
+
+		verify {
+			operations.pop("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `pop returning an empty Mono`() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.pop(any()) } returns Mono.empty();
+
+		runBlocking {
+			assertThat(operations.popAndAwait("foo")).isNull()
 		}
 
 		verify {
@@ -218,6 +234,21 @@ class ReactiveSetOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.randomMemberAndAwait("foo")).isEqualTo("bar")
+		}
+
+		verify {
+			operations.randomMember("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `randomMember returning an empty Mono`() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.randomMember(any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.randomMemberAndAwait("foo")).isNull()
 		}
 
 		verify {

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensionsUnitTests.kt
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.data.redis.connection.stream.*
+import reactor.core.publisher.Mono
+
+/**
+ * Unit tests for [ReactiveStreamOperationsExtensions].
+ *
+ * @author Mark Paluch
+ */
+class ReactiveStreamOperationsExtensionsUnitTests {
+
+	@Test // DATAREDIS-937
+	fun acknowledge() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.acknowledge("foo", "bar", "0-0") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.acknowledgeAndAwait("foo", "bar", "0-0")).isEqualTo(1)
+		}
+
+		verify {
+			operations.acknowledge("foo", "bar", "0-0")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun acknowledgeRecordId() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		val recordId = RecordId.of("0-0")
+		every { operations.acknowledge("foo", "bar", recordId) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.acknowledgeAndAwait("foo", "bar", recordId)).isEqualTo(1)
+		}
+
+		verify {
+			operations.acknowledge("foo", "bar", recordId)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun acknowledgeRecord() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.acknowledge(any(), any<Record<String, String>>()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.acknowledgeAndAwait("foo", Record.of("bar"))).isEqualTo(1)
+		}
+
+		verify {
+			operations.acknowledge("foo", Record.of("bar"))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun add() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		val record = MapRecord.create("foo", mapOf("a" to "b"))
+		val redordId = RecordId.of("0-0")
+		every { operations.add(record) } returns Mono.just(redordId)
+
+		runBlocking {
+			assertThat(operations.addAndAwait(record)).isEqualTo(redordId)
+		}
+
+		verify {
+			operations.add(record)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun addRecord() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		val record = Record.of<String, String>("foo").withStreamKey("bar")
+		val recordId = RecordId.of("0-0")
+		every { operations.add(record) } returns Mono.just(recordId)
+
+		runBlocking {
+			assertThat(operations.addAndAwait(record)).isEqualTo(recordId)
+		}
+
+		verify {
+			operations.add(record)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun delete() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		val recordId = RecordId.of("0-0")
+		every { operations.delete("foo", recordId) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait("foo", recordId)).isEqualTo(1)
+		}
+
+		verify {
+			operations.delete("foo", recordId)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun deleteRecord() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		val record = Record.of<String, String>("foo").withStreamKey("bar")
+		every { operations.delete(record) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait(record)).isEqualTo(1)
+		}
+
+		verify {
+			operations.delete(record)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun deleteRecordIds() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.delete("foo", "0-0") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait("foo", "0-0")).isEqualTo(1)
+		}
+
+		verify {
+			operations.delete("foo", "0-0")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun createGroup() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.createGroup(any(), any()) } returns Mono.just("OK")
+
+		runBlocking {
+			assertThat(operations.createGroupAndAwait("foo", "bar")).isEqualTo("OK")
+		}
+
+		verify {
+			operations.createGroup("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun createGroupWithOffset() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.createGroup(any(), ReadOffset.lastConsumed(), any()) } returns Mono.just("OK")
+
+		runBlocking {
+			assertThat(operations.createGroupAndAwait("foo", ReadOffset.lastConsumed(), "bar")).isEqualTo("OK")
+		}
+
+		verify {
+			operations.createGroup("foo", ReadOffset.lastConsumed(), "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun deleteConsumer() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.deleteConsumer(any(), any()) } returns Mono.just("OK")
+
+		runBlocking {
+			assertThat(operations.deleteConsumerAndAwait("foo", Consumer.from("bar", "baz"))).isEqualTo("OK")
+		}
+
+		verify {
+			operations.deleteConsumer("foo", Consumer.from("bar", "baz"))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun destroyGroup() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.destroyGroup(any(), any()) } returns Mono.just("OK")
+
+		runBlocking {
+			assertThat(operations.destroyGroupAndAwait("foo", "bar")).isEqualTo("OK")
+		}
+
+		verify {
+			operations.destroyGroup("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun size() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.size(any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.sizeAndAwait("foo")).isEqualTo(1)
+		}
+
+		verify {
+			operations.size("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun trim() {
+
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.trim(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.trimAndAwait("foo", 1)).isEqualTo(1)
+		}
+
+		verify {
+			operations.trim("foo", 1)
+		}
+	}
+}

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensionsUnitTests.kt
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.data.redis.connection.BitFieldSubCommands
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * Unit tests for [ReactiveValueOperationsExtensions].
+ *
+ * @author Mark Paluch
+ */
+class ReactiveValueOperationsExtensionsUnitTests {
+
+	@Test // DATAREDIS-937
+	fun set() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.set(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.setAndAwait("foo", "bar")).isTrue()
+		}
+
+		verify {
+			operations.set("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun setWithDuration() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.set(any(), any(), any<Duration>()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.setAndAwait("foo", "bar", Duration.ofDays(1))).isTrue()
+		}
+
+		verify {
+			operations.set("foo", "bar", Duration.ofDays(1))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun setIfAbsent() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.setIfAbsent(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.setIfAbsentAndAwait("foo", "bar")).isTrue()
+		}
+
+		verify {
+			operations.setIfAbsent("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun setIfAbsentWithDuration() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.setIfAbsent(any(), any(), any<Duration>()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.setIfAbsentAndAwait("foo", "bar", Duration.ofDays(1))).isTrue()
+		}
+
+		verify {
+			operations.setIfAbsent("foo", "bar", Duration.ofDays(1))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun setIfPresent() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.setIfPresent(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.setIfPresentAndAwait("foo", "bar")).isTrue()
+		}
+
+		verify {
+			operations.setIfPresent("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun setIfPresentWithDuration() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.setIfPresent(any(), any(), any<Duration>()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.setIfPresentAndAwait("foo", "bar", Duration.ofDays(1))).isTrue()
+		}
+
+		verify {
+			operations.setIfPresent("foo", "bar", Duration.ofDays(1))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun multiSet() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.multiSet(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.multiSetAndAwait(mapOf("foo" to "bar"))).isTrue()
+		}
+
+		verify {
+			operations.multiSet(mapOf("foo" to "bar"))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun multiSetIfAbsent() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.multiSetIfAbsent(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.multiSetIfAbsentAndAwait(mapOf("foo" to "bar"))).isTrue()
+		}
+
+		verify {
+			operations.multiSetIfAbsent(mapOf("foo" to "bar"))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun get() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.get(any()) } returns Mono.just("bar")
+
+		runBlocking {
+			assertThat(operations.getAndAwait("foo")).isEqualTo("bar")
+		}
+
+		verify {
+			operations.get("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun getAndSet() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.getAndSet(any(), any()) } returns Mono.just("baz")
+
+		runBlocking {
+			assertThat(operations.getAndSetAndAwait("foo", "bar")).isEqualTo("baz")
+		}
+
+		verify {
+			operations.getAndSet("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun multiGet() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.multiGet(any()) } returns Mono.just(listOf("baz"))
+
+		runBlocking {
+			assertThat(operations.multiGetAndAwait("foo", "bar")).isEqualTo(listOf("baz"))
+		}
+
+		verify {
+			operations.multiGet(listOf("foo", "bar"))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun increment() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.increment(any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.incrementAndAwait("foo")).isEqualTo(1)
+		}
+
+		verify {
+			operations.increment("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun incrementWithDelta() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.increment(any(), 2) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.incrementAndAwait("foo", 2)).isEqualTo(1)
+		}
+
+		verify {
+			operations.increment("foo", 2)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun incrementWithDoubleDelta() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.increment(any(), 2.0) } returns Mono.just(1.0)
+
+		runBlocking {
+			assertThat(operations.incrementAndAwait("foo", 2.0)).isEqualTo(1.0)
+		}
+
+		verify {
+			operations.increment("foo", 2.0)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun decrement() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.decrement(any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.decrementAndAwait("foo")).isEqualTo(1)
+		}
+
+		verify {
+			operations.decrement("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun decrementWithDelta() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.decrement(any(), 2) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.decrementAndAwait("foo", 2)).isEqualTo(1)
+		}
+
+		verify {
+			operations.decrement("foo", 2)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun append() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.append(any(), any()) } returns Mono.just(2)
+
+		runBlocking {
+			assertThat(operations.appendAndAwait("foo", "bar")).isEqualTo(2)
+		}
+
+		verify {
+			operations.append("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun getSubstring() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.get(any(), any(), any()) } returns Mono.just("foo")
+
+		runBlocking {
+			assertThat(operations.getAndAwait("foo", 1, 2)).isEqualTo("foo")
+		}
+
+		verify {
+			operations.get("foo", 1, 2)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun setSubstring() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.set(any(), any(), any<Long>()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.setAndAwait("foo", "bar", 2)).isEqualTo(1)
+		}
+
+		verify {
+			operations.set("foo", "bar", 2)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun size() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.size(any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.sizeAndAwait("foo")).isEqualTo(1)
+		}
+
+		verify {
+			operations.size("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun setBit() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.setBit(any(), any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.setBitAndAwait("foo", 1, true)).isTrue()
+		}
+
+		verify {
+			operations.setBit("foo", 1, true)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun getBit() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.getBit(any(), any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.getBitAndAwait("foo", 1)).isTrue()
+		}
+
+		verify {
+			operations.getBit("foo", 1)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun bitField() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		val commands = BitFieldSubCommands.create();
+		every { operations.bitField(any(), any()) } returns Mono.just(listOf(1L))
+
+		runBlocking {
+			assertThat(operations.bitFieldAndAwait("foo", commands)).isEqualTo(listOf(1L))
+		}
+
+		verify {
+			operations.bitField("foo", commands)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun delete() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.delete(any()) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.deleteAndAwait("foo")).isTrue()
+		}
+
+		verify {
+			operations.delete("foo")
+		}
+	}
+}

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensionsUnitTests.kt
@@ -29,6 +29,7 @@ import java.time.Duration
  * Unit tests for [ReactiveValueOperationsExtensions].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 class ReactiveValueOperationsExtensionsUnitTests {
 
@@ -168,6 +169,21 @@ class ReactiveValueOperationsExtensionsUnitTests {
 	}
 
 	@Test // DATAREDIS-937
+	fun `get returning an empty Mono`() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.get(any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.getAndAwait("foo")).isNull()
+		}
+
+		verify {
+			operations.get("foo")
+		}
+	}
+
+	@Test // DATAREDIS-937
 	fun getAndSet() {
 
 		val operations = mockk<ReactiveValueOperations<String, String>>()
@@ -175,6 +191,21 @@ class ReactiveValueOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.getAndSetAndAwait("foo", "bar")).isEqualTo("baz")
+		}
+
+		verify {
+			operations.getAndSet("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `getAndSet returning an empty Mono`() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.getAndSet(any(), any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.getAndSetAndAwait("foo", "bar")).isNull()
 		}
 
 		verify {
@@ -295,6 +326,21 @@ class ReactiveValueOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.getAndAwait("foo", 1, 2)).isEqualTo("foo")
+		}
+
+		verify {
+			operations.get("foo", 1, 2)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `getSubstring returning an empty Mono`() {
+
+		val operations = mockk<ReactiveValueOperations<String, String>>()
+		every { operations.get(any(), any(), any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.getAndAwait("foo", 1, 2)).isNull()
 		}
 
 		verify {

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensionsUnitTests.kt
@@ -30,6 +30,7 @@ import reactor.core.publisher.Mono
  * Unit tests for [ReactiveZSetOperationsExtensions].
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 class ReactiveZSetOperationsExtensionsUnitTests {
 
@@ -109,6 +110,21 @@ class ReactiveZSetOperationsExtensionsUnitTests {
 	}
 
 	@Test // DATAREDIS-937
+	fun `rank returning an empty Mono`() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.rank(any(), any()) } returns Mono.empty();
+
+		runBlocking {
+			assertThat(operations.rankAndAwait("foo", "bar")).isNull()
+		}
+
+		verify {
+			operations.rank("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
 	fun reverseRank() {
 
 		val operations = mockk<ReactiveZSetOperations<String, String>>()
@@ -116,6 +132,21 @@ class ReactiveZSetOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.reverseRankAndAwait("foo", "bar")).isEqualTo(1)
+		}
+
+		verify {
+			operations.reverseRank("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `reverseRank returning an enpty Mono`() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.reverseRank(any(), any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.reverseRankAndAwait("foo", "bar")).isNull()
 		}
 
 		verify {
@@ -146,6 +177,21 @@ class ReactiveZSetOperationsExtensionsUnitTests {
 
 		runBlocking {
 			assertThat(operations.scoreAndAwait("foo", "bar")).isEqualTo(1.0)
+		}
+
+		verify {
+			operations.score("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun `score returning an empty Mono`() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.score(any(), any()) } returns Mono.empty()
+
+		runBlocking {
+			assertThat(operations.scoreAndAwait("foo", "bar")).isNull()
 		}
 
 		verify {

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensionsUnitTests.kt
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.data.domain.Range
+import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate
+import org.springframework.data.redis.connection.RedisZSetCommands.Weights
+import reactor.core.publisher.Mono
+
+/**
+ * Unit tests for [ReactiveZSetOperationsExtensions].
+ *
+ * @author Mark Paluch
+ */
+class ReactiveZSetOperationsExtensionsUnitTests {
+
+	@Test // DATAREDIS-937
+	fun add() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.add(any(), any(), 1.0) } returns Mono.just(true)
+
+		runBlocking {
+			assertThat(operations.addAndAwait("foo", "bar", 1.0)).isTrue()
+		}
+
+		verify {
+			operations.add("foo", "bar", 1.0)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun addAll() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.addAll(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.addAllAndAwait("foo", listOf(DefaultTypedTuple("v", 1.0)))).isEqualTo(1)
+		}
+
+		verify {
+			operations.addAll("foo", listOf(DefaultTypedTuple("v", 1.0)))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun remove() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.remove("foo", "bar") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.removeAndAwait("foo", "bar")).isEqualTo(1)
+		}
+
+		verify {
+			operations.remove("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun incrementScore() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.incrementScore(any(), any(), 1.0) } returns Mono.just(1.0)
+
+		runBlocking {
+			assertThat(operations.incrementScoreAndAwait("foo", "bar", 1.0)).isEqualTo(1.0)
+		}
+
+		verify {
+			operations.incrementScore("foo", "bar", 1.0)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun rank() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.rank(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.rankAndAwait("foo", "bar")).isEqualTo(1)
+		}
+
+		verify {
+			operations.rank("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun reverseRank() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.reverseRank(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.reverseRankAndAwait("foo", "bar")).isEqualTo(1)
+		}
+
+		verify {
+			operations.reverseRank("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun count() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.count(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.countAndAwait("foo", Range.unbounded())).isEqualTo(1)
+		}
+
+		verify {
+			operations.count("foo", Range.unbounded())
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun score() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.score(any(), any()) } returns Mono.just(1.0)
+
+		runBlocking {
+			assertThat(operations.scoreAndAwait("foo", "bar")).isEqualTo(1.0)
+		}
+
+		verify {
+			operations.score("foo", "bar")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun removeRange() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.removeRange(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.removeRangeAndAwait("foo", Range.unbounded())).isEqualTo(1)
+		}
+
+		verify {
+			operations.removeRange("foo", Range.unbounded())
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun removeRangeByScore() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.removeRangeByScore(any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.removeRangeByScoreAndAwait("foo", Range.unbounded())).isEqualTo(1)
+		}
+
+		verify {
+			operations.removeRangeByScore("foo", Range.unbounded())
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun unionAndStore() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.unionAndStore("foo", "bar", "baz") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.unionAndStoreAndAwait("foo", "bar", "baz")).isEqualTo(1)
+		}
+
+		verify {
+			operations.unionAndStore("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun unionAndStoreListOfKeys() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.unionAndStore("foo", listOf("bar"), "baz") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.unionAndStoreAndAwait("foo", listOf("bar"), "baz")).isEqualTo(1)
+		}
+
+		verify {
+			operations.unionAndStore("foo", listOf("bar"), "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun unionAndStoreAggregate() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.unionAndStore(any(), any(), any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.unionAndStoreAndAwait("foo", listOf("bar"), "baz", Aggregate.MAX)).isEqualTo(1)
+		}
+
+		verify {
+			operations.unionAndStore("foo", listOf("bar"), "baz", Aggregate.MAX)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun unionAndStoreWeights() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.unionAndStore(any(), any(), any(), any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.unionAndStoreAndAwait("foo", listOf("bar"), "baz", Aggregate.MAX, Weights.fromSetCount(1))).isEqualTo(1)
+		}
+
+		verify {
+			operations.unionAndStore("foo", listOf("bar"), "baz", Aggregate.MAX, Weights.fromSetCount(1))
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun intersectAndStore() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.intersectAndStore("foo", "bar", "baz") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.intersectAndStoreAndAwait("foo", "bar", "baz")).isEqualTo(1)
+		}
+
+		verify {
+			operations.intersectAndStore("foo", "bar", "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun intersectAndStoreListOfKeys() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.intersectAndStore("foo", listOf("bar"), "baz") } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.intersectAndStoreAndAwait("foo", listOf("bar"), "baz")).isEqualTo(1)
+		}
+
+		verify {
+			operations.intersectAndStore("foo", listOf("bar"), "baz")
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun intersectAndStoreAggregate() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.intersectAndStore(any(), any(), any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.intersectAndStoreAndAwait("foo", listOf("bar"), "baz", Aggregate.MAX)).isEqualTo(1)
+		}
+
+		verify {
+			operations.intersectAndStore("foo", listOf("bar"), "baz", Aggregate.MAX)
+		}
+	}
+
+	@Test // DATAREDIS-937
+	fun intersectAndStoreWeights() {
+
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.intersectAndStore(any(), any(), any(), any(), any()) } returns Mono.just(1)
+
+		runBlocking {
+			assertThat(operations.intersectAndStoreAndAwait("foo", listOf("bar"), "baz", Aggregate.MAX, Weights.fromSetCount(1))).isEqualTo(1)
+		}
+
+		verify {
+			operations.intersectAndStore("foo", listOf("bar"), "baz", Aggregate.MAX, Weights.fromSetCount(1))
+		}
+	}
+}


### PR DESCRIPTION
This commit introduces Coroutines support for `ReactiveRedisOperations` and its sub-operation APIs via Kotlin extensions that provide
suspendable functions prefixed by `await` or suffixed by `AndAwait` for Mono based APIs.

Extensions for `Flux` will be added when Kotlin/kotlinx.coroutines#254 will be fixed.

Adds also `equals`/`hashCode` methods to `RedisZSetCommands.Weights`.

---

Related ticket: [DATAREDIS-937](https://jira.spring.io/browse/DATAREDIS-937).