### PR TITLE
DATAREDIS-939 - Add timeout to Redis URI when Sentinel is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>1.8.19.BUILD-SNAPSHOT</version>
+	<version>1.8.19.DATAREDIS-939-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -68,6 +68,7 @@ import com.lambdaworks.redis.resource.ClientResources;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Balázs Németh
+ * @author Dmytro Liash
  */
 public class LettuceConnectionFactory implements InitializingBean, DisposableBean, RedisConnectionFactory {
 
@@ -601,6 +602,9 @@ public class LettuceConnectionFactory implements InitializingBean, DisposableBea
 		if (StringUtils.hasText(password)) {
 			redisUri.setPassword(password);
 		}
+
+		redisUri.setTimeout(timeout);
+		redisUri.setUnit(TimeUnit.MILLISECONDS);
 
 		return redisUri;
 	}


### PR DESCRIPTION
Apply timeout to Redis URI in the case when `RedisSentinelConfiguration` is used.

----
Related ticket: [DATAREDIS-939](https://jira.spring.io/browse/DATAREDIS-939)
