### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-[![Spring Data Redis](https://spring.io/badges/spring-data-redis/ga.svg)](http://projects.spring.io/spring-data-redis/#quick-start)
-[![Spring Data Redis](https://spring.io/badges/spring-data-redis/snapshot.svg)](http://projects.spring.io/spring-data-redis/#quick-start)
+[![Spring Data Redis](https://spring.io/badges/spring-data-redis/ga.svg)](https://projects.spring.io/spring-data-redis/#quick-start)
+[![Spring Data Redis](https://spring.io/badges/spring-data-redis/snapshot.svg)](https://projects.spring.io/spring-data-redis/#quick-start)
 
 Spring Data Redis
 =======================
 
-The primary goal of the [Spring Data](http://projects.spring.io/spring-data/) project is to make it easier to build Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce frameworks, and cloud based data services.
-This modules provides integration with the [Redis](http://redis.io/) store. 
+The primary goal of the [Spring Data](https://projects.spring.io/spring-data/) project is to make it easier to build Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce frameworks, and cloud based data services.
+This modules provides integration with the [Redis](https://redis.io/) store. 
 
 # Docs
 
-You can find out more details from the [user documentation](http://docs.spring.io/spring-data/data-redis/docs/current/reference/html/) or by browsing the [javadocs](http://docs.spring.io/spring-data/data-redis/docs/current/api/).
+You can find out more details from the [user documentation](https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/) or by browsing the [javadocs](https://docs.spring.io/spring-data/data-redis/docs/current/api/).
 
 # Examples
 
@@ -41,7 +41,7 @@ If you'd rather like the latest snapshots of the upcoming major version, use our
 <repository>
   <id>spring-libs-snapshot</id>
   <name>Spring Snapshot Repository</name>
-  <url>http://repo.spring.io/libs-snapshot</url>
+  <url>https://repo.spring.io/libs-snapshot</url>
 </repository>
 ```
 
@@ -49,8 +49,8 @@ If you'd rather like the latest snapshots of the upcoming major version, use our
 
 ```groovy
 repositories {
-   maven { url "http://repo.spring.io/libs-milestone" }
-   maven { url "http://repo.spring.io/libs-snapshot" }
+   maven { url "https://repo.spring.io/libs-milestone" }
+   maven { url "https://repo.spring.io/libs-snapshot" }
 }
 
 // used for nightly builds
@@ -68,7 +68,7 @@ dependencies {
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
   
   <bean id="jedisFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory"/>
   
@@ -115,15 +115,15 @@ You can alternatively use the provided `Makefile` which runs the build plus down
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on the Stackoverflow.  Please help out on the [spring-data-redis](http://stackoverflow.com/questions/tagged/spring-data-redis) tag by responding to questions and joining the debate.
+* Get involved with the Spring community on the Stackoverflow.  Please help out on the [spring-data-redis](https://stackoverflow.com/questions/tagged/spring-data-redis) tag by responding to questions and joining the debate.
 * Create [JIRA](https://jira.spring.io/browse/DATAREDIS) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
 * Watch for upcoming articles on Spring by [subscribing](https://spring.io/blog) to spring.io.
 
 Before we accept a non-trivial patch or pull request we will need you to [sign the Contributor License Agreement](https://cla.pivotal.io/sign/spring). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request.
 
-Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, read the Spring Framework [contributor guidelines] (https://github.com/spring-projects/spring-framework/blob/master/CONTRIBUTING.md).
+Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/). If you want to contribute code this way, read the Spring Framework [contributor guidelines] (https://github.com/spring-projects/spring-framework/blob/master/CONTRIBUTING.md).
 
 # Staying in touch
 
-Follow the project team ([@SpringData](http://twitter.com/springdata)) on Twitter. In-depth articles can be
+Follow the project team ([@SpringData](https://twitter.com/springdata)) on Twitter. In-depth articles can be
 found at the Spring [team blog](https://spring.io/blog), and releases are announced via our [news feed](https://spring.io/blog/category/news).

--- a/src/main/asciidoc/appendix/appendix-schema.adoc
+++ b/src/main/asciidoc/appendix/appendix-schema.adoc
@@ -2,4 +2,4 @@
 [appendix]
 = Schema
 
-link:http://www.springframework.org/schema/redis/spring-redis-1.0.xsd[Spring Data Redis Schema (redis-namespace)]
+link:https://www.springframework.org/schema/redis/spring-redis-1.0.xsd[Spring Data Redis Schema (redis-namespace)]

--- a/src/main/asciidoc/introduction/getting-started.adoc
+++ b/src/main/asciidoc/introduction/getting-started.adoc
@@ -11,17 +11,17 @@ As explained in <<why-spring-redis>>, Spring Data Redis (SDR) provides integrati
 [[get-started:first-steps:spring]]
 === Learning Spring
 
-Spring Data uses Spring framework's http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html[core] functionality, such as the http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html[IoC] container, http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html#resources[resource] abstract, and the http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html#aop[AOP] infrastructure. While it is not important to know the Spring APIs, understanding the concepts behind them is important. At a minimum, the idea behind IoC should be familiar. That being said, the more knowledge you have about the Spring, the faster you can pick up Spring Data Redis. In addition to the Spring Framework's comprehensive documentation, there are a lot of articles, blog entries, and books on the matter. The Spring Guides http://spring.io/guides[home page] offer a good place to start. In general, this should be the starting point for developers wanting to try Spring Data Redis.
+Spring Data uses Spring framework's https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html[core] functionality, such as the https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html[IoC] container, https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html#resources[resource] abstract, and the https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html#aop[AOP] infrastructure. While it is not important to know the Spring APIs, understanding the concepts behind them is important. At a minimum, the idea behind IoC should be familiar. That being said, the more knowledge you have about the Spring, the faster you can pick up Spring Data Redis. In addition to the Spring Framework's comprehensive documentation, there are a lot of articles, blog entries, and books on the matter. The Spring Guides https://spring.io/guides[home page] offer a good place to start. In general, this should be the starting point for developers wanting to try Spring Data Redis.
 
 [[get-started:first-steps:nosql]]
 === Learning NoSQL and Key Value Stores
 
-NoSQL stores have taken the storage world by storm. It is a vast domain with a plethora of solutions, terms, and patterns (to make things worse, even the term itself has multiple http://www.google.com/search?q=nosoql+acronym[meanings]). While some of the principles are common, it is crucial that you be familiar to some degree with the stores supported by SDR. The best way to get acquainted with these solutions is to read their documentation and follow their examples. It usually does not take more then five to ten minutes to go through them and, if you come from an RDMBS-only background, many times these exercises can be eye-openers.
+NoSQL stores have taken the storage world by storm. It is a vast domain with a plethora of solutions, terms, and patterns (to make things worse, even the term itself has multiple https://www.google.com/search?q=nosoql+acronym[meanings]). While some of the principles are common, it is crucial that you be familiar to some degree with the stores supported by SDR. The best way to get acquainted with these solutions is to read their documentation and follow their examples. It usually does not take more then five to ten minutes to go through them and, if you come from an RDMBS-only background, many times these exercises can be eye-openers.
 
 [[get-started:first-steps:samples]]
 === Trying out the Samples
 
-One can find various samples for key-value stores in the dedicated Spring Data example repo, at https://github.com/spring-projects/spring-data-keyvalue-examples[http://github.com/spring-projects/spring-data-keyvalue-examples]. For Spring Data Redis, you should pay particular attention to the `retwisj` sample, a Twitter-clone built on top of Redis that can be run locally or be deployed into the cloud. See its http://static.springsource.org/spring-data/data-keyvalue/examples/retwisj/current/[documentation], the following blog http://blog.springsource.com/2011/04/27/getting-started-redis-spring-cloud-foundry/[entry] for more information.
+One can find various samples for key-value stores in the dedicated Spring Data example repo, at https://github.com/spring-projects/spring-data-keyvalue-examples[https://github.com/spring-projects/spring-data-keyvalue-examples]. For Spring Data Redis, you should pay particular attention to the `retwisj` sample, a Twitter-clone built on top of Redis that can be run locally or be deployed into the cloud. See its https://docs.spring.io/spring-data/data-keyvalue/examples/retwisj/current/[documentation], the following blog https://spring.io/blog/2011/04/27/getting-started-redis-spring-cloud-foundry/[entry] for more information.
 
 [[get-started:help]]
 == Need Help?
@@ -31,23 +31,23 @@ If you encounter issues or you are just looking for advice, use one of the links
 [[get-started:help:community]]
 === Community Support
 
-The Spring Data tag on http://stackoverflow.com/questions/tagged/spring-data[Stack Overflow] is a message board for all Spring Data (not just Redis) users to share information and help each other. Note that registration is needed *only* for posting.
+The Spring Data tag on https://stackoverflow.com/questions/tagged/spring-data[Stack Overflow] is a message board for all Spring Data (not just Redis) users to share information and help each other. Note that registration is needed *only* for posting.
 
 [[get-started:help:professional]]
 === Professional Support
 
-Professional, from-the-source support, with guaranteed response time, is available from http://www.pivotal.io/[Pivotal Software, Inc.], the company behind Spring Data and Spring.
+Professional, from-the-source support, with guaranteed response time, is available from https://www.pivotal.io/[Pivotal Software, Inc.], the company behind Spring Data and Spring.
 
 [[get-started:up-to-date]]
 == Following Development
 
-For information on the Spring Data source code repository, nightly builds, and snapshot artifacts, see the Spring Data home http://spring.io/spring-data[page].
+For information on the Spring Data source code repository, nightly builds, and snapshot artifacts, see the Spring Data home https://spring.io/spring-data[page].
 
 You can help make Spring Data best serve the needs of the Spring community by interacting with developers on Stack Overflow at either
-http://stackoverflow.com/questions/tagged/spring-data[spring-data] or http://stackoverflow.com/questions/tagged/spring-data-redis[spring-data-redis].
+https://stackoverflow.com/questions/tagged/spring-data[spring-data] or https://stackoverflow.com/questions/tagged/spring-data-redis[spring-data-redis].
 
 If you encounter a bug or want to suggest an improvement (including to this documentation), please create a ticket on the Spring Data issue https://jira.spring.io/browse/DATAREDIS[tracker].
 
-To stay up to date with the latest news and announcements in the Spring eco system, subscribe to the Spring Community http://spring.io/[Portal].
+To stay up to date with the latest news and announcements in the Spring eco system, subscribe to the Spring Community https://spring.io/[Portal].
 
-Lastly, you can follow the Spring http://spring.io/blog/[blog] or the project team (http://twitter.com/SpringData[@SpringData]) on Twitter.
+Lastly, you can follow the Spring https://spring.io/blog/[blog] or the project team (https://twitter.com/SpringData[@SpringData]) on Twitter.

--- a/src/main/asciidoc/introduction/requirements.adoc
+++ b/src/main/asciidoc/introduction/requirements.adoc
@@ -1,6 +1,6 @@
 [[requirements]]
 = Requirements
 
-Spring Data Redis 2.x binaries require JDK level 8.0 and above and http://projects.spring.io/spring-framework/[Spring Framework] {springVersion} and above.
+Spring Data Redis 2.x binaries require JDK level 8.0 and above and https://projects.spring.io/spring-framework/[Spring Framework] {springVersion} and above.
 
-In terms of key-value stores, http://redis.io[Redis] 2.6.x or higher is required. Spring Data Redis is currently tested against the latest 4.0 release.
+In terms of key-value stores, https://redis.io[Redis] 2.6.x or higher is required. Spring Data Redis is currently tested against the latest 4.0 release.

--- a/src/main/asciidoc/introduction/why-sdr.adoc
+++ b/src/main/asciidoc/introduction/why-sdr.adoc
@@ -3,6 +3,6 @@
 
 The Spring Framework is the leading full-stack Java/JEE application framework. It provides a lightweight container and a non-invasive programming model enabled by the use of dependency injection, AOP, and portable service abstractions.
 
-http://en.wikipedia.org/wiki/NoSQL[NoSQL] storage systems provide an alternative to classical RDBMS for horizontal scalability and speed. In terms of implementation, key-value stores represent one of the largest (and oldest) members in the NoSQL space.
+https://en.wikipedia.org/wiki/NoSQL[NoSQL] storage systems provide an alternative to classical RDBMS for horizontal scalability and speed. In terms of implementation, key-value stores represent one of the largest (and oldest) members in the NoSQL space.
 
 The Spring Data Redis (SDR) framework makes it easy to write Spring applications that use the Redis key-value store by eliminating the redundant tasks and boilerplate code required for interacting with the store through Spring's excellent infrastructure support.

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -41,7 +41,7 @@ This section briefly covers items that are new and noteworthy in the latest rele
 
 * Upgrade to Jedis 2.9.
 * Upgrade to `Lettuce` 4.2 (Note: Lettuce 4.2 requires Java 8).
-* Support for Redis http://redis.io/commands#geo[GEO] commands.
+* Support for Redis https://redis.io/commands#geo[GEO] commands.
 * Support for Geospatial Indexes using Spring Data Repository abstractions (see <<redis.repositories.indexes.geospatial>>).
 * `MappingRedisConverter`-based `HashMapper` implementation (see <<redis.hashmappers.root>>).
 * Support for `PartialUpdate` in repositories (see <<redis.repositories.partial-updates>>).
@@ -51,7 +51,7 @@ This section briefly covers items that are new and noteworthy in the latest rele
 [[new-in-1.7.0]]
 == New in Spring Data Redis 1.7
 
-* Support for http://redis.io/topics/cluster-tutorial[RedisCluster].
+* Support for https://redis.io/topics/cluster-tutorial[RedisCluster].
 * Support for Spring Data Repository abstractions (see <<redis.repositories>>).
 
 [[new-in-1-6-0]]

--- a/src/main/asciidoc/reference/pipelining.adoc
+++ b/src/main/asciidoc/reference/pipelining.adoc
@@ -1,7 +1,7 @@
 [[pipeline]]
 = Pipelining
 
-Redis provides support for http://redis.io/topics/pipelining[pipelining], which involves sending multiple commands to the server without waiting for the replies and then reading the replies in a single step. Pipelining can improve performance when you need to send several commands in a row, such as adding many elements to the same List.
+Redis provides support for https://redis.io/topics/pipelining[pipelining], which involves sending multiple commands to the server without waiting for the replies and then reading the replies in a single step. Pipelining can improve performance when you need to send several commands in a row, such as adding many elements to the same List.
 
 Spring Data Redis provides several `RedisTemplate` methods for executing commands in a pipeline. If you do not care about the results of the pipelined operations, you can use the standard `execute` method, passing `true` for the `pipeline` argument. The `executePipelined` methods run the provided `RedisCallback` or `SessionCallback` in a pipeline and return the results, as shown in the following example:
 

--- a/src/main/asciidoc/reference/reactive-redis.adoc
+++ b/src/main/asciidoc/reference/reactive-redis.adoc
@@ -7,7 +7,7 @@ This section covers reactive Redis support and how to get started. Reactive Redi
 [[redis:reactive:requirements]]
 == Redis Requirements
 
-Spring Data Redis currently integrates with http://github.com/lettuce-io/lettuce-core[Lettuce] as the only reactive Java connector. https://projectreactor.io/[Project Reactor] is used as reactive composition library.
+Spring Data Redis currently integrates with https://github.com/lettuce-io/lettuce-core[Lettuce] as the only reactive Java connector. https://projectreactor.io/[Project Reactor] is used as reactive composition library.
 
 [[redis:reactive:connectors]]
 == Connecting to Redis by Using a Reactive Driver
@@ -18,14 +18,14 @@ One of the first tasks when using Redis and Spring is to connect to the store th
 === Redis Operation Modes
 
 Redis can be run as a standalone server, with <<redis:sentinel,Redis Sentinel>>, or in <<cluster,Redis Cluster>> mode.
-http://github.com/lettuce-io/lettuce-core[Lettuce] supports all of the previously mentioned connection types.
+https://github.com/lettuce-io/lettuce-core[Lettuce] supports all of the previously mentioned connection types.
 
 [[redis:reactive:connectors:connection]]
 === `ReactiveRedisConnection` and `ReactiveRedisConnectionFactory`
 
-`ReactiveRedisConnection` is the core of Redis communication, as it handles the communication with the Redis back-end. It also automatically translates the underlying driver exceptions to Spring's consistent DAO exception http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#dao-exceptions[hierarchy], so you can switch the connectors without any code changes, as the operation semantics remain the same.
+`ReactiveRedisConnection` is the core of Redis communication, as it handles the communication with the Redis back-end. It also automatically translates the underlying driver exceptions to Spring's consistent DAO exception https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#dao-exceptions[hierarchy], so you can switch the connectors without any code changes, as the operation semantics remain the same.
 
-`ReactiveRedisConnectionFactory` creates active `ReactiveRedisConnection` instances. In addition, the factories act as `PersistenceExceptionTranslator` instances, meaning that, once declared, they let you do transparent exception translation -- for example, exception translation through the use of the `@Repository` annotation and AOP. For more information, see the dedicated http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#orm-exception-translation[section] in the Spring Framework documentation.
+`ReactiveRedisConnectionFactory` creates active `ReactiveRedisConnection` instances. In addition, the factories act as `PersistenceExceptionTranslator` instances, meaning that, once declared, they let you do transparent exception translation -- for example, exception translation through the use of the `@Repository` annotation and AOP. For more information, see the dedicated https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#orm-exception-translation[section] in the Spring Framework documentation.
 
 NOTE: Depending on the underlying configuration, the factory can return a new connection or an existing connection (in case a pool or shared native connection is used).
 
@@ -70,7 +70,7 @@ For more detailed client configuration tweaks, see https://docs.spring.io/spring
 
 Most users are likely to use `ReactiveRedisTemplate` and its corresponding package, `org.springframework.data.redis.core`. Due to its rich feature set, the template is, in fact, the central class of the Redis module. The template offers a high-level abstraction for Redis interactions. While `ReactiveRedisConnection` offers low-level methods that accept and return binary values (`ByteBuffer`), the template takes care of serialization and connection management, freeing you from dealing with such details.
 
-Moreover, the template provides operation views (following the grouping from Redis command http://redis.io/commands[reference]) that offer rich, generified interfaces for working against a certain type as described in the following table:
+Moreover, the template provides operation views (following the grouping from Redis command https://redis.io/commands[reference]) that offer rich, generified interfaces for working against a certain type as described in the following table:
 
 .Operational views
 [width="80%",cols="<1,<2",options="header"]

--- a/src/main/asciidoc/reference/redis-cluster.adoc
+++ b/src/main/asciidoc/reference/redis-cluster.adoc
@@ -1,7 +1,7 @@
 [[cluster]]
 = Redis Cluster
 
-Working with http://redis.io/topics/cluster-spec[Redis Cluster] requires Redis Server version 3.0+. See the http://redis.io/topics/cluster-tutorial[Cluster Tutorial] for more information.
+Working with https://redis.io/topics/cluster-spec[Redis Cluster] requires Redis Server version 3.0+. See the https://redis.io/topics/cluster-tutorial[Cluster Tutorial] for more information.
 
 == Enabling Redis Cluster
 

--- a/src/main/asciidoc/reference/redis-messaging.adoc
+++ b/src/main/asciidoc/reference/redis-messaging.adoc
@@ -87,8 +87,8 @@ Notice how the above implementation of the `MessageDelegate` interface (the abov
  <beans xmlns="http://www.springframework.org/schema/beans"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns:redis="http://www.springframework.org/schema/redis"
-   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-   http://www.springframework.org/schema/redis http://www.springframework.org/schema/redis/spring-redis.xsd">
+   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+   http://www.springframework.org/schema/redis https://www.springframework.org/schema/redis/spring-redis.xsd">
 
 <!-- the default ConnectionFactory -->
 <redis:listener-container>

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -379,7 +379,7 @@ public class ApplicationConfig {
 
 [[redis.repositories.indexes]]
 == Secondary Indexes
-http://redis.io/topics/indexes[Secondary indexes] are used to enable lookup operations based on native Redis structures. Values are written to the according indexes on every save and are removed when objects are deleted or <<redis.repositories.expirations,expire>>.
+https://redis.io/topics/indexes[Secondary indexes] are used to enable lookup operations based on native Redis structures. Values are written to the according indexes on every save and are removed when objects are deleted or <<redis.repositories.expirations,expire>>.
 
 [[redis.repositories.indexes.simple]]
 === Simple Property Index
@@ -578,7 +578,7 @@ public class TimeToLiveOnMethod {
 
 NOTE: Annotating a property explicitly with `@TimeToLive` reads back the actual `TTL` or `PTTL` value from Redis. -1 indicates that the object has no associated expiration.
 
-The repository implementation ensures subscription to http://redis.io/topics/notifications[Redis keyspace notifications] via `RedisMessageListenerContainer`.
+The repository implementation ensures subscription to https://redis.io/topics/notifications[Redis keyspace notifications] via `RedisMessageListenerContainer`.
 
 When the expiration is set to a positive value, the corresponding `EXPIRE` command is executed. In addition to persisting the original, a phantom copy is persisted in Redis and set to expire five minutes after the original one. This is done to enable the Repository support to publish `RedisKeyExpiredEvent`, holding the expired value in Spring's `ApplicationEventPublisher` whenever a key expires, even though the original values have already been removed. Expiry events are received on all connected applications that use Spring Data Redis repositories.
 

--- a/src/main/asciidoc/reference/redis-scripting.adoc
+++ b/src/main/asciidoc/reference/redis-scripting.adoc
@@ -1,7 +1,7 @@
 [[scripting]]
 = Redis Scripting
 
-Redis versions 2.6 and higher provide support for execution of Lua scripts through the http://redis.io/commands/eval[eval] and http://redis.io/commands/evalsha[evalsha] commands. Spring Data Redis provides a high-level abstraction for script execution that handles serialization and automatically uses the Redis script cache.
+Redis versions 2.6 and higher provide support for execution of Lua scripts through the https://redis.io/commands/eval[eval] and https://redis.io/commands/evalsha[evalsha] commands. Spring Data Redis provides a high-level abstraction for script execution that handles serialization and automatically uses the Redis script cache.
 
 Scripts can be run by calling the `execute` methods of `RedisTemplate` and `ReactiveRedisTemplate`. Both use a configurable `ScriptExecutor` (or `ReactiveScriptExecutor`) to run the provided script. By default, the `ScriptExecutor` (or `ReactiveScriptExecutor`) takes care of serializing the provided keys and arguments and deserializing the script result. This is done through the key and value serializers of the template. There is an additional overload that lets you pass custom serializers for the script arguments and the result.
 
@@ -49,4 +49,4 @@ TIP: It is ideal to configure a single instance of `DefaultRedisScript` in your 
 
 The `checkAndSet` method above then runs the scripts. Scripts can be run within a `SessionCallback` as part of a transaction or pipeline. See "`<<tx>>`" and "`<<pipeline>>`" for more information.
 
-The scripting support provided by Spring Data Redis also lets you schedule Redis scripts for periodic execution by using the Spring Task and Scheduler abstractions. See the http://projects.spring.io/spring-framework/[Spring Framework] documentation for more details.
+The scripting support provided by Spring Data Redis also lets you schedule Redis scripts for periodic execution by using the Spring Task and Scheduler abstractions. See the https://projects.spring.io/spring-framework/[Spring Framework] documentation for more details.

--- a/src/main/asciidoc/reference/redis-transactions.adoc
+++ b/src/main/asciidoc/reference/redis-transactions.adoc
@@ -1,7 +1,7 @@
 [[tx]]
 = Redis Transactions
 
-Redis provides support for http://redis.io/topics/transactions[transactions] through the `multi`, `exec`, and `discard` commands. These operations are available on `RedisTemplate`. However, `RedisTemplate` is not guaranteed to execute all operations in the transaction with the same connection.
+Redis provides support for https://redis.io/topics/transactions[transactions] through the `multi`, `exec`, and `discard` commands. These operations are available on `RedisTemplate`. However, `RedisTemplate` is not guaranteed to execute all operations in the transaction with the same connection.
 
 Spring Data Redis provides the `SessionCallback` interface for use when multiple operations need to be performed with the same `connection`, such as when using Redis transactions. The following example uses the `multi` method:
 
@@ -63,7 +63,7 @@ public class RedisTxContextConfiguration {
   }
 }
 ----
-<1> Configures a Spring Context to enable http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#transaction-declarative[declarative transaction management].
+<1> Configures a Spring Context to enable https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#transaction-declarative[declarative transaction management].
 <2> Configures `RedisTemplate` to participate in transactions by binding connections to the current thread.
 <3> Transaction management requires a `PlatformTransactionManager`. Spring Data Redis does not ship with a `PlatformTransactionManager` implementation. Assuming your application uses JDBC, Spring Data Redis can participate in transactions by using existing transaction managers.
 ====

--- a/src/main/asciidoc/reference/redis.adoc
+++ b/src/main/asciidoc/reference/redis.adoc
@@ -2,7 +2,7 @@
 = Redis support
 :referenceDir: .
 
-One of the key-value stores supported by Spring Data is http://redis.io[Redis]. To quote the Redis project home page:
+One of the key-value stores supported by Spring Data is https://redis.io[Redis]. To quote the Redis project home page:
 
 [quote]
 Redis is an advanced key-value store. It is similar to memcached but the dataset is not volatile, and values can be strings, exactly like in memcached, but also lists, sets, and ordered sets. All this data types can be manipulated with atomic operations to push/pop elements, add/remove elements, perform server side union, intersection, difference between sets, and so forth. Redis supports different kind of sorting abilities.
@@ -12,7 +12,7 @@ Spring Data Redis provides easy configuration and access to Redis from Spring ap
 [[redis:requirements]]
 == Redis Requirements
 
-Spring Redis requires Redis 2.6 or above and Spring Data Redis integrates with http://github.com/lettuce-io/lettuce-core[Lettuce] and http://github.com/xetorthio/jedis[Jedis], two popular open-source Java libraries for Redis.
+Spring Redis requires Redis 2.6 or above and Spring Data Redis integrates with https://github.com/lettuce-io/lettuce-core[Lettuce] and https://github.com/xetorthio/jedis[Jedis], two popular open-source Java libraries for Redis.
 
 [[redis:architecture]]
 == Redis Support High-level View
@@ -27,11 +27,11 @@ One of the first tasks when using Redis and Spring is to connect to the store th
 [[redis:connectors:connection]]
 === RedisConnection and RedisConnectionFactory
 
-`RedisConnection` provides the core building block for Redis communication, as it handles the communication with the Redis back end. It also automatically translates the underlying connecting library exceptions to Spring's consistent DAO exception http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#dao-exceptions[hierarchy] so that you can switch the connectors without any code changes, as the operation semantics remain the same.
+`RedisConnection` provides the core building block for Redis communication, as it handles the communication with the Redis back end. It also automatically translates the underlying connecting library exceptions to Spring's consistent DAO exception https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#dao-exceptions[hierarchy] so that you can switch the connectors without any code changes, as the operation semantics remain the same.
 
 NOTE: For the corner cases where the native library API is required, `RedisConnection` provides a dedicated method (`getNativeConnection`) that returns the raw, underlying object used for communication.
 
-Active `RedisConnection` objects are created through `RedisConnectionFactory`. In addition, the factory acts as `PersistenceExceptionTranslator` objects, meaning that, once declared, they let you do transparent exception translation. For example, you can do exception translation through the use of the `@Repository` annotation and AOP. For more information, see the dedicated http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#orm-exception-translation[section] in the Spring Framework documentation.
+Active `RedisConnection` objects are created through `RedisConnectionFactory`. In addition, the factory acts as `PersistenceExceptionTranslator` objects, meaning that, once declared, they let you do transparent exception translation. For example, you can do exception translation through the use of the `@Repository` annotation and AOP. For more information, see the dedicated https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#orm-exception-translation[section] in the Spring Framework documentation.
 
 NOTE: Depending on the underlying configuration, the factory can return a new connection or an existing connection (when a pool or shared native connection is used).
 
@@ -42,7 +42,7 @@ IMPORTANT: Unfortunately, currently, not all connectors support all Redis featur
 [[redis:connectors:lettuce]]
 === Configuring the Lettuce Connector
 
-https://github.com/lettuce-io/lettuce-core[Lettuce] is a http://netty.io/[Netty]-based open-source connector supported by Spring Data Redis through the `org.springframework.data.redis.connection.lettuce` package. The following example shows how to create a new Lettuce connection factory:
+https://github.com/lettuce-io/lettuce-core[Lettuce] is a https://netty.io/[Netty]-based open-source connector supported by Spring Data Redis through the `org.springframework.data.redis.connection.lettuce` package. The following example shows how to create a new Lettuce connection factory:
 
 [source,java]
 ----
@@ -59,7 +59,7 @@ class AppConfig {
 
 There are also a few Lettuce-specific connection parameters that can be tweaked. By default, all `LettuceConnection` instances created by the `LettuceConnectionFactory` share the same thread-safe native connection for all non-blocking and non-transactional operations. To use a dedicated connection each time, set `shareNativeConnection` to `false`. `LettuceConnectionFactory` can also be configured to use a `LettucePool` for pooling blocking and transactional connections or all connections if `shareNativeConnection` is set to `false`.
 
-Lettuce integrates with Netty's http://netty.io/wiki/native-transports.html[native transports], letting you use Unix domain sockets to communicate with Redis. Make sure to include the appropriate native transport dependencies that match your runtime environment. The following example shows how to create a Lettuce Connection factory for a Unix domain socket at `/var/run/redis.sock`:
+Lettuce integrates with Netty's https://netty.io/wiki/native-transports.html[native transports], letting you use Unix domain sockets to communicate with Redis. Make sure to include the appropriate native transport dependencies that match your runtime environment. The following example shows how to create a Lettuce Connection factory for a Unix domain socket at `/var/run/redis.sock`:
 
 [source,java]
 ----
@@ -79,7 +79,7 @@ NOTE: Netty currently supports the epoll (Linux) and kqueue (BSD/macOS) interfac
 [[redis:connectors:jedis]]
 === Configuring the Jedis Connector
 
-http://github.com/xetorthio/jedis[Jedis] is a community-driven connector supported by the Spring Data Redis module through the `org.springframework.data.redis.connection.jedis` package. In its simplest form, the Jedis configuration looks as follow:
+https://github.com/xetorthio/jedis[Jedis] is a community-driven connector supported by the Spring Data Redis module through the `org.springframework.data.redis.connection.jedis` package. In its simplest form, the Jedis configuration looks as follow:
 
 [source,java]
 ----
@@ -138,7 +138,7 @@ TIP: For environments reporting non-public addresses through the `INFO` command 
 [[redis:sentinel]]
 == Redis Sentinel Support
 
-For dealing with high-availability Redis, Spring Data Redis has support for http://redis.io/topics/sentinel[Redis Sentinel], using `RedisSentinelConfiguration`, as shown in the following example:
+For dealing with high-availability Redis, Spring Data Redis has support for https://redis.io/topics/sentinel[Redis Sentinel], using `RedisSentinelConfiguration`, as shown in the following example:
 
 [source,java]
 ----
@@ -183,7 +183,7 @@ Sometimes, direct interaction with one of the Sentinels is required. Using `Redi
 
 Most users are likely to use `RedisTemplate` and its corresponding package, `org.springframework.data.redis.core`. The template is, in fact, the central class of the Redis module, due to its rich feature set. The template offers a high-level abstraction for Redis interactions. While `RedisConnection` offers low-level methods that accept and return binary values (`byte` arrays), the template takes care of serialization and connection management, freeing the user from dealing with such details.
 
-Moreover, the template provides operations views (following the grouping from the Redis command http://redis.io/commands[reference]) that offer rich, generified interfaces for working against a certain type or certain key (through the `KeyBound` interfaces) as described in the following table:
+Moreover, the template provides operations views (following the grouping from the Redis command https://redis.io/commands[reference]) that offer rich, generified interfaces for working against a certain type or certain key (through the `KeyBound` interfaces) as described in the following table:
 
 .Operational views
 [width="80%",cols="<1,<2",options="header"]
@@ -251,7 +251,7 @@ For cases where you need a certain template view, declare the view as a dependen
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <bean id="jedisConnectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory" p:use-pool="true"/>
   <!-- redis template definition -->
@@ -290,7 +290,7 @@ Since it is quite common for the keys and values stored in Redis to be `java.lan
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <bean id="jedisConnectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory" p:use-pool="true"/>
 
@@ -347,7 +347,7 @@ Multiple implementations are available (including two that have been already men
 * `JdkSerializationRedisSerializer`, which is used by default for `RedisCache` and `RedisTemplate`.
 * the `StringRedisSerializer`.
 
-However one can use `OxmSerializer` for Object/XML mapping through Spring http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#oxm[OXM] support or `Jackson2JsonRedisSerializer` or `GenericJackson2JsonRedisSerializer` for storing data in http://en.wikipedia.org/wiki/JSON[JSON] format.
+However one can use `OxmSerializer` for Object/XML mapping through Spring https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#oxm[OXM] support or `Jackson2JsonRedisSerializer` or `GenericJackson2JsonRedisSerializer` for storing data in https://en.wikipedia.org/wiki/JSON[JSON] format.
 
 Do note that the storage format is not limited only to values. It can be used for keys, values, or hashes without any restrictions.
 
@@ -358,14 +358,14 @@ By default, `RedisCache` and `RedisTemplate` are configured to use Java native s
 If you are concerned about security vulnerabilities due to Java serialization, consider the general-purpose serialization filter mechanism at the core JVM level, originally developed for JDK 9 but backported to JDK 8, 7, and 6:
 
 * https://blogs.oracle.com/java-platform-group/entry/incoming_filter_serialization_data_a[Filter Incoming Serialization Data].
-* http://openjdk.java.net/jeps/290[JEP 290].
+* https://openjdk.java.net/jeps/290[JEP 290].
 * https://www.owasp.org/index.php/Deserialization_of_untrusted_data[OWASP: Deserialization of untrusted data].
 ====
 
 [[redis.hashmappers.root]]
 == Hash mapping
 
-Data can be stored by using various data structures within Redis. `Jackson2JsonRedisSerializer` can convert objects in http://en.wikipedia.org/wiki/JSON[JSON] format. Ideally, JSON can be stored as a value by using plain keys. You can achieve a more sophisticated mapping of structured objects by using Redis hashes. Spring Data Redis offers various strategies for mapping data to hashes (depending on the use case):
+Data can be stored by using various data structures within Redis. `Jackson2JsonRedisSerializer` can convert objects in https://en.wikipedia.org/wiki/JSON[JSON] format. Ideally, JSON can be stored as a value by using plain keys. You can achieve a more sophisticated mapping of structured objects by using Redis hashes. Spring Data Redis offers various strategies for mapping data to hashes (depending on the use case):
 
 * Direct mapping, by using `HashOperations` and a <<redis:serializer,serializer>>
 * Using <<redis.repositories>>
@@ -377,7 +377,7 @@ Hash mappers are converters of map objects to a `Map<K, V>` and back. `HashMappe
 
 Multiple implementations are available:
 
-* `BeanUtilsHashMapper` using Spring's http://docs.spring.io/spring/docs/{springVersion}/javadoc-api/org/springframework/beans/BeanUtils.html[BeanUtils].
+* `BeanUtilsHashMapper` using Spring's https://docs.spring.io/spring/docs/{springVersion}/javadoc-api/org/springframework/beans/BeanUtils.html[BeanUtils].
 * `ObjectHashMapper` using <<redis.repositories.mapping>>.
 * <<redis.hashmappers.jackson2,`Jackson2HashMapper`>> using https://github.com/FasterXML/jackson[FasterXML Jackson].
 
@@ -494,7 +494,7 @@ include::{referenceDir}/redis-scripting.adoc[]
 [[redis:support]]
 == Support Classes
 
-Package `org.springframework.data.redis.support` offers various reusable components that rely on Redis as a backing store. Currently, the package contains various JDK-based interface implementations on top of Redis, such as http://download.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/package-summary.html[atomic] counters and JDK http://download.oracle.com/javase/8/docs/api/java/util/Collection.html[Collections].
+Package `org.springframework.data.redis.support` offers various reusable components that rely on Redis as a backing store. Currently, the package contains various JDK-based interface implementations on top of Redis, such as https://download.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/package-summary.html[atomic] counters and JDK https://download.oracle.com/javase/8/docs/api/java/util/Collection.html[Collections].
 
 The atomic counters make it easy to wrap Redis key incrementation while the collections allow easy management of Redis keys with minimal storage exposure or API leakage. In particular, the `RedisSet` and `RedisZSet` interfaces offer easy access to the set operations supported by Redis, such as `intersection` and `union`. `RedisList` implements the `List`, `Queue`, and `Deque` contracts (and their equivalent blocking siblings) on top of Redis, exposing the storage as a FIFO (First-In-First-Out), LIFO (Last-In-First-Out) or capped collection with minimal configuration. The following example shows the configuration for a bean that uses a `RedisList`:
 
@@ -504,7 +504,7 @@ The atomic counters make it easy to wrap Redis key incrementation while the coll
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <bean id="queue" class="org.springframework.data.redis.support.collections.DefaultRedisList">
     <constructor-arg ref="redisTemplate"/>
@@ -536,7 +536,7 @@ As shown in the preceding example, the consuming code is decoupled from the actu
 
 NOTE: Changed in 2.0
 
-Spring Redis provides an implementation for the Spring http://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/integration.html#cache[cache abstraction] through the `org.springframework.data.redis.cache` package. To use Redis as a backing implementation, add `RedisCacheManager` to your configuration, as follows:
+Spring Redis provides an implementation for the Spring https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/integration.html#cache[cache abstraction] through the `org.springframework.data.redis.cache` package. To use Redis as a backing implementation, add `RedisCacheManager` to your configuration, as follows:
 
 [source,java]
 ----

--- a/src/main/java/org/springframework/data/redis/connection/BitFieldSubCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/BitFieldSubCommands.java
@@ -328,7 +328,7 @@ public class BitFieldSubCommands implements Iterable<BitFieldSubCommand> {
 
 	/**
 	 * Offset used inside a {@link BitFieldSubCommand}. Can be zero or type based. See
-	 * <a href="http://redis.io/commands/bitfield#bits-and-positional-offsets">Bits and positional offsets</a> in the
+	 * <a href="https://redis.io/commands/bitfield#bits-and-positional-offsets">Bits and positional offsets</a> in the
 	 * Redis reference.
 	 *
 	 * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveGeoCommands.java
@@ -57,7 +57,7 @@ public interface ReactiveGeoCommands {
 	 * {@code GEOADD} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	class GeoAddCommand extends KeyCommand {
 
@@ -121,7 +121,7 @@ public interface ReactiveGeoCommands {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	default Mono<Long> geoAdd(ByteBuffer key, Point point, ByteBuffer member) {
 
@@ -138,7 +138,7 @@ public interface ReactiveGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param location must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	default Mono<Long> geoAdd(ByteBuffer key, GeoLocation<ByteBuffer> location) {
 
@@ -154,7 +154,7 @@ public interface ReactiveGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param locations must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	default Mono<Long> geoAdd(ByteBuffer key, Collection<GeoLocation<ByteBuffer>> locations) {
 
@@ -169,7 +169,7 @@ public interface ReactiveGeoCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Flux<NumericResponse<GeoAddCommand, Long>> geoAdd(Publisher<GeoAddCommand> commands);
 
@@ -177,7 +177,7 @@ public interface ReactiveGeoCommands {
 	 * {@code GEODIST} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	class GeoDistCommand extends KeyCommand {
 
@@ -306,7 +306,7 @@ public interface ReactiveGeoCommands {
 	 * @param from must not be {@literal null}.
 	 * @param to must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	default Mono<Distance> geoDist(ByteBuffer key, ByteBuffer from, ByteBuffer to) {
 		return geoDist(key, from, to, DistanceUnit.METERS);
@@ -320,7 +320,7 @@ public interface ReactiveGeoCommands {
 	 * @param to must not be {@literal null}.
 	 * @param metric must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	default Mono<Distance> geoDist(ByteBuffer key, ByteBuffer from, ByteBuffer to, Metric metric) {
 
@@ -339,7 +339,7 @@ public interface ReactiveGeoCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	Flux<CommandResponse<GeoDistCommand, Distance>> geoDist(Publisher<GeoDistCommand> commands);
 
@@ -347,7 +347,7 @@ public interface ReactiveGeoCommands {
 	 * {@code GEOHASH} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	class GeoHashCommand extends KeyCommand {
 
@@ -413,7 +413,7 @@ public interface ReactiveGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	default Mono<String> geoHash(ByteBuffer key, ByteBuffer member) {
 
@@ -429,7 +429,7 @@ public interface ReactiveGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	default Mono<List<String>> geoHash(ByteBuffer key, Collection<ByteBuffer> members) {
 
@@ -446,7 +446,7 @@ public interface ReactiveGeoCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	Flux<MultiValueResponse<GeoHashCommand, String>> geoHash(Publisher<GeoHashCommand> commands);
 
@@ -454,7 +454,7 @@ public interface ReactiveGeoCommands {
 	 * {@code GEOPOS} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	class GeoPosCommand extends KeyCommand {
 
@@ -520,7 +520,7 @@ public interface ReactiveGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	default Mono<Point> geoPos(ByteBuffer key, ByteBuffer member) {
 
@@ -536,7 +536,7 @@ public interface ReactiveGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	default Mono<List<Point>> geoPos(ByteBuffer key, Collection<ByteBuffer> members) {
 
@@ -551,7 +551,7 @@ public interface ReactiveGeoCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	Flux<MultiValueResponse<GeoPosCommand, Point>> geoPos(Publisher<GeoPosCommand> commands);
 
@@ -559,7 +559,7 @@ public interface ReactiveGeoCommands {
 	 * {@code GEORADIUS} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	class GeoRadiusCommand extends KeyCommand {
 
@@ -868,7 +868,7 @@ public interface ReactiveGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param circle must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	default Flux<GeoResult<GeoLocation<ByteBuffer>>> geoRadius(ByteBuffer key, Circle circle) {
 		return geoRadius(key, circle, GeoRadiusCommandArgs.newGeoRadiusArgs());
@@ -881,7 +881,7 @@ public interface ReactiveGeoCommands {
 	 * @param circle must not be {@literal null}.
 	 * @param geoRadiusArgs must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	default Flux<GeoResult<GeoLocation<ByteBuffer>>> geoRadius(ByteBuffer key, Circle circle,
 			GeoRadiusCommandArgs geoRadiusArgs) {
@@ -899,7 +899,7 @@ public interface ReactiveGeoCommands {
 	 *
 	 * @param commands
 	 * @return
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	Flux<CommandResponse<GeoRadiusCommand, Flux<GeoResult<GeoLocation<ByteBuffer>>>>> geoRadius(
 			Publisher<GeoRadiusCommand> commands);
@@ -908,7 +908,7 @@ public interface ReactiveGeoCommands {
 	 * {@code GEORADIUSBYMEMBER} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	class GeoRadiusByMemberCommand extends KeyCommand {
 
@@ -1201,7 +1201,7 @@ public interface ReactiveGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	default Flux<GeoResult<GeoLocation<ByteBuffer>>> geoRadiusByMember(ByteBuffer key, ByteBuffer member,
 			Distance distance) {
@@ -1215,7 +1215,7 @@ public interface ReactiveGeoCommands {
 	 * @param member must not be {@literal null}.
 	 * @param geoRadiusArgs must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	default Flux<GeoResult<GeoLocation<ByteBuffer>>> geoRadiusByMember(ByteBuffer key, ByteBuffer member,
 			Distance distance, GeoRadiusCommandArgs geoRadiusArgs) {
@@ -1235,7 +1235,7 @@ public interface ReactiveGeoCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	Flux<CommandResponse<GeoRadiusByMemberCommand, Flux<GeoResult<GeoLocation<ByteBuffer>>>>> geoRadiusByMember(
 			Publisher<GeoRadiusByMemberCommand> commands);

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -51,7 +51,7 @@ public interface ReactiveHashCommands {
 	 * {@literal HSET} {@link Command}.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/hset">Redis Documentation: HSET</a>
+	 * @see <a href="https://redis.io/commands/hset">Redis Documentation: HSET</a>
 	 */
 	class HSetCommand extends KeyCommand {
 
@@ -154,7 +154,7 @@ public interface ReactiveHashCommands {
 	 * @param field must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hset">Redis Documentation: HSET</a>
+	 * @see <a href="https://redis.io/commands/hset">Redis Documentation: HSET</a>
 	 */
 	default Mono<Boolean> hSet(ByteBuffer key, ByteBuffer field, ByteBuffer value) {
 
@@ -172,7 +172,7 @@ public interface ReactiveHashCommands {
 	 * @param field must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hsetnx">Redis Documentation: HSETNX</a>
+	 * @see <a href="https://redis.io/commands/hsetnx">Redis Documentation: HSETNX</a>
 	 */
 	default Mono<Boolean> hSetNX(ByteBuffer key, ByteBuffer field, ByteBuffer value) {
 
@@ -190,7 +190,7 @@ public interface ReactiveHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param fieldValueMap must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hmset">Redis Documentation: HMSET</a>
+	 * @see <a href="https://redis.io/commands/hmset">Redis Documentation: HMSET</a>
 	 */
 	default Mono<Boolean> hMSet(ByteBuffer key, Map<ByteBuffer, ByteBuffer> fieldValueMap) {
 
@@ -205,7 +205,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hset">Redis Documentation: HSET</a>
+	 * @see <a href="https://redis.io/commands/hset">Redis Documentation: HSET</a>
 	 */
 	Flux<BooleanResponse<HSetCommand>> hSet(Publisher<HSetCommand> commands);
 
@@ -213,7 +213,7 @@ public interface ReactiveHashCommands {
 	 * {@literal HGET} {@link Command}.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/hget">Redis Documentation: HGET</a>
+	 * @see <a href="https://redis.io/commands/hget">Redis Documentation: HGET</a>
 	 */
 	class HGetCommand extends KeyCommand {
 
@@ -279,7 +279,7 @@ public interface ReactiveHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param field must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hget">Redis Documentation: HGET</a>
+	 * @see <a href="https://redis.io/commands/hget">Redis Documentation: HGET</a>
 	 */
 	default Mono<ByteBuffer> hGet(ByteBuffer key, ByteBuffer field) {
 		return hMGet(key, Collections.singletonList(field)).map(val -> val.isEmpty() ? null : val.iterator().next());
@@ -291,7 +291,7 @@ public interface ReactiveHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param fields must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hmget">Redis Documentation: HMGET</a>
+	 * @see <a href="https://redis.io/commands/hmget">Redis Documentation: HMGET</a>
 	 */
 	default Mono<List<ByteBuffer>> hMGet(ByteBuffer key, Collection<ByteBuffer> fields) {
 
@@ -306,7 +306,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hmget">Redis Documentation: HMGET</a>
+	 * @see <a href="https://redis.io/commands/hmget">Redis Documentation: HMGET</a>
 	 */
 	Flux<MultiValueResponse<HGetCommand, ByteBuffer>> hMGet(Publisher<HGetCommand> commands);
 
@@ -314,7 +314,7 @@ public interface ReactiveHashCommands {
 	 * {@literal HEXISTS} {@link Command}.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/hexists">Redis Documentation: HEXISTS</a>
+	 * @see <a href="https://redis.io/commands/hexists">Redis Documentation: HEXISTS</a>
 	 */
 	class HExistsCommand extends KeyCommand {
 
@@ -367,7 +367,7 @@ public interface ReactiveHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param field must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hexists">Redis Documentation: HEXISTS</a>
+	 * @see <a href="https://redis.io/commands/hexists">Redis Documentation: HEXISTS</a>
 	 */
 	default Mono<Boolean> hExists(ByteBuffer key, ByteBuffer field) {
 
@@ -382,13 +382,13 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param commands
 	 * @return
-	 * @see <a href="http://redis.io/commands/hexists">Redis Documentation: HEXISTS</a>
+	 * @see <a href="https://redis.io/commands/hexists">Redis Documentation: HEXISTS</a>
 	 */
 	Flux<BooleanResponse<HExistsCommand>> hExists(Publisher<HExistsCommand> commands);
 
 	/**
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/hdel">Redis Documentation: HDEL</a>
+	 * @see <a href="https://redis.io/commands/hdel">Redis Documentation: HDEL</a>
 	 */
 	class HDelCommand extends KeyCommand {
 
@@ -454,7 +454,7 @@ public interface ReactiveHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param field must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hdel">Redis Documentation: HDEL</a>
+	 * @see <a href="https://redis.io/commands/hdel">Redis Documentation: HDEL</a>
 	 */
 	default Mono<Boolean> hDel(ByteBuffer key, ByteBuffer field) {
 
@@ -469,7 +469,7 @@ public interface ReactiveHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param fields must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hdel">Redis Documentation: HDEL</a>
+	 * @see <a href="https://redis.io/commands/hdel">Redis Documentation: HDEL</a>
 	 */
 	default Mono<Long> hDel(ByteBuffer key, Collection<ByteBuffer> fields) {
 
@@ -484,7 +484,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hdel">Redis Documentation: HDEL</a>
+	 * @see <a href="https://redis.io/commands/hdel">Redis Documentation: HDEL</a>
 	 */
 	Flux<NumericResponse<HDelCommand, Long>> hDel(Publisher<HDelCommand> commands);
 
@@ -493,7 +493,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hlen">Redis Documentation: HLEN</a>
+	 * @see <a href="https://redis.io/commands/hlen">Redis Documentation: HLEN</a>
 	 */
 	default Mono<Long> hLen(ByteBuffer key) {
 
@@ -507,7 +507,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hlen">Redis Documentation: HLEN</a>
+	 * @see <a href="https://redis.io/commands/hlen">Redis Documentation: HLEN</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> hLen(Publisher<KeyCommand> commands);
 
@@ -516,7 +516,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>
+	 * @see <a href="https://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>
 	 */
 	default Flux<ByteBuffer> hKeys(ByteBuffer key) {
 
@@ -530,7 +530,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>
+	 * @see <a href="https://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> hKeys(Publisher<KeyCommand> commands);
 
@@ -539,7 +539,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hvals">Redis Documentation: HVALS</a>
+	 * @see <a href="https://redis.io/commands/hvals">Redis Documentation: HVALS</a>
 	 */
 	default Flux<ByteBuffer> hVals(ByteBuffer key) {
 
@@ -553,7 +553,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hvals">Redis Documentation: HVALS</a>
+	 * @see <a href="https://redis.io/commands/hvals">Redis Documentation: HVALS</a>
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> hVals(Publisher<KeyCommand> commands);
 
@@ -562,7 +562,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
+	 * @see <a href="https://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
 	 */
 	default Flux<Map.Entry<ByteBuffer, ByteBuffer>> hGetAll(ByteBuffer key) {
 
@@ -576,7 +576,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
+	 * @see <a href="https://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<Map.Entry<ByteBuffer, ByteBuffer>>>> hGetAll(Publisher<KeyCommand> commands);
 
@@ -587,7 +587,7 @@ public interface ReactiveHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @return the {@link Flux} emitting {@link java.util.Map.Entry entries} one by one.
 	 * @throws IllegalArgumentException in case the given key is {@literal null}.
-	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @see <a href="https://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<Map.Entry<ByteBuffer, ByteBuffer>> hScan(ByteBuffer key) {
@@ -602,7 +602,7 @@ public interface ReactiveHashCommands {
 	 * @param options must not be {@literal null}. Use {@link ScanOptions#NONE} instead.
 	 * @return the {@link Flux} emitting the raw {@link java.util.Map.Entry entries} one by one.
 	 * @throws IllegalArgumentException in case one of the required arguments is {@literal null}.
-	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @see <a href="https://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<Map.Entry<ByteBuffer, ByteBuffer>> hScan(ByteBuffer key, ScanOptions options) {
@@ -617,14 +617,14 @@ public interface ReactiveHashCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return the {@link Flux} emitting {@link CommandResponse} one by one.
-	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @see <a href="https://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
 	 * @since 2.1
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<Map.Entry<ByteBuffer, ByteBuffer>>>> hScan(Publisher<KeyScanCommand> commands);
 
 	/**
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/hstrlen">Redis Documentation: HSTRLEN</a>
+	 * @see <a href="https://redis.io/commands/hstrlen">Redis Documentation: HSTRLEN</a>
 	 * @since 2.1
 	 */
 	class HStrLenCommand extends KeyCommand {

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHyperLogLogCommands.java
@@ -44,7 +44,7 @@ public interface ReactiveHyperLogLogCommands {
 	 * {@code PFADD} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
+	 * @see <a href="https://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
 	 */
 	class PfAddCommand extends KeyCommand {
 
@@ -109,7 +109,7 @@ public interface ReactiveHyperLogLogCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
+	 * @see <a href="https://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
 	 */
 	default Mono<Long> pfAdd(ByteBuffer key, ByteBuffer value) {
 
@@ -124,7 +124,7 @@ public interface ReactiveHyperLogLogCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
+	 * @see <a href="https://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
 	 */
 	default Mono<Long> pfAdd(ByteBuffer key, Collection<ByteBuffer> values) {
 
@@ -139,7 +139,7 @@ public interface ReactiveHyperLogLogCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
+	 * @see <a href="https://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
 	 */
 	Flux<NumericResponse<PfAddCommand, Long>> pfAdd(Publisher<PfAddCommand> commands);
 
@@ -147,7 +147,7 @@ public interface ReactiveHyperLogLogCommands {
 	 * {@code PFCOUNT} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
+	 * @see <a href="https://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
 	 */
 	class PfCountCommand implements Command {
 
@@ -206,7 +206,7 @@ public interface ReactiveHyperLogLogCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
+	 * @see <a href="https://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
 	 */
 	default Mono<Long> pfCount(ByteBuffer key) {
 
@@ -220,7 +220,7 @@ public interface ReactiveHyperLogLogCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
+	 * @see <a href="https://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
 	 */
 	default Mono<Long> pfCount(Collection<ByteBuffer> keys) {
 
@@ -234,7 +234,7 @@ public interface ReactiveHyperLogLogCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
+	 * @see <a href="https://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
 	 */
 	Flux<NumericResponse<PfCountCommand, Long>> pfCount(Publisher<PfCountCommand> commands);
 
@@ -242,7 +242,7 @@ public interface ReactiveHyperLogLogCommands {
 	 * {@code PFMERGE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
+	 * @see <a href="https://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
 	 */
 	class PfMergeCommand extends KeyCommand {
 
@@ -295,7 +295,7 @@ public interface ReactiveHyperLogLogCommands {
 	 * @param destinationKey must not be {@literal null}.
 	 * @param sourceKeys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
+	 * @see <a href="https://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
 	 */
 	default Mono<Boolean> pfMerge(ByteBuffer destinationKey, Collection<ByteBuffer> sourceKeys) {
 
@@ -311,7 +311,7 @@ public interface ReactiveHyperLogLogCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
+	 * @see <a href="https://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
 	 */
 	Flux<BooleanResponse<PfMergeCommand>> pfMerge(Publisher<PfMergeCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
@@ -48,7 +48,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
+	 * @see <a href="https://redis.io/commands/exists">Redis Documentation: EXISTS</a>
 	 */
 	default Mono<Boolean> exists(ByteBuffer key) {
 
@@ -62,7 +62,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
+	 * @see <a href="https://redis.io/commands/exists">Redis Documentation: EXISTS</a>
 	 */
 	Flux<BooleanResponse<KeyCommand>> exists(Publisher<KeyCommand> keys);
 
@@ -71,7 +71,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/type">Redis Documentation: TYPE</a>
+	 * @see <a href="https://redis.io/commands/type">Redis Documentation: TYPE</a>
 	 */
 	default Mono<DataType> type(ByteBuffer key) {
 
@@ -85,7 +85,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/type">Redis Documentation: TYPE</a>
+	 * @see <a href="https://redis.io/commands/type">Redis Documentation: TYPE</a>
 	 */
 	Flux<CommandResponse<KeyCommand, DataType>> type(Publisher<KeyCommand> keys);
 
@@ -94,7 +94,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@link Mono} emitting the number of keys touched.
-	 * @see <a href="http://redis.io/commands/touch">Redis Documentation: TOUCH</a>
+	 * @see <a href="https://redis.io/commands/touch">Redis Documentation: TOUCH</a>
 	 * @since 2.1
 	 */
 	default Mono<Long> touch(Collection<ByteBuffer> keys) {
@@ -106,7 +106,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/touch">Redis Documentation: TOUCH</a>
+	 * @see <a href="https://redis.io/commands/touch">Redis Documentation: TOUCH</a>
 	 * @since 2.1
 	 */
 	Flux<NumericResponse<Collection<ByteBuffer>, Long>> touch(Publisher<Collection<ByteBuffer>> keys);
@@ -118,7 +118,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param pattern must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
+	 * @see <a href="https://redis.io/commands/keys">Redis Documentation: KEYS</a>
 	 */
 	default Mono<List<ByteBuffer>> keys(ByteBuffer pattern) {
 
@@ -134,7 +134,7 @@ public interface ReactiveKeyCommands {
 	 * 
 	 * @param patterns must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
+	 * @see <a href="https://redis.io/commands/keys">Redis Documentation: KEYS</a>
 	 */
 	Flux<MultiValueResponse<ByteBuffer, ByteBuffer>> keys(Publisher<ByteBuffer> patterns);
 
@@ -143,7 +143,7 @@ public interface ReactiveKeyCommands {
 	 * commands itself as long as the subscriber signals demand.
 	 *
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @see <a href="https://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<ByteBuffer> scan() {
@@ -157,7 +157,7 @@ public interface ReactiveKeyCommands {
 	 * @param options must not be {@literal null}.
 	 * @return the {@link Flux} emitting {@link ByteBuffer keys} one by one.
 	 * @throws IllegalArgumentException when options is {@literal null}.
-	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @see <a href="https://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 * @since 2.1
 	 */
 	Flux<ByteBuffer> scan(ScanOptions options);
@@ -166,7 +166,7 @@ public interface ReactiveKeyCommands {
 	 * Return a random key from the keyspace.
 	 *
 	 * @return
-	 * @see <a href="http://redis.io/commands/randomkey">Redis Documentation: RANDOMKEY</a>
+	 * @see <a href="https://redis.io/commands/randomkey">Redis Documentation: RANDOMKEY</a>
 	 */
 	Mono<ByteBuffer> randomKey();
 
@@ -174,7 +174,7 @@ public interface ReactiveKeyCommands {
 	 * {@code RENAME} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/rename">Redis Documentation: RENAME</a>
+	 * @see <a href="https://redis.io/commands/rename">Redis Documentation: RENAME</a>
 	 */
 	class RenameCommand extends KeyCommand {
 
@@ -228,7 +228,7 @@ public interface ReactiveKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param newName must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rename">Redis Documentation: RENAME</a>
+	 * @see <a href="https://redis.io/commands/rename">Redis Documentation: RENAME</a>
 	 */
 	default Mono<Boolean> rename(ByteBuffer key, ByteBuffer newName) {
 
@@ -242,7 +242,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param command must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rename">Redis Documentation: RENAME</a>
+	 * @see <a href="https://redis.io/commands/rename">Redis Documentation: RENAME</a>
 	 */
 	Flux<BooleanResponse<RenameCommand>> rename(Publisher<RenameCommand> command);
 
@@ -252,7 +252,7 @@ public interface ReactiveKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param newName must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
+	 * @see <a href="https://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
 	 */
 	default Mono<Boolean> renameNX(ByteBuffer key, ByteBuffer newName) {
 
@@ -266,7 +266,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param command must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
+	 * @see <a href="https://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
 	 */
 	Flux<BooleanResponse<RenameCommand>> renameNX(Publisher<RenameCommand> command);
 
@@ -275,7 +275,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	default Mono<Long> del(ByteBuffer key) {
 
@@ -289,7 +289,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} removed along with the deletion result.
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> del(Publisher<KeyCommand> keys);
 
@@ -298,7 +298,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	default Mono<Long> mDel(List<ByteBuffer> keys) {
 
@@ -312,7 +312,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal keys} removed along with the deletion result.
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	Flux<NumericResponse<List<ByteBuffer>, Long>> mDel(Publisher<List<ByteBuffer>> keys);
 
@@ -322,7 +322,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	default Mono<Long> unlink(ByteBuffer key) {
@@ -338,7 +338,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} removed along with the unlink result.
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> unlink(Publisher<KeyCommand> keys);
@@ -349,7 +349,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	default Mono<Long> mUnlink(List<ByteBuffer> keys) {
@@ -365,7 +365,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} removed along with the deletion result.
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	Flux<NumericResponse<List<ByteBuffer>, Long>> mUnlink(Publisher<List<ByteBuffer>> keys);
@@ -374,8 +374,8 @@ public interface ReactiveKeyCommands {
 	 * {@code EXPIRE}/{@code PEXPIRE} command parameters.
 	 *
 	 * @author Mark Paluch
-	 * @see <a href="http://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
-	 * @see <a href="http://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
+	 * @see <a href="https://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
+	 * @see <a href="https://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
 	 */
 	class ExpireCommand extends KeyCommand {
 
@@ -429,7 +429,7 @@ public interface ReactiveKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param timeout must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
+	 * @see <a href="https://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
 	 */
 	default Mono<Boolean> expire(ByteBuffer key, Duration timeout) {
 
@@ -445,7 +445,7 @@ public interface ReactiveKeyCommands {
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link BooleanResponse} holding the {@literal key} removed along with the expiration
 	 *         result.
-	 * @see <a href="http://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
+	 * @see <a href="https://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
 	 */
 	Flux<BooleanResponse<ExpireCommand>> expire(Publisher<ExpireCommand> commands);
 
@@ -455,7 +455,7 @@ public interface ReactiveKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param timeout must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
+	 * @see <a href="https://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
 	 */
 	default Mono<Boolean> pExpire(ByteBuffer key, Duration timeout) {
 
@@ -471,7 +471,7 @@ public interface ReactiveKeyCommands {
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link BooleanResponse} holding the {@literal key} removed along with the expiration
 	 *         result.
-	 * @see <a href="http://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
+	 * @see <a href="https://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
 	 */
 	Flux<BooleanResponse<ExpireCommand>> pExpire(Publisher<ExpireCommand> commands);
 
@@ -479,8 +479,8 @@ public interface ReactiveKeyCommands {
 	 * {@code EXPIREAT}/{@code PEXPIREAT} command parameters.
 	 *
 	 * @author Mark Paluch
-	 * @see <a href="http://redis.io/commands/expire">Redis Documentation: EXPIREAT</a>
-	 * @see <a href="http://redis.io/commands/pexpire">Redis Documentation: PEXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/expire">Redis Documentation: EXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/pexpire">Redis Documentation: PEXPIREAT</a>
 	 */
 	class ExpireAtCommand extends KeyCommand {
 
@@ -534,7 +534,7 @@ public interface ReactiveKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param expireAt must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
 	 */
 	default Mono<Boolean> expireAt(ByteBuffer key, Instant expireAt) {
 
@@ -550,7 +550,7 @@ public interface ReactiveKeyCommands {
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link BooleanResponse} holding the {@literal key} removed along with the expiration
 	 *         result.
-	 * @see <a href="http://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
 	 */
 	Flux<BooleanResponse<ExpireAtCommand>> expireAt(Publisher<ExpireAtCommand> commands);
 
@@ -560,7 +560,7 @@ public interface ReactiveKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param expireAt must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
 	 */
 	default Mono<Boolean> pExpireAt(ByteBuffer key, Instant expireAt) {
 
@@ -576,7 +576,7 @@ public interface ReactiveKeyCommands {
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link BooleanResponse} holding the {@literal key} removed along with the expiration
 	 *         result.
-	 * @see <a href="http://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
 	 */
 	Flux<BooleanResponse<ExpireAtCommand>> pExpireAt(Publisher<ExpireAtCommand> commands);
 
@@ -585,7 +585,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/persist">Redis Documentation: PERSIST</a>
+	 * @see <a href="https://redis.io/commands/persist">Redis Documentation: PERSIST</a>
 	 */
 	default Mono<Boolean> persist(ByteBuffer key) {
 
@@ -599,7 +599,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link BooleanResponse} holding the {@literal key} persisted along with the persist result.
-	 * @see <a href="http://redis.io/commands/persist">Redis Documentation: PERSIST</a>
+	 * @see <a href="https://redis.io/commands/persist">Redis Documentation: PERSIST</a>
 	 */
 	Flux<BooleanResponse<KeyCommand>> persist(Publisher<KeyCommand> commands);
 
@@ -608,7 +608,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see <a href="https://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 */
 	default Mono<Long> ttl(ByteBuffer key) {
 
@@ -622,7 +622,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} along with the time to live result.
-	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see <a href="https://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> ttl(Publisher<KeyCommand> commands);
 
@@ -631,7 +631,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see <a href="https://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 */
 	default Mono<Long> pTtl(ByteBuffer key) {
 
@@ -645,7 +645,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link NumericResponse} holding the {@literal key} along with the time to live result.
-	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
+	 * @see <a href="https://redis.io/commands/pttl">Redis Documentation: PTTL</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> pTtl(Publisher<KeyCommand> commands);
 
@@ -653,7 +653,7 @@ public interface ReactiveKeyCommands {
 	 * {@code MOVE} command parameters.
 	 *
 	 * @author Mark Paluch
-	 * @see <a href="http://redis.io/commands/move">Redis Documentation: MOVE</a>
+	 * @see <a href="https://redis.io/commands/move">Redis Documentation: MOVE</a>
 	 */
 	class MoveCommand extends KeyCommand {
 
@@ -704,7 +704,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/move">Redis Documentation: MOVE</a>
+	 * @see <a href="https://redis.io/commands/move">Redis Documentation: MOVE</a>
 	 */
 	default Mono<Boolean> move(ByteBuffer key, int database) {
 
@@ -718,7 +718,7 @@ public interface ReactiveKeyCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link BooleanResponse} holding the {@literal key} to move along with the move result.
-	 * @see <a href="http://redis.io/commands/move">Redis Documentation: MOVE</a>
+	 * @see <a href="https://redis.io/commands/move">Redis Documentation: MOVE</a>
 	 */
 	Flux<BooleanResponse<MoveCommand>> move(Publisher<MoveCommand> commands);
 
@@ -728,7 +728,7 @@ public interface ReactiveKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @return the {@link Mono} emitting {@link org.springframework.data.redis.connection.ValueEncoding}.
 	 * @throws IllegalArgumentException if {@code key} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/object">Redis Documentation: OBJECT ENCODING</a>
+	 * @see <a href="https://redis.io/commands/object">Redis Documentation: OBJECT ENCODING</a>
 	 * @since 2.1
 	 */
 	Mono<ValueEncoding> encodingOf(ByteBuffer key);
@@ -739,7 +739,7 @@ public interface ReactiveKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @return the {@link Mono} emitting the idletime of the key of {@link Mono#empty()} if the key does not exist.
 	 * @throws IllegalArgumentException if {@code key} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/object">Redis Documentation: OBJECT IDLETIME</a>
+	 * @see <a href="https://redis.io/commands/object">Redis Documentation: OBJECT IDLETIME</a>
 	 * @since 2.1
 	 */
 	Mono<Duration> idletime(ByteBuffer key);
@@ -750,7 +750,7 @@ public interface ReactiveKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @return {@link Mono#empty()} if key does not exist.
 	 * @throws IllegalArgumentException if {@code key} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/object">Redis Documentation: OBJECT REFCOUNT</a>
+	 * @see <a href="https://redis.io/commands/object">Redis Documentation: OBJECT REFCOUNT</a>
 	 * @since 2.1
 	 */
 	Mono<Long> refcount(ByteBuffer key);

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveListCommands.java
@@ -57,8 +57,8 @@ public interface ReactiveListCommands {
 	 * {@code LPUSH}/{@literal RPUSH} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	class PushCommand extends KeyCommand {
 
@@ -169,7 +169,7 @@ public interface ReactiveListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	default Mono<Long> rPush(ByteBuffer key, List<ByteBuffer> values) {
 
@@ -185,7 +185,7 @@ public interface ReactiveListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
+	 * @see <a href="https://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
 	 */
 	default Mono<Long> rPushX(ByteBuffer key, ByteBuffer value) {
 
@@ -201,7 +201,7 @@ public interface ReactiveListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	default Mono<Long> lPush(ByteBuffer key, List<ByteBuffer> values) {
 
@@ -217,7 +217,7 @@ public interface ReactiveListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
+	 * @see <a href="https://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
 	 */
 	default Mono<Long> lPushX(ByteBuffer key, ByteBuffer value) {
 
@@ -232,8 +232,8 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	Flux<NumericResponse<PushCommand, Long>> push(Publisher<PushCommand> commands);
 
@@ -242,7 +242,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 * @see <a href="https://redis.io/commands/llen">Redis Documentation: LLEN</a>
 	 */
 	default Mono<Long> lLen(ByteBuffer key) {
 
@@ -256,7 +256,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 * @see <a href="https://redis.io/commands/llen">Redis Documentation: LLEN</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> lLen(Publisher<KeyCommand> commands);
 
@@ -267,7 +267,7 @@ public interface ReactiveListCommands {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 * @see <a href="https://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
 	default Flux<ByteBuffer> lRange(ByteBuffer key, long start, long end) {
 
@@ -281,7 +281,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 * @see <a href="https://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
 	Flux<CommandResponse<RangeCommand, Flux<ByteBuffer>>> lRange(Publisher<RangeCommand> commands);
 
@@ -292,7 +292,7 @@ public interface ReactiveListCommands {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 * @see <a href="https://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
 	 */
 	default Mono<Boolean> lTrim(ByteBuffer key, long start, long end) {
 
@@ -308,7 +308,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 * @see <a href="https://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
 	 */
 	Flux<BooleanResponse<RangeCommand>> lTrim(Publisher<RangeCommand> commands);
 
@@ -316,7 +316,7 @@ public interface ReactiveListCommands {
 	 * {@code LINDEX} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 * @see <a href="https://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
 	 */
 	class LIndexCommand extends KeyCommand {
 
@@ -365,7 +365,7 @@ public interface ReactiveListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @return
-	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 * @see <a href="https://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
 	 */
 	default Mono<ByteBuffer> lIndex(ByteBuffer key, long index) {
 
@@ -379,7 +379,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 * @see <a href="https://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
 	 */
 	Flux<ByteBufferResponse<LIndexCommand>> lIndex(Publisher<LIndexCommand> commands);
 
@@ -387,7 +387,7 @@ public interface ReactiveListCommands {
 	 * {@code LINSERT} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
+	 * @see <a href="https://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
 	 */
 	class LInsertCommand extends KeyCommand {
 
@@ -490,7 +490,7 @@ public interface ReactiveListCommands {
 	 * @param pivot must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
+	 * @see <a href="https://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
 	 */
 	default Mono<Long> lInsert(ByteBuffer key, Position position, ByteBuffer pivot, ByteBuffer value) {
 
@@ -511,7 +511,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
+	 * @see <a href="https://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
 	 */
 	Flux<NumericResponse<LInsertCommand, Long>> lInsert(Publisher<LInsertCommand> commands);
 
@@ -519,7 +519,7 @@ public interface ReactiveListCommands {
 	 * {@code LSET} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 * @see <a href="https://redis.io/commands/lset">Redis Documentation: LSET</a>
 	 */
 	class LSetCommand extends KeyCommand {
 
@@ -592,7 +592,7 @@ public interface ReactiveListCommands {
 	 * @param index
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 * @see <a href="https://redis.io/commands/lset">Redis Documentation: LSET</a>
 	 */
 	default Mono<Boolean> lSet(ByteBuffer key, long index, ByteBuffer value) {
 
@@ -607,7 +607,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands
 	 * @return
-	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 * @see <a href="https://redis.io/commands/lset">Redis Documentation: LSET</a>
 	 */
 	Flux<BooleanResponse<LSetCommand>> lSet(Publisher<LSetCommand> commands);
 
@@ -615,7 +615,7 @@ public interface ReactiveListCommands {
 	 * {@code LREM} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see <a href="https://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 */
 	class LRemCommand extends KeyCommand {
 
@@ -707,7 +707,7 @@ public interface ReactiveListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see <a href="https://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 */
 	default Mono<Long> lRem(ByteBuffer key, ByteBuffer value) {
 
@@ -724,7 +724,7 @@ public interface ReactiveListCommands {
 	 * @param count must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see <a href="https://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 */
 	default Mono<Long> lRem(ByteBuffer key, Long count, ByteBuffer value) {
 
@@ -742,7 +742,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see <a href="https://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 */
 	Flux<NumericResponse<LRemCommand, Long>> lRem(Publisher<LRemCommand> commands);
 
@@ -750,8 +750,8 @@ public interface ReactiveListCommands {
 	 * {@code LPOP}/{@literal RPOP} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
-	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 * @see <a href="https://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 * @see <a href="https://redis.io/commands/rpop">Redis Documentation: RPOP</a>
 	 */
 	class PopCommand extends KeyCommand {
 
@@ -808,7 +808,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 * @see <a href="https://redis.io/commands/lpop">Redis Documentation: LPOP</a>
 	 */
 	default Mono<ByteBuffer> lPop(ByteBuffer key) {
 
@@ -822,7 +822,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 * @see <a href="https://redis.io/commands/rpop">Redis Documentation: RPOP</a>
 	 */
 	default Mono<ByteBuffer> rPop(ByteBuffer key) {
 
@@ -836,15 +836,15 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
-	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 * @see <a href="https://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 * @see <a href="https://redis.io/commands/rpop">Redis Documentation: RPOP</a>
 	 */
 	Flux<ByteBufferResponse<PopCommand>> pop(Publisher<PopCommand> commands);
 
 	/**
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
-	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
 	 */
 	class BPopCommand implements Command {
 
@@ -977,7 +977,7 @@ public interface ReactiveListCommands {
 	 * @param keys must not be {@literal null}.
 	 * @param timeout must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
 	 */
 	default Mono<PopResult> blPop(List<ByteBuffer> keys, Duration timeout) {
 
@@ -994,7 +994,7 @@ public interface ReactiveListCommands {
 	 * @param keys must not be {@literal null}.
 	 * @param timeout must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
 	 */
 	default Mono<PopResult> brPop(List<ByteBuffer> keys, Duration timeout) {
 
@@ -1011,8 +1011,8 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands
 	 * @return
-	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
-	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
 	 */
 	Flux<PopResponse> bPop(Publisher<BPopCommand> commands);
 
@@ -1020,7 +1020,7 @@ public interface ReactiveListCommands {
 	 * {@code RPOPLPUSH} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
 	 */
 	class RPopLPushCommand extends KeyCommand {
 
@@ -1074,7 +1074,7 @@ public interface ReactiveListCommands {
 	 * @param source must not be {@literal null}.
 	 * @param destination must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
 	 */
 	default Mono<ByteBuffer> rPopLPush(ByteBuffer source, ByteBuffer destination) {
 
@@ -1092,7 +1092,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
 	 */
 	Flux<ByteBufferResponse<RPopLPushCommand>> rPopLPush(Publisher<RPopLPushCommand> commands);
 
@@ -1100,7 +1100,7 @@ public interface ReactiveListCommands {
 	 * {@code BRPOPLPUSH} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
 	 */
 	class BRPopLPushCommand extends KeyCommand {
 
@@ -1178,7 +1178,7 @@ public interface ReactiveListCommands {
 	 * @param source must not be {@literal null}.
 	 * @param destination must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
 	 */
 	default Mono<ByteBuffer> bRPopLPush(ByteBuffer source, ByteBuffer destination, Duration timeout) {
 
@@ -1196,7 +1196,7 @@ public interface ReactiveListCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
 	 */
 	Flux<ByteBufferResponse<BRPopLPushCommand>> bRPopLPush(Publisher<BRPopLPushCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveNumberCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveNumberCommands.java
@@ -40,7 +40,7 @@ public interface ReactiveNumberCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 * @see <a href="https://redis.io/commands/incr">Redis Documentation: INCR</a>
 	 */
 	default Mono<Long> incr(ByteBuffer key) {
 
@@ -54,7 +54,7 @@ public interface ReactiveNumberCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 * @see <a href="https://redis.io/commands/incr">Redis Documentation: INCR</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> incr(Publisher<KeyCommand> keys);
 
@@ -62,7 +62,7 @@ public interface ReactiveNumberCommands {
 	 * {@code INCRBY} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
+	 * @see <a href="https://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
 	 */
 	class IncrByCommand<T extends Number> extends KeyCommand {
 
@@ -116,8 +116,8 @@ public interface ReactiveNumberCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
-	 * @see <a href="http://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
+	 * @see <a href="https://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
+	 * @see <a href="https://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
 	 */
 	default <T extends Number> Mono<T> incrBy(ByteBuffer key, T value) {
 
@@ -132,8 +132,8 @@ public interface ReactiveNumberCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
-	 * @see <a href="http://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
+	 * @see <a href="https://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
+	 * @see <a href="https://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
 	 */
 	<T extends Number> Flux<NumericResponse<ReactiveNumberCommands.IncrByCommand<T>, T>> incrBy(
 			Publisher<ReactiveNumberCommands.IncrByCommand<T>> commands);
@@ -142,7 +142,7 @@ public interface ReactiveNumberCommands {
 	 * {@code DECRBY} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
+	 * @see <a href="https://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
 	 */
 	class DecrByCommand<T extends Number> extends KeyCommand {
 
@@ -194,7 +194,7 @@ public interface ReactiveNumberCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/decr">Redis Documentation: DECR</a>
+	 * @see <a href="https://redis.io/commands/decr">Redis Documentation: DECR</a>
 	 */
 	default Mono<Long> decr(ByteBuffer key) {
 
@@ -208,7 +208,7 @@ public interface ReactiveNumberCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/decr">Redis Documentation: DECR</a>
+	 * @see <a href="https://redis.io/commands/decr">Redis Documentation: DECR</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> decr(Publisher<KeyCommand> keys);
 
@@ -218,7 +218,7 @@ public interface ReactiveNumberCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
+	 * @see <a href="https://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
 	 */
 	default <T extends Number> Mono<T> decrBy(ByteBuffer key, T value) {
 
@@ -240,7 +240,7 @@ public interface ReactiveNumberCommands {
 	 * {@code HINCRBY} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
+	 * @see <a href="https://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
 	 */
 	class HIncrByCommand<T extends Number> extends KeyCommand {
 
@@ -318,7 +318,7 @@ public interface ReactiveNumberCommands {
 	 * @param field must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
+	 * @see <a href="https://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
 	 */
 	default <T extends Number> Mono<T> hIncrBy(ByteBuffer key, ByteBuffer field, T value) {
 
@@ -334,7 +334,7 @@ public interface ReactiveNumberCommands {
 	 * Increment {@literal value} of a hash {@literal field} by the given {@literal value}.
 	 *
 	 * @return
-	 * @see <a href="http://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
+	 * @see <a href="https://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
 	 */
 	<T extends Number> Flux<NumericResponse<HIncrByCommand<T>, T>> hIncrBy(Publisher<HIncrByCommand<T>> commands);
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactivePubSubCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactivePubSubCommands.java
@@ -45,7 +45,7 @@ public interface ReactivePubSubCommands {
 	 * @param channel the channel to publish to. Must not be {@literal null}.
 	 * @param message message to publish. Must not be {@literal null}.
 	 * @return the number of clients that received the message.
-	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 * @see <a href="https://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
 	 */
 	default Mono<Long> publish(ByteBuffer channel, ByteBuffer message) {
 		return publish(Mono.just(new ChannelMessage<>(channel, message))).next();
@@ -56,7 +56,7 @@ public interface ReactivePubSubCommands {
 	 *
 	 * @param messageStream the messages to publish to. Must not be {@literal null}.
 	 * @return the number of clients that received the message.
-	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 * @see <a href="https://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
 	 */
 	Flux<Long> publish(Publisher<ChannelMessage<ByteBuffer, ByteBuffer>> messageStream);
 
@@ -68,7 +68,7 @@ public interface ReactivePubSubCommands {
 	 * Note that cancellation of the {@link Flux} will unsubscribe from {@code channels}.
 	 *
 	 * @param channels channel names, must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/subscribe">Redis Documentation: SUBSCRIBE</a>
+	 * @see <a href="https://redis.io/commands/subscribe">Redis Documentation: SUBSCRIBE</a>
 	 */
 	Mono<Void> subscribe(ByteBuffer... channels);
 
@@ -80,7 +80,7 @@ public interface ReactivePubSubCommands {
 	 * Note that cancellation of the {@link Flux} will unsubscribe from {@code patterns}.
 	 *
 	 * @param patterns channel name patterns, must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
+	 * @see <a href="https://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
 	 */
 	Mono<Void> pSubscribe(ByteBuffer... patterns);
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisConnection.java
@@ -164,7 +164,7 @@ public interface ReactiveRedisConnection extends Closeable {
 	 * Test connection.
 	 *
 	 * @return {@link Mono} wrapping server response message - usually {@literal PONG}.
-	 * @see <a href="http://redis.io/commands/ping">Redis Documentation: PING</a>
+	 * @see <a href="https://redis.io/commands/ping">Redis Documentation: PING</a>
 	 */
 	Mono<String> ping();
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveScriptingCommands.java
@@ -36,14 +36,14 @@ public interface ReactiveScriptingCommands {
 	/**
 	 * Flush lua script cache.
 	 *
-	 * @see <a href="http://redis.io/commands/script-flush">Redis Documentation: SCRIPT FLUSH</a>
+	 * @see <a href="https://redis.io/commands/script-flush">Redis Documentation: SCRIPT FLUSH</a>
 	 */
 	Mono<String> scriptFlush();
 
 	/**
 	 * Kill current lua script execution.
 	 *
-	 * @see <a href="http://redis.io/commands/script-kill">Redis Documentation: SCRIPT KILL</a>
+	 * @see <a href="https://redis.io/commands/script-kill">Redis Documentation: SCRIPT KILL</a>
 	 */
 	Mono<String> scriptKill();
 
@@ -53,7 +53,7 @@ public interface ReactiveScriptingCommands {
 	 *
 	 * @param script must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/script-load">Redis Documentation: SCRIPT LOAD</a>
+	 * @see <a href="https://redis.io/commands/script-load">Redis Documentation: SCRIPT LOAD</a>
 	 */
 	Mono<String> scriptLoad(ByteBuffer script);
 
@@ -74,7 +74,7 @@ public interface ReactiveScriptingCommands {
 	 *
 	 * @param scriptShas must not be {@literal null}.
 	 * @return {@link Flux} emitting one entry per scriptSha in given {@link List}.
-	 * @see <a href="http://redis.io/commands/script-exists">Redis Documentation: SCRIPT EXISTS</a>
+	 * @see <a href="https://redis.io/commands/script-exists">Redis Documentation: SCRIPT EXISTS</a>
 	 */
 	Flux<Boolean> scriptExists(List<String> scriptShas);
 
@@ -87,7 +87,7 @@ public interface ReactiveScriptingCommands {
 	 * @param numKeys
 	 * @param keysAndArgs must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/eval">Redis Documentation: EVAL</a>
+	 * @see <a href="https://redis.io/commands/eval">Redis Documentation: EVAL</a>
 	 */
 	<T> Flux<T> eval(ByteBuffer script, ReturnType returnType, int numKeys, ByteBuffer... keysAndArgs);
 
@@ -100,7 +100,7 @@ public interface ReactiveScriptingCommands {
 	 * @param numKeys
 	 * @param keysAndArgs must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
+	 * @see <a href="https://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
 	 */
 	<T> Flux<T> evalSha(String scriptSha, ReturnType returnType, int numKeys, ByteBuffer... keysAndArgs);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveServerCommands.java
@@ -35,7 +35,7 @@ public interface ReactiveServerCommands {
 	 * Start an {@literal Append Only File} rewrite process on server.
 	 *
 	 * @return {@link Mono} indicating command completion.
-	 * @see <a href="http://redis.io/commands/bgrewriteaof">Redis Documentation: BGREWRITEAOF</a>
+	 * @see <a href="https://redis.io/commands/bgrewriteaof">Redis Documentation: BGREWRITEAOF</a>
 	 */
 	Mono<String> bgReWriteAof();
 
@@ -44,7 +44,7 @@ public interface ReactiveServerCommands {
 	 *
 	 * @return {@link Mono} indicating command received by server. Operation success needs to be checked via
 	 *         {@link #lastSave()}.
-	 * @see <a href="http://redis.io/commands/bgsave">Redis Documentation: BGSAVE</a>
+	 * @see <a href="https://redis.io/commands/bgsave">Redis Documentation: BGSAVE</a>
 	 */
 	Mono<String> bgSave();
 
@@ -52,7 +52,7 @@ public interface ReactiveServerCommands {
 	 * Get time unix timestamp of last successful {@link #bgSave()} operation in seconds.
 	 *
 	 * @return {@link Mono} wrapping unix timestamp.
-	 * @see <a href="http://redis.io/commands/lastsave">Redis Documentation: LASTSAVE</a>
+	 * @see <a href="https://redis.io/commands/lastsave">Redis Documentation: LASTSAVE</a>
 	 */
 	Mono<Long> lastSave();
 
@@ -60,7 +60,7 @@ public interface ReactiveServerCommands {
 	 * Synchronous save current db snapshot on server.
 	 *
 	 * @return {@link Mono} indicating command completion.
-	 * @see <a href="http://redis.io/commands/save">Redis Documentation: SAVE</a>
+	 * @see <a href="https://redis.io/commands/save">Redis Documentation: SAVE</a>
 	 */
 	Mono<String> save();
 
@@ -68,7 +68,7 @@ public interface ReactiveServerCommands {
 	 * Get the total number of available keys in currently selected database.
 	 *
 	 * @return {@link Mono} wrapping number of keys.
-	 * @see <a href="http://redis.io/commands/dbsize">Redis Documentation: DBSIZE</a>
+	 * @see <a href="https://redis.io/commands/dbsize">Redis Documentation: DBSIZE</a>
 	 */
 	Mono<Long> dbSize();
 
@@ -76,7 +76,7 @@ public interface ReactiveServerCommands {
 	 * Delete all keys of the currently selected database.
 	 *
 	 * @return {@link Mono} indicating command completion.
-	 * @see <a href="http://redis.io/commands/flushdb">Redis Documentation: FLUSHDB</a>
+	 * @see <a href="https://redis.io/commands/flushdb">Redis Documentation: FLUSHDB</a>
 	 */
 	Mono<String> flushDb();
 
@@ -84,7 +84,7 @@ public interface ReactiveServerCommands {
 	 * Delete all <b>all keys</b> from <b>all databases</b>.
 	 *
 	 * @return {@link Mono} indicating command completion.
-	 * @see <a href="http://redis.io/commands/flushall">Redis Documentation: FLUSHALL</a>
+	 * @see <a href="https://redis.io/commands/flushall">Redis Documentation: FLUSHALL</a>
 	 */
 	Mono<String> flushAll();
 
@@ -98,7 +98,7 @@ public interface ReactiveServerCommands {
 	 * <p>
 	 *
 	 * @return {@link Mono} wrapping server information.
-	 * @see <a href="http://redis.io/commands/info">Redis Documentation: INFO</a>
+	 * @see <a href="https://redis.io/commands/info">Redis Documentation: INFO</a>
 	 */
 	Mono<Properties> info();
 
@@ -108,7 +108,7 @@ public interface ReactiveServerCommands {
 	 * @param section must not be {@literal null} nor {@literal empty}.
 	 * @return {@link Mono} wrapping server information of given {@code section}.
 	 * @throws IllegalArgumentException when section is {@literal null} or {@literal empty}.
-	 * @see <a href="http://redis.io/commands/info">Redis Documentation: INFO</a>
+	 * @see <a href="https://redis.io/commands/info">Redis Documentation: INFO</a>
 	 */
 	Mono<Properties> info(String section);
 
@@ -118,7 +118,7 @@ public interface ReactiveServerCommands {
 	 * @param pattern must not be {@literal null}.
 	 * @return {@link Mono} wrapping configuration parameters matching given {@code pattern}.
 	 * @throws IllegalArgumentException when {@code pattern} is {@literal null} or {@literal empty}.
-	 * @see <a href="http://redis.io/commands/config-get">Redis Documentation: CONFIG GET</a>
+	 * @see <a href="https://redis.io/commands/config-get">Redis Documentation: CONFIG GET</a>
 	 */
 	Mono<Properties> getConfig(String pattern);
 
@@ -128,7 +128,7 @@ public interface ReactiveServerCommands {
 	 * @param param must not be {@literal null} nor {@literal empty}.
 	 * @param value must not be {@literal null} nor {@literal empty}.
 	 * @throws IllegalArgumentException when {@code pattern} / {@code value} is {@literal null} or {@literal empty}.
-	 * @see <a href="http://redis.io/commands/config-set">Redis Documentation: CONFIG SET</a>
+	 * @see <a href="https://redis.io/commands/config-set">Redis Documentation: CONFIG SET</a>
 	 */
 	Mono<String> setConfig(String param, String value);
 
@@ -137,7 +137,7 @@ public interface ReactiveServerCommands {
 	 * Counters can be retrieved using {@link #info()}.
 	 *
 	 * @return {@link Mono} indicating command completion.
-	 * @see <a href="http://redis.io/commands/config-resetstat">Redis Documentation: CONFIG RESETSTAT</a>
+	 * @see <a href="https://redis.io/commands/config-resetstat">Redis Documentation: CONFIG RESETSTAT</a>
 	 */
 	Mono<String> resetConfigStats();
 
@@ -145,7 +145,7 @@ public interface ReactiveServerCommands {
 	 * Request server timestamp using {@code TIME} command.
 	 *
 	 * @return {@link Mono} wrapping current server time in milliseconds.
-	 * @see <a href="http://redis.io/commands/time">Redis Documentation: TIME</a>
+	 * @see <a href="https://redis.io/commands/time">Redis Documentation: TIME</a>
 	 */
 	Mono<Long> time();
 
@@ -156,7 +156,7 @@ public interface ReactiveServerCommands {
 	 * @param port of connection to close
 	 * @return {@link Mono} wrapping {@link String} representation of the command result.
 	 * @throws IllegalArgumentException if {@code host} is {@literal null} or {@literal empty}.
-	 * @see <a href="http://redis.io/commands/client-kill">Redis Documentation: CLIENT KILL</a>
+	 * @see <a href="https://redis.io/commands/client-kill">Redis Documentation: CLIENT KILL</a>
 	 */
 	Mono<String> killClient(String host, int port);
 
@@ -165,7 +165,7 @@ public interface ReactiveServerCommands {
 	 *
 	 * @param name must not be {@literal null} nor {@literal empty}.
 	 * @throws IllegalArgumentException when {@code name} is {@literal null} or {@literal empty}.
-	 * @see <a href="http://redis.io/commands/client-setname">Redis Documentation: CLIENT SETNAME</a>
+	 * @see <a href="https://redis.io/commands/client-setname">Redis Documentation: CLIENT SETNAME</a>
 	 */
 	Mono<String> setClientName(String name);
 
@@ -173,7 +173,7 @@ public interface ReactiveServerCommands {
 	 * Returns the name of the current connection.
 	 *
 	 * @return {@link Mono} wrapping the connection name.
-	 * @see <a href="http://redis.io/commands/client-getname">Redis Documentation: CLIENT GETNAME</a>
+	 * @see <a href="https://redis.io/commands/client-getname">Redis Documentation: CLIENT GETNAME</a>
 	 */
 	Mono<String> getClientName();
 
@@ -181,7 +181,7 @@ public interface ReactiveServerCommands {
 	 * Request information and statistics about connected clients.
 	 *
 	 * @return {@link Flux} emitting {@link RedisClientInfo} objects.
-	 * @see <a href="http://redis.io/commands/client-list">Redis Documentation: CLIENT LIST</a>
+	 * @see <a href="https://redis.io/commands/client-list">Redis Documentation: CLIENT LIST</a>
 	 */
 	Flux<RedisClientInfo> getClientList();
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
@@ -50,7 +50,7 @@ public interface ReactiveSetCommands {
 	 * {@code SADD} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see <a href="https://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 */
 	class SAddCommand extends KeyCommand {
 
@@ -116,7 +116,7 @@ public interface ReactiveSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see <a href="https://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 */
 	default Mono<Long> sAdd(ByteBuffer key, ByteBuffer value) {
 
@@ -131,7 +131,7 @@ public interface ReactiveSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see <a href="https://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 */
 	default Mono<Long> sAdd(ByteBuffer key, Collection<ByteBuffer> values) {
 
@@ -146,7 +146,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see <a href="https://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 */
 	Flux<NumericResponse<SAddCommand, Long>> sAdd(Publisher<SAddCommand> commands);
 
@@ -154,7 +154,7 @@ public interface ReactiveSetCommands {
 	 * {@code SREM} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see <a href="https://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 */
 	class SRemCommand extends KeyCommand {
 
@@ -220,7 +220,7 @@ public interface ReactiveSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see <a href="https://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 */
 	default Mono<Long> sRem(ByteBuffer key, ByteBuffer value) {
 
@@ -235,7 +235,7 @@ public interface ReactiveSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see <a href="https://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 */
 	default Mono<Long> sRem(ByteBuffer key, Collection<ByteBuffer> values) {
 
@@ -250,7 +250,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see <a href="https://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 */
 	Flux<NumericResponse<SRemCommand, Long>> sRem(Publisher<SRemCommand> commands);
 
@@ -258,7 +258,7 @@ public interface ReactiveSetCommands {
 	 * {@code SPOP} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	class SPopCommand extends KeyCommand {
 
@@ -311,7 +311,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	default Mono<ByteBuffer> sPop(ByteBuffer key) {
 
@@ -326,7 +326,7 @@ public interface ReactiveSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param count number of random members to pop from the set.
 	 * @return
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	default Flux<ByteBuffer> sPop(ByteBuffer key, long count) {
 
@@ -340,7 +340,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param command must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	Flux<ByteBuffer> sPop(SPopCommand command);
 
@@ -349,7 +349,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands
 	 * @return
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	Flux<ByteBufferResponse<KeyCommand>> sPop(Publisher<KeyCommand> commands);
 
@@ -357,7 +357,7 @@ public interface ReactiveSetCommands {
 	 * {@code SMOVE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 * @see <a href="https://redis.io/commands/smove">Redis Documentation: SMOVE</a>
 	 */
 	class SMoveCommand extends KeyCommand {
 
@@ -434,7 +434,7 @@ public interface ReactiveSetCommands {
 	 * @param destinationKey must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 * @see <a href="https://redis.io/commands/smove">Redis Documentation: SMOVE</a>
 	 */
 	default Mono<Boolean> sMove(ByteBuffer sourceKey, ByteBuffer destinationKey, ByteBuffer value) {
 
@@ -451,7 +451,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 * @see <a href="https://redis.io/commands/smove">Redis Documentation: SMOVE</a>
 	 */
 	Flux<BooleanResponse<SMoveCommand>> sMove(Publisher<SMoveCommand> commands);
 
@@ -460,7 +460,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 * @see <a href="https://redis.io/commands/scard">Redis Documentation: SCARD</a>
 	 */
 	default Mono<Long> sCard(ByteBuffer key) {
 
@@ -474,7 +474,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 * @see <a href="https://redis.io/commands/scard">Redis Documentation: SCARD</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> sCard(Publisher<KeyCommand> commands);
 
@@ -482,7 +482,7 @@ public interface ReactiveSetCommands {
 	 * {@code SISMEMBER} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 * @see <a href="https://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
 	 */
 	class SIsMemberCommand extends KeyCommand {
 
@@ -535,7 +535,7 @@ public interface ReactiveSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 * @see <a href="https://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
 	 */
 	default Mono<Boolean> sIsMember(ByteBuffer key, ByteBuffer value) {
 
@@ -550,7 +550,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 * @see <a href="https://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
 	 */
 	Flux<BooleanResponse<SIsMemberCommand>> sIsMember(Publisher<SIsMemberCommand> commands);
 
@@ -558,7 +558,7 @@ public interface ReactiveSetCommands {
 	 * {@code SINTER} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	class SInterCommand implements Command {
 
@@ -604,7 +604,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	default Flux<ByteBuffer> sInter(Collection<ByteBuffer> keys) {
 
@@ -618,7 +618,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	Flux<CommandResponse<SInterCommand, Flux<ByteBuffer>>> sInter(Publisher<SInterCommand> commands);
 
@@ -626,7 +626,7 @@ public interface ReactiveSetCommands {
 	 * {@code SINTERSTORE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	class SInterStoreCommand extends KeyCommand {
 
@@ -680,7 +680,7 @@ public interface ReactiveSetCommands {
 	 * @param destinationKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return size of set stored a {@literal destinationKey}.
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	default Mono<Long> sInterStore(ByteBuffer destinationKey, Collection<ByteBuffer> keys) {
 
@@ -696,7 +696,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	Flux<NumericResponse<SInterStoreCommand, Long>> sInterStore(Publisher<SInterStoreCommand> commands);
 
@@ -704,7 +704,7 @@ public interface ReactiveSetCommands {
 	 * {@code SUNION} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	class SUnionCommand implements Command {
 
@@ -750,7 +750,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	default Flux<ByteBuffer> sUnion(Collection<ByteBuffer> keys) {
 
@@ -764,7 +764,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	Flux<CommandResponse<SUnionCommand, Flux<ByteBuffer>>> sUnion(Publisher<SUnionCommand> commands);
 
@@ -772,7 +772,7 @@ public interface ReactiveSetCommands {
 	 * {@code SUNIONSTORE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	class SUnionStoreCommand extends KeyCommand {
 
@@ -826,7 +826,7 @@ public interface ReactiveSetCommands {
 	 * @param destinationKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return size of set stored a {@literal destinationKey}.
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	default Mono<Long> sUnionStore(ByteBuffer destinationKey, Collection<ByteBuffer> keys) {
 
@@ -842,7 +842,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	Flux<NumericResponse<SUnionStoreCommand, Long>> sUnionStore(Publisher<SUnionStoreCommand> commands);
 
@@ -850,7 +850,7 @@ public interface ReactiveSetCommands {
 	 * {@code SDIFF} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	class SDiffCommand implements Command {
 
@@ -896,7 +896,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	default Flux<ByteBuffer> sDiff(Collection<ByteBuffer> keys) {
 
@@ -910,7 +910,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	Flux<CommandResponse<SDiffCommand, Flux<ByteBuffer>>> sDiff(Publisher<SDiffCommand> commands);
 
@@ -918,7 +918,7 @@ public interface ReactiveSetCommands {
 	 * {@code SDIFFSTORE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	class SDiffStoreCommand extends KeyCommand {
 
@@ -972,7 +972,7 @@ public interface ReactiveSetCommands {
 	 * @param destinationKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return size of set stored a {@literal destinationKey}.
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	default Mono<Long> sDiffStore(ByteBuffer destinationKey, Collection<ByteBuffer> keys) {
 
@@ -988,7 +988,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	Flux<NumericResponse<SDiffStoreCommand, Long>> sDiffStore(Publisher<SDiffStoreCommand> commands);
 
@@ -997,7 +997,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 * @see <a href="https://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
 	default Flux<ByteBuffer> sMembers(ByteBuffer key) {
 
@@ -1011,7 +1011,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 * @see <a href="https://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> sMembers(Publisher<KeyCommand> commands);
 
@@ -1022,7 +1022,7 @@ public interface ReactiveSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @return the {@link Flux} emitting the raw {@link ByteBuffer members} one by one.
 	 * @throws IllegalArgumentException when options is {@literal null}.
-	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @see <a href="https://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<ByteBuffer> sScan(ByteBuffer key) {
@@ -1037,7 +1037,7 @@ public interface ReactiveSetCommands {
 	 * @param options must not be {@literal null}. Use {@link ScanOptions#NONE} instead.
 	 * @return the {@link Flux} emitting the raw {@link ByteBuffer members} one by one.
 	 * @throws IllegalArgumentException when one of the required arguments is {@literal null}.
-	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @see <a href="https://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<ByteBuffer> sScan(ByteBuffer key, ScanOptions options) {
@@ -1052,7 +1052,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @see <a href="https://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
 	 * @since 2.1
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<ByteBuffer>>> sScan(Publisher<KeyScanCommand> commands);
@@ -1061,7 +1061,7 @@ public interface ReactiveSetCommands {
 	 * {@code SRANDMEMBER} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	class SRandMembersCommand extends KeyCommand {
 
@@ -1118,7 +1118,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	default Mono<ByteBuffer> sRandMember(ByteBuffer key) {
 		return sRandMember(key, 1L).singleOrEmpty();
@@ -1130,7 +1130,7 @@ public interface ReactiveSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param count must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	default Flux<ByteBuffer> sRandMember(ByteBuffer key, Long count) {
 
@@ -1145,7 +1145,7 @@ public interface ReactiveSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	Flux<CommandResponse<SRandMembersCommand, Flux<ByteBuffer>>> sRandMember(Publisher<SRandMembersCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
@@ -53,7 +53,7 @@ public interface ReactiveStreamCommands {
 	/**
 	 * {@code XACK} command parameters.
 	 *
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	class AcknowledgeCommand extends KeyCommand {
 
@@ -140,7 +140,7 @@ public interface ReactiveStreamCommands {
 	 * @param group name of the consumer group.
 	 * @param recordIds record Id's to acknowledge.
 	 * @return {@link Mono} emitting the nr of acknowledged messages.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	default Mono<Long> xAck(ByteBuffer key, String group, String... recordIds) {
 
@@ -158,7 +158,7 @@ public interface ReactiveStreamCommands {
 	 * @param group name of the consumer group.
 	 * @param recordIds record Id's to acknowledge.
 	 * @return {@link Mono} emitting the nr of acknowledged messages.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	default Mono<Long> xAck(ByteBuffer key, String group, RecordId... recordIds) {
 
@@ -174,14 +174,14 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} emitting the nr of acknowledged messages per {@link AcknowledgeCommand}.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	Flux<NumericResponse<AcknowledgeCommand, Long>> xAck(Publisher<AcknowledgeCommand> commands);
 
 	/**
 	 * {@code XADD} command parameters.
 	 *
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	class AddStreamRecord extends KeyCommand {
 
@@ -247,7 +247,7 @@ public interface ReactiveStreamCommands {
 	 * @param key must not be {@literal null}.
 	 * @param body must not be {@literal null}.
 	 * @return {@link Mono} emitting the server generated {@link RecordId id}.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	default Mono<RecordId> xAdd(ByteBuffer key, Map<ByteBuffer, ByteBuffer> body) {
 
@@ -262,7 +262,7 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param record must not be {@literal null}.
 	 * @return {@link Mono} the {@link RecordId id}.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	default Mono<RecordId> xAdd(ByteBufferRecord record) {
 
@@ -276,14 +276,14 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} emitting the {@link RecordId} on by for for the given {@link AddStreamRecord} commands.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	Flux<CommandResponse<AddStreamRecord, RecordId>> xAdd(Publisher<AddStreamRecord> commands);
 
 	/**
 	 * {@code XDEL} command parameters.
 	 *
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	class DeleteCommand extends KeyCommand {
 
@@ -350,7 +350,7 @@ public interface ReactiveStreamCommands {
 	 * @param key the stream key.
 	 * @param recordIds stream record Id's.
 	 * @return {@link Mono} emitting the number of removed entries.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	default Mono<Long> xDel(ByteBuffer key, String... recordIds) {
 
@@ -367,7 +367,7 @@ public interface ReactiveStreamCommands {
 	 * @param key the stream key.
 	 * @param recordIds stream record Id's.
 	 * @return {@link Mono} emitting the number of removed entries.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	default Mono<Long> xDel(ByteBuffer key, RecordId... recordIds) {
 
@@ -383,7 +383,7 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Mono} emitting the number of removed entries.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	Flux<CommandResponse<DeleteCommand, Long>> xDel(Publisher<DeleteCommand> commands);
 
@@ -392,7 +392,7 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@link Mono} emitting the length of the stream.
-	 * @see <a href="http://redis.io/commands/xlen">Redis Documentation: XLEN</a>
+	 * @see <a href="https://redis.io/commands/xlen">Redis Documentation: XLEN</a>
 	 */
 	default Mono<Long> xLen(ByteBuffer key) {
 
@@ -406,15 +406,15 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} emitting the length of the stream per {@link KeyCommand}.
-	 * @see <a href="http://redis.io/commands/xlen">Redis Documentation: XLEN</a>
+	 * @see <a href="https://redis.io/commands/xlen">Redis Documentation: XLEN</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> xLen(Publisher<KeyCommand> commands);
 
 	/**
 	 * {@code XRANGE}/{@code XREVRANGE} command parameters.
 	 *
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	class RangeCommand extends KeyCommand {
 
@@ -502,7 +502,7 @@ public interface ReactiveStreamCommands {
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return {@link Flux} emitting with members of the stream.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	default Flux<ByteBufferRecord> xRange(ByteBuffer key, Range<String> range) {
 		return xRange(key, range, Limit.unlimited());
@@ -515,7 +515,7 @@ public interface ReactiveStreamCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return {@link Flux} emitting with members of the stream.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	default Flux<ByteBufferRecord> xRange(ByteBuffer key, Range<String> range, Limit limit) {
 
@@ -532,15 +532,15 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} emitting with members of the stream per {@link RangeCommand}.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	Flux<CommandResponse<RangeCommand, Flux<ByteBufferRecord>>> xRange(Publisher<RangeCommand> commands);
 
 	/**
 	 * {@code XRANGE}/{@code XREVRANGE} command parameters.
 	 *
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	class ReadCommand {
 
@@ -634,7 +634,7 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param streams the streams to read from.
 	 * @return {@link Flux} emitting with members of the stream.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	default Flux<ByteBufferRecord> xRead(StreamOffset<ByteBuffer>... streams) {
 		return xRead(StreamReadOptions.empty(), streams);
@@ -646,7 +646,7 @@ public interface ReactiveStreamCommands {
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return {@link Flux} emitting with members of the stream.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	default Flux<ByteBufferRecord> xRead(StreamReadOptions readOptions, StreamOffset<ByteBuffer>... streams) {
 
@@ -662,8 +662,8 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} emitting the members of the stream per {@link ReadCommand}.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	Flux<CommandResponse<ReadCommand, Flux<ByteBufferRecord>>> read(Publisher<ReadCommand> commands);
 
@@ -810,7 +810,7 @@ public interface ReactiveStreamCommands {
 	 * @param consumer consumer/group.
 	 * @param streams the streams to read from.
 	 * @return {@link Flux} emitting the members of the stream
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	default Flux<ByteBufferRecord> xReadGroup(Consumer consumer, StreamOffset<ByteBuffer>... streams) {
 		return xReadGroup(consumer, StreamReadOptions.empty(), streams);
@@ -823,7 +823,7 @@ public interface ReactiveStreamCommands {
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return {@link Flux} emitting the members of the stream.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	default Flux<ByteBufferRecord> xReadGroup(Consumer consumer, StreamReadOptions readOptions,
 			StreamOffset<ByteBuffer>... streams) {
@@ -842,7 +842,7 @@ public interface ReactiveStreamCommands {
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return {@link Flux} emitting the members of the stream in reverse.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	default Flux<ByteBufferRecord> xRevRange(ByteBuffer key, Range<String> range) {
 		return xRevRange(key, range, Limit.unlimited());
@@ -855,7 +855,7 @@ public interface ReactiveStreamCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return {@link Flux} emitting the members of the stream in reverse.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	default Flux<ByteBufferRecord> xRevRange(ByteBuffer key, Range<String> range, Limit limit) {
 
@@ -872,14 +872,14 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} emitting the members of the stream in reverse.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	Flux<CommandResponse<RangeCommand, Flux<ByteBufferRecord>>> xRevRange(Publisher<RangeCommand> commands);
 
 	/**
 	 * {@code XTRIM} command parameters.
 	 *
-	 * @see <a href="http://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
+	 * @see <a href="https://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
 	 */
 	class TrimCommand extends KeyCommand {
 
@@ -930,7 +930,7 @@ public interface ReactiveStreamCommands {
 	 * @param key the stream key.
 	 * @param count length of the stream.
 	 * @return {@link Mono} emitting the number of removed entries.
-	 * @see <a href="http://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
+	 * @see <a href="https://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
 	 */
 	default Mono<Long> xTrim(ByteBuffer key, long count) {
 
@@ -944,7 +944,7 @@ public interface ReactiveStreamCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} emitting the number of removed entries per {@link TrimCommand}.
-	 * @see <a href="http://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
+	 * @see <a href="https://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> xTrim(Publisher<TrimCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
@@ -55,7 +55,7 @@ public interface ReactiveStringCommands {
 	 * {@code SET} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	class SetCommand extends KeyCommand {
 
@@ -154,7 +154,7 @@ public interface ReactiveStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	default Mono<Boolean> set(ByteBuffer key, ByteBuffer value) {
 
@@ -172,7 +172,7 @@ public interface ReactiveStringCommands {
 	 * @param expiration must not be {@literal null}.
 	 * @param option must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	default Mono<Boolean> set(ByteBuffer key, ByteBuffer value, Expiration expiration, SetOption option) {
 
@@ -188,7 +188,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link BooleanResponse} holding the {@link SetCommand} along with the command result.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	Flux<BooleanResponse<SetCommand>> set(Publisher<SetCommand> commands);
 
@@ -197,7 +197,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@link Mono#empty()} in case {@literal key} does not exist.
-	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 * @see <a href="https://redis.io/commands/get">Redis Documentation: GET</a>
 	 */
 	default Mono<ByteBuffer> get(ByteBuffer key) {
 
@@ -213,7 +213,7 @@ public interface ReactiveStringCommands {
 	 * @param keys must not be {@literal null}.
 	 * @return {@link Flux} of {@link ByteBufferResponse} holding the {@literal key} to get along with the value
 	 *         retrieved.
-	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 * @see <a href="https://redis.io/commands/get">Redis Documentation: GET</a>
 	 */
 	Flux<ByteBufferResponse<KeyCommand>> get(Publisher<KeyCommand> keys);
 
@@ -223,7 +223,7 @@ public interface ReactiveStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@link Mono#empty()} if key did not exist.
-	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 * @see <a href="https://redis.io/commands/getset">Redis Documentation: GETSET</a>
 	 */
 	default Mono<ByteBuffer> getSet(ByteBuffer key, ByteBuffer value) {
 
@@ -240,7 +240,7 @@ public interface ReactiveStringCommands {
 	 * @param commands must not be {@literal null}.
 	 * @return {@link Flux} of {@link ByteBufferResponse} holding the {@link SetCommand} along with the previously
 	 *         existing value.
-	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 * @see <a href="https://redis.io/commands/getset">Redis Documentation: GETSET</a>
 	 */
 	Flux<ByteBufferResponse<SetCommand>> getSet(Publisher<SetCommand> commands);
 
@@ -249,7 +249,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/mget">Redis Documentation: MGET</a>
+	 * @see <a href="https://redis.io/commands/mget">Redis Documentation: MGET</a>
 	 */
 	default Mono<List<ByteBuffer>> mGet(List<ByteBuffer> keys) {
 
@@ -263,7 +263,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param keysets must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/mget">Redis Documentation: MGET</a>
+	 * @see <a href="https://redis.io/commands/mget">Redis Documentation: MGET</a>
 	 */
 	Flux<MultiValueResponse<List<ByteBuffer>, ByteBuffer>> mGet(Publisher<List<ByteBuffer>> keysets);
 
@@ -273,7 +273,7 @@ public interface ReactiveStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 * @see <a href="https://redis.io/commands/setnx">Redis Documentation: SETNX</a>
 	 */
 	default Mono<Boolean> setNX(ByteBuffer key, ByteBuffer value) {
 
@@ -288,7 +288,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param values must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 * @see <a href="https://redis.io/commands/setnx">Redis Documentation: SETNX</a>
 	 */
 	Flux<BooleanResponse<SetCommand>> setNX(Publisher<SetCommand> values);
 
@@ -299,7 +299,7 @@ public interface ReactiveStringCommands {
 	 * @param value must not be {@literal null}.
 	 * @param expireTimeout must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see <a href="https://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 */
 	default Mono<Boolean> setEX(ByteBuffer key, ByteBuffer value, Expiration expireTimeout) {
 
@@ -316,7 +316,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see <a href="https://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 */
 	Flux<BooleanResponse<SetCommand>> setEX(Publisher<SetCommand> commands);
 
@@ -327,7 +327,7 @@ public interface ReactiveStringCommands {
 	 * @param value must not be {@literal null}.
 	 * @param expireTimeout must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
+	 * @see <a href="https://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
 	 */
 	default Mono<Boolean> pSetEX(ByteBuffer key, ByteBuffer value, Expiration expireTimeout) {
 
@@ -344,7 +344,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
+	 * @see <a href="https://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
 	 */
 	Flux<BooleanResponse<SetCommand>> pSetEX(Publisher<SetCommand> commands);
 
@@ -352,7 +352,7 @@ public interface ReactiveStringCommands {
 	 * {@code MSET} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 * @see <a href="https://redis.io/commands/mset">Redis Documentation: MSET</a>
 	 */
 	class MSetCommand implements Command {
 
@@ -398,7 +398,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param keyValuePairs must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 * @see <a href="https://redis.io/commands/mset">Redis Documentation: MSET</a>
 	 */
 	default Mono<Boolean> mSet(Map<ByteBuffer, ByteBuffer> keyValuePairs) {
 
@@ -412,7 +412,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 * @see <a href="https://redis.io/commands/mset">Redis Documentation: MSET</a>
 	 */
 	Flux<BooleanResponse<MSetCommand>> mSet(Publisher<MSetCommand> commands);
 
@@ -422,7 +422,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param keyValuePairs must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
+	 * @see <a href="https://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
 	 */
 	default Mono<Boolean> mSetNX(Map<ByteBuffer, ByteBuffer> keyValuePairs) {
 
@@ -437,7 +437,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param source must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
+	 * @see <a href="https://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
 	 */
 	Flux<BooleanResponse<MSetCommand>> mSetNX(Publisher<MSetCommand> source);
 
@@ -445,7 +445,7 @@ public interface ReactiveStringCommands {
 	 * {@code APPEND} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 * @see <a href="https://redis.io/commands/append">Redis Documentation: APPEND</a>
 	 */
 	class AppendCommand extends KeyCommand {
 
@@ -499,7 +499,7 @@ public interface ReactiveStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 * @see <a href="https://redis.io/commands/append">Redis Documentation: APPEND</a>
 	 */
 	default Mono<Long> append(ByteBuffer key, ByteBuffer value) {
 
@@ -514,7 +514,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 * @see <a href="https://redis.io/commands/append">Redis Documentation: APPEND</a>
 	 */
 	Flux<NumericResponse<AppendCommand, Long>> append(Publisher<AppendCommand> commands);
 
@@ -525,7 +525,7 @@ public interface ReactiveStringCommands {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 * @see <a href="https://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
 	 */
 	default Mono<ByteBuffer> getRange(ByteBuffer key, long start, long end) {
 
@@ -541,7 +541,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 * @see <a href="https://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
 	 */
 	Flux<ByteBufferResponse<RangeCommand>> getRange(Publisher<RangeCommand> commands);
 
@@ -549,7 +549,7 @@ public interface ReactiveStringCommands {
 	 * {@code SETRANGE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 * @see <a href="https://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
 	 */
 	class SetRangeCommand extends KeyCommand {
 
@@ -623,7 +623,7 @@ public interface ReactiveStringCommands {
 	 * @param value must not be {@literal null}.
 	 * @param offset
 	 * @return
-	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 * @see <a href="https://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
 	 */
 	default Mono<Long> setRange(ByteBuffer key, ByteBuffer value, long offset) {
 
@@ -640,7 +640,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 * @see <a href="https://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
 	 */
 	Flux<NumericResponse<SetRangeCommand, Long>> setRange(Publisher<SetRangeCommand> commands);
 
@@ -648,7 +648,7 @@ public interface ReactiveStringCommands {
 	 * {@code GETBIT} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
+	 * @see <a href="https://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
 	 */
 	class GetBitCommand extends KeyCommand {
 
@@ -699,7 +699,7 @@ public interface ReactiveStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param offset
 	 * @return
-	 * @see <a href="http://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
+	 * @see <a href="https://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
 	 */
 	default Mono<Boolean> getBit(ByteBuffer key, long offset) {
 
@@ -713,7 +713,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
+	 * @see <a href="https://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
 	 */
 	Flux<BooleanResponse<GetBitCommand>> getBit(Publisher<GetBitCommand> commands);
 
@@ -721,7 +721,7 @@ public interface ReactiveStringCommands {
 	 * {@code SETBIT} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
+	 * @see <a href="https://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
 	 */
 	class SetBitCommand extends KeyCommand {
 
@@ -805,7 +805,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
+	 * @see <a href="https://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
 	 */
 	Flux<BooleanResponse<SetBitCommand>> setBit(Publisher<SetBitCommand> commands);
 
@@ -813,7 +813,7 @@ public interface ReactiveStringCommands {
 	 * {@code BITCOUNT} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see <a href="https://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 */
 	class BitCountCommand extends KeyCommand {
 
@@ -865,7 +865,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see <a href="https://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 */
 	default Mono<Long> bitCount(ByteBuffer key) {
 
@@ -882,7 +882,7 @@ public interface ReactiveStringCommands {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see <a href="https://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 */
 	default Mono<Long> bitCount(ByteBuffer key, long start, long end) {
 
@@ -899,7 +899,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see <a href="https://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 */
 	Flux<NumericResponse<BitCountCommand, Long>> bitCount(Publisher<BitCountCommand> commands);
 
@@ -907,7 +907,7 @@ public interface ReactiveStringCommands {
 	 * {@code BITFIELD} command parameters.
 	 *
 	 * @author Mark Paluch
-	 * @see <a href="http://redis.io/commands/bitfield">Redis Documentation: BITFIELD</a>
+	 * @see <a href="https://redis.io/commands/bitfield">Redis Documentation: BITFIELD</a>
 	 * @since 2.1
 	 */
 	class BitFieldCommand extends KeyCommand {
@@ -960,7 +960,7 @@ public interface ReactiveStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param subCommands
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitfield">Redis Documentation: BITFIELD</a>
+	 * @see <a href="https://redis.io/commands/bitfield">Redis Documentation: BITFIELD</a>
 	 * @since 2.1
 	 */
 	default Mono<List<Long>> bitField(ByteBuffer key, BitFieldSubCommands subCommands) {
@@ -978,7 +978,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitfield">Redis Documentation: BITFIELD</a>
+	 * @see <a href="https://redis.io/commands/bitfield">Redis Documentation: BITFIELD</a>
 	 * @since 2.1
 	 */
 	Flux<MultiValueResponse<BitFieldCommand, Long>> bitField(Publisher<BitFieldCommand> commands);
@@ -987,7 +987,7 @@ public interface ReactiveStringCommands {
 	 * {@code BITOP} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/bitop">Redis Documentation: BITOP</a>
+	 * @see <a href="https://redis.io/commands/bitop">Redis Documentation: BITOP</a>
 	 */
 	class BitOpCommand {
 
@@ -1073,7 +1073,7 @@ public interface ReactiveStringCommands {
 	 * @param bitOp must not be {@literal null}.
 	 * @param destination must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitop">Redis Documentation: BITOP</a>
+	 * @see <a href="https://redis.io/commands/bitop">Redis Documentation: BITOP</a>
 	 */
 	default Mono<Long> bitOp(Collection<ByteBuffer> keys, BitOperation bitOp, ByteBuffer destination) {
 
@@ -1091,7 +1091,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitop">Redis Documentation: BITOP</a>
+	 * @see <a href="https://redis.io/commands/bitop">Redis Documentation: BITOP</a>
 	 */
 	Flux<NumericResponse<BitOpCommand, Long>> bitOp(Publisher<BitOpCommand> commands);
 
@@ -1174,7 +1174,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 * @see <a href="https://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
 	 */
 	default Mono<Long> strLen(ByteBuffer key) {
 
@@ -1188,7 +1188,7 @@ public interface ReactiveStringCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 * @see <a href="https://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> strLen(Publisher<KeyCommand> keys);
 }

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveZSetCommands.java
@@ -54,7 +54,7 @@ public interface ReactiveZSetCommands {
 	 * {@code ZADD} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	class ZAddCommand extends KeyCommand {
 
@@ -189,7 +189,7 @@ public interface ReactiveZSetCommands {
 	 * @param score must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	default Mono<Long> zAdd(ByteBuffer key, Double score, ByteBuffer value) {
 
@@ -207,7 +207,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param tuples must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	default Mono<Long> zAdd(ByteBuffer key, Collection<? extends Tuple> tuples) {
 
@@ -223,7 +223,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	Flux<NumericResponse<ZAddCommand, Number>> zAdd(Publisher<ZAddCommand> commands);
 
@@ -231,7 +231,7 @@ public interface ReactiveZSetCommands {
 	 * {@code ZREM} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	class ZRemCommand extends KeyCommand {
 
@@ -297,7 +297,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	default Mono<Long> zRem(ByteBuffer key, ByteBuffer value) {
 
@@ -312,7 +312,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	default Mono<Long> zRem(ByteBuffer key, Collection<ByteBuffer> values) {
 
@@ -327,7 +327,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	Flux<NumericResponse<ZRemCommand, Long>> zRem(Publisher<ZRemCommand> commands);
 
@@ -335,7 +335,7 @@ public interface ReactiveZSetCommands {
 	 * {@code ZINCRBY} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 */
 	class ZIncrByCommand extends KeyCommand {
 
@@ -413,7 +413,7 @@ public interface ReactiveZSetCommands {
 	 * @param increment must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 */
 	default Mono<Double> zIncrBy(ByteBuffer key, Number increment, ByteBuffer value) {
 
@@ -431,7 +431,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 */
 	Flux<NumericResponse<ZIncrByCommand, Double>> zIncrBy(Publisher<ZIncrByCommand> commands);
 
@@ -439,8 +439,8 @@ public interface ReactiveZSetCommands {
 	 * {@code ZRANK}/{@literal ZREVRANK} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
-	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 * @see <a href="https://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 * @see <a href="https://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 */
 	class ZRankCommand extends KeyCommand {
 
@@ -516,7 +516,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 * @see <a href="https://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
 	 */
 	default Mono<Long> zRank(ByteBuffer key, ByteBuffer value) {
 
@@ -532,7 +532,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 * @see <a href="https://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 */
 	default Mono<Long> zRevRank(ByteBuffer key, ByteBuffer value) {
 
@@ -549,8 +549,8 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
-	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 * @see <a href="https://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 * @see <a href="https://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 */
 	Flux<NumericResponse<ZRankCommand, Long>> zRank(Publisher<ZRankCommand> commands);
 
@@ -558,8 +558,8 @@ public interface ReactiveZSetCommands {
 	 * {@code ZRANGE}/{@literal ZREVRANGE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	class ZRangeCommand extends KeyCommand {
 
@@ -655,7 +655,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	default Flux<ByteBuffer> zRange(ByteBuffer key, Range<Long> range) {
 
@@ -672,7 +672,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	default Flux<Tuple> zRangeWithScores(ByteBuffer key, Range<Long> range) {
 
@@ -688,7 +688,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	default Flux<ByteBuffer> zRevRange(ByteBuffer key, Range<Long> range) {
 
@@ -704,7 +704,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	default Flux<Tuple> zRevRangeWithScores(ByteBuffer key, Range<Long> range) {
 
@@ -719,8 +719,8 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	Flux<CommandResponse<ZRangeCommand, Flux<Tuple>>> zRange(Publisher<ZRangeCommand> commands);
 
@@ -728,8 +728,8 @@ public interface ReactiveZSetCommands {
 	 * {@literal ZRANGEBYSCORE}/{@literal ZREVRANGEBYSCORE}.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	class ZRangeByScoreCommand extends KeyCommand {
 
@@ -847,7 +847,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	default Flux<ByteBuffer> zRangeByScore(ByteBuffer key, Range<Double> range) {
 
@@ -866,7 +866,7 @@ public interface ReactiveZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	default Flux<ByteBuffer> zRangeByScore(ByteBuffer key, Range<Double> range, Limit limit) {
 
@@ -885,7 +885,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	default Flux<Tuple> zRangeByScoreWithScores(ByteBuffer key, Range<Double> range) {
 
@@ -903,7 +903,7 @@ public interface ReactiveZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	default Flux<Tuple> zRangeByScoreWithScores(ByteBuffer key, Range<Double> range, Limit limit) {
 
@@ -921,7 +921,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	default Flux<ByteBuffer> zRevRangeByScore(ByteBuffer key, Range<Double> range) {
 
@@ -939,7 +939,7 @@ public interface ReactiveZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	default Flux<ByteBuffer> zRevRangeByScore(ByteBuffer key, Range<Double> range, Limit limit) {
 
@@ -958,7 +958,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	default Flux<Tuple> zRevRangeByScoreWithScores(ByteBuffer key, Range<Double> range) {
 
@@ -976,7 +976,7 @@ public interface ReactiveZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	default Flux<Tuple> zRevRangeByScoreWithScores(ByteBuffer key, Range<Double> range, Limit limit) {
 
@@ -994,8 +994,8 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Flux<CommandResponse<ZRangeByScoreCommand, Flux<Tuple>>> zRangeByScore(Publisher<ZRangeByScoreCommand> commands);
 
@@ -1006,7 +1006,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @return the {@link Flux} emitting the raw {@link Tuple tuples} one by one.
 	 * @throws IllegalArgumentException when key is {@literal null}.
-	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @see <a href="https://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<Tuple> zScan(ByteBuffer key) {
@@ -1021,7 +1021,7 @@ public interface ReactiveZSetCommands {
 	 * @param options must not be {@literal null}. Use {@link ScanOptions#NONE} instead.
 	 * @return the {@link Flux} emitting the raw {@link Tuple tuples} one by one.
 	 * @throws IllegalArgumentException when one of the required arguments is {@literal null}.
-	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @see <a href="https://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<Tuple> zScan(ByteBuffer key, ScanOptions options) {
@@ -1036,7 +1036,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @see <a href="https://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
 	 * @since 2.1
 	 */
 	Flux<CommandResponse<KeyCommand, Flux<Tuple>>> zScan(Publisher<KeyScanCommand> commands);
@@ -1045,7 +1045,7 @@ public interface ReactiveZSetCommands {
 	 * {@code ZCOUNT} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see <a href="https://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	class ZCountCommand extends KeyCommand {
 
@@ -1099,7 +1099,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see <a href="https://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	default Mono<Long> zCount(ByteBuffer key, Range<Double> range) {
 
@@ -1116,7 +1116,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see <a href="https://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	Flux<NumericResponse<ZCountCommand, Long>> zCount(Publisher<ZCountCommand> commands);
 
@@ -1125,7 +1125,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see <a href="https://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 */
 	default Mono<Long> zCard(ByteBuffer key) {
 
@@ -1139,7 +1139,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see <a href="https://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 */
 	Flux<NumericResponse<KeyCommand, Long>> zCard(Publisher<KeyCommand> commands);
 
@@ -1147,7 +1147,7 @@ public interface ReactiveZSetCommands {
 	 * {@code ZSCORE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
+	 * @see <a href="https://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
 	 */
 	class ZScoreCommand extends KeyCommand {
 
@@ -1199,7 +1199,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
+	 * @see <a href="https://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
 	 */
 	default Mono<Double> zScore(ByteBuffer key, ByteBuffer value) {
 
@@ -1215,7 +1215,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
+	 * @see <a href="https://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
 	 */
 	Flux<NumericResponse<ZScoreCommand, Double>> zScore(Publisher<ZScoreCommand> commands);
 
@@ -1223,7 +1223,7 @@ public interface ReactiveZSetCommands {
 	 * {@code ZREMRANGEBYRANK} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
 	 */
 	class ZRemRangeByRankCommand extends KeyCommand {
 
@@ -1274,7 +1274,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
 	 */
 	default Mono<Long> zRemRangeByRank(ByteBuffer key, Range<Long> range) {
 
@@ -1290,7 +1290,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
 	 */
 	Flux<NumericResponse<ZRemRangeByRankCommand, Long>> zRemRangeByRank(Publisher<ZRemRangeByRankCommand> commands);
 
@@ -1298,7 +1298,7 @@ public interface ReactiveZSetCommands {
 	 * {@code ZREMRANGEBYSCORE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	class ZRemRangeByScoreCommand extends KeyCommand {
 
@@ -1347,7 +1347,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	default Mono<Long> zRemRangeByScore(ByteBuffer key, Range<Double> range) {
 
@@ -1363,7 +1363,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	Flux<NumericResponse<ZRemRangeByScoreCommand, Long>> zRemRangeByScore(Publisher<ZRemRangeByScoreCommand> commands);
 
@@ -1371,7 +1371,7 @@ public interface ReactiveZSetCommands {
 	 * {@code ZUNIONSTORE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	class ZUnionStoreCommand extends KeyCommand {
 
@@ -1476,7 +1476,7 @@ public interface ReactiveZSetCommands {
 	 * @param destinationKey must not be {@literal null}.
 	 * @param sets must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets) {
 		return zUnionStore(destinationKey, sets, Collections.emptyList());
@@ -1490,7 +1490,7 @@ public interface ReactiveZSetCommands {
 	 * @param sets must not be {@literal null}.
 	 * @param weights must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights) {
 		return zUnionStore(destinationKey, sets, weights, null);
@@ -1505,7 +1505,7 @@ public interface ReactiveZSetCommands {
 	 * @param weights must not be {@literal null}.
 	 * @return
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets, Weights weights) {
 		return zUnionStore(destinationKey, sets, weights, null);
@@ -1520,7 +1520,7 @@ public interface ReactiveZSetCommands {
 	 * @param weights can be {@literal null}.
 	 * @param aggregateFunction can be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights,
 			@Nullable Aggregate aggregateFunction) {
@@ -1543,7 +1543,7 @@ public interface ReactiveZSetCommands {
 	 * @param aggregateFunction can be {@literal null}.
 	 * @return
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	default Mono<Long> zUnionStore(ByteBuffer destinationKey, List<ByteBuffer> sets, Weights weights,
 			@Nullable Aggregate aggregateFunction) {
@@ -1562,7 +1562,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands
 	 * @return
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	Flux<NumericResponse<ZUnionStoreCommand, Long>> zUnionStore(Publisher<ZUnionStoreCommand> commands);
 
@@ -1570,7 +1570,7 @@ public interface ReactiveZSetCommands {
 	 * {@code ZINTERSTORE} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	class ZInterStoreCommand extends KeyCommand {
 
@@ -1676,7 +1676,7 @@ public interface ReactiveZSetCommands {
 	 * @param destinationKey must not be {@literal null}.
 	 * @param sets must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets) {
 		return zInterStore(destinationKey, sets, Collections.emptyList());
@@ -1690,7 +1690,7 @@ public interface ReactiveZSetCommands {
 	 * @param sets must not be {@literal null}.
 	 * @param weights must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights) {
 		return zInterStore(destinationKey, sets, weights, null);
@@ -1705,7 +1705,7 @@ public interface ReactiveZSetCommands {
 	 * @param weights must not be {@literal null}.
 	 * @return
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets, Weights weights) {
 		return zInterStore(destinationKey, sets, weights, null);
@@ -1720,7 +1720,7 @@ public interface ReactiveZSetCommands {
 	 * @param weights must not be {@literal null}.
 	 * @param aggregateFunction can be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets, List<Double> weights,
 			@Nullable Aggregate aggregateFunction) {
@@ -1743,7 +1743,7 @@ public interface ReactiveZSetCommands {
 	 * @param aggregateFunction can be {@literal null}.
 	 * @return
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	default Mono<Long> zInterStore(ByteBuffer destinationKey, List<ByteBuffer> sets, Weights weights,
 			@Nullable Aggregate aggregateFunction) {
@@ -1762,7 +1762,7 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands
 	 * @return
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	Flux<NumericResponse<ZInterStoreCommand, Long>> zInterStore(Publisher<ZInterStoreCommand> commands);
 
@@ -1770,8 +1770,8 @@ public interface ReactiveZSetCommands {
 	 * {@code ZRANGEBYLEX}/{@literal ZREVRANGEBYLEX} command parameters.
 	 *
 	 * @author Christoph Strobl
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
-	 * @see <a href="http://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
 	 */
 	class ZRangeByLexCommand extends KeyCommand {
 
@@ -1868,7 +1868,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	default Flux<ByteBuffer> zRangeByLex(ByteBuffer key, Range<String> range) {
 		return zRangeByLex(key, range, Limit.unlimited());
@@ -1882,7 +1882,7 @@ public interface ReactiveZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit can be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	default Flux<ByteBuffer> zRangeByLex(ByteBuffer key, Range<String> range, Limit limit) {
 
@@ -1899,7 +1899,7 @@ public interface ReactiveZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
 	 */
 	default Flux<ByteBuffer> zRevRangeByLex(ByteBuffer key, Range<String> range) {
 		return zRevRangeByLex(key, range, Limit.unlimited());
@@ -1913,7 +1913,7 @@ public interface ReactiveZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
 	 */
 	default Flux<ByteBuffer> zRevRangeByLex(ByteBuffer key, Range<String> range, Limit limit) {
 
@@ -1931,8 +1931,8 @@ public interface ReactiveZSetCommands {
 	 *
 	 * @param commands must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
-	 * @see <a href="http://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
 	 */
 	Flux<CommandResponse<ZRangeByLexCommand, Flux<ByteBuffer>>> zRangeByLex(Publisher<ZRangeByLexCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} using connecting
- * to <a href="http://redis.io/topics/cluster-spec">Redis Cluster</a>. Useful when setting up a high availability Redis
+ * to <a href="https://redis.io/topics/cluster-spec">Redis Cluster</a>. Useful when setting up a high availability Redis
  * environment.
  *
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConnection.java
@@ -58,7 +58,7 @@ public interface RedisClusterConnection extends RedisConnection, RedisClusterCom
 	 * @param options must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @see <a href="https://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 */
 	Cursor<byte[]> scan(RedisClusterNode node, ScanOptions options);
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisConnectionCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisConnectionCommands.java
@@ -30,7 +30,7 @@ public interface RedisConnectionCommands {
 	 * Select the DB with given positive {@code dbIndex}.
 	 *
 	 * @param dbIndex the database index.
-	 * @see <a href="http://redis.io/commands/select">Redis Documentation: SELECT</a>
+	 * @see <a href="https://redis.io/commands/select">Redis Documentation: SELECT</a>
 	 */
 	void select(int dbIndex);
 
@@ -39,7 +39,7 @@ public interface RedisConnectionCommands {
 	 *
 	 * @param message the message to echo.
 	 * @return the message or {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/echo">Redis Documentation: ECHO</a>
+	 * @see <a href="https://redis.io/commands/echo">Redis Documentation: ECHO</a>
 	 */
 	@Nullable
 	byte[] echo(byte[] message);
@@ -48,7 +48,7 @@ public interface RedisConnectionCommands {
 	 * Test connection.
 	 *
 	 * @return Server response message - usually {@literal PONG}. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/ping">Redis Documentation: PING</a>
+	 * @see <a href="https://redis.io/commands/ping">Redis Documentation: PING</a>
 	 */
 	@Nullable
 	String ping();

--- a/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
@@ -49,7 +49,7 @@ public interface RedisGeoCommands {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long geoAdd(byte[] key, Point point, byte[] member);
@@ -60,7 +60,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	default Long geoAdd(byte[] key, GeoLocation<byte[]> location) {
@@ -77,7 +77,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long geoAdd(byte[] key, Map<byte[], Point> memberCoordinateMap);
@@ -88,7 +88,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long geoAdd(byte[] key, Iterable<GeoLocation<byte[]>> locations);
@@ -100,7 +100,7 @@ public interface RedisGeoCommands {
 	 * @param member1 must not be {@literal null}.
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	@Nullable
 	Distance geoDist(byte[] key, byte[] member1, byte[] member2);
@@ -113,7 +113,7 @@ public interface RedisGeoCommands {
 	 * @param member2 must not be {@literal null}.
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	@Nullable
 	Distance geoDist(byte[] key, byte[] member1, byte[] member2, Metric metric);
@@ -124,7 +124,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return empty list when key or members do not exists. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	@Nullable
 	List<String> geoHash(byte[] key, byte[]... members);
@@ -135,7 +135,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return empty {@link List} when key of members do not exist. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	@Nullable
 	List<Point> geoPos(byte[] key, byte[]... members);
@@ -146,7 +146,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param within must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within);
@@ -158,7 +158,7 @@ public interface RedisGeoCommands {
 	 * @param within must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<byte[]>> geoRadius(byte[] key, Circle within, GeoRadiusCommandArgs args);
@@ -171,7 +171,7 @@ public interface RedisGeoCommands {
 	 * @param member must not be {@literal null}.
 	 * @param radius
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	@Nullable
 	default GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, double radius) {
@@ -186,7 +186,7 @@ public interface RedisGeoCommands {
 	 * @param member must not be {@literal null}.
 	 * @param radius must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction..
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius);
@@ -200,7 +200,7 @@ public interface RedisGeoCommands {
 	 * @param radius must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<byte[]>> geoRadiusByMember(byte[] key, byte[] member, Distance radius,
@@ -212,7 +212,7 @@ public interface RedisGeoCommands {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return Number of elements removed. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	@Nullable
 	Long geoRemove(byte[] key, byte[]... members);

--- a/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
@@ -39,7 +39,7 @@ public interface RedisHashCommands {
 	 * @param field must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hset">Redis Documentation: HSET</a>
+	 * @see <a href="https://redis.io/commands/hset">Redis Documentation: HSET</a>
 	 */
 	@Nullable
 	Boolean hSet(byte[] key, byte[] field, byte[] value);
@@ -51,7 +51,7 @@ public interface RedisHashCommands {
 	 * @param field must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hsetnx">Redis Documentation: HSETNX</a>
+	 * @see <a href="https://redis.io/commands/hsetnx">Redis Documentation: HSETNX</a>
 	 */
 	@Nullable
 	Boolean hSetNX(byte[] key, byte[] field, byte[] value);
@@ -62,7 +62,7 @@ public interface RedisHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param field must not be {@literal null}.
 	 * @return {@literal null} when key or field do not exists or when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hget">Redis Documentation: HGET</a>
+	 * @see <a href="https://redis.io/commands/hget">Redis Documentation: HGET</a>
 	 */
 	@Nullable
 	byte[] hGet(byte[] key, byte[] field);
@@ -73,7 +73,7 @@ public interface RedisHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param fields must not be {@literal empty}.
 	 * @return empty {@link List} if key or fields do not exists. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hmget">Redis Documentation: HMGET</a>
+	 * @see <a href="https://redis.io/commands/hmget">Redis Documentation: HMGET</a>
 	 */
 	@Nullable
 	List<byte[]> hMGet(byte[] key, byte[]... fields);
@@ -83,7 +83,7 @@ public interface RedisHashCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param hashes must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/hmset">Redis Documentation: HMSET</a>
+	 * @see <a href="https://redis.io/commands/hmset">Redis Documentation: HMSET</a>
 	 */
 	void hMSet(byte[] key, Map<byte[], byte[]> hashes);
 
@@ -94,7 +94,7 @@ public interface RedisHashCommands {
 	 * @param field must not be {@literal null}.
 	 * @param delta
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
+	 * @see <a href="https://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
 	 */
 	@Nullable
 	Long hIncrBy(byte[] key, byte[] field, long delta);
@@ -106,7 +106,7 @@ public interface RedisHashCommands {
 	 * @param field must not be {@literal null}.
 	 * @param delta
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hincrbyfloat">Redis Documentation: HINCRBYFLOAT</a>
+	 * @see <a href="https://redis.io/commands/hincrbyfloat">Redis Documentation: HINCRBYFLOAT</a>
 	 */
 	@Nullable
 	Double hIncrBy(byte[] key, byte[] field, double delta);
@@ -117,7 +117,7 @@ public interface RedisHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param field must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hexits">Redis Documentation: HEXISTS</a>
+	 * @see <a href="https://redis.io/commands/hexits">Redis Documentation: HEXISTS</a>
 	 */
 	@Nullable
 	Boolean hExists(byte[] key, byte[] field);
@@ -128,7 +128,7 @@ public interface RedisHashCommands {
 	 * @param key must not be {@literal null}.
 	 * @param fields must not be {@literal empty}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hdel">Redis Documentation: HDEL</a>
+	 * @see <a href="https://redis.io/commands/hdel">Redis Documentation: HDEL</a>
 	 */
 	@Nullable
 	Long hDel(byte[] key, byte[]... fields);
@@ -138,7 +138,7 @@ public interface RedisHashCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hlen">Redis Documentation: HLEN</a>
+	 * @see <a href="https://redis.io/commands/hlen">Redis Documentation: HLEN</a>
 	 */
 	@Nullable
 	Long hLen(byte[] key);
@@ -148,7 +148,7 @@ public interface RedisHashCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>?
+	 * @see <a href="https://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>?
 	 */
 	@Nullable
 	Set<byte[]> hKeys(byte[] key);
@@ -158,7 +158,7 @@ public interface RedisHashCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return empty {@link List} if key does not exist. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hvals">Redis Documentation: HVALS</a>
+	 * @see <a href="https://redis.io/commands/hvals">Redis Documentation: HVALS</a>
 	 */
 	@Nullable
 	List<byte[]> hVals(byte[] key);
@@ -168,7 +168,7 @@ public interface RedisHashCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return empty {@link Map} if key does not exist or {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
+	 * @see <a href="https://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
 	 */
 	@Nullable
 	Map<byte[], byte[]> hGetAll(byte[] key);
@@ -180,7 +180,7 @@ public interface RedisHashCommands {
 	 * @param options must not be {@literal null}.
 	 * @return
 	 * @since 1.4
-	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @see <a href="https://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
 	 */
 	Cursor<Map.Entry<byte[], byte[]>> hScan(byte[] key, ScanOptions options);
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisHyperLogLogCommands.java
@@ -32,7 +32,7 @@ public interface RedisHyperLogLogCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
+	 * @see <a href="https://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
 	 */
 	@Nullable
 	Long pfAdd(byte[] key, byte[]... values);
@@ -42,7 +42,7 @@ public interface RedisHyperLogLogCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
+	 * @see <a href="https://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
 	 */
 	@Nullable
 	Long pfCount(byte[]... keys);
@@ -52,7 +52,7 @@ public interface RedisHyperLogLogCommands {
 	 *
 	 * @param destinationKey must not be {@literal null}.
 	 * @param sourceKeys must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
+	 * @see <a href="https://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
 	 */
 	void pfMerge(byte[] destinationKey, byte[]... sourceKeys);
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisKeyCommands.java
@@ -39,7 +39,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal true} if key exists. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
+	 * @see <a href="https://redis.io/commands/exists">Redis Documentation: EXISTS</a>
 	 */
 	@Nullable
 	default Boolean exists(byte[] key) {
@@ -66,7 +66,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	@Nullable
 	Long del(byte[]... keys);
@@ -77,7 +77,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -88,7 +88,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/type">Redis Documentation: TYPE</a>
+	 * @see <a href="https://redis.io/commands/type">Redis Documentation: TYPE</a>
 	 */
 	@Nullable
 	DataType type(byte[] key);
@@ -98,7 +98,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/touch">Redis Documentation: TOUCH</a>
+	 * @see <a href="https://redis.io/commands/touch">Redis Documentation: TOUCH</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -109,7 +109,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param pattern must not be {@literal null}.
 	 * @return empty {@link Set} if no match found. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
+	 * @see <a href="https://redis.io/commands/keys">Redis Documentation: KEYS</a>
 	 */
 	@Nullable
 	Set<byte[]> keys(byte[] pattern);
@@ -120,7 +120,7 @@ public interface RedisKeyCommands {
 	 * @param options must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 1.4
-	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @see <a href="https://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 */
 	Cursor<byte[]> scan(ScanOptions options);
 
@@ -128,7 +128,7 @@ public interface RedisKeyCommands {
 	 * Return a random key from the keyspace.
 	 *
 	 * @return {@literal null} if no keys available or when used in pipeline or transaction.
-	 * @see <a href="http://redis.io/commands/randomkey">Redis Documentation: RANDOMKEY</a>
+	 * @see <a href="https://redis.io/commands/randomkey">Redis Documentation: RANDOMKEY</a>
 	 */
 	@Nullable
 	byte[] randomKey();
@@ -138,7 +138,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param sourceKey must not be {@literal null}.
 	 * @param targetKey must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/rename">Redis Documentation: RENAME</a>
+	 * @see <a href="https://redis.io/commands/rename">Redis Documentation: RENAME</a>
 	 */
 	void rename(byte[] sourceKey, byte[] targetKey);
 
@@ -148,7 +148,7 @@ public interface RedisKeyCommands {
 	 * @param sourceKey must not be {@literal null}.
 	 * @param targetKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
+	 * @see <a href="https://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
 	 */
 	@Nullable
 	Boolean renameNX(byte[] sourceKey, byte[] targetKey);
@@ -159,7 +159,7 @@ public interface RedisKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param seconds
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
+	 * @see <a href="https://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
 	 */
 	@Nullable
 	Boolean expire(byte[] key, long seconds);
@@ -170,7 +170,7 @@ public interface RedisKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param millis
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
+	 * @see <a href="https://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
 	 */
 	@Nullable
 	Boolean pExpire(byte[] key, long millis);
@@ -181,7 +181,7 @@ public interface RedisKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param unixTime
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
 	 */
 	@Nullable
 	Boolean expireAt(byte[] key, long unixTime);
@@ -192,7 +192,7 @@ public interface RedisKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param unixTimeInMillis
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
 	 */
 	@Nullable
 	Boolean pExpireAt(byte[] key, long unixTimeInMillis);
@@ -202,7 +202,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/persist">Redis Documentation: PERSIST</a>
+	 * @see <a href="https://redis.io/commands/persist">Redis Documentation: PERSIST</a>
 	 */
 	@Nullable
 	Boolean persist(byte[] key);
@@ -213,7 +213,7 @@ public interface RedisKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param dbIndex
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/move">Redis Documentation: MOVE</a>
+	 * @see <a href="https://redis.io/commands/move">Redis Documentation: MOVE</a>
 	 */
 	@Nullable
 	Boolean move(byte[] key, int dbIndex);
@@ -223,7 +223,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see <a href="https://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 */
 	@Nullable
 	Long ttl(byte[] key);
@@ -235,7 +235,7 @@ public interface RedisKeyCommands {
 	 * @param timeUnit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see <a href="https://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 */
 	@Nullable
 	Long ttl(byte[] key, TimeUnit timeUnit);
@@ -245,7 +245,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
+	 * @see <a href="https://redis.io/commands/pttl">Redis Documentation: PTTL</a>
 	 */
 	@Nullable
 	Long pTtl(byte[] key);
@@ -257,7 +257,7 @@ public interface RedisKeyCommands {
 	 * @param timeUnit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
+	 * @see <a href="https://redis.io/commands/pttl">Redis Documentation: PTTL</a>
 	 */
 	@Nullable
 	Long pTtl(byte[] key, TimeUnit timeUnit);
@@ -268,7 +268,7 @@ public interface RedisKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param params must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 * @see <a href="https://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	@Nullable
 	List<byte[]> sort(byte[] key, SortParameters params);
@@ -280,7 +280,7 @@ public interface RedisKeyCommands {
 	 * @param params must not be {@literal null}.
 	 * @param storeKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 * @see <a href="https://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	@Nullable
 	Long sort(byte[] key, SortParameters params, byte[] storeKey);
@@ -290,7 +290,7 @@ public interface RedisKeyCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} if key does not exist or when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/dump">Redis Documentation: DUMP</a>
+	 * @see <a href="https://redis.io/commands/dump">Redis Documentation: DUMP</a>
 	 */
 	@Nullable
 	byte[] dump(byte[] key);
@@ -301,7 +301,7 @@ public interface RedisKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @param ttlInMillis
 	 * @param serializedValue must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/restore">Redis Documentation: RESTORE</a>
+	 * @see <a href="https://redis.io/commands/restore">Redis Documentation: RESTORE</a>
 	 */
 	default void restore(byte[] key, long ttlInMillis, byte[] serializedValue) {
 		restore(key, ttlInMillis, serializedValue, false);
@@ -315,7 +315,7 @@ public interface RedisKeyCommands {
 	 * @param serializedValue must not be {@literal null}.
 	 * @param replace use {@literal true} to replace a potentially existing value instead of erroring.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/restore">Redis Documentation: RESTORE</a>
+	 * @see <a href="https://redis.io/commands/restore">Redis Documentation: RESTORE</a>
 	 */
 	void restore(byte[] key, long ttlInMillis, byte[] serializedValue, boolean replace);
 
@@ -326,7 +326,7 @@ public interface RedisKeyCommands {
 	 * @return {@link org.springframework.data.redis.connection.ValueEncoding.RedisValueEncoding#VACANT} if key does not
 	 *         exist or {@literal null} when used in pipeline / transaction.
 	 * @throws IllegalArgumentException if {@code key} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/object">Redis Documentation: OBJECT ENCODING</a>
+	 * @see <a href="https://redis.io/commands/object">Redis Documentation: OBJECT ENCODING</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -338,7 +338,7 @@ public interface RedisKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} if key does not exist or when used in pipeline / transaction.
 	 * @throws IllegalArgumentException if {@code key} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/object">Redis Documentation: OBJECT IDLETIME</a>
+	 * @see <a href="https://redis.io/commands/object">Redis Documentation: OBJECT IDLETIME</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -350,7 +350,7 @@ public interface RedisKeyCommands {
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} if key does not exist or when used in pipeline / transaction.
 	 * @throws IllegalArgumentException if {@code key} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/object">Redis Documentation: OBJECT REFCOUNT</a>
+	 * @see <a href="https://redis.io/commands/object">Redis Documentation: OBJECT REFCOUNT</a>
 	 * @since 2.1
 	 */
 	@Nullable

--- a/src/main/java/org/springframework/data/redis/connection/RedisListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisListCommands.java
@@ -41,7 +41,7 @@ public interface RedisListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be empty.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	@Nullable
 	Long rPush(byte[] key, byte[]... values);
@@ -52,7 +52,7 @@ public interface RedisListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be empty.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	@Nullable
 	Long lPush(byte[] key, byte[]... values);
@@ -63,7 +63,7 @@ public interface RedisListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
+	 * @see <a href="https://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
 	 */
 	@Nullable
 	Long rPushX(byte[] key, byte[] value);
@@ -74,7 +74,7 @@ public interface RedisListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
+	 * @see <a href="https://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
 	 */
 	@Nullable
 	Long lPushX(byte[] key, byte[] value);
@@ -84,7 +84,7 @@ public interface RedisListCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 * @see <a href="https://redis.io/commands/llen">Redis Documentation: LLEN</a>
 	 */
 	@Nullable
 	Long lLen(byte[] key);
@@ -97,7 +97,7 @@ public interface RedisListCommands {
 	 * @param end
 	 * @return empty {@link List} if key does not exists or range does not contain values. {@literal null} when used in
 	 *         pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 * @see <a href="https://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
 	@Nullable
 	List<byte[]> lRange(byte[] key, long start, long end);
@@ -108,7 +108,7 @@ public interface RedisListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param start
 	 * @param end
-	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 * @see <a href="https://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
 	 */
 	void lTrim(byte[] key, long start, long end);
 
@@ -118,7 +118,7 @@ public interface RedisListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param index zero based index value. Use negative number to designate elements starting at the tail.
 	 * @return {@literal null} when index is out of range or when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 * @see <a href="https://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
 	 */
 	@Nullable
 	byte[] lIndex(byte[] key, long index);
@@ -131,7 +131,7 @@ public interface RedisListCommands {
 	 * @param pivot must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
+	 * @see <a href="https://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
 	 */
 	@Nullable
 	Long lInsert(byte[] key, Position where, byte[] pivot, byte[] value);
@@ -142,7 +142,7 @@ public interface RedisListCommands {
 	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @param value
-	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 * @see <a href="https://redis.io/commands/lset">Redis Documentation: LSET</a>
 	 */
 	void lSet(byte[] key, long index, byte[] value);
 
@@ -153,7 +153,7 @@ public interface RedisListCommands {
 	 * @param count
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see <a href="https://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 */
 	@Nullable
 	Long lRem(byte[] key, long count, byte[] value);
@@ -163,7 +163,7 @@ public interface RedisListCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 * @see <a href="https://redis.io/commands/lpop">Redis Documentation: LPOP</a>
 	 */
 	@Nullable
 	byte[] lPop(byte[] key);
@@ -173,7 +173,7 @@ public interface RedisListCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 * @see <a href="https://redis.io/commands/rpop">Redis Documentation: RPOP</a>
 	 */
 	@Nullable
 	byte[] rPop(byte[] key);
@@ -186,7 +186,7 @@ public interface RedisListCommands {
 	 * @param keys must not be {@literal null}.
 	 * @return empty {@link List} when no element could be popped and the timeout was reached. {@literal null} when used
 	 *         in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
 	 * @see #lPop(byte[])
 	 */
 	@Nullable
@@ -200,7 +200,7 @@ public interface RedisListCommands {
 	 * @param keys must not be {@literal null}.
 	 * @return empty {@link List} when no element could be popped and the timeout was reached. {@literal null} when used
 	 *         in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
 	 * @see #rPop(byte[])
 	 */
 	@Nullable
@@ -212,7 +212,7 @@ public interface RedisListCommands {
 	 * @param srcKey must not be {@literal null}.
 	 * @param dstKey must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
 	 */
 	@Nullable
 	byte[] rPopLPush(byte[] srcKey, byte[] dstKey);
@@ -225,7 +225,7 @@ public interface RedisListCommands {
 	 * @param srcKey must not be {@literal null}.
 	 * @param dstKey must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
 	 * @see #rPopLPush(byte[], byte[])
 	 */
 	@Nullable

--- a/src/main/java/org/springframework/data/redis/connection/RedisPubSubCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisPubSubCommands.java
@@ -47,7 +47,7 @@ public interface RedisPubSubCommands {
 	 * @param channel the channel to publish to. Must not be {@literal null}.
 	 * @param message message to publish. Must not be {@literal null}.
 	 * @return the number of clients that received the message or {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 * @see <a href="https://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
 	 */
 	@Nullable
 	Long publish(byte[] channel, byte[] message);
@@ -60,7 +60,7 @@ public interface RedisPubSubCommands {
 	 *
 	 * @param listener message listener, must not be {@literal null}.
 	 * @param channels channel names, must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/subscribe">Redis Documentation: SUBSCRIBE</a>
+	 * @see <a href="https://redis.io/commands/subscribe">Redis Documentation: SUBSCRIBE</a>
 	 */
 	void subscribe(MessageListener listener, byte[]... channels);
 
@@ -73,7 +73,7 @@ public interface RedisPubSubCommands {
 	 *
 	 * @param listener message listener, must not be {@literal null}.
 	 * @param patterns channel name patterns, must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
+	 * @see <a href="https://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
 	 */
 	void pSubscribe(MessageListener listener, byte[]... patterns);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisScriptingCommands.java
@@ -32,14 +32,14 @@ public interface RedisScriptingCommands {
 	/**
 	 * Flush lua script cache.
 	 *
-	 * @see <a href="http://redis.io/commands/script-flush">Redis Documentation: SCRIPT FLUSH</a>
+	 * @see <a href="https://redis.io/commands/script-flush">Redis Documentation: SCRIPT FLUSH</a>
 	 */
 	void scriptFlush();
 
 	/**
 	 * Kill current lua script execution.
 	 *
-	 * @see <a href="http://redis.io/commands/script-kill">Redis Documentation: SCRIPT KILL</a>
+	 * @see <a href="https://redis.io/commands/script-kill">Redis Documentation: SCRIPT KILL</a>
 	 */
 	void scriptKill();
 
@@ -49,7 +49,7 @@ public interface RedisScriptingCommands {
 	 *
 	 * @param script must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/script-load">Redis Documentation: SCRIPT LOAD</a>
+	 * @see <a href="https://redis.io/commands/script-load">Redis Documentation: SCRIPT LOAD</a>
 	 */
 	@Nullable
 	String scriptLoad(byte[] script);
@@ -60,7 +60,7 @@ public interface RedisScriptingCommands {
 	 * @param scriptShas
 	 * @return one entry per given scriptSha in returned {@link List} or {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/script-exists">Redis Documentation: SCRIPT EXISTS</a>
+	 * @see <a href="https://redis.io/commands/script-exists">Redis Documentation: SCRIPT EXISTS</a>
 	 */
 	@Nullable
 	List<Boolean> scriptExists(String... scriptShas);
@@ -73,7 +73,7 @@ public interface RedisScriptingCommands {
 	 * @param numKeys
 	 * @param keysAndArgs must not be {@literal null}.
 	 * @return script result. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/eval">Redis Documentation: EVAL</a>
+	 * @see <a href="https://redis.io/commands/eval">Redis Documentation: EVAL</a>
 	 */
 	@Nullable
 	<T> T eval(byte[] script, ReturnType returnType, int numKeys, byte[]... keysAndArgs);
@@ -86,7 +86,7 @@ public interface RedisScriptingCommands {
 	 * @param numKeys
 	 * @param keysAndArgs must not be {@literal null}.
 	 * @return script result. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
+	 * @see <a href="https://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
 	 */
 	@Nullable
 	<T> T evalSha(String scriptSha, ReturnType returnType, int numKeys, byte[]... keysAndArgs);
@@ -100,7 +100,7 @@ public interface RedisScriptingCommands {
 	 * @param keysAndArgs must not be {@literal null}.
 	 * @return script result. {@literal null} when used in pipeline / transaction.
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
+	 * @see <a href="https://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
 	 */
 	@Nullable
 	<T> T evalSha(byte[] scriptSha, ReturnType returnType, int numKeys, byte[]... keysAndArgs);

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} using connecting
- * to <a href="http://redis.io/topics/sentinel">Redis Sentinel(s)</a>. Useful when setting up a high availability Redis
+ * to <a href="https://redis.io/topics/sentinel">Redis Sentinel(s)</a>. Useful when setting up a high availability Redis
  * environment.
  *
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/RedisServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisServerCommands.java
@@ -46,7 +46,7 @@ public interface RedisServerCommands {
 	 * Start an {@literal Append Only File} rewrite process on server.
 	 *
 	 * @deprecated As of 1.3, use {@link #bgReWriteAof}.
-	 * @see <a href="http://redis.io/commands/bgrewriteaof">Redis Documentation: BGREWRITEAOF</a>
+	 * @see <a href="https://redis.io/commands/bgrewriteaof">Redis Documentation: BGREWRITEAOF</a>
 	 */
 	@Deprecated
 	default void bgWriteAof() {
@@ -57,14 +57,14 @@ public interface RedisServerCommands {
 	 * Start an {@literal Append Only File} rewrite process on server.
 	 *
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/bgrewriteaof">Redis Documentation: BGREWRITEAOF</a>
+	 * @see <a href="https://redis.io/commands/bgrewriteaof">Redis Documentation: BGREWRITEAOF</a>
 	 */
 	void bgReWriteAof();
 
 	/**
 	 * Start background saving of db on server.
 	 *
-	 * @see <a href="http://redis.io/commands/bgsave">Redis Documentation: BGSAVE</a>
+	 * @see <a href="https://redis.io/commands/bgsave">Redis Documentation: BGSAVE</a>
 	 */
 	void bgSave();
 
@@ -72,7 +72,7 @@ public interface RedisServerCommands {
 	 * Get time of last {@link #bgSave()} operation in seconds.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lastsave">Redis Documentation: LASTSAVE</a>
+	 * @see <a href="https://redis.io/commands/lastsave">Redis Documentation: LASTSAVE</a>
 	 */
 	@Nullable
 	Long lastSave();
@@ -80,7 +80,7 @@ public interface RedisServerCommands {
 	/**
 	 * Synchronous save current db snapshot on server.
 	 *
-	 * @see <a href="http://redis.io/commands/save">Redis Documentation: SAVE</a>
+	 * @see <a href="https://redis.io/commands/save">Redis Documentation: SAVE</a>
 	 */
 	void save();
 
@@ -88,7 +88,7 @@ public interface RedisServerCommands {
 	 * Get the total number of available keys in currently selected database.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/dbsize">Redis Documentation: DBSIZE</a>
+	 * @see <a href="https://redis.io/commands/dbsize">Redis Documentation: DBSIZE</a>
 	 */
 	@Nullable
 	Long dbSize();
@@ -96,14 +96,14 @@ public interface RedisServerCommands {
 	/**
 	 * Delete all keys of the currently selected database.
 	 *
-	 * @see <a href="http://redis.io/commands/flushdb">Redis Documentation: FLUSHDB</a>
+	 * @see <a href="https://redis.io/commands/flushdb">Redis Documentation: FLUSHDB</a>
 	 */
 	void flushDb();
 
 	/**
 	 * Delete all <b>all keys</b> from <b>all databases</b>.
 	 *
-	 * @see <a href="http://redis.io/commands/flushall">Redis Documentation: FLUSHALL</a>
+	 * @see <a href="https://redis.io/commands/flushall">Redis Documentation: FLUSHALL</a>
 	 */
 	void flushAll();
 
@@ -117,7 +117,7 @@ public interface RedisServerCommands {
 	 * <p>
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/info">Redis Documentation: INFO</a>
+	 * @see <a href="https://redis.io/commands/info">Redis Documentation: INFO</a>
 	 */
 	@Nullable
 	Properties info();
@@ -126,7 +126,7 @@ public interface RedisServerCommands {
 	 * Load server information for given {@code selection}.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/info">Redis Documentation: INFO</a>
+	 * @see <a href="https://redis.io/commands/info">Redis Documentation: INFO</a>
 	 */
 	@Nullable
 	Properties info(String section);
@@ -134,14 +134,14 @@ public interface RedisServerCommands {
 	/**
 	 * Shutdown server.
 	 *
-	 * @see <a href="http://redis.io/commands/shutdown">Redis Documentation: SHUTDOWN</a>
+	 * @see <a href="https://redis.io/commands/shutdown">Redis Documentation: SHUTDOWN</a>
 	 */
 	void shutdown();
 
 	/**
 	 * Shutdown server.
 	 *
-	 * @see <a href="http://redis.io/commands/shutdown">Redis Documentation: SHUTDOWN</a>
+	 * @see <a href="https://redis.io/commands/shutdown">Redis Documentation: SHUTDOWN</a>
 	 * @since 1.3
 	 */
 	void shutdown(ShutdownOption option);
@@ -151,7 +151,7 @@ public interface RedisServerCommands {
 	 *
 	 * @param pattern must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/config-get">Redis Documentation: CONFIG GET</a>
+	 * @see <a href="https://redis.io/commands/config-get">Redis Documentation: CONFIG GET</a>
 	 */
 	@Nullable
 	Properties getConfig(String pattern);
@@ -161,7 +161,7 @@ public interface RedisServerCommands {
 	 *
 	 * @param param must not be {@literal null}.
 	 * @param value must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/config-set">Redis Documentation: CONFIG SET</a>
+	 * @see <a href="https://redis.io/commands/config-set">Redis Documentation: CONFIG SET</a>
 	 */
 	void setConfig(String param, String value);
 
@@ -169,7 +169,7 @@ public interface RedisServerCommands {
 	 * Reset statistic counters on server. <br>
 	 * Counters can be retrieved using {@link #info()}.
 	 *
-	 * @see <a href="http://redis.io/commands/config-resetstat">Redis Documentation: CONFIG RESETSTAT</a>
+	 * @see <a href="https://redis.io/commands/config-resetstat">Redis Documentation: CONFIG RESETSTAT</a>
 	 */
 	void resetConfigStats();
 
@@ -178,7 +178,7 @@ public interface RedisServerCommands {
 	 *
 	 * @return current server time in milliseconds or {@literal null} when used in pipeline / transaction.
 	 * @since 1.1
-	 * @see <a href="http://redis.io/commands/time">Redis Documentation: TIME</a>
+	 * @see <a href="https://redis.io/commands/time">Redis Documentation: TIME</a>
 	 */
 	@Nullable
 	Long time();
@@ -189,7 +189,7 @@ public interface RedisServerCommands {
 	 * @param host of connection to close.
 	 * @param port of connection to close
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/client-kill">Redis Documentation: CLIENT KILL</a>
+	 * @see <a href="https://redis.io/commands/client-kill">Redis Documentation: CLIENT KILL</a>
 	 */
 	void killClient(String host, int port);
 
@@ -198,14 +198,14 @@ public interface RedisServerCommands {
 	 *
 	 * @param name
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/client-setname">Redis Documentation: CLIENT SETNAME</a>
+	 * @see <a href="https://redis.io/commands/client-setname">Redis Documentation: CLIENT SETNAME</a>
 	 */
 	void setClientName(byte[] name);
 
 	/**
 	 * Returns the name of the current connection.
 	 *
-	 * @see <a href="http://redis.io/commands/client-getname">Redis Documentation: CLIENT GETNAME</a>
+	 * @see <a href="https://redis.io/commands/client-getname">Redis Documentation: CLIENT GETNAME</a>
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.3
 	 */
@@ -217,7 +217,7 @@ public interface RedisServerCommands {
 	 *
 	 * @return {@link List} of {@link RedisClientInfo} objects or {@literal null} when used in pipeline / transaction.
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/client-list">Redis Documentation: CLIENT LIST</a>
+	 * @see <a href="https://redis.io/commands/client-list">Redis Documentation: CLIENT LIST</a>
 	 */
 	@Nullable
 	List<RedisClientInfo> getClientList();
@@ -228,7 +228,7 @@ public interface RedisServerCommands {
 	 * @param host must not be {@literal null}.
 	 * @param port
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
+	 * @see <a href="https://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
 	 */
 	void slaveOf(String host, int port);
 
@@ -236,7 +236,7 @@ public interface RedisServerCommands {
 	 * Change server into master.
 	 *
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
+	 * @see <a href="https://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
 	 */
 	void slaveOfNoOne();
 
@@ -249,7 +249,7 @@ public interface RedisServerCommands {
 	 * @param dbIndex
 	 * @param option can be {@literal null}. Defaulted to {@link MigrateOption#COPY}.
 	 * @since 1.7
-	 * @see <a href="http://redis.io/commands/migrate">Redis Documentation: MIGRATE</a>
+	 * @see <a href="https://redis.io/commands/migrate">Redis Documentation: MIGRATE</a>
 	 */
 	void migrate(byte[] key, RedisNode target, int dbIndex, @Nullable MigrateOption option);
 
@@ -263,7 +263,7 @@ public interface RedisServerCommands {
 	 * @param option can be {@literal null}. Defaulted to {@link MigrateOption#COPY}.
 	 * @param timeout
 	 * @since 1.7
-	 * @see <a href="http://redis.io/commands/migrate">Redis Documentation: MIGRATE</a>
+	 * @see <a href="https://redis.io/commands/migrate">Redis Documentation: MIGRATE</a>
 	 */
 	void migrate(byte[] key, RedisNode target, int dbIndex, @Nullable MigrateOption option, long timeout);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSetCommands.java
@@ -37,7 +37,7 @@ public interface RedisSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be empty.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see <a href="https://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 */
 	@Nullable
 	Long sAdd(byte[] key, byte[]... values);
@@ -48,7 +48,7 @@ public interface RedisSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be empty.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see <a href="https://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 */
 	@Nullable
 	Long sRem(byte[] key, byte[]... values);
@@ -58,7 +58,7 @@ public interface RedisSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	@Nullable
 	byte[] sPop(byte[] key);
@@ -69,7 +69,7 @@ public interface RedisSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param count number of random members to pop from the set.
 	 * @return empty {@link List} if set does not exist. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 * @since 2.0
 	 */
 	@Nullable
@@ -82,7 +82,7 @@ public interface RedisSetCommands {
 	 * @param destKey must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 * @see <a href="https://redis.io/commands/smove">Redis Documentation: SMOVE</a>
 	 */
 	@Nullable
 	Boolean sMove(byte[] srcKey, byte[] destKey, byte[] value);
@@ -92,7 +92,7 @@ public interface RedisSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 * @see <a href="https://redis.io/commands/scard">Redis Documentation: SCARD</a>
 	 */
 	@Nullable
 	Long sCard(byte[] key);
@@ -103,7 +103,7 @@ public interface RedisSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 * @see <a href="https://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
 	 */
 	@Nullable
 	Boolean sIsMember(byte[] key, byte[] value);
@@ -113,7 +113,7 @@ public interface RedisSetCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return empty {@link Set} if no intersection found. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	@Nullable
 	Set<byte[]> sInter(byte[]... keys);
@@ -124,7 +124,7 @@ public interface RedisSetCommands {
 	 * @param destKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	@Nullable
 	Long sInterStore(byte[] destKey, byte[]... keys);
@@ -134,7 +134,7 @@ public interface RedisSetCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return empty {@link Set} if keys do not exist. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	@Nullable
 	Set<byte[]> sUnion(byte[]... keys);
@@ -145,7 +145,7 @@ public interface RedisSetCommands {
 	 * @param destKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	@Nullable
 	Long sUnionStore(byte[] destKey, byte[]... keys);
@@ -155,7 +155,7 @@ public interface RedisSetCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	@Nullable
 	Set<byte[]> sDiff(byte[]... keys);
@@ -166,7 +166,7 @@ public interface RedisSetCommands {
 	 * @param destKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	@Nullable
 	Long sDiffStore(byte[] destKey, byte[]... keys);
@@ -176,7 +176,7 @@ public interface RedisSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return empty {@link Set} when key does not exist. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 * @see <a href="https://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
 	@Nullable
 	Set<byte[]> sMembers(byte[] key);
@@ -186,7 +186,7 @@ public interface RedisSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	@Nullable
 	byte[] sRandMember(byte[] key);
@@ -197,7 +197,7 @@ public interface RedisSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	@Nullable
 	List<byte[]> sRandMember(byte[] key, long count);
@@ -209,7 +209,7 @@ public interface RedisSetCommands {
 	 * @param options must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 1.4
-	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @see <a href="https://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 */
 	Cursor<byte[]> sScan(byte[] key, ScanOptions options);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisSocketConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSocketConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.util.Assert;
 
 /**
  * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} connecting to
- * single <a href="http://redis.io/">Redis</a> using a local unix domain socket.
+ * single <a href="https://redis.io/">Redis</a> using a local unix domain socket.
  *
  * @author Mark Paluch
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
@@ -22,7 +22,7 @@ import org.springframework.util.Assert;
 
 /**
  * Configuration class used for setting up {@link RedisConnection} via {@link RedisConnectionFactory} using connecting
- * to a single node <a href="http://redis.io/">Redis</a> installation.
+ * to a single node <a href="https://redis.io/">Redis</a> installation.
  *
  * @author Mark Paluch
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
@@ -41,7 +41,7 @@ public interface RedisStreamCommands {
 	 * @param group name of the consumer group.
 	 * @param recordIds the String representation of the {@literal id's} of the records to acknowledge.
 	 * @return length of acknowledged messages. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	@Nullable
 	default Long xAck(byte[] key, String group, String... recordIds) {
@@ -55,7 +55,7 @@ public interface RedisStreamCommands {
 	 * @param group name of the consumer group.
 	 * @param recordIds the {@literal id's} of the records to acknowledge.
 	 * @return length of acknowledged messages. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	@Nullable
 	Long xAck(byte[] key, String group, RecordId... recordIds);
@@ -66,7 +66,7 @@ public interface RedisStreamCommands {
 	 * @param key the {@literal key} the stream is stored at.
 	 * @param content the records content modeled as {@link Map field/value pairs}.
 	 * @return the server generated {@link RecordId id}. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	@Nullable
 	default RecordId xAdd(byte[] key, Map<byte[], byte[]> content) {
@@ -90,7 +90,7 @@ public interface RedisStreamCommands {
 	 * @param key the {@literal key} the stream is stored at.
 	 * @param recordIds the id's of the records to remove.
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	@Nullable
 	default Long xDel(byte[] key, String... recordIds) {
@@ -104,7 +104,7 @@ public interface RedisStreamCommands {
 	 * @param key the {@literal key} the stream is stored at.
 	 * @param recordIds the id's of the records to remove.
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	Long xDel(byte[] key, RecordId... recordIds);
 
@@ -157,7 +157,7 @@ public interface RedisStreamCommands {
 	 *
 	 * @param key the {@literal key} the stream is stored at.
 	 * @return length of the stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xlen">Redis Documentation: XLEN</a>
+	 * @see <a href="https://redis.io/commands/xlen">Redis Documentation: XLEN</a>
 	 */
 	@Nullable
 	Long xLen(byte[] key);
@@ -170,7 +170,7 @@ public interface RedisStreamCommands {
 	 * @param key the {@literal key} the stream is stored at.
 	 * @param range must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	@Nullable
 	default List<ByteRecord> xRange(byte[] key, Range<String> range) {
@@ -187,7 +187,7 @@ public interface RedisStreamCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	@Nullable
 	List<ByteRecord> xRange(byte[] key, Range<String> range, Limit limit);
@@ -197,7 +197,7 @@ public interface RedisStreamCommands {
 	 *
 	 * @param streams the streams to read from.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	default List<ByteRecord> xRead(StreamOffset<byte[]>... streams) {
@@ -210,7 +210,7 @@ public interface RedisStreamCommands {
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	List<ByteRecord> xRead(StreamReadOptions readOptions, StreamOffset<byte[]>... streams);
@@ -221,7 +221,7 @@ public interface RedisStreamCommands {
 	 * @param consumer consumer/group.
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	default List<ByteRecord> xReadGroup(Consumer consumer, StreamOffset<byte[]>... streams) {
@@ -235,7 +235,7 @@ public interface RedisStreamCommands {
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	List<ByteRecord> xReadGroup(Consumer consumer, StreamReadOptions readOptions, StreamOffset<byte[]>... streams);
@@ -246,7 +246,7 @@ public interface RedisStreamCommands {
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	@Nullable
 	default List<ByteRecord> xRevRange(byte[] key, Range<String> range) {
@@ -260,7 +260,7 @@ public interface RedisStreamCommands {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	@Nullable
 	List<ByteRecord> xRevRange(byte[] key, Range<String> range, Limit limit);
@@ -271,7 +271,7 @@ public interface RedisStreamCommands {
 	 * @param key the stream key.
 	 * @param count length of the stream.
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
+	 * @see <a href="https://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
 	 */
 	@Nullable
 	Long xTrim(byte[] key, long count);

--- a/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
@@ -40,7 +40,7 @@ public interface RedisStringCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 * @see <a href="https://redis.io/commands/get">Redis Documentation: GET</a>
 	 */
 	@Nullable
 	byte[] get(byte[] key);
@@ -51,7 +51,7 @@ public interface RedisStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} if key did not exist before or when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 * @see <a href="https://redis.io/commands/getset">Redis Documentation: GETSET</a>
 	 */
 	@Nullable
 	byte[] getSet(byte[] key, byte[] value);
@@ -61,7 +61,7 @@ public interface RedisStringCommands {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return empty {@link List} if keys do not exist or when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/mget">Redis Documentation: MGET</a>
+	 * @see <a href="https://redis.io/commands/mget">Redis Documentation: MGET</a>
 	 */
 	@Nullable
 	List<byte[]> mGet(byte[]... keys);
@@ -72,7 +72,7 @@ public interface RedisStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	@Nullable
 	Boolean set(byte[] key, byte[] value);
@@ -87,7 +87,7 @@ public interface RedisStringCommands {
 	 * @param option must not be {@literal null}. Use {@link SetOption#upsert()} to add non existing.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.7
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	@Nullable
 	Boolean set(byte[] key, byte[] value, Expiration expiration, SetOption option);
@@ -98,7 +98,7 @@ public interface RedisStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 * @see <a href="https://redis.io/commands/setnx">Redis Documentation: SETNX</a>
 	 */
 	@Nullable
 	Boolean setNX(byte[] key, byte[] value);
@@ -110,7 +110,7 @@ public interface RedisStringCommands {
 	 * @param seconds
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see <a href="https://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 */
 	@Nullable
 	Boolean setEx(byte[] key, long seconds, byte[] value);
@@ -123,7 +123,7 @@ public interface RedisStringCommands {
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
+	 * @see <a href="https://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
 	 */
 	@Nullable
 	Boolean pSetEx(byte[] key, long milliseconds, byte[] value);
@@ -133,7 +133,7 @@ public interface RedisStringCommands {
 	 *
 	 * @param tuple must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 * @see <a href="https://redis.io/commands/mset">Redis Documentation: MSET</a>
 	 */
 	@Nullable
 	Boolean mSet(Map<byte[], byte[]> tuple);
@@ -144,7 +144,7 @@ public interface RedisStringCommands {
 	 *
 	 * @param tuple must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
+	 * @see <a href="https://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
 	 */
 	@Nullable
 	Boolean mSetNX(Map<byte[], byte[]> tuple);
@@ -154,7 +154,7 @@ public interface RedisStringCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 * @see <a href="https://redis.io/commands/incr">Redis Documentation: INCR</a>
 	 */
 	@Nullable
 	Long incr(byte[] key);
@@ -165,7 +165,7 @@ public interface RedisStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
+	 * @see <a href="https://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
 	 */
 	@Nullable
 	Long incrBy(byte[] key, long value);
@@ -176,7 +176,7 @@ public interface RedisStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
+	 * @see <a href="https://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
 	 */
 	@Nullable
 	Double incrBy(byte[] key, double value);
@@ -186,7 +186,7 @@ public interface RedisStringCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/decr">Redis Documentation: DECR</a>
+	 * @see <a href="https://redis.io/commands/decr">Redis Documentation: DECR</a>
 	 */
 	@Nullable
 	Long decr(byte[] key);
@@ -197,7 +197,7 @@ public interface RedisStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
+	 * @see <a href="https://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
 	 */
 	@Nullable
 	Long decrBy(byte[] key, long value);
@@ -208,7 +208,7 @@ public interface RedisStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 * @see <a href="https://redis.io/commands/append">Redis Documentation: APPEND</a>
 	 */
 	@Nullable
 	Long append(byte[] key, byte[] value);
@@ -220,7 +220,7 @@ public interface RedisStringCommands {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 * @see <a href="https://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
 	 */
 	@Nullable
 	byte[] getRange(byte[] key, long start, long end);
@@ -231,7 +231,7 @@ public interface RedisStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @param offset
-	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 * @see <a href="https://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
 	 */
 	void setRange(byte[] key, byte[] value, long offset);
 
@@ -241,7 +241,7 @@ public interface RedisStringCommands {
 	 * @param key must not be {@literal null}.
 	 * @param offset
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
+	 * @see <a href="https://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
 	 */
 	@Nullable
 	Boolean getBit(byte[] key, long offset);
@@ -253,7 +253,7 @@ public interface RedisStringCommands {
 	 * @param offset
 	 * @param value
 	 * @return the original bit value stored at {@code offset} or {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
+	 * @see <a href="https://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
 	 */
 	@Nullable
 	Boolean setBit(byte[] key, long offset, boolean value);
@@ -263,7 +263,7 @@ public interface RedisStringCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see <a href="https://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 */
 	@Nullable
 	Long bitCount(byte[] key);
@@ -276,7 +276,7 @@ public interface RedisStringCommands {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see <a href="https://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 */
 	@Nullable
 	Long bitCount(byte[] key, long start, long end);
@@ -300,7 +300,7 @@ public interface RedisStringCommands {
 	 * @param destination must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/bitop">Redis Documentation: BITOP</a>
+	 * @see <a href="https://redis.io/commands/bitop">Redis Documentation: BITOP</a>
 	 */
 	@Nullable
 	Long bitOp(BitOperation op, byte[] destination, byte[]... keys);
@@ -312,7 +312,7 @@ public interface RedisStringCommands {
 	 * @param bit the bit value to look for.
 	 * @return {@literal null} when used in pipeline / transaction. The position of the first bit set to 1 or 0 according
 	 *         to the request.
-	 * @see <a href="http://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
+	 * @see <a href="https://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -330,7 +330,7 @@ public interface RedisStringCommands {
 	 * @param range must not be {@literal null}. Use {@link Range#unbounded()} to not limit search.
 	 * @return {@literal null} when used in pipeline / transaction. The position of the first bit set to 1 or 0 according
 	 *         to the request.
-	 * @see <a href="http://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
+	 * @see <a href="https://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -341,7 +341,7 @@ public interface RedisStringCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 * @see <a href="https://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
 	 */
 	@Nullable
 	Long strLen(byte[] key);

--- a/src/main/java/org/springframework/data/redis/connection/RedisTxCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisTxCommands.java
@@ -31,7 +31,7 @@ public interface RedisTxCommands {
 	 * Commands will be queued and can then be executed by calling {@link #exec()} or rolled back using {@link #discard()}
 	 * <p>
 	 *
-	 * @see <a href="http://redis.io/commands/multi">Redis Documentation: MULTI</a>
+	 * @see <a href="https://redis.io/commands/multi">Redis Documentation: MULTI</a>
 	 */
 	void multi();
 
@@ -40,14 +40,14 @@ public interface RedisTxCommands {
 	 * If used along with {@link #watch(byte[]...)} the operation will fail if any of watched keys has been modified.
 	 *
 	 * @return List of replies for each executed command.
-	 * @see <a href="http://redis.io/commands/exec">Redis Documentation: EXEC</a>
+	 * @see <a href="https://redis.io/commands/exec">Redis Documentation: EXEC</a>
 	 */
 	List<Object> exec();
 
 	/**
 	 * Discard all commands issued after {@link #multi()}.
 	 *
-	 * @see <a href="http://redis.io/commands/discard">Redis Documentation: DISCARD</a>
+	 * @see <a href="https://redis.io/commands/discard">Redis Documentation: DISCARD</a>
 	 */
 	void discard();
 
@@ -55,14 +55,14 @@ public interface RedisTxCommands {
 	 * Watch given {@code keys} for modifications during transaction started with {@link #multi()}.
 	 *
 	 * @param keys must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/watch">Redis Documentation: WATCH</a>
+	 * @see <a href="https://redis.io/commands/watch">Redis Documentation: WATCH</a>
 	 */
 	void watch(byte[]... keys);
 
 	/**
 	 * Flushes all the previously {@link #watch(byte[]...)} keys.
 	 *
-	 * @see <a href="http://redis.io/commands/unwatch">Redis Documentation: UNWATCH</a>
+	 * @see <a href="https://redis.io/commands/unwatch">Redis Documentation: UNWATCH</a>
 	 */
 	void unwatch();
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisZSetCommands.java
@@ -402,7 +402,7 @@ public interface RedisZSetCommands {
 	 * @param score the score.
 	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	@Nullable
 	Boolean zAdd(byte[] key, double score, byte[] value);
@@ -413,7 +413,7 @@ public interface RedisZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param tuples must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	@Nullable
 	Long zAdd(byte[] key, Set<Tuple> tuples);
@@ -424,7 +424,7 @@ public interface RedisZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	@Nullable
 	Long zRem(byte[] key, byte[]... values);
@@ -436,7 +436,7 @@ public interface RedisZSetCommands {
 	 * @param increment
 	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 */
 	@Nullable
 	Double zIncrBy(byte[] key, double increment, byte[] value);
@@ -447,7 +447,7 @@ public interface RedisZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value the value. Must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 * @see <a href="https://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
 	 */
 	@Nullable
 	Long zRank(byte[] key, byte[] value);
@@ -458,7 +458,7 @@ public interface RedisZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 * @see <a href="https://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 */
 	@Nullable
 	Long zRevRank(byte[] key, byte[] value);
@@ -471,7 +471,7 @@ public interface RedisZSetCommands {
 	 * @param end
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	@Nullable
 	Set<byte[]> zRange(byte[] key, long start, long end);
@@ -484,7 +484,7 @@ public interface RedisZSetCommands {
 	 * @param end
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	@Nullable
 	Set<Tuple> zRangeWithScores(byte[] key, long start, long end);
@@ -497,7 +497,7 @@ public interface RedisZSetCommands {
 	 * @param max
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<byte[]> zRangeByScore(byte[] key, double min, double max) {
@@ -512,7 +512,7 @@ public interface RedisZSetCommands {
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<Tuple> zRangeByScoreWithScores(byte[] key, Range range) {
@@ -527,7 +527,7 @@ public interface RedisZSetCommands {
 	 * @param max
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<Tuple> zRangeByScoreWithScores(byte[] key, double min, double max) {
@@ -545,7 +545,7 @@ public interface RedisZSetCommands {
 	 * @param count
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<byte[]> zRangeByScore(byte[] key, double min, double max, long offset, long count) {
@@ -564,7 +564,7 @@ public interface RedisZSetCommands {
 	 * @param count
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<Tuple> zRangeByScoreWithScores(byte[] key, double min, double max, long offset, long count) {
@@ -582,7 +582,7 @@ public interface RedisZSetCommands {
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<Tuple> zRangeByScoreWithScores(byte[] key, Range range, Limit limit);
@@ -595,7 +595,7 @@ public interface RedisZSetCommands {
 	 * @param end
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	@Nullable
 	Set<byte[]> zRevRange(byte[] key, long start, long end);
@@ -608,7 +608,7 @@ public interface RedisZSetCommands {
 	 * @param end
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	@Nullable
 	Set<Tuple> zRevRangeWithScores(byte[] key, long start, long end);
@@ -621,7 +621,7 @@ public interface RedisZSetCommands {
 	 * @param max
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	@Nullable
 	default Set<byte[]> zRevRangeByScore(byte[] key, double min, double max) {
@@ -637,7 +637,7 @@ public interface RedisZSetCommands {
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<byte[]> zRevRangeByScore(byte[] key, Range range) {
@@ -653,7 +653,7 @@ public interface RedisZSetCommands {
 	 * @param max
 	 * @return empty {@link Set} when key does not exists or no members in range. {@literal null} when used in pipeline /
 	 *         transaction.
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<Tuple> zRevRangeByScoreWithScores(byte[] key, double min, double max) {
@@ -670,7 +670,7 @@ public interface RedisZSetCommands {
 	 * @param offset
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<byte[]> zRevRangeByScore(byte[] key, double min, double max, long offset, long count) {
@@ -688,7 +688,7 @@ public interface RedisZSetCommands {
 	 * @param limit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<byte[]> zRevRangeByScore(byte[] key, Range range, Limit limit);
@@ -703,7 +703,7 @@ public interface RedisZSetCommands {
 	 * @param offset
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<Tuple> zRevRangeByScoreWithScores(byte[] key, double min, double max, long offset, long count) {
@@ -720,7 +720,7 @@ public interface RedisZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<Tuple> zRevRangeByScoreWithScores(byte[] key, Range range) {
@@ -736,7 +736,7 @@ public interface RedisZSetCommands {
 	 * @param limit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<Tuple> zRevRangeByScoreWithScores(byte[] key, Range range, Limit limit);
@@ -748,7 +748,7 @@ public interface RedisZSetCommands {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see <a href="https://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	@Nullable
 	default Long zCount(byte[] key, double min, double max) {
@@ -762,7 +762,7 @@ public interface RedisZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see <a href="https://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	@Nullable
 	Long zCount(byte[] key, Range range);
@@ -772,7 +772,7 @@ public interface RedisZSetCommands {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see <a href="https://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 */
 	@Nullable
 	Long zCard(byte[] key);
@@ -783,7 +783,7 @@ public interface RedisZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
+	 * @see <a href="https://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
 	 */
 	@Nullable
 	Double zScore(byte[] key, byte[] value);
@@ -795,7 +795,7 @@ public interface RedisZSetCommands {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
 	 */
 	@Nullable
 	Long zRemRange(byte[] key, long start, long end);
@@ -807,7 +807,7 @@ public interface RedisZSetCommands {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Long zRemRangeByScore(byte[] key, double min, double max) {
@@ -821,7 +821,7 @@ public interface RedisZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Long zRemRangeByScore(byte[] key, Range range);
@@ -832,7 +832,7 @@ public interface RedisZSetCommands {
 	 * @param destKey must not be {@literal null}.
 	 * @param sets must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	Long zUnionStore(byte[] destKey, byte[]... sets);
@@ -845,7 +845,7 @@ public interface RedisZSetCommands {
 	 * @param weights must not be {@literal null}.
 	 * @param sets must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	default Long zUnionStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
@@ -861,7 +861,7 @@ public interface RedisZSetCommands {
 	 * @param sets must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	Long zUnionStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets);
@@ -872,7 +872,7 @@ public interface RedisZSetCommands {
 	 * @param destKey must not be {@literal null}.
 	 * @param sets must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	Long zInterStore(byte[] destKey, byte[]... sets);
@@ -885,7 +885,7 @@ public interface RedisZSetCommands {
 	 * @param weights
 	 * @param sets must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	default Long zInterStore(byte[] destKey, Aggregate aggregate, int[] weights, byte[]... sets) {
@@ -901,7 +901,7 @@ public interface RedisZSetCommands {
 	 * @param sets must not be {@literal null}.
 	 * @return
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	Long zInterStore(byte[] destKey, Aggregate aggregate, Weights weights, byte[]... sets);
@@ -913,7 +913,7 @@ public interface RedisZSetCommands {
 	 * @param options must not be {@literal null}.
 	 * @return
 	 * @since 1.4
-	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @see <a href="https://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
 	 */
 	Cursor<Tuple> zScan(byte[] key, ScanOptions options);
 
@@ -925,7 +925,7 @@ public interface RedisZSetCommands {
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<byte[]> zRangeByScore(byte[] key, String min, String max) {
@@ -939,7 +939,7 @@ public interface RedisZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	default Set<byte[]> zRangeByScore(byte[] key, Range range) {
@@ -957,7 +957,7 @@ public interface RedisZSetCommands {
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<byte[]> zRangeByScore(byte[] key, String min, String max, long offset, long count);
@@ -971,7 +971,7 @@ public interface RedisZSetCommands {
 	 * @param limit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<byte[]> zRangeByScore(byte[] key, Range range, Limit limit);
@@ -982,7 +982,7 @@ public interface RedisZSetCommands {
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	@Nullable
 	default Set<byte[]> zRangeByLex(byte[] key) {
@@ -996,7 +996,7 @@ public interface RedisZSetCommands {
 	 * @param range must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	@Nullable
 	default Set<byte[]> zRangeByLex(byte[] key, Range range) {
@@ -1012,7 +1012,7 @@ public interface RedisZSetCommands {
 	 * @param limit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	@Nullable
 	Set<byte[]> zRangeByLex(byte[] key, Range range, Limit limit);

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -95,7 +95,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
+	 * @see <a href="https://redis.io/commands/exists">Redis Documentation: EXISTS</a>
 	 * @see RedisKeyCommands#exists(byte[])
 	 */
 	Boolean exists(String key);
@@ -105,7 +105,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
+	 * @see <a href="https://redis.io/commands/exists">Redis Documentation: EXISTS</a>
 	 * @see RedisKeyCommands#exists(byte[][])
 	 * @since 2.1
 	 */
@@ -117,7 +117,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed.
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 * @see RedisKeyCommands#del(byte[]...)
 	 */
 	Long del(String... keys);
@@ -128,7 +128,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -139,7 +139,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/type">Redis Documentation: TYPE</a>
+	 * @see <a href="https://redis.io/commands/type">Redis Documentation: TYPE</a>
 	 * @see RedisKeyCommands#type(byte[])
 	 */
 	DataType type(String key);
@@ -149,7 +149,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/touch">Redis Documentation: TOUCH</a>
+	 * @see <a href="https://redis.io/commands/touch">Redis Documentation: TOUCH</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -160,7 +160,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param pattern must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
+	 * @see <a href="https://redis.io/commands/keys">Redis Documentation: KEYS</a>
 	 * @see RedisKeyCommands#keys(byte[])
 	 */
 	Collection<String> keys(String pattern);
@@ -170,7 +170,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param oldName must not be {@literal null}.
 	 * @param newName must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/rename">Redis Documentation: RENAME</a>
+	 * @see <a href="https://redis.io/commands/rename">Redis Documentation: RENAME</a>
 	 * @see RedisKeyCommands#rename(byte[], byte[])
 	 */
 	void rename(String oldName, String newName);
@@ -181,7 +181,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param oldName must not be {@literal null}.
 	 * @param newName must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
+	 * @see <a href="https://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
 	 * @see RedisKeyCommands#renameNX(byte[], byte[])
 	 */
 	Boolean renameNX(String oldName, String newName);
@@ -192,7 +192,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param seconds
 	 * @return
-	 * @see <a href="http://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
+	 * @see <a href="https://redis.io/commands/expire">Redis Documentation: EXPIRE</a>
 	 * @see RedisKeyCommands#expire(byte[], long)
 	 */
 	Boolean expire(String key, long seconds);
@@ -203,7 +203,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param millis
 	 * @return
-	 * @see <a href="http://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
+	 * @see <a href="https://redis.io/commands/pexpire">Redis Documentation: PEXPIRE</a>
 	 * @see RedisKeyCommands#pExpire(byte[], long)
 	 */
 	Boolean pExpire(String key, long millis);
@@ -214,7 +214,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param unixTime
 	 * @return
-	 * @see <a href="http://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/expireat">Redis Documentation: EXPIREAT</a>
 	 * @see RedisKeyCommands#expireAt(byte[], long)
 	 */
 	Boolean expireAt(String key, long unixTime);
@@ -225,7 +225,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param unixTimeInMillis
 	 * @return
-	 * @see <a href="http://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
+	 * @see <a href="https://redis.io/commands/pexpireat">Redis Documentation: PEXPIREAT</a>
 	 * @see RedisKeyCommands#pExpireAt(byte[], long)
 	 */
 	Boolean pExpireAt(String key, long unixTimeInMillis);
@@ -235,7 +235,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/persist">Redis Documentation: PERSIST</a>
+	 * @see <a href="https://redis.io/commands/persist">Redis Documentation: PERSIST</a>
 	 * @see RedisKeyCommands#persist(byte[])
 	 */
 	Boolean persist(String key);
@@ -246,7 +246,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param dbIndex
 	 * @return
-	 * @see <a href="http://redis.io/commands/move">Redis Documentation: MOVE</a>
+	 * @see <a href="https://redis.io/commands/move">Redis Documentation: MOVE</a>
 	 * @see RedisKeyCommands#move(byte[], int)
 	 */
 	Boolean move(String key, int dbIndex);
@@ -256,7 +256,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see <a href="https://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 * @see RedisKeyCommands#ttl(byte[])
 	 */
 	Long ttl(String key);
@@ -268,7 +268,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param timeUnit must not be {@literal null}.
 	 * @return
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see <a href="https://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 * @see RedisKeyCommands#ttl(byte[], TimeUnit)
 	 */
 	Long ttl(String key, TimeUnit timeUnit);
@@ -278,7 +278,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
+	 * @see <a href="https://redis.io/commands/pttl">Redis Documentation: PTTL</a>
 	 * @see RedisKeyCommands#pTtl(byte[])
 	 */
 	Long pTtl(String key);
@@ -290,7 +290,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param timeUnit must not be {@literal null}.
 	 * @return
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
+	 * @see <a href="https://redis.io/commands/pttl">Redis Documentation: PTTL</a>
 	 * @see RedisKeyCommands#pTtl(byte[], TimeUnit)
 	 */
 	Long pTtl(String key, TimeUnit timeUnit);
@@ -300,7 +300,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param message the message to echo.
 	 * @return
-	 * @see <a href="http://redis.io/commands/echo">Redis Documentation: ECHO</a>
+	 * @see <a href="https://redis.io/commands/echo">Redis Documentation: ECHO</a>
 	 * @see RedisConnectionCommands#echo(byte[])
 	 */
 	String echo(String message);
@@ -311,7 +311,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param params must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 * @see <a href="https://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	List<String> sort(String key, SortParameters params);
 
@@ -322,7 +322,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param params must not be {@literal null}.
 	 * @param storeKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 * @see <a href="https://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	Long sort(String key, SortParameters params, String storeKey);
 
@@ -368,7 +368,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 * @see <a href="https://redis.io/commands/get">Redis Documentation: GET</a>
 	 * @see RedisStringCommands#get(byte[])
 	 */
 	String get(String key);
@@ -379,7 +379,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 * @see <a href="https://redis.io/commands/getset">Redis Documentation: GETSET</a>
 	 * @see RedisStringCommands#getSet(byte[], byte[])
 	 */
 	String getSet(String key, String value);
@@ -389,7 +389,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/mget">Redis Documentation: MGET</a>
+	 * @see <a href="https://redis.io/commands/mget">Redis Documentation: MGET</a>
 	 * @see RedisStringCommands#mGet(byte[]...)
 	 */
 	List<String> mGet(String... keys);
@@ -399,7 +399,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @see RedisStringCommands#set(byte[], byte[])
 	 */
 	@Nullable
@@ -414,7 +414,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param expiration can be {@literal null}. Defaulted to {@link Expiration#persistent()}.
 	 * @param option can be {@literal null}. Defaulted to {@link SetOption#UPSERT}.
 	 * @since 1.7
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @see RedisStringCommands#set(byte[], byte[], Expiration, SetOption)
 	 */
 	@Nullable
@@ -426,7 +426,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 * @see <a href="https://redis.io/commands/setnx">Redis Documentation: SETNX</a>
 	 * @see RedisStringCommands#setNX(byte[], byte[])
 	 */
 	@Nullable
@@ -438,7 +438,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param seconds
 	 * @param value must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see <a href="https://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 * @see RedisStringCommands#setEx(byte[], long, byte[])
 	 */
 	@Nullable
@@ -451,7 +451,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param milliseconds
 	 * @param value must not be {@literal null}.
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
+	 * @see <a href="https://redis.io/commands/psetex">Redis Documentation: PSETEX</a>
 	 * @see RedisStringCommands#pSetEx(byte[], long, byte[])
 	 */
 	@Nullable
@@ -461,7 +461,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple}.
 	 *
 	 * @param tuple must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 * @see <a href="https://redis.io/commands/mset">Redis Documentation: MSET</a>
 	 * @see RedisStringCommands#mSet(Map)
 	 */
 	@Nullable
@@ -472,7 +472,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * not exist.
 	 *
 	 * @param tuple must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
+	 * @see <a href="https://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
 	 * @see RedisStringCommands#mSetNX(Map)
 	 */
 	Boolean mSetNXString(Map<String, String> tuple);
@@ -482,7 +482,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 * @see <a href="https://redis.io/commands/incr">Redis Documentation: INCR</a>
 	 * @see RedisStringCommands#incr(byte[])
 	 */
 	Long incr(String key);
@@ -493,7 +493,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
+	 * @see <a href="https://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
 	 * @see RedisStringCommands#incrBy(byte[], long)
 	 */
 	Long incrBy(String key, long value);
@@ -504,7 +504,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
+	 * @see <a href="https://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
 	 * @see RedisStringCommands#incrBy(byte[], double)
 	 */
 	Double incrBy(String key, double value);
@@ -514,7 +514,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/decr">Redis Documentation: DECR</a>
+	 * @see <a href="https://redis.io/commands/decr">Redis Documentation: DECR</a>
 	 * @see RedisStringCommands#decr(byte[])
 	 */
 	Long decr(String key);
@@ -525,7 +525,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
+	 * @see <a href="https://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
 	 * @see RedisStringCommands#decrBy(byte[], long)
 	 */
 	Long decrBy(String key, long value);
@@ -536,7 +536,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 * @see <a href="https://redis.io/commands/append">Redis Documentation: APPEND</a>
 	 * @see RedisStringCommands#append(byte[], byte[])
 	 */
 	Long append(String key, String value);
@@ -548,7 +548,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 * @see <a href="https://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
 	 * @see RedisStringCommands#getRange(byte[], long, long)
 	 */
 	String getRange(String key, long start, long end);
@@ -559,7 +559,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @param offset
-	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 * @see <a href="https://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
 	 * @see RedisStringCommands#setRange(byte[], byte[], long)
 	 */
 	void setRange(String key, String value, long offset);
@@ -570,7 +570,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param offset
 	 * @return
-	 * @see <a href="http://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
+	 * @see <a href="https://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
 	 * @see RedisStringCommands#getBit(byte[], long)
 	 */
 	Boolean getBit(String key, long offset);
@@ -582,7 +582,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param offset
 	 * @param value
 	 * @return the original bit value stored at {@code offset}.
-	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
+	 * @see <a href="https://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
 	 * @see RedisStringCommands#setBit(byte[], long, boolean)
 	 */
 	Boolean setBit(String key, long offset, boolean value);
@@ -592,7 +592,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see <a href="https://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 * @see RedisStringCommands#bitCount(byte[])
 	 */
 	Long bitCount(String key);
@@ -605,7 +605,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
+	 * @see <a href="https://redis.io/commands/bitcount">Redis Documentation: BITCOUNT</a>
 	 * @see RedisStringCommands#bitCount(byte[], long, long)
 	 */
 	Long bitCount(String key, long start, long end);
@@ -617,7 +617,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param destination must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/bitop">Redis Documentation: BITOP</a>
+	 * @see <a href="https://redis.io/commands/bitop">Redis Documentation: BITOP</a>
 	 * @see RedisStringCommands#bitOp(BitOperation, byte[], byte[]...)
 	 */
 	Long bitOp(BitOperation op, String destination, String... keys);
@@ -629,7 +629,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param bit the bit value to look for.
 	 * @return {@literal null} when used in pipeline / transaction. The position of the first bit set to 1 or 0 according
 	 *         to the request.
-	 * @see <a href="http://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
+	 * @see <a href="https://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
 	 * @since 2.1
 	 */
 	default Long bitPos(String key, boolean bit) {
@@ -647,7 +647,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param range must not be {@literal null}. Use {@link Range#unbounded()} to not limit search.
 	 * @return {@literal null} when used in pipeline / transaction. The position of the first bit set to 1 or 0 according
 	 *         to the request.
-	 * @see <a href="http://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
+	 * @see <a href="https://redis.io/commands/bitpos">Redis Documentation: BITPOS</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -658,7 +658,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 * @see <a href="https://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
 	 * @see RedisStringCommands#strLen(byte[])
 	 */
 	Long strLen(String key);
@@ -673,7 +673,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 * @see RedisListCommands#rPush(byte[], byte[]...)
 	 */
 	Long rPush(String key, String... values);
@@ -684,7 +684,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 * @see RedisListCommands#lPush(byte[], byte[]...)
 	 */
 	Long lPush(String key, String... values);
@@ -695,7 +695,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
+	 * @see <a href="https://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
 	 * @see RedisListCommands#rPushX(byte[], byte[])
 	 */
 	Long rPushX(String key, String value);
@@ -706,7 +706,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
+	 * @see <a href="https://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
 	 * @see RedisListCommands#lPushX(byte[], byte[])
 	 */
 	Long lPushX(String key, String value);
@@ -716,7 +716,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 * @see <a href="https://redis.io/commands/llen">Redis Documentation: LLEN</a>
 	 * @see RedisListCommands#lLen(byte[])
 	 */
 	Long lLen(String key);
@@ -728,7 +728,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 * @see <a href="https://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 * @see RedisListCommands#lRange(byte[], long, long)
 	 */
 	List<String> lRange(String key, long start, long end);
@@ -739,7 +739,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param start
 	 * @param end
-	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 * @see <a href="https://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
 	 * @see RedisListCommands#lTrim(byte[], long, long)
 	 */
 	void lTrim(String key, long start, long end);
@@ -750,7 +750,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @return
-	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 * @see <a href="https://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
 	 * @see RedisListCommands#lIndex(byte[], long)
 	 */
 	String lIndex(String key, long index);
@@ -763,7 +763,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param pivot
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
+	 * @see <a href="https://redis.io/commands/linsert">Redis Documentation: LINSERT</a>
 	 * @see RedisListCommands#lIndex(byte[], long)
 	 */
 	Long lInsert(String key, Position where, String pivot, String value);
@@ -774,7 +774,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @param value
-	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 * @see <a href="https://redis.io/commands/lset">Redis Documentation: LSET</a>
 	 * @see RedisListCommands#lSet(byte[], long, byte[])
 	 */
 	void lSet(String key, long index, String value);
@@ -786,7 +786,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param count
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see <a href="https://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 * @see RedisListCommands#lRem(byte[], long, byte[])
 	 */
 	Long lRem(String key, long count, String value);
@@ -796,7 +796,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 * @see <a href="https://redis.io/commands/lpop">Redis Documentation: LPOP</a>
 	 * @see RedisListCommands#lPop(byte[])
 	 */
 	String lPop(String key);
@@ -806,7 +806,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 * @see <a href="https://redis.io/commands/rpop">Redis Documentation: RPOP</a>
 	 * @see RedisListCommands#rPop(byte[])
 	 */
 	String rPop(String key);
@@ -818,7 +818,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param timeout
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
 	 * @see RedisListCommands#bLPop(int, byte[]...)
 	 */
 	List<String> bLPop(int timeout, String... keys);
@@ -830,7 +830,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param timeout
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
 	 * @see RedisListCommands#bRPop(int, byte[]...)
 	 */
 	List<String> bRPop(int timeout, String... keys);
@@ -841,7 +841,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param srcKey must not be {@literal null}.
 	 * @param dstKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
 	 * @see RedisListCommands#rPopLPush(byte[], byte[])
 	 */
 	String rPopLPush(String srcKey, String dstKey);
@@ -855,7 +855,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param srcKey must not be {@literal null}.
 	 * @param dstKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
 	 * @see RedisListCommands#bRPopLPush(int, byte[], byte[])
 	 */
 	String bRPopLPush(int timeout, String srcKey, String dstKey);
@@ -870,7 +870,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
-	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see <a href="https://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 * @see RedisSetCommands#sAdd(byte[], byte[]...)
 	 */
 	Long sAdd(String key, String... values);
@@ -881,7 +881,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
-	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see <a href="https://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 * @see RedisSetCommands#sRem(byte[], byte[]...)
 	 */
 	Long sRem(String key, String... values);
@@ -891,7 +891,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 * @see RedisSetCommands#sPop(byte[])
 	 */
 	String sPop(String key);
@@ -902,7 +902,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param count the number of random members to return.
 	 * @return empty {@link List} if {@literal key} does not exist.
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 * @see RedisSetCommands#sPop(byte[], long)
 	 * @since 2.0
 	 */
@@ -915,7 +915,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param destKey must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 * @see <a href="https://redis.io/commands/smove">Redis Documentation: SMOVE</a>
 	 * @see RedisSetCommands#sMove(byte[], byte[], byte[])
 	 */
 	Boolean sMove(String srcKey, String destKey, String value);
@@ -925,7 +925,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 * @see <a href="https://redis.io/commands/scard">Redis Documentation: SCARD</a>
 	 * @see RedisSetCommands#sCard(byte[])
 	 */
 	Long sCard(String key);
@@ -936,7 +936,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 * @see <a href="https://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
 	 * @see RedisSetCommands#sIsMember(byte[], byte[])
 	 */
 	Boolean sIsMember(String key, String value);
@@ -946,7 +946,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 * @see RedisSetCommands#sInter(byte[]...)
 	 */
 	Set<String> sInter(String... keys);
@@ -957,7 +957,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param destKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 * @see RedisSetCommands#sInterStore(byte[], byte[]...)
 	 */
 	Long sInterStore(String destKey, String... keys);
@@ -967,7 +967,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 * @see RedisSetCommands#sUnion(byte[]...)
 	 */
 	Set<String> sUnion(String... keys);
@@ -978,7 +978,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param destKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 * @see RedisSetCommands#sUnionStore(byte[], byte[]...)
 	 */
 	Long sUnionStore(String destKey, String... keys);
@@ -988,7 +988,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 * @see RedisSetCommands#sDiff(byte[]...)
 	 */
 	Set<String> sDiff(String... keys);
@@ -999,7 +999,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param destKey must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 * @see RedisSetCommands#sDiffStore(byte[], byte[]...)
 	 */
 	Long sDiffStore(String destKey, String... keys);
@@ -1009,7 +1009,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 * @see <a href="https://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 * @see RedisSetCommands#sMembers(byte[])
 	 */
 	Set<String> sMembers(String key);
@@ -1019,7 +1019,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 * @see RedisSetCommands#sRandMember(byte[])
 	 */
 	String sRandMember(String key);
@@ -1030,7 +1030,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param count
 	 * @return
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 * @see RedisSetCommands#sRem(byte[], byte[]...)
 	 */
 	List<String> sRandMember(String key, long count);
@@ -1042,7 +1042,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param options must not be {@literal null}.
 	 * @return
 	 * @since 1.4
-	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @see <a href="https://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 * @see RedisSetCommands#sScan(byte[], ScanOptions)
 	 */
 	Cursor<String> sScan(String key, ScanOptions options);
@@ -1058,7 +1058,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param score the score.
 	 * @param value the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 * @see RedisZSetCommands#zAdd(byte[], double, byte[])
 	 */
 	Boolean zAdd(String key, double score, String value);
@@ -1069,7 +1069,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param tuples the tuples.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 * @see RedisZSetCommands#zAdd(byte[], Set)
 	 */
 	Long zAdd(String key, Set<StringTuple> tuples);
@@ -1080,7 +1080,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 * @see RedisZSetCommands#zRem(byte[], byte[]...)
 	 */
 	Long zRem(String key, String... values);
@@ -1092,7 +1092,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param increment
 	 * @param value the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 * @see RedisZSetCommands#zIncrBy(byte[], double, byte[])
 	 */
 	Double zIncrBy(String key, double increment, String value);
@@ -1103,7 +1103,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 * @see <a href="https://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
 	 * @see RedisZSetCommands#zRank(byte[], byte[])
 	 */
 	Long zRank(String key, String value);
@@ -1114,7 +1114,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 * @see <a href="https://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 * @see RedisZSetCommands#zRevRank(byte[], byte[])
 	 */
 	Long zRevRank(String key, String value);
@@ -1126,7 +1126,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 * @see RedisZSetCommands#zRange(byte[], long, long)
 	 */
 	Set<String> zRange(String key, long start, long end);
@@ -1138,7 +1138,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 * @see RedisZSetCommands#zRangeWithScores(byte[], long, long)
 	 */
 	Set<StringTuple> zRangeWithScores(String key, long start, long end);
@@ -1150,7 +1150,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param min
 	 * @param max
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRangeByScore(byte[], double, double)
 	 */
 	Set<String> zRangeByScore(String key, double min, double max);
@@ -1162,7 +1162,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param min
 	 * @param max
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRangeByScoreWithScores(byte[], double, double)
 	 */
 	Set<StringTuple> zRangeByScoreWithScores(String key, double min, double max);
@@ -1177,7 +1177,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param offset
 	 * @param count
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRangeByScore(byte[], double, double, long, long)
 	 */
 	Set<String> zRangeByScore(String key, double min, double max, long offset, long count);
@@ -1192,7 +1192,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param offset
 	 * @param count
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRangeByScoreWithScores(byte[], double, double, long, long)
 	 */
 	Set<StringTuple> zRangeByScoreWithScores(String key, double min, double max, long offset, long count);
@@ -1204,7 +1204,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 * @see RedisZSetCommands#zRevRange(byte[], long, long)
 	 */
 	Set<String> zRevRange(String key, long start, long end);
@@ -1216,7 +1216,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 * @see RedisZSetCommands#zRevRangeWithScores(byte[], long, long)
 	 */
 	Set<StringTuple> zRevRangeWithScores(String key, long start, long end);
@@ -1228,7 +1228,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param min
 	 * @param max
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 * @see RedisZSetCommands#zRevRangeByScore(byte[], double, double)
 	 */
 	Set<String> zRevRangeByScore(String key, double min, double max);
@@ -1241,7 +1241,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param min
 	 * @param max
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRevRangeByScoreWithScores(byte[], double, double)
 	 */
 	Set<StringTuple> zRevRangeByScoreWithScores(String key, double min, double max);
@@ -1256,7 +1256,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param offset
 	 * @param count
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRevRangeByScore(byte[], double, double, long, long)
 	 */
 	Set<String> zRevRangeByScore(String key, double min, double max, long offset, long count);
@@ -1271,7 +1271,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param offset
 	 * @param count
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRevRangeByScoreWithScores(byte[], double, double, long, long)
 	 */
 	Set<StringTuple> zRevRangeByScoreWithScores(String key, double min, double max, long offset, long count);
@@ -1283,7 +1283,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param min
 	 * @param max
 	 * @return
-	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see <a href="https://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 * @see RedisZSetCommands#zCount(byte[], double, double)
 	 */
 	Long zCount(String key, double min, double max);
@@ -1293,7 +1293,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see <a href="https://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 * @see RedisZSetCommands#zCard(byte[])
 	 */
 	Long zCard(String key);
@@ -1304,7 +1304,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param value the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
+	 * @see <a href="https://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
 	 * @see RedisZSetCommands#zScore(byte[], byte[])
 	 */
 	Double zScore(String key, String value);
@@ -1316,7 +1316,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
 	 * @see RedisZSetCommands#zRemRange(byte[], long, long)
 	 */
 	Long zRemRange(String key, long start, long end);
@@ -1328,7 +1328,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param min
 	 * @param max
 	 * @return
-	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRemRangeByScore(byte[], double, double)
 	 */
 	Long zRemRangeByScore(String key, double min, double max);
@@ -1339,7 +1339,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param destKey must not be {@literal null}.
 	 * @param sets must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 * @see RedisZSetCommands#zUnionStore(byte[], byte[]...)
 	 */
 	Long zUnionStore(String destKey, String... sets);
@@ -1352,7 +1352,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param weights
 	 * @param sets must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 * @see RedisZSetCommands#zUnionStore(byte[], Aggregate, int[], byte[]...)
 	 */
 	Long zUnionStore(String destKey, Aggregate aggregate, int[] weights, String... sets);
@@ -1363,7 +1363,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param destKey must not be {@literal null}.
 	 * @param sets must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 * @see RedisZSetCommands#zInterStore(byte[], byte[]...)
 	 */
 	Long zInterStore(String destKey, String... sets);
@@ -1376,7 +1376,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param weights
 	 * @param sets must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 * @see RedisZSetCommands#zInterStore(byte[], Aggregate, int[], byte[]...)
 	 */
 	Long zInterStore(String destKey, Aggregate aggregate, int[] weights, String... sets);
@@ -1388,7 +1388,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param options must not be {@literal null}.
 	 * @return
 	 * @since 1.4
-	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @see <a href="https://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
 	 * @see RedisZSetCommands#zScan(byte[], ScanOptions)
 	 */
 	Cursor<StringTuple> zScan(String key, ScanOptions options);
@@ -1401,7 +1401,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param max must not be {@literal null}.
 	 * @return
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRangeByScore(byte[], String, String)
 	 */
 	Set<String> zRangeByScore(String key, String min, String max);
@@ -1417,7 +1417,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param count
 	 * @return
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 * @see RedisZSetCommands#zRangeByScore(byte[], double, double, long, long)
 	 */
 	Set<String> zRangeByScore(String key, String min, String max, long offset, long count);
@@ -1428,7 +1428,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @return
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 * @see RedisZSetCommands#zRangeByLex(byte[])
 	 */
 	Set<String> zRangeByLex(String key);
@@ -1440,7 +1440,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param range must not be {@literal null}.
 	 * @return
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 * @see RedisZSetCommands#zRangeByLex(byte[], Range)
 	 */
 	Set<String> zRangeByLex(String key, Range range);
@@ -1454,7 +1454,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param range can be {@literal null}.
 	 * @return
 	 * @since 1.6
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 * @see RedisZSetCommands#zRangeByLex(byte[], Range, Limit)
 	 */
 	Set<String> zRangeByLex(String key, Range range, Limit limit);
@@ -1470,7 +1470,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param field must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/hset">Redis Documentation: HSET</a>
+	 * @see <a href="https://redis.io/commands/hset">Redis Documentation: HSET</a>
 	 * @see RedisHashCommands#hSet(byte[], byte[], byte[])
 	 */
 	Boolean hSet(String key, String field, String value);
@@ -1482,7 +1482,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param field must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/hsetnx">Redis Documentation: HSETNX</a>
+	 * @see <a href="https://redis.io/commands/hsetnx">Redis Documentation: HSETNX</a>
 	 * @see RedisHashCommands#hSetNX(byte[], byte[], byte[])
 	 */
 	Boolean hSetNX(String key, String field, String value);
@@ -1493,7 +1493,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param field must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hget">Redis Documentation: HGET</a>
+	 * @see <a href="https://redis.io/commands/hget">Redis Documentation: HGET</a>
 	 * @see RedisHashCommands#hGet(byte[], byte[])
 	 */
 	String hGet(String key, String field);
@@ -1504,7 +1504,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param fields must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hmget">Redis Documentation: HMGET</a>
+	 * @see <a href="https://redis.io/commands/hmget">Redis Documentation: HMGET</a>
 	 * @see RedisHashCommands#hMGet(byte[], byte[]...)
 	 */
 	List<String> hMGet(String key, String... fields);
@@ -1514,7 +1514,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param hashes must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/hmset">Redis Documentation: HMSET</a>
+	 * @see <a href="https://redis.io/commands/hmset">Redis Documentation: HMSET</a>
 	 * @see RedisHashCommands#hMGet(byte[], byte[]...)
 	 */
 	void hMSet(String key, Map<String, String> hashes);
@@ -1526,7 +1526,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param field must not be {@literal null}.
 	 * @param delta
 	 * @return
-	 * @see <a href="http://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
+	 * @see <a href="https://redis.io/commands/hincrby">Redis Documentation: HINCRBY</a>
 	 * @see RedisHashCommands#hIncrBy(byte[], byte[], long)
 	 */
 	Long hIncrBy(String key, String field, long delta);
@@ -1538,7 +1538,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param field
 	 * @param delta
 	 * @return
-	 * @see <a href="http://redis.io/commands/hincrbyfloat">Redis Documentation: HINCRBYFLOAT</a>
+	 * @see <a href="https://redis.io/commands/hincrbyfloat">Redis Documentation: HINCRBYFLOAT</a>
 	 * @see RedisHashCommands#hIncrBy(byte[], byte[], double)
 	 */
 	Double hIncrBy(String key, String field, double delta);
@@ -1549,7 +1549,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param field must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hexits">Redis Documentation: HEXISTS</a>
+	 * @see <a href="https://redis.io/commands/hexits">Redis Documentation: HEXISTS</a>
 	 * @see RedisHashCommands#hExists(byte[], byte[])
 	 */
 	Boolean hExists(String key, String field);
@@ -1560,7 +1560,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key must not be {@literal null}.
 	 * @param fields must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hdel">Redis Documentation: HDEL</a>
+	 * @see <a href="https://redis.io/commands/hdel">Redis Documentation: HDEL</a>
 	 * @see RedisHashCommands#hDel(byte[], byte[]...)
 	 */
 	Long hDel(String key, String... fields);
@@ -1570,7 +1570,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hlen">Redis Documentation: HLEN</a>
+	 * @see <a href="https://redis.io/commands/hlen">Redis Documentation: HLEN</a>
 	 * @see RedisHashCommands#hLen(byte[])
 	 */
 	Long hLen(String key);
@@ -1580,7 +1580,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>?
+	 * @see <a href="https://redis.io/commands/hkeys">Redis Documentation: HKEYS</a>?
 	 * @see RedisHashCommands#hKeys(byte[])
 	 */
 	Set<String> hKeys(String key);
@@ -1590,7 +1590,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hvals">Redis Documentation: HVALS</a>
+	 * @see <a href="https://redis.io/commands/hvals">Redis Documentation: HVALS</a>
 	 * @see RedisHashCommands#hVals(byte[])
 	 */
 	List<String> hVals(String key);
@@ -1600,7 +1600,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
+	 * @see <a href="https://redis.io/commands/hgetall">Redis Documentation: HGETALL</a>
 	 * @see RedisHashCommands#hGetAll(byte[])
 	 */
 	Map<String, String> hGetAll(String key);
@@ -1612,7 +1612,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param options must not be {@literal null}.
 	 * @return
 	 * @since 1.4
-	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @see <a href="https://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
 	 * @see RedisHashCommands#hScan(byte[], ScanOptions)
 	 */
 	Cursor<Map.Entry<String, String>> hScan(String key, ScanOptions options);
@@ -1640,7 +1640,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param values must not be {@literal null}.
 	 * @return
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
+	 * @see <a href="https://redis.io/commands/pfadd">Redis Documentation: PFADD</a>
 	 * @see RedisHyperLogLogCommands#pfAdd(byte[], byte[]...)
 	 */
 	Long pfAdd(String key, String... values);
@@ -1650,7 +1650,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
+	 * @see <a href="https://redis.io/commands/pfcount">Redis Documentation: PFCOUNT</a>
 	 * @see RedisHyperLogLogCommands#pfCount(byte[]...)
 	 */
 	Long pfCount(String... keys);
@@ -1660,7 +1660,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param destinationKey must not be {@literal null}.
 	 * @param sourceKeys must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
+	 * @see <a href="https://redis.io/commands/pfmerge">Redis Documentation: PFMERGE</a>
 	 * @see RedisHyperLogLogCommands#pfMerge(byte[], byte[]...)
 	 */
 	void pfMerge(String destinationKey, String... sourceKeys);
@@ -1677,7 +1677,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @see RedisGeoCommands#geoAdd(byte[], Point, byte[])
 	 */
 	Long geoAdd(String key, Point point, String member);
@@ -1689,7 +1689,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @see RedisGeoCommands#geoAdd(byte[], GeoLocation)
 	 */
 	Long geoAdd(String key, GeoLocation<String> location);
@@ -1701,7 +1701,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @see RedisGeoCommands#geoAdd(byte[], Map)
 	 */
 	Long geoAdd(String key, Map<String, Point> memberCoordinateMap);
@@ -1713,7 +1713,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @see RedisGeoCommands#geoAdd(byte[], Iterable)
 	 */
 	Long geoAdd(String key, Iterable<GeoLocation<String>> locations);
@@ -1726,7 +1726,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 * @see RedisGeoCommands#geoDist(byte[], byte[], byte[])
 	 */
 	Distance geoDist(String key, String member1, String member2);
@@ -1740,7 +1740,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 * @see RedisGeoCommands#geoDist(byte[], byte[], byte[], Metric)
 	 */
 	Distance geoDist(String key, String member1, String member2, Metric metric);
@@ -1752,7 +1752,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 * @see RedisGeoCommands#geoHash(byte[], byte[]...)
 	 */
 	List<String> geoHash(String key, String... members);
@@ -1764,7 +1764,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 * @see RedisGeoCommands#geoPos(byte[], byte[]...)
 	 */
 	List<Point> geoPos(String key, String... members);
@@ -1776,7 +1776,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 * @see RedisGeoCommands#geoRadius(byte[], Circle)
 	 */
 	GeoResults<GeoLocation<String>> geoRadius(String key, Circle within);
@@ -1789,7 +1789,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 * @see RedisGeoCommands#geoRadius(byte[], Circle, GeoRadiusCommandArgs)
 	 */
 	GeoResults<GeoLocation<String>> geoRadius(String key, Circle within, GeoRadiusCommandArgs args);
@@ -1803,7 +1803,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param radius
 	 * @return never {@literal null}.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 * @see RedisGeoCommands#geoRadiusByMember(byte[], byte[], double)
 	 */
 	GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, double radius);
@@ -1817,7 +1817,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param radius must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 * @see RedisGeoCommands#geoRadiusByMember(byte[], byte[], Distance)
 	 */
 	GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, Distance radius);
@@ -1832,7 +1832,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
 	 * @since 1.8
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 * @see RedisGeoCommands#geoRadiusByMember(byte[], byte[], Distance, GeoRadiusCommandArgs)
 	 */
 	GeoResults<GeoLocation<String>> geoRadiusByMember(String key, String member, Distance radius,
@@ -1845,7 +1845,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param members must not be {@literal null}.
 	 * @since 1.8
 	 * @return Number of members elements removed.
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 * @see RedisGeoCommands#geoRemove(byte[], byte[]...)
 	 */
 	Long geoRemove(String key, String... members);
@@ -1860,7 +1860,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param channel the channel to publish to, must not be {@literal null}.
 	 * @param message message to publish
 	 * @return the number of clients that received the message
-	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 * @see <a href="https://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
 	 * @see RedisPubSubCommands#publish(byte[], byte[])
 	 */
 	Long publish(String channel, String message);
@@ -1873,7 +1873,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param listener message listener, must not be {@literal null}.
 	 * @param channels channel names, must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/subscribe">Redis Documentation: SUBSCRIBE</a>
+	 * @see <a href="https://redis.io/commands/subscribe">Redis Documentation: SUBSCRIBE</a>
 	 * @see RedisPubSubCommands#subscribe(MessageListener, byte[]...)
 	 */
 	void subscribe(MessageListener listener, String... channels);
@@ -1887,7 +1887,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param listener message listener, must not be {@literal null}.
 	 * @param patterns channel name patterns, must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
+	 * @see <a href="https://redis.io/commands/psubscribe">Redis Documentation: PSUBSCRIBE</a>
 	 * @see RedisPubSubCommands#pSubscribe(MessageListener, byte[]...)
 	 */
 	void pSubscribe(MessageListener listener, String... patterns);
@@ -1902,7 +1902,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param script must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/script-load">Redis Documentation: SCRIPT LOAD</a>
+	 * @see <a href="https://redis.io/commands/script-load">Redis Documentation: SCRIPT LOAD</a>
 	 * @see RedisScriptingCommands#scriptLoad(byte[])
 	 */
 	String scriptLoad(String script);
@@ -1915,7 +1915,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param numKeys
 	 * @param keysAndArgs must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/eval">Redis Documentation: EVAL</a>
+	 * @see <a href="https://redis.io/commands/eval">Redis Documentation: EVAL</a>
 	 * @see RedisScriptingCommands#eval(byte[], ReturnType, int, byte[]...)
 	 */
 	<T> T eval(String script, ReturnType returnType, int numKeys, String... keysAndArgs);
@@ -1928,7 +1928,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param numKeys
 	 * @param keysAndArgs must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
+	 * @see <a href="https://redis.io/commands/evalsha">Redis Documentation: EVALSHA</a>
 	 * @see RedisScriptingCommands#evalSha(String, ReturnType, int, byte[]...)
 	 */
 	<T> T evalSha(String scriptSha, ReturnType returnType, int numKeys, String... keysAndArgs);
@@ -1938,7 +1938,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @param name
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/client-setname">Redis Documentation: CLIENT SETNAME</a>
+	 * @see <a href="https://redis.io/commands/client-setname">Redis Documentation: CLIENT SETNAME</a>
 	 * @see RedisServerCommands#setClientName(byte[])
 	 */
 	void setClientName(String name);
@@ -1948,7 +1948,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 *
 	 * @return {@link List} of {@link RedisClientInfo} objects.
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/client-list">Redis Documentation: CLIENT LIST</a>
+	 * @see <a href="https://redis.io/commands/client-list">Redis Documentation: CLIENT LIST</a>
 	 * @see RedisServerCommands#getClientList()
 	 */
 	List<RedisClientInfo> getClientList();
@@ -1984,7 +1984,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param entryIds record Id's to acknowledge.
 	 * @return length of acknowledged records. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	@Nullable
 	default Long xAck(String key, String group, String... entryIds) {
@@ -2000,7 +2000,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param body record body.
 	 * @return the record Id. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	@Nullable
 	default RecordId xAdd(String key, Map<String, String> body) {
@@ -2017,7 +2017,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param entryIds stream record Id's.
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	@Nullable
 	default Long xDel(String key, String... entryIds) {
@@ -2066,7 +2066,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param key the stream key.
 	 * @return length of the stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xlen">Redis Documentation: XLEN</a>
+	 * @see <a href="https://redis.io/commands/xlen">Redis Documentation: XLEN</a>
 	 */
 	@Nullable
 	Long xLen(String key);
@@ -2078,7 +2078,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param range must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	@Nullable
 	default List<StringRecord> xRange(String key, org.springframework.data.domain.Range<String> range) {
@@ -2093,7 +2093,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param limit must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	@Nullable
 	List<StringRecord> xRange(String key, org.springframework.data.domain.Range<String> range, Limit limit);
@@ -2104,7 +2104,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param stream the streams to read from.
 	 * @return list ith members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	default List<StringRecord> xReadAsString(StreamOffset<String> stream) {
@@ -2117,7 +2117,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	default List<StringRecord> xReadAsString(StreamOffset<String>... streams) {
@@ -2131,7 +2131,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param stream the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	default List<StringRecord> xReadAsString(StreamReadOptions readOptions, StreamOffset<String> stream) {
@@ -2145,7 +2145,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	List<StringRecord> xReadAsString(StreamReadOptions readOptions, StreamOffset<String>... streams);
@@ -2157,7 +2157,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param stream the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	default List<StringRecord> xReadGroupAsString(Consumer consumer, StreamOffset<String> stream) {
@@ -2171,7 +2171,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	default List<StringRecord> xReadGroupAsString(Consumer consumer, StreamOffset<String>... streams) {
@@ -2186,7 +2186,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param stream the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	default List<StringRecord> xReadGroupAsString(Consumer consumer, StreamReadOptions readOptions,
@@ -2202,7 +2202,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	List<StringRecord> xReadGroupAsString(Consumer consumer, StreamReadOptions readOptions,
@@ -2215,7 +2215,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param range must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	@Nullable
 	default List<StringRecord> xRevRange(String key, org.springframework.data.domain.Range<String> range) {
@@ -2230,7 +2230,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param limit must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	@Nullable
 	List<StringRecord> xRevRange(String key, org.springframework.data.domain.Range<String> range, Limit limit);
@@ -2242,7 +2242,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param count length of the stream.
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
 	 * @since 2.2
-	 * @see <a href="http://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
+	 * @see <a href="https://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
 	 */
 	@Nullable
 	Long xTrim(String key, long count);

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -49,7 +49,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * {@code RedisConnection} implementation on top of <a href="http://github.com/xetorthio/jedis">Jedis</a> library.
+ * {@code RedisConnection} implementation on top of <a href="https://github.com/xetorthio/jedis">Jedis</a> library.
  *
  * @author Costin Leau
  * @author Jennifer Hickey

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -61,7 +61,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * Connection factory creating <a href="http://github.com/xetorthio/jedis">Jedis</a> based connections.
+ * Connection factory creating <a href="https://github.com/xetorthio/jedis">Jedis</a> based connections.
  * <p>
  * {@link JedisConnectionFactory} should be configured using an environmental configuration and the
  * {@link JedisClientConfiguration client configuration}. Jedis supports the following environmental configurations:

--- a/src/main/java/org/springframework/data/redis/connection/jedis/package-info.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Connection package for <a href="http://github.com/xetorthio/jedis">Jedis</a> library.
+ * Connection package for <a href="https://github.com/xetorthio/jedis">Jedis</a> library.
  */
 @org.springframework.lang.NonNullApi
 @org.springframework.lang.NonNullFields

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -58,7 +58,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
- * Connection factory creating <a href="http://github.com/mp911de/lettuce">Lettuce</a>-based connections.
+ * Connection factory creating <a href="https://github.com/mp911de/lettuce">Lettuce</a>-based connections.
  * <p>
  * This factory creates a new {@link LettuceConnection} on each call to {@link #getConnection()}. Multiple
  * {@link LettuceConnection}s share a single thread-safe native connection by default.

--- a/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundGeoOperations.java
@@ -44,7 +44,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long add(Point point, M member);
@@ -55,7 +55,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @deprecated since 2.0, use {@link #add(Point, Object)}.
 	 */
 	@Deprecated
@@ -70,7 +70,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long add(GeoLocation<M> location);
@@ -80,7 +80,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 *
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @deprecated since 2.0, use {@link #add(GeoLocation)}.
 	 */
 	@Deprecated
@@ -95,7 +95,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long add(Map<M, Point> memberCoordinateMap);
@@ -105,7 +105,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 *
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @deprecated since 2.0, use {@link #add(Map)}.
 	 */
 	@Deprecated
@@ -120,7 +120,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long add(Iterable<GeoLocation<M>> locations);
@@ -130,7 +130,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 *
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @deprecated since 2.0, use {@link #add(Iterable)}.
 	 */
 	@Deprecated
@@ -146,7 +146,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	@Nullable
 	Distance distance(M member1, M member2);
@@ -157,7 +157,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member1 must not be {@literal null}.
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 * @deprecated since 2.0, use {@link #distance(Object, Object)}.
 	 */
 	@Deprecated
@@ -174,7 +174,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	@Nullable
 	Distance distance(M member1, M member2, Metric metric);
@@ -186,7 +186,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member2 must not be {@literal null}.
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 * @deprecated since 2.0, use {@link #distance(Object, Object, Metric)}.
 	 */
 	@Deprecated
@@ -201,7 +201,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	@Nullable
 	List<String> hash(M... members);
@@ -211,7 +211,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 *
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 * @deprecated since 2.0, use {@link #hash(Object[])}.
 	 */
 	@Deprecated
@@ -226,7 +226,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	@Nullable
 	List<Point> position(M... members);
@@ -236,7 +236,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 *
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 * @deprecated since 2.0, use {@link #position(Object[])}.
 	 */
 	@Deprecated
@@ -251,7 +251,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(Circle within);
@@ -261,7 +261,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 *
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 * @deprecated since 2.0, use {@link #radius(Circle)}.
 	 */
 	@Deprecated
@@ -277,7 +277,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(Circle within, GeoRadiusCommandArgs args);
@@ -288,7 +288,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param within must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 * @deprecated since 2.0, use {@link #radius(Circle, GeoRadiusCommandArgs)}.
 	 */
 	@Deprecated
@@ -305,7 +305,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param radius
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(K key, M member, double radius);
@@ -317,7 +317,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member must not be {@literal null}.
 	 * @param radius
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 * @deprecated since 2.0, use {@link #radius(Object, Object, double)}.
 	 */
 	@Deprecated
@@ -334,7 +334,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param distance must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(M member, Distance distance);
@@ -346,7 +346,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param member must not be {@literal null}.
 	 * @param distance must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 * @deprecated since 2.0, use {@link #radius(Object, Distance)}.
 	 */
 	@Deprecated
@@ -364,7 +364,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(M member, Distance distance, GeoRadiusCommandArgs args);
@@ -377,7 +377,7 @@ public interface BoundGeoOperations<K, M> extends BoundKeyOperations<K> {
 	 * @param distance must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 * @deprecated since 2.0, use {@link #radius(Object, Distance, GeoRadiusCommandArgs)}.
 	 */
 	@Deprecated

--- a/src/main/java/org/springframework/data/redis/core/BoundListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundListOperations.java
@@ -34,7 +34,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 * @see <a href="https://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
 	@Nullable
 	List<V> range(long start, long end);
@@ -44,7 +44,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param start
 	 * @param end
-	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 * @see <a href="https://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
 	 */
 	void trim(long start, long end);
 
@@ -52,7 +52,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 * Get the size of list stored at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 * @see <a href="https://redis.io/commands/llen">Redis Documentation: LLEN</a>
 	 */
 	@Nullable
 	Long size();
@@ -62,7 +62,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	@Nullable
 	Long leftPush(V value);
@@ -72,7 +72,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param values
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	@Nullable
 	Long leftPushAll(V... values);
@@ -82,7 +82,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
+	 * @see <a href="https://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
 	 */
 	@Nullable
 	Long leftPushIfPresent(V value);
@@ -92,7 +92,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	@Nullable
 	Long leftPush(V pivot, V value);
@@ -102,7 +102,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	@Nullable
 	Long rightPush(V value);
@@ -112,7 +112,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param values
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	@Nullable
 	Long rightPushAll(V... values);
@@ -122,7 +122,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
+	 * @see <a href="https://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
 	 */
 	@Nullable
 	Long rightPushIfPresent(V value);
@@ -132,7 +132,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: RPUSH</a>
 	 */
 	@Nullable
 	Long rightPush(V pivot, V value);
@@ -142,7 +142,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param index
 	 * @param value
-	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 * @see <a href="https://redis.io/commands/lset">Redis Documentation: LSET</a>
 	 */
 	void set(long index, V value);
 
@@ -152,7 +152,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param count
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see <a href="https://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 */
 	@Nullable
 	Long remove(long count, Object value);
@@ -162,7 +162,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param index
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 * @see <a href="https://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
 	 */
 	@Nullable
 	V index(long index);
@@ -171,7 +171,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 * Removes and returns first element in list stored at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 * @see <a href="https://redis.io/commands/lpop">Redis Documentation: LPOP</a>
 	 */
 	@Nullable
 	V leftPop();
@@ -183,7 +183,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param timeout
 	 * @param unit must not be {@literal null}.
 	 * @return {@literal null} when timeout reached or used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
 	 */
 	@Nullable
 	V leftPop(long timeout, TimeUnit unit);
@@ -192,7 +192,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 * Removes and returns last element in list stored at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 * @see <a href="https://redis.io/commands/rpop">Redis Documentation: RPOP</a>
 	 */
 	@Nullable
 	V rightPop();
@@ -204,7 +204,7 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param timeout
 	 * @param unit must not be {@literal null}.
 	 * @return {@literal null} when timeout reached or used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
 	 */
 	@Nullable
 	V rightPop(long timeout, TimeUnit unit);

--- a/src/main/java/org/springframework/data/redis/core/BoundSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundSetOperations.java
@@ -34,7 +34,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param values
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see <a href="https://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 */
 	@Nullable
 	Long add(V... values);
@@ -44,7 +44,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param values
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see <a href="https://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 */
 	@Nullable
 	Long remove(Object... values);
@@ -53,7 +53,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * Remove and return a random member from set at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	@Nullable
 	V pop();
@@ -64,7 +64,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param destKey must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 * @see <a href="https://redis.io/commands/smove">Redis Documentation: SMOVE</a>
 	 */
 	@Nullable
 	Boolean move(K destKey, V value);
@@ -73,7 +73,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * Get size of set at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 * @see <a href="https://redis.io/commands/scard">Redis Documentation: SCARD</a>
 	 */
 	@Nullable
 	Long size();
@@ -83,7 +83,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param o
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 * @see <a href="https://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
 	 */
 	@Nullable
 	Boolean isMember(Object o);
@@ -93,7 +93,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	@Nullable
 	Set<V> intersect(K key);
@@ -103,7 +103,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	@Nullable
 	Set<V> intersect(Collection<K> keys);
@@ -113,7 +113,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	void intersectAndStore(K key, K destKey);
 
@@ -122,7 +122,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	void intersectAndStore(Collection<K> keys, K destKey);
 
@@ -131,7 +131,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	@Nullable
 	Set<V> union(K key);
@@ -141,7 +141,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	@Nullable
 	Set<V> union(Collection<K> keys);
@@ -151,7 +151,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	void unionAndStore(K key, K destKey);
 
@@ -160,7 +160,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	void unionAndStore(Collection<K> keys, K destKey);
 
@@ -169,7 +169,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	@Nullable
 	Set<V> diff(K key);
@@ -179,7 +179,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	@Nullable
 	Set<V> diff(Collection<K> keys);
@@ -189,7 +189,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	void diffAndStore(K keys, K destKey);
 
@@ -198,7 +198,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	void diffAndStore(Collection<K> keys, K destKey);
 
@@ -206,7 +206,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * Get all elements of set at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 * @see <a href="https://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
 	@Nullable
 	Set<V> members();
@@ -215,7 +215,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * Get random element from set at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	@Nullable
 	V randomMember();
@@ -225,7 +225,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	@Nullable
 	Set<V> distinctRandomMembers(long count);
@@ -235,7 +235,7 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	@Nullable
 	List<V> randomMembers(long count);

--- a/src/main/java/org/springframework/data/redis/core/BoundStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundStreamOperations.java
@@ -42,7 +42,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 * @param group name of the consumer group.
 	 * @param recordIds record Id's to acknowledge.
 	 * @return length of acknowledged records. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	@Nullable
 	Long acknowledge(String group, String... recordIds);
@@ -52,7 +52,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 *
 	 * @param body record body.
 	 * @return the record Id. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	@Nullable
 	RecordId add(Map<HK, HV> body);
@@ -63,7 +63,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 *
 	 * @param recordIds stream record Id's.
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	@Nullable
 	Long delete(String... recordIds);
@@ -100,7 +100,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 * Get the length of a stream.
 	 *
 	 * @return length of the stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xlen">Redis Documentation: XLEN</a>
+	 * @see <a href="https://redis.io/commands/xlen">Redis Documentation: XLEN</a>
 	 */
 	@Nullable
 	Long size();
@@ -110,7 +110,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 *
 	 * @param range must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	@Nullable
 	default List<MapRecord<K, HK, HV>> range(Range<String> range) {
@@ -123,7 +123,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	@Nullable
 	List<MapRecord<K, HK, HV>> range(Range<String> range, Limit limit);
@@ -133,7 +133,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 *
 	 * @param readOffset the offset to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	default List<MapRecord<K, HK, HV>> read(ReadOffset readOffset) {
@@ -146,7 +146,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 * @param readOptions read arguments.
 	 * @param readOffset the offset to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	List<MapRecord<K, HK, HV>> read(StreamReadOptions readOptions, ReadOffset readOffset);
@@ -157,7 +157,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 * @param consumer consumer/group.
 	 * @param readOffset the offset to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	default List<MapRecord<K, HK, HV>> read(Consumer consumer, ReadOffset readOffset) {
@@ -171,7 +171,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 * @param readOptions read arguments.
 	 * @param readOffset the offset to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	List<MapRecord<K, HK, HV>> read(Consumer consumer, StreamReadOptions readOptions, ReadOffset readOffset);
@@ -181,7 +181,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 *
 	 * @param range must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	@Nullable
 	default List<MapRecord<K, HK, HV>> reverseRange(Range<String> range) {
@@ -194,7 +194,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	@Nullable
 	List<MapRecord<K, HK, HV>> reverseRange(Range<String> range, Limit limit);
@@ -204,7 +204,7 @@ public interface BoundStreamOperations<K, HK, HV> {
 	 *
 	 * @param count length of the stream.
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
+	 * @see <a href="https://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
 	 */
 	@Nullable
 	Long trim(long count);

--- a/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
@@ -35,7 +35,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * Set {@code value} for the bound key.
 	 *
 	 * @param value must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	void set(V value);
 
@@ -45,7 +45,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param value must not be {@literal null}.
 	 * @param timeout
 	 * @param unit must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see <a href="https://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 */
 	void set(V value, long timeout, TimeUnit unit);
 
@@ -55,7 +55,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param value must not be {@literal null}.
 	 * @param timeout must not be {@literal null}.
 	 * @throws IllegalArgumentException if either {@code value} or {@code timeout} is not present.
-	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see <a href="https://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 * @since 2.1
 	 */
 	default void set(V value, Duration timeout) {
@@ -74,7 +74,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 * @see <a href="https://redis.io/commands/setnx">Redis Documentation: SETNX</a>
 	 */
 	@Nullable
 	Boolean setIfAbsent(V value);
@@ -87,7 +87,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param unit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	@Nullable
 	Boolean setIfAbsent(V value, long timeout, TimeUnit unit);
@@ -99,7 +99,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param timeout must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @throws IllegalArgumentException if either {@code value} or {@code timeout} is not present.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -120,7 +120,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param value must not be {@literal null}.
 	 * @return command result indicating if the key has been set.
 	 * @throws IllegalArgumentException if {@code value} is not present.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -134,7 +134,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param unit must not be {@literal null}.
 	 * @return command result indicating if the key has been set.
 	 * @throws IllegalArgumentException if either {@code value} or {@code timeout} is not present.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -147,7 +147,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param timeout must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @throws IllegalArgumentException if either {@code value} or {@code timeout} is not present.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -166,7 +166,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * Get the value of the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 * @see <a href="https://redis.io/commands/get">Redis Documentation: GET</a>
 	 */
 	@Nullable
 	V get();
@@ -175,7 +175,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * Set {@code value} of the bound key and return its old value.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 * @see <a href="https://redis.io/commands/getset">Redis Documentation: GETSET</a>
 	 */
 	@Nullable
 	V getAndSet(V value);
@@ -185,7 +185,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 * @see <a href="https://redis.io/commands/incr">Redis Documentation: INCR</a>
 	 */
 	@Nullable
 	Long increment();
@@ -195,7 +195,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param delta
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
+	 * @see <a href="https://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
 	 */
 	@Nullable
 	Long increment(long delta);
@@ -205,7 +205,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param delta
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
+	 * @see <a href="https://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
 	 */
 	@Nullable
 	Double increment(double delta);
@@ -215,7 +215,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/decr">Redis Documentation: DECR</a>
+	 * @see <a href="https://redis.io/commands/decr">Redis Documentation: DECR</a>
 	 */
 	@Nullable
 	Long decrement();
@@ -226,7 +226,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param delta
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
+	 * @see <a href="https://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
 	 */
 	@Nullable
 	Long decrement(long delta);
@@ -236,7 +236,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 * @see <a href="https://redis.io/commands/append">Redis Documentation: APPEND</a>
 	 */
 	@Nullable
 	Integer append(String value);
@@ -247,7 +247,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 * @see <a href="https://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
 	 */
 	@Nullable
 	String get(long start, long end);
@@ -257,7 +257,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param value must not be {@literal null}.
 	 * @param offset
-	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 * @see <a href="https://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
 	 */
 	void set(V value, long offset);
 
@@ -265,7 +265,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * Get the length of the value stored at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 * @see <a href="https://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
 	 */
 	@Nullable
 	Long size();

--- a/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundZSetOperations.java
@@ -42,7 +42,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param score the score.
 	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	@Nullable
 	Boolean add(V value, double score);
@@ -52,7 +52,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param tuples must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	@Nullable
 	Long add(Set<TypedTuple<V>> tuples);
@@ -62,7 +62,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param values must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	@Nullable
 	Long remove(Object... values);
@@ -73,7 +73,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param delta
 	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 */
 	@Nullable
 	Double incrementScore(V value, double delta);
@@ -83,7 +83,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param o the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 * @see <a href="https://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
 	 */
 	@Nullable
 	Long rank(Object o);
@@ -93,7 +93,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param o the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 * @see <a href="https://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 */
 	@Nullable
 	Long reverseRank(Object o);
@@ -104,7 +104,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	@Nullable
 	Set<V> range(long start, long end);
@@ -115,7 +115,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> rangeWithScores(long start, long end);
@@ -126,7 +126,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<V> rangeByScore(double min, double max);
@@ -137,7 +137,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> rangeByScoreWithScores(double min, double max);
@@ -148,7 +148,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	@Nullable
 	Set<V> reverseRange(long start, long end);
@@ -159,7 +159,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> reverseRangeWithScores(long start, long end);
@@ -170,7 +170,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	@Nullable
 	Set<V> reverseRangeByScore(double min, double max);
@@ -182,7 +182,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> reverseRangeByScoreWithScores(double min, double max);
@@ -193,7 +193,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see <a href="https://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	@Nullable
 	Long count(double min, double max);
@@ -203,7 +203,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @see #zCard()
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see <a href="https://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 */
 	@Nullable
 	Long size();
@@ -213,7 +213,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see <a href="https://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 */
 	@Nullable
 	Long zCard();
@@ -223,7 +223,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 *
 	 * @param o the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
+	 * @see <a href="https://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
 	 */
 	@Nullable
 	Double score(Object o);
@@ -234,7 +234,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
 	 */
 	@Nullable
 	Long removeRange(long start, long end);
@@ -245,7 +245,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Long removeRangeByScore(double min, double max);
@@ -256,7 +256,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	Long unionAndStore(K otherKey, K destKey);
@@ -267,7 +267,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	Long unionAndStore(Collection<K> otherKeys, K destKey);
@@ -280,7 +280,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param aggregate must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	Long unionAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate);
@@ -294,7 +294,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param weights must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	Long unionAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
@@ -305,7 +305,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	Long intersectAndStore(K otherKey, K destKey);
@@ -316,7 +316,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	Long intersectAndStore(Collection<K> otherKeys, K destKey);
@@ -329,7 +329,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param aggregate must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	Long intersectAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate);
@@ -343,7 +343,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param weights must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	Long intersectAndStore(Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
@@ -365,7 +365,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param range must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.7
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	@Nullable
 	Set<V> rangeByLex(Range range);
@@ -379,7 +379,7 @@ public interface BoundZSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @param limit can be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.7
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	@Nullable
 	Set<V> rangeByLex(Range range, Limit limit);

--- a/src/main/java/org/springframework/data/redis/core/GeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/GeoOperations.java
@@ -33,7 +33,7 @@ import org.springframework.lang.Nullable;
  * @author Ninad Divadkar
  * @author Christoph Strobl
  * @author Mark Paluch
- * @see <a href="http://redis.io/commands#geo">Redis Documentation: Geo Commands</a>
+ * @see <a href="https://redis.io/commands#geo">Redis Documentation: Geo Commands</a>
  * @since 1.8
  */
 public interface GeoOperations<K, M> {
@@ -46,7 +46,7 @@ public interface GeoOperations<K, M> {
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long add(K key, Point point, M member);
@@ -58,7 +58,7 @@ public interface GeoOperations<K, M> {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @deprecated since 2.0, use {@link #add(Object, Point, Object)}.
 	 */
 	@Deprecated
@@ -74,7 +74,7 @@ public interface GeoOperations<K, M> {
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long add(K key, GeoLocation<M> location);
@@ -85,7 +85,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @deprecated since 2.0, use {@link #add(Object, GeoLocation)}.
 	 */
 	@Deprecated
@@ -101,7 +101,7 @@ public interface GeoOperations<K, M> {
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long add(K key, Map<M, Point> memberCoordinateMap);
@@ -112,7 +112,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @deprecated since 2.0, use {@link #add(Object, Map)}.
 	 */
 	@Deprecated
@@ -128,7 +128,7 @@ public interface GeoOperations<K, M> {
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	@Nullable
 	Long add(K key, Iterable<GeoLocation<M>> locations);
@@ -139,7 +139,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 * @deprecated since 2.0, use {@link #add(Object, Iterable)}.
 	 */
 	@Deprecated
@@ -156,7 +156,7 @@ public interface GeoOperations<K, M> {
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	@Nullable
 	Distance distance(K key, M member1, M member2);
@@ -168,7 +168,7 @@ public interface GeoOperations<K, M> {
 	 * @param member1 must not be {@literal null}.
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 * @deprecated since 2.0, use {@link #distance(Object, Object, Object)}.
 	 */
 	@Deprecated
@@ -186,7 +186,7 @@ public interface GeoOperations<K, M> {
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	@Nullable
 	Distance distance(K key, M member1, M member2, Metric metric);
@@ -199,7 +199,7 @@ public interface GeoOperations<K, M> {
 	 * @param member2 must not be {@literal null}.
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 * @deprecated since 2.0, use {@link #distance(Object, Object, Object, Metric)}.
 	 */
 	@Deprecated
@@ -215,7 +215,7 @@ public interface GeoOperations<K, M> {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	@Nullable
 	List<String> hash(K key, M... members);
@@ -226,7 +226,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 * @deprecated since 2.0, use {@link #hash(Object, Object[])}.
 	 */
 	@Deprecated
@@ -242,7 +242,7 @@ public interface GeoOperations<K, M> {
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	@Nullable
 	List<Point> position(K key, M... members);
@@ -253,7 +253,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 * @deprecated since 2.0, use {@link #position(Object, Object[])}.
 	 */
 	@Deprecated
@@ -269,7 +269,7 @@ public interface GeoOperations<K, M> {
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(K key, Circle within);
@@ -280,7 +280,7 @@ public interface GeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 * @deprecated since 2.0, use {@link #radius(Object, Circle)}.
 	 */
 	@Deprecated
@@ -297,7 +297,7 @@ public interface GeoOperations<K, M> {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(K key, Circle within, GeoRadiusCommandArgs args);
@@ -309,7 +309,7 @@ public interface GeoOperations<K, M> {
 	 * @param within must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 * @deprecated since 2.0, use {@link #radius(Object, Circle, GeoRadiusCommandArgs)}.
 	 */
 	@Deprecated
@@ -327,7 +327,7 @@ public interface GeoOperations<K, M> {
 	 * @param radius
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(K key, M member, double radius);
@@ -340,7 +340,7 @@ public interface GeoOperations<K, M> {
 	 * @param member must not be {@literal null}.
 	 * @param radius
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 * @deprecated since 2.0, use {@link #radius(Object, Object, double)}.
 	 */
 	@Deprecated
@@ -358,7 +358,7 @@ public interface GeoOperations<K, M> {
 	 * @param distance must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(K key, M member, Distance distance);
@@ -371,7 +371,7 @@ public interface GeoOperations<K, M> {
 	 * @param member must not be {@literal null}.
 	 * @param distance must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 * @deprecated since 2.0, use {@link #radius(Object, Object, Distance)}.
 	 */
 	@Deprecated
@@ -390,7 +390,7 @@ public interface GeoOperations<K, M> {
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
 	 * @since 2.0
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	@Nullable
 	GeoResults<GeoLocation<M>> radius(K key, M member, Distance distance, GeoRadiusCommandArgs args);
@@ -404,7 +404,7 @@ public interface GeoOperations<K, M> {
 	 * @param distance must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null} unless used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 * @deprecated since 2.0, use {@link #radius(Object, Object, Distance, GeoRadiusCommandArgs)}.
 	 */
 	@Deprecated

--- a/src/main/java/org/springframework/data/redis/core/IndexWriter.java
+++ b/src/main/java/org/springframework/data/redis/core/IndexWriter.java
@@ -32,7 +32,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
 /**
- * {@link IndexWriter} takes care of writing <a href="http://redis.io/topics/indexes">secondary index</a> structures to
+ * {@link IndexWriter} takes care of writing <a href="https://redis.io/topics/indexes">secondary index</a> structures to
  * Redis. Depending on the type of {@link IndexedData} it uses eg. Sets with specific names to add actually referenced
  * keys to. While doing so {@link IndexWriter} also keeps track of all indexes associated with the root types key, which
  * allows to remove the root key from all indexes in case of deletion.

--- a/src/main/java/org/springframework/data/redis/core/ListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ListOperations.java
@@ -39,7 +39,7 @@ public interface ListOperations<K, V> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 * @see <a href="https://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
 	@Nullable
 	List<V> range(K key, long start, long end);
@@ -50,7 +50,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param start
 	 * @param end
-	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 * @see <a href="https://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
 	 */
 	void trim(K key, long start, long end);
 
@@ -59,7 +59,7 @@ public interface ListOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 * @see <a href="https://redis.io/commands/llen">Redis Documentation: LLEN</a>
 	 */
 	@Nullable
 	Long size(K key);
@@ -70,7 +70,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	@Nullable
 	Long leftPush(K key, V value);
@@ -81,7 +81,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	@Nullable
 	Long leftPushAll(K key, V... values);
@@ -93,7 +93,7 @@ public interface ListOperations<K, V> {
 	 * @param values must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	@Nullable
 	Long leftPushAll(K key, Collection<V> values);
@@ -104,7 +104,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
+	 * @see <a href="https://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
 	 */
 	@Nullable
 	Long leftPushIfPresent(K key, V value);
@@ -115,7 +115,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	@Nullable
 	Long leftPush(K key, V pivot, V value);
@@ -126,7 +126,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	@Nullable
 	Long rightPush(K key, V value);
@@ -137,7 +137,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	@Nullable
 	Long rightPushAll(K key, V... values);
@@ -149,7 +149,7 @@ public interface ListOperations<K, V> {
 	 * @param values
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	@Nullable
 	Long rightPushAll(K key, Collection<V> values);
@@ -160,7 +160,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
+	 * @see <a href="https://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
 	 */
 	@Nullable
 	Long rightPushIfPresent(K key, V value);
@@ -171,7 +171,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: RPUSH</a>
 	 */
 	@Nullable
 	Long rightPush(K key, V pivot, V value);
@@ -182,7 +182,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @param value
-	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 * @see <a href="https://redis.io/commands/lset">Redis Documentation: LSET</a>
 	 */
 	void set(K key, long index, V value);
 
@@ -193,7 +193,7 @@ public interface ListOperations<K, V> {
 	 * @param count
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see <a href="https://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 */
 	@Nullable
 	Long remove(K key, long count, Object value);
@@ -204,7 +204,7 @@ public interface ListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 * @see <a href="https://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
 	 */
 	@Nullable
 	V index(K key, long index);
@@ -214,7 +214,7 @@ public interface ListOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 * @see <a href="https://redis.io/commands/lpop">Redis Documentation: LPOP</a>
 	 */
 	@Nullable
 	V leftPop(K key);
@@ -227,7 +227,7 @@ public interface ListOperations<K, V> {
 	 * @param timeout
 	 * @param unit must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
 	 */
 	@Nullable
 	V leftPop(K key, long timeout, TimeUnit unit);
@@ -237,7 +237,7 @@ public interface ListOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 * @see <a href="https://redis.io/commands/rpop">Redis Documentation: RPOP</a>
 	 */
 	@Nullable
 	V rightPop(K key);
@@ -250,7 +250,7 @@ public interface ListOperations<K, V> {
 	 * @param timeout
 	 * @param unit must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
 	 */
 	@Nullable
 	V rightPop(K key, long timeout, TimeUnit unit);
@@ -261,7 +261,7 @@ public interface ListOperations<K, V> {
 	 * @param sourceKey must not be {@literal null}.
 	 * @param destinationKey must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
 	 */
 	@Nullable
 	V rightPopAndLeftPush(K sourceKey, K destinationKey);
@@ -275,7 +275,7 @@ public interface ListOperations<K, V> {
 	 * @param timeout
 	 * @param unit must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
 	 */
 	@Nullable
 	V rightPopAndLeftPush(K sourceKey, K destinationKey, long timeout, TimeUnit unit);

--- a/src/main/java/org/springframework/data/redis/core/ReactiveGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveGeoOperations.java
@@ -36,7 +36,7 @@ import org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusComma
  *
  * @author Mark Paluch
  * @author Christoph Strobl
- * @see <a href="http://redis.io/commands#geo">Redis Documentation: Geo Commands</a>
+ * @see <a href="https://redis.io/commands#geo">Redis Documentation: Geo Commands</a>
  * @since 2.0
  */
 public interface ReactiveGeoOperations<K, M> {
@@ -48,7 +48,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param point must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Mono<Long> add(K key, Point point, M member);
 
@@ -58,7 +58,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param location must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Mono<Long> add(K key, GeoLocation<M> location);
 
@@ -68,7 +68,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param memberCoordinateMap must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Mono<Long> add(K key, Map<M, Point> memberCoordinateMap);
 
@@ -78,7 +78,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Mono<Long> add(K key, Iterable<GeoLocation<M>> locations);
 
@@ -88,7 +88,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param locations must not be {@literal null}.
 	 * @return Number of elements added.
-	 * @see <a href="http://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
+	 * @see <a href="https://redis.io/commands/geoadd">Redis Documentation: GEOADD</a>
 	 */
 	Flux<Long> add(K key, Publisher<? extends Collection<GeoLocation<M>>> locations);
 
@@ -99,7 +99,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param member1 must not be {@literal null}.
 	 * @param member2 must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	Mono<Distance> distance(K key, M member1, M member2);
 
@@ -111,7 +111,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param member2 must not be {@literal null}.
 	 * @param metric must not be {@literal null}.
 	 * @return can be {@literal null}.
-	 * @see <a href="http://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
+	 * @see <a href="https://redis.io/commands/geodist">Redis Documentation: GEODIST</a>
 	 */
 	Mono<Distance> distance(K key, M member1, M member2, Metric metric);
 
@@ -121,7 +121,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	Mono<String> hash(K key, M member);
 
@@ -131,7 +131,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
+	 * @see <a href="https://redis.io/commands/geohash">Redis Documentation: GEOHASH</a>
 	 */
 	Mono<List<String>> hash(K key, M... members);
 
@@ -141,7 +141,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param member must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	Mono<Point> position(K key, M member);
 
@@ -151,7 +151,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param members must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
+	 * @see <a href="https://redis.io/commands/geopos">Redis Documentation: GEOPOS</a>
 	 */
 	Mono<List<Point>> position(K key, M... members);
 
@@ -161,7 +161,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param key must not be {@literal null}.
 	 * @param within must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	Flux<GeoResult<GeoLocation<M>>> radius(K key, Circle within);
 
@@ -172,7 +172,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param within must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
+	 * @see <a href="https://redis.io/commands/georadius">Redis Documentation: GEORADIUS</a>
 	 */
 	Flux<GeoResult<GeoLocation<M>>> radius(K key, Circle within, GeoRadiusCommandArgs args);
 
@@ -184,7 +184,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param member must not be {@literal null}.
 	 * @param radius
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	Flux<GeoResult<GeoLocation<M>>> radius(K key, M member, double radius);
 
@@ -196,7 +196,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param member must not be {@literal null}.
 	 * @param distance must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	Flux<GeoResult<GeoLocation<M>>> radius(K key, M member, Distance distance);
 
@@ -209,7 +209,7 @@ public interface ReactiveGeoOperations<K, M> {
 	 * @param distance must not be {@literal null}.
 	 * @param args must not be {@literal null}.
 	 * @return never {@literal null}.
-	 * @see <a href="http://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
+	 * @see <a href="https://redis.io/commands/georadiusbymember">Redis Documentation: GEORADIUSBYMEMBER</a>
 	 */
 	Flux<GeoResult<GeoLocation<M>>> radius(K key, M member, Distance distance, GeoRadiusCommandArgs args);
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
@@ -154,7 +154,7 @@ public interface ReactiveHashOperations<H, HK, HV> {
 	 * @return the {@link Flux} emitting the {@link java.util.Map.Entry entries} on by one or an {@link Flux#empty() empty
 	 *         flux} if the key does not exist.
 	 * @throws IllegalArgumentException when the given {@code key} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @see <a href="https://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<Map.Entry<HK, HV>> scan(H key) {
@@ -170,7 +170,7 @@ public interface ReactiveHashOperations<H, HK, HV> {
 	 * @return the {@link Flux} emitting the {@link java.util.Map.Entry entries} on by one or an {@link Flux#empty() empty
 	 *         flux} if the key does not exist.
 	 * @throws IllegalArgumentException when one of the required arguments is {@literal null}.
-	 * @see <a href="http://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
+	 * @see <a href="https://redis.io/commands/hscan">Redis Documentation: HSCAN</a>
 	 * @since 2.1
 	 */
 	Flux<Map.Entry<HK, HV>> scan(H key, ScanOptions options);

--- a/src/main/java/org/springframework/data/redis/core/ReactiveListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveListOperations.java
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
- * @see <a href="http://redis.io/commands#list">Redis Documentation: List Commands</a>
+ * @see <a href="https://redis.io/commands#list">Redis Documentation: List Commands</a>
  * @since 2.0
  */
 public interface ReactiveListOperations<K, V> {
@@ -39,7 +39,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param start
 	 * @param end
 	 * @return
-	 * @see <a href="http://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
+	 * @see <a href="https://redis.io/commands/lrange">Redis Documentation: LRANGE</a>
 	 */
 	Flux<V> range(K key, long start, long end);
 
@@ -49,7 +49,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param start
 	 * @param end
-	 * @see <a href="http://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
+	 * @see <a href="https://redis.io/commands/ltrim">Redis Documentation: LTRIM</a>
 	 */
 	Mono<Boolean> trim(K key, long start, long end);
 
@@ -58,7 +58,7 @@ public interface ReactiveListOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/llen">Redis Documentation: LLEN</a>
+	 * @see <a href="https://redis.io/commands/llen">Redis Documentation: LLEN</a>
 	 */
 	Mono<Long> size(K key);
 
@@ -68,7 +68,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	Mono<Long> leftPush(K key, V value);
 
@@ -78,7 +78,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	Mono<Long> leftPushAll(K key, V... values);
 
@@ -89,7 +89,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param values must not be {@literal null}.
 	 * @return
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	Mono<Long> leftPushAll(K key, Collection<V> values);
 
@@ -99,7 +99,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
+	 * @see <a href="https://redis.io/commands/lpushx">Redis Documentation: LPUSHX</a>
 	 */
 	Mono<Long> leftPushIfPresent(K key, V value);
 
@@ -109,7 +109,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: LPUSH</a>
 	 */
 	Mono<Long> leftPush(K key, V pivot, V value);
 
@@ -119,7 +119,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	Mono<Long> rightPush(K key, V value);
 
@@ -129,7 +129,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	Mono<Long> rightPushAll(K key, V... values);
 
@@ -140,7 +140,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param values
 	 * @return
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpush">Redis Documentation: RPUSH</a>
 	 */
 	Mono<Long> rightPushAll(K key, Collection<V> values);
 
@@ -150,7 +150,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
+	 * @see <a href="https://redis.io/commands/rpushx">Redis Documentation: RPUSHX</a>
 	 */
 	Mono<Long> rightPushIfPresent(K key, V value);
 
@@ -160,7 +160,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpush">Redis Documentation: RPUSH</a>
+	 * @see <a href="https://redis.io/commands/lpush">Redis Documentation: RPUSH</a>
 	 */
 	Mono<Long> rightPush(K key, V pivot, V value);
 
@@ -170,7 +170,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @param value
-	 * @see <a href="http://redis.io/commands/lset">Redis Documentation: LSET</a>
+	 * @see <a href="https://redis.io/commands/lset">Redis Documentation: LSET</a>
 	 */
 	Mono<Boolean> set(K key, long index, V value);
 
@@ -181,7 +181,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param count
 	 * @param value
 	 * @return
-	 * @see <a href="http://redis.io/commands/lrem">Redis Documentation: LREM</a>
+	 * @see <a href="https://redis.io/commands/lrem">Redis Documentation: LREM</a>
 	 */
 	Mono<Long> remove(K key, long count, Object value);
 
@@ -191,7 +191,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param index
 	 * @return
-	 * @see <a href="http://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
+	 * @see <a href="https://redis.io/commands/lindex">Redis Documentation: LINDEX</a>
 	 */
 	Mono<V> index(K key, long index);
 
@@ -200,7 +200,7 @@ public interface ReactiveListOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/lpop">Redis Documentation: LPOP</a>
+	 * @see <a href="https://redis.io/commands/lpop">Redis Documentation: LPOP</a>
 	 */
 	Mono<V> leftPop(K key);
 
@@ -213,7 +213,7 @@ public interface ReactiveListOperations<K, V> {
 	 *          {@link Duration#ZERO} or greater {@link 1 second}, must not be {@literal null}. A timeout of zero can be
 	 *          used to wait indefinitely. Durations between zero and one second are not supported.
 	 * @return
-	 * @see <a href="http://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
 	 */
 	Mono<V> leftPop(K key, Duration timeout);
 
@@ -222,7 +222,7 @@ public interface ReactiveListOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpop">Redis Documentation: RPOP</a>
+	 * @see <a href="https://redis.io/commands/rpop">Redis Documentation: RPOP</a>
 	 */
 	Mono<V> rightPop(K key);
 
@@ -235,7 +235,7 @@ public interface ReactiveListOperations<K, V> {
 	 *          {@link Duration#ZERO} or greater {@link 1 second}, must not be {@literal null}. A timeout of zero can be
 	 *          used to wait indefinitely. Durations between zero and one second are not supported.
 	 * @return
-	 * @see <a href="http://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
 	 */
 	Mono<V> rightPop(K key, Duration timeout);
 
@@ -245,7 +245,7 @@ public interface ReactiveListOperations<K, V> {
 	 * @param sourceKey must not be {@literal null}.
 	 * @param destinationKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/rpoplpush">Redis Documentation: RPOPLPUSH</a>
 	 */
 	Mono<V> rightPopAndLeftPush(K sourceKey, K destinationKey);
 
@@ -259,7 +259,7 @@ public interface ReactiveListOperations<K, V> {
 	 *          either {@link Duration#ZERO} or greater {@link 1 second}, must not be {@literal null}. A timeout of zero
 	 *          can be used to wait indefinitely. Durations between zero and one second are not supported.
 	 * @return
-	 * @see <a href="http://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 * @see <a href="https://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
 	 */
 	Mono<V> rightPopAndLeftPush(K sourceKey, K destinationKey, Duration timeout);
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
@@ -74,7 +74,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 * @param message message to publish. Must not be {@literal null}.
 	 * @return the number of clients that received the message
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 * @see <a href="https://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
 	 */
 	Mono<Long> convertAndSend(String destination, V message);
 
@@ -125,7 +125,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
+	 * @see <a href="https://redis.io/commands/exists">Redis Documentation: EXISTS</a>
 	 */
 	Mono<Boolean> hasKey(K key);
 
@@ -134,7 +134,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/type">Redis Documentation: TYPE</a>
+	 * @see <a href="https://redis.io/commands/type">Redis Documentation: TYPE</a>
 	 */
 	Mono<DataType> type(K key);
 
@@ -146,7 +146,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 * @param pattern must not be {@literal null}.
 	 * @return the {@link Flux} emitting matching keys one by one.
 	 * @throws IllegalArgumentException in case the pattern is {@literal null}.
-	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
+	 * @see <a href="https://redis.io/commands/keys">Redis Documentation: KEYS</a>
 	 */
 	Flux<K> keys(K pattern);
 
@@ -156,7 +156,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 *
 	 * @return the {@link Flux} emitting the {@literal keys} one by one or an {@link Flux#empty() empty flux} if none
 	 *         exist.
-	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @see <a href="https://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<K> scan() {
@@ -171,7 +171,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 * @return the {@link Flux} emitting the {@literal keys} one by one or an {@link Flux#empty() empty flux} if none
 	 *         exist.
 	 * @throws IllegalArgumentException when the given {@code options} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 * @see <a href="https://redis.io/commands/scan">Redis Documentation: SCAN</a>
 	 * @since 2.1
 	 */
 	Flux<K> scan(ScanOptions options);
@@ -180,7 +180,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 * Return a random key from the keyspace.
 	 *
 	 * @return
-	 * @see <a href="http://redis.io/commands/randomkey">Redis Documentation: RANDOMKEY</a>
+	 * @see <a href="https://redis.io/commands/randomkey">Redis Documentation: RANDOMKEY</a>
 	 */
 	Mono<K> randomKey();
 
@@ -189,7 +189,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 *
 	 * @param oldKey must not be {@literal null}.
 	 * @param newKey must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/rename">Redis Documentation: RENAME</a>
+	 * @see <a href="https://redis.io/commands/rename">Redis Documentation: RENAME</a>
 	 */
 	Mono<Boolean> rename(K oldKey, K newKey);
 
@@ -199,7 +199,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 * @param oldKey must not be {@literal null}.
 	 * @param newKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
+	 * @see <a href="https://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
 	 */
 	Mono<Boolean> renameIfAbsent(K oldKey, K newKey);
 
@@ -208,7 +208,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return The number of keys that were removed.
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	Mono<Long> delete(K... key);
 
@@ -218,7 +218,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed.
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	Mono<Long> delete(Publisher<K> keys);
 
@@ -228,7 +228,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	Mono<Long> unlink(K... key);
@@ -240,7 +240,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	Mono<Long> unlink(Publisher<K> keys);
@@ -268,7 +268,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/persist">Redis Documentation: PERSIST</a>
+	 * @see <a href="https://redis.io/commands/persist">Redis Documentation: PERSIST</a>
 	 */
 	Mono<Boolean> persist(K key);
 
@@ -278,7 +278,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param dbIndex
 	 * @return
-	 * @see <a href="http://redis.io/commands/move">Redis Documentation: MOVE</a>
+	 * @see <a href="https://redis.io/commands/move">Redis Documentation: MOVE</a>
 	 */
 	Mono<Boolean> move(K key, int dbIndex);
 
@@ -288,7 +288,7 @@ public interface ReactiveRedisOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @return the {@link Duration} of the associated key. {@link Duration#ZERO} if no timeout associated or empty
 	 *         {@link Mono} if the key does not exist.
-	 * @see <a href="http://redis.io/commands/pttl">Redis Documentation: PTTL</a>
+	 * @see <a href="https://redis.io/commands/pttl">Redis Documentation: PTTL</a>
 	 */
 	Mono<Duration> getExpire(K key);
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveSetOperations.java
@@ -26,7 +26,7 @@ import java.util.Collection;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Roman Bezpalko
- * @see <a href="http://redis.io/commands#set">Redis Documentation: Set Commands</a>
+ * @see <a href="https://redis.io/commands#set">Redis Documentation: Set Commands</a>
  * @since 2.0
  */
 public interface ReactiveSetOperations<K, V> {
@@ -37,7 +37,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
-	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see <a href="https://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 */
 	Mono<Long> add(K key, V... values);
 
@@ -47,7 +47,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return
-	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see <a href="https://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 */
 	Mono<Long> remove(K key, Object... values);
 
@@ -56,7 +56,7 @@ public interface ReactiveSetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	Mono<V> pop(K key);
 
@@ -66,7 +66,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param count number of random members to pop from the set.
 	 * @return {@link Flux} emitting random members.
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	Flux<V> pop(K key, long count);
 
@@ -77,7 +77,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param value
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 * @see <a href="https://redis.io/commands/smove">Redis Documentation: SMOVE</a>
 	 */
 	Mono<Boolean> move(K sourceKey, V value, K destKey);
 
@@ -86,7 +86,7 @@ public interface ReactiveSetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 * @see <a href="https://redis.io/commands/scard">Redis Documentation: SCARD</a>
 	 */
 	Mono<Long> size(K key);
 
@@ -96,7 +96,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param o
 	 * @return
-	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 * @see <a href="https://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
 	 */
 	Mono<Boolean> isMember(K key, Object o);
 
@@ -106,7 +106,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	Flux<V> intersect(K key, K otherKey);
 
@@ -116,7 +116,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKeys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	Flux<V> intersect(K key, Collection<K> otherKeys);
 
@@ -125,7 +125,7 @@ public interface ReactiveSetOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 * @since 2.2
 	 */
 	Flux<V> intersect(Collection<K> keys);
@@ -137,7 +137,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	Mono<Long> intersectAndStore(K key, K otherKey, K destKey);
 
@@ -148,7 +148,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey);
 
@@ -158,7 +158,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 * @since 2.2
 	 */
 	Mono<Long> intersectAndStore(Collection<K> keys, K destKey);
@@ -169,7 +169,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	Flux<V> union(K key, K otherKey);
 
@@ -179,7 +179,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKeys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	Flux<V> union(K key, Collection<K> otherKeys);
 
@@ -188,7 +188,7 @@ public interface ReactiveSetOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 * @since 2.2
 	 */
 	Flux<V> union(Collection<K> keys);
@@ -200,7 +200,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	Mono<Long> unionAndStore(K key, K otherKey, K destKey);
 
@@ -211,7 +211,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey);
 
@@ -221,7 +221,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 * @since 2.2
 	 */
 	Mono<Long> unionAndStore(Collection<K> keys, K destKey);
@@ -232,7 +232,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	Flux<V> difference(K key, K otherKey);
 
@@ -242,7 +242,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKeys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	Flux<V> difference(K key, Collection<K> otherKeys);
 
@@ -251,7 +251,7 @@ public interface ReactiveSetOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 * @since 2.2
 	 */
 	Flux<V> difference(Collection<K> keys);
@@ -263,7 +263,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	Mono<Long> differenceAndStore(K key, K otherKey, K destKey);
 
@@ -274,7 +274,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	Mono<Long> differenceAndStore(K key, Collection<K> otherKeys, K destKey);
 
@@ -284,7 +284,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 * @since 2.2
 	 */
 	Mono<Long> differenceAndStore(Collection<K> keys, K destKey);
@@ -294,7 +294,7 @@ public interface ReactiveSetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 * @see <a href="https://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
 	Flux<V> members(K key);
 
@@ -306,7 +306,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return the {@link Flux} emitting the {@literal values} one by one or an {@link Flux#empty() empty Flux} if none
 	 *         exist.
 	 * @throws IllegalArgumentException when given {@code key} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @see <a href="https://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<V> scan(K key) {
@@ -322,7 +322,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @return the {@link Flux} emitting the {@literal values} one by one or an {@link Flux#empty() empty Flux} if the key
 	 *         does not exist.
 	 * @throws IllegalArgumentException when one of the required arguments is {@literal null}.
-	 * @see <a href="http://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
+	 * @see <a href="https://redis.io/commands/sscan">Redis Documentation: SSCAN</a>
 	 * @since 2.1
 	 */
 	Flux<V> scan(K key, ScanOptions options);
@@ -332,7 +332,7 @@ public interface ReactiveSetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	Mono<V> randomMember(K key);
 
@@ -342,7 +342,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param count number of members to return.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	Flux<V> distinctRandomMembers(K key, long count);
 
@@ -352,7 +352,7 @@ public interface ReactiveSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param count number of members to return.
 	 * @return
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	Flux<V> randomMembers(K key, long count);
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
@@ -52,7 +52,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param group name of the consumer group.
 	 * @param recordIds record Id's to acknowledge.
 	 * @return the {@link Mono} emitting the length of acknowledged records.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	default Mono<Long> acknowledge(K key, String group, String... recordIds) {
 		return acknowledge(key, group, Arrays.stream(recordIds).map(RecordId::of).toArray(RecordId[]::new));
@@ -65,7 +65,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param group name of the consumer group.
 	 * @param recordIds record Id's to acknowledge.
 	 * @return the {@link Mono} emitting the length of acknowledged records.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	Mono<Long> acknowledge(K key, String group, RecordId... recordIds);
 
@@ -75,7 +75,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param group name of the consumer group.
 	 * @param record the {@link Record} to acknowledge.
 	 * @return the {@link Mono} emitting the length of acknowledged records.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	default Mono<Long> acknowledge(String group, Record<K, ?> record) {
 		return acknowledge(record.getStream(), group, record.getId());
@@ -87,7 +87,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param key the stream key.
 	 * @param bodyPublisher record body {@link Publisher}.
 	 * @return the record Ids.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	default Flux<RecordId> add(K key, Publisher<? extends Map<? extends HK, ? extends HV>> bodyPublisher) {
 		return Flux.from(bodyPublisher).flatMap(it -> add(key, it));
@@ -99,7 +99,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param key the stream key.
 	 * @param content record content as Map.
 	 * @return the {@link Mono} emitting the {@link RecordId}.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	default Mono<RecordId> add(K key, Map<? extends HK, ? extends HV> content) {
 		return add(StreamRecords.newRecord().in(key).ofMap(content));
@@ -110,7 +110,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 *
 	 * @param record the record to append.
 	 * @return the {@link Mono} emitting the {@link RecordId}.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	@SuppressWarnings("unchecked")
 	default Mono<RecordId> add(MapRecord<K, ? extends HK, ? extends HV> record) {
@@ -134,7 +134,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param key the stream key.
 	 * @param recordIds stream record Id's.
 	 * @return the {@link Mono} emitting the number of removed records.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	default Mono<Long> delete(K key, String... recordIds) {
 		return delete(key, Arrays.stream(recordIds).map(RecordId::of).toArray(RecordId[]::new));
@@ -157,7 +157,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param key the stream key.
 	 * @param recordIds stream record Id's.
 	 * @return the {@link Mono} emitting the number of removed records.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	Mono<Long> delete(K key, RecordId... recordIds);
 
@@ -206,7 +206,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 *
 	 * @param key the stream key.
 	 * @return the {@link Mono} emitting the length of the stream.
-	 * @see <a href="http://redis.io/commands/xlen">Redis Documentation: XLEN</a>
+	 * @see <a href="https://redis.io/commands/xlen">Redis Documentation: XLEN</a>
 	 */
 	Mono<Long> size(K key);
 
@@ -216,7 +216,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	default Flux<MapRecord<K, HK, HV>> range(K key, Range<String> range) {
 		return range(key, range, Limit.unlimited());
@@ -229,7 +229,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return lthe {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	Flux<MapRecord<K, HK, HV>> range(K key, Range<String> range, Limit limit);
 
@@ -240,7 +240,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	default <V> Flux<ObjectRecord<K, V>> range(Class<V> targetType, K key, Range<String> range) {
 		return range(targetType, key, range, Limit.unlimited());
@@ -254,7 +254,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	default <V> Flux<ObjectRecord<K, V>> range(Class<V> targetType, K key, Range<String> range, Limit limit) {
 
@@ -268,7 +268,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 *
 	 * @param stream the stream to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@SuppressWarnings("unchecked")
 	default Flux<MapRecord<K, HK, HV>> read(StreamOffset<K> stream) {
@@ -284,7 +284,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param targetType the target type of the payload.
 	 * @param stream the stream to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@SuppressWarnings("unchecked")
 	default <V> Flux<ObjectRecord<K, V>> read(Class<V> targetType, StreamOffset<K> stream) {
@@ -299,7 +299,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 *
 	 * @param streams the streams to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	default Flux<MapRecord<K, HK, HV>> read(StreamOffset<K>... streams) {
 		return read(StreamReadOptions.empty(), streams);
@@ -311,7 +311,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param targetType the target type of the payload.
 	 * @param streams the streams to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	default <V> Flux<ObjectRecord<K, V>> read(Class<V> targetType, StreamOffset<K>... streams) {
 		return read(targetType, StreamReadOptions.empty(), streams);
@@ -323,7 +323,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	Flux<MapRecord<K, HK, HV>> read(StreamReadOptions readOptions, StreamOffset<K>... streams);
 
@@ -334,7 +334,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	default <V> Flux<ObjectRecord<K, V>> read(Class<V> targetType, StreamReadOptions readOptions,
 			StreamOffset<K>... streams) {
@@ -350,7 +350,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param consumer consumer/group.
 	 * @param streams the streams to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	default Flux<MapRecord<K, HK, HV>> read(Consumer consumer, StreamOffset<K>... streams) {
 		return read(consumer, StreamReadOptions.empty(), streams);
@@ -363,7 +363,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param consumer consumer/group.
 	 * @param streams the streams to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	default <V> Flux<ObjectRecord<K, V>> read(Class<V> targetType, Consumer consumer, StreamOffset<K>... streams) {
 		return read(targetType, consumer, StreamReadOptions.empty(), streams);
@@ -376,7 +376,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	Flux<MapRecord<K, HK, HV>> read(Consumer consumer, StreamReadOptions readOptions, StreamOffset<K>... streams);
 
@@ -388,7 +388,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	default <V> Flux<ObjectRecord<K, V>> read(Class<V> targetType, Consumer consumer, StreamReadOptions readOptions,
 			StreamOffset<K>... streams) {
@@ -404,7 +404,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	default Flux<MapRecord<K, HK, HV>> reverseRange(K key, Range<String> range) {
 		return reverseRange(key, range, Limit.unlimited());
@@ -417,7 +417,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	Flux<MapRecord<K, HK, HV>> reverseRange(K key, Range<String> range, Limit limit);
 
@@ -428,7 +428,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	default <V> Flux<ObjectRecord<K, V>> reverseRange(Class<V> targetType, K key, Range<String> range) {
 		return reverseRange(targetType, key, range, Limit.unlimited());
@@ -443,7 +443,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return the {@link Flux} emitting records one by one.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	default <V> Flux<ObjectRecord<K, V>> reverseRange(Class<V> targetType, K key, Range<String> range, Limit limit) {
 
@@ -458,7 +458,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @param key the stream key.
 	 * @param count length of the stream.
 	 * @return number of removed entries.
-	 * @see <a href="http://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
+	 * @see <a href="https://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
 	 */
 	Mono<Long> trim(K key, long count);
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveValueOperations.java
@@ -38,7 +38,7 @@ public interface ReactiveValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	Mono<Boolean> set(K key, V value);
 
@@ -48,7 +48,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @param timeout must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see <a href="https://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 */
 	Mono<Boolean> set(K key, V value, Duration timeout);
 
@@ -57,7 +57,7 @@ public interface ReactiveValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
-	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 * @see <a href="https://redis.io/commands/setnx">Redis Documentation: SETNX</a>
 	 */
 	Mono<Boolean> setIfAbsent(K key, V value);
 
@@ -68,7 +68,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * @param value
 	 * @param timeout must not be {@literal null}.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	Mono<Boolean> setIfAbsent(K key, V value, Duration timeout);
 
@@ -77,7 +77,7 @@ public interface ReactiveValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	Mono<Boolean> setIfPresent(K key, V value);
 
@@ -88,7 +88,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * @param value
 	 * @param timeout must not be {@literal null}.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	Mono<Boolean> setIfPresent(K key, V value, Duration timeout);
 
@@ -96,7 +96,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple}.
 	 *
 	 * @param map must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 * @see <a href="https://redis.io/commands/mset">Redis Documentation: MSET</a>
 	 */
 	Mono<Boolean> multiSet(Map<? extends K, ? extends V> map);
 
@@ -105,7 +105,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * not exist.
 	 *
 	 * @param map must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
+	 * @see <a href="https://redis.io/commands/msetnx">Redis Documentation: MSETNX</a>
 	 */
 	Mono<Boolean> multiSetIfAbsent(Map<? extends K, ? extends V> map);
 
@@ -113,7 +113,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * Get the value of {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 * @see <a href="https://redis.io/commands/get">Redis Documentation: GET</a>
 	 */
 	Mono<V> get(Object key);
 
@@ -121,7 +121,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * Set {@code value} of {@code key} and return its old value.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 * @see <a href="https://redis.io/commands/getset">Redis Documentation: GETSET</a>
 	 */
 	Mono<V> getAndSet(K key, V value);
 
@@ -129,7 +129,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * Get multiple {@code keys}. Values are returned in the order of the requested keys.
 	 *
 	 * @param keys must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/mget">Redis Documentation: MGET</a>
+	 * @see <a href="https://redis.io/commands/mget">Redis Documentation: MGET</a>
 	 */
 	Mono<List<V>> multiGet(Collection<K> keys);
 
@@ -138,7 +138,7 @@ public interface ReactiveValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 * @see <a href="https://redis.io/commands/incr">Redis Documentation: INCR</a>
 	 */
 	Mono<Long> increment(K key);
 
@@ -148,7 +148,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param delta
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
+	 * @see <a href="https://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
 	 */
 	Mono<Long> increment(K key, long delta);
 
@@ -158,7 +158,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param delta
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
+	 * @see <a href="https://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
 	 */
 	Mono<Double> increment(K key, double delta);
 
@@ -167,7 +167,7 @@ public interface ReactiveValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/decr">Redis Documentation: DECR</a>
+	 * @see <a href="https://redis.io/commands/decr">Redis Documentation: DECR</a>
 	 */
 	Mono<Long> decrement(K key);
 
@@ -177,7 +177,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param delta
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
+	 * @see <a href="https://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
 	 */
 	Mono<Long> decrement(K key, long delta);
 
@@ -186,7 +186,7 @@ public interface ReactiveValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value
-	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 * @see <a href="https://redis.io/commands/append">Redis Documentation: APPEND</a>
 	 */
 	Mono<Long> append(K key, String value);
 
@@ -196,7 +196,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param start
 	 * @param end
-	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 * @see <a href="https://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
 	 */
 	Mono<String> get(K key, long start, long end);
 
@@ -206,7 +206,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @param offset
-	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 * @see <a href="https://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
 	 */
 	Mono<Long> set(K key, V value, long offset);
 
@@ -214,7 +214,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * Get the length of the value stored at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 * @see <a href="https://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
 	 */
 	Mono<Long> size(K key);
 
@@ -224,7 +224,7 @@ public interface ReactiveValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param offset
 	 * @param value
-	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
+	 * @see <a href="https://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
 	 */
 	Mono<Boolean> setBit(K key, long offset, boolean value);
 
@@ -233,7 +233,7 @@ public interface ReactiveValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param offset
-	 * @see <a href="http://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
+	 * @see <a href="https://redis.io/commands/getbit">Redis Documentation: GETBIT</a>
 	 */
 	Mono<Boolean> getBit(K key, long offset);
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveZSetOperations.java
@@ -32,7 +32,7 @@ import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
- * @see <a href="http://redis.io/commands#zset">Redis Documentation: Sorted Set Commands</a>
+ * @see <a href="https://redis.io/commands#zset">Redis Documentation: Sorted Set Commands</a>
  * @since 2.0
  */
 public interface ReactiveZSetOperations<K, V> {
@@ -44,7 +44,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param score the score.
 	 * @param value the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	Mono<Boolean> add(K key, V value, double score);
 
@@ -54,7 +54,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param tuples the score.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	Mono<Long> addAll(K key, Collection<? extends TypedTuple<V>> tuples);
 
@@ -64,7 +64,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	Mono<Long> remove(K key, Object... values);
 
@@ -75,7 +75,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param delta
 	 * @param value the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 */
 	Mono<Double> incrementScore(K key, V value, double delta);
 
@@ -85,7 +85,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param o the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 * @see <a href="https://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
 	 */
 	Mono<Long> rank(K key, Object o);
 
@@ -95,7 +95,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param o the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 * @see <a href="https://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 */
 	Mono<Long> reverseRank(K key, Object o);
 
@@ -105,7 +105,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	Flux<V> range(K key, Range<Long> range);
 
@@ -115,7 +115,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	Flux<TypedTuple<V>> rangeWithScores(K key, Range<Long> range);
 
@@ -125,7 +125,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Flux<V> rangeByScore(K key, Range<Double> range);
 
@@ -135,7 +135,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Flux<TypedTuple<V>> rangeByScoreWithScores(K key, Range<Double> range);
 
@@ -147,7 +147,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param range
 	 * @param limit
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Flux<V> rangeByScore(K key, Range<Double> range, Limit limit);
 
@@ -159,7 +159,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param range
 	 * @param limit
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	Flux<TypedTuple<V>> rangeByScoreWithScores(K key, Range<Double> range, Limit limit);
 
@@ -169,7 +169,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	Flux<V> reverseRange(K key, Range<Long> range);
 
@@ -179,7 +179,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	Flux<TypedTuple<V>> reverseRangeWithScores(K key, Range<Long> range);
 
@@ -189,7 +189,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	Flux<V> reverseRangeByScore(K key, Range<Double> range);
 
@@ -200,7 +200,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Flux<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range);
 
@@ -212,7 +212,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param range
 	 * @param limit
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Flux<V> reverseRangeByScore(K key, Range<Double> range, Limit limit);
 
@@ -224,7 +224,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param range
 	 * @param limit
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	Flux<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range, Limit limit);
 
@@ -236,7 +236,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return the {@link Flux} emitting the {@literal values} one by one or an {@link Flux#empty() empty Flux} if none
 	 *         exist.
 	 * @throws IllegalArgumentException when given {@code key} is {@literal null}.
-	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @see <a href="https://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
 	 * @since 2.1
 	 */
 	default Flux<TypedTuple<V>> scan(K key) {
@@ -253,7 +253,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @return the {@link Flux} emitting the {@literal values} one by one or an {@link Flux#empty() empty Flux} if none
 	 *         exist.
 	 * @throws IllegalArgumentException when one of the required arguments is {@literal null}.
-	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @see <a href="https://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
 	 * @since 2.1
 	 */
 	Flux<TypedTuple<V>> scan(K key, ScanOptions options);
@@ -264,7 +264,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range
 	 * @return
-	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see <a href="https://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	Mono<Long> count(K key, Range<Double> range);
 
@@ -273,7 +273,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 *
 	 * @param key
 	 * @return
-	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see <a href="https://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 */
 	Mono<Long> size(K key);
 
@@ -283,7 +283,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param o the value.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
+	 * @see <a href="https://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
 	 */
 	Mono<Double> score(K key, Object o);
 
@@ -293,7 +293,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range
 	 * @return
-	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
 	 */
 	Mono<Long> removeRange(K key, Range<Long> range);
 
@@ -303,7 +303,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param range
 	 * @return
-	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	Mono<Long> removeRangeByScore(K key, Range<Double> range);
 
@@ -314,7 +314,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	Mono<Long> unionAndStore(K key, K otherKey, K destKey);
 
@@ -325,7 +325,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey);
 
@@ -338,7 +338,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param aggregate must not be {@literal null}.
 	 * @return
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	default Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
 		return unionAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
@@ -354,7 +354,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param weights must not be {@literal null}.
 	 * @return
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	Mono<Long> unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
 
@@ -365,7 +365,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	Mono<Long> intersectAndStore(K key, K otherKey, K destKey);
 
@@ -376,7 +376,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey);
 
@@ -389,7 +389,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param aggregate must not be {@literal null}.
 	 * @return
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	default Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
 		return intersectAndStore(key, otherKeys, destKey, aggregate, Weights.fromSetCount(1 + otherKeys.size()));
@@ -405,7 +405,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param weights must not be {@literal null}.
 	 * @return
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	Mono<Long> intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
 
@@ -415,7 +415,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Flux<V> rangeByLex(K key, Range<String> range);
 
@@ -428,7 +428,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param range must not be {@literal null}.
 	 * @param limit can be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	Flux<V> rangeByLex(K key, Range<String> range, Limit limit);
 
@@ -438,7 +438,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param range must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
 	 */
 	Flux<V> reverseRangeByLex(K key, Range<String> range);
 
@@ -451,7 +451,7 @@ public interface ReactiveZSetOperations<K, V> {
 	 * @param range must not be {@literal null}.
 	 * @param limit can be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebylex">Redis Documentation: ZREVRANGEBYLEX</a>
 	 */
 	Flux<V> reverseRangeByLex(K key, Range<String> range, Limit limit);
 

--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -159,7 +159,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
-	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
+	 * @see <a href="https://redis.io/commands/exists">Redis Documentation: EXISTS</a>
 	 */
 	@Nullable
 	Boolean hasKey(K key);
@@ -170,7 +170,7 @@ public interface RedisOperations<K, V> {
 	 * @param keys must not be {@literal null}.
 	 * @return The number of keys existing among the ones specified as arguments. Keys mentioned multiple times and
 	 *         existing are counted multiple times.
-	 * @see <a href="http://redis.io/commands/exists">Redis Documentation: EXISTS</a>
+	 * @see <a href="https://redis.io/commands/exists">Redis Documentation: EXISTS</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -181,7 +181,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal true} if the key was removed.
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	@Nullable
 	Boolean delete(K key);
@@ -191,7 +191,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/del">Redis Documentation: DEL</a>
+	 * @see <a href="https://redis.io/commands/del">Redis Documentation: DEL</a>
 	 */
 	@Nullable
 	Long delete(Collection<K> keys);
@@ -202,7 +202,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -214,7 +214,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return The number of keys that were removed. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis Documentation: UNLINK</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -225,7 +225,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/type">Redis Documentation: TYPE</a>
+	 * @see <a href="https://redis.io/commands/type">Redis Documentation: TYPE</a>
 	 */
 	@Nullable
 	DataType type(K key);
@@ -235,7 +235,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param pattern must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/keys">Redis Documentation: KEYS</a>
+	 * @see <a href="https://redis.io/commands/keys">Redis Documentation: KEYS</a>
 	 */
 	@Nullable
 	Set<K> keys(K pattern);
@@ -244,7 +244,7 @@ public interface RedisOperations<K, V> {
 	 * Return a random key from the keyspace.
 	 *
 	 * @return {@literal null} no keys exist or when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/randomkey">Redis Documentation: RANDOMKEY</a>
+	 * @see <a href="https://redis.io/commands/randomkey">Redis Documentation: RANDOMKEY</a>
 	 */
 	@Nullable
 	K randomKey();
@@ -254,7 +254,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param oldKey must not be {@literal null}.
 	 * @param newKey must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/rename">Redis Documentation: RENAME</a>
+	 * @see <a href="https://redis.io/commands/rename">Redis Documentation: RENAME</a>
 	 */
 	void rename(K oldKey, K newKey);
 
@@ -264,7 +264,7 @@ public interface RedisOperations<K, V> {
 	 * @param oldKey must not be {@literal null}.
 	 * @param newKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
+	 * @see <a href="https://redis.io/commands/renamenx">Redis Documentation: RENAMENX</a>
 	 */
 	@Nullable
 	Boolean renameIfAbsent(K oldKey, K newKey);
@@ -295,7 +295,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/persist">Redis Documentation: PERSIST</a>
+	 * @see <a href="https://redis.io/commands/persist">Redis Documentation: PERSIST</a>
 	 */
 	@Nullable
 	Boolean persist(K key);
@@ -306,7 +306,7 @@ public interface RedisOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param dbIndex
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/move">Redis Documentation: MOVE</a>
+	 * @see <a href="https://redis.io/commands/move">Redis Documentation: MOVE</a>
 	 */
 	@Nullable
 	Boolean move(K key, int dbIndex);
@@ -316,7 +316,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/dump">Redis Documentation: DUMP</a>
+	 * @see <a href="https://redis.io/commands/dump">Redis Documentation: DUMP</a>
 	 */
 	@Nullable
 	byte[] dump(K key);
@@ -328,7 +328,7 @@ public interface RedisOperations<K, V> {
 	 * @param value must not be {@literal null}.
 	 * @param timeToLive
 	 * @param unit must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/restore">Redis Documentation: RESTORE</a>
+	 * @see <a href="https://redis.io/commands/restore">Redis Documentation: RESTORE</a>
 	 */
 	default void restore(K key, byte[] value, long timeToLive, TimeUnit unit) {
 		restore(key, value, timeToLive, unit, false);
@@ -343,7 +343,7 @@ public interface RedisOperations<K, V> {
 	 * @param unit must not be {@literal null}.
 	 * @param replace use {@literal true} to replace a potentially existing value instead of erroring.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/restore">Redis Documentation: RESTORE</a>
+	 * @see <a href="https://redis.io/commands/restore">Redis Documentation: RESTORE</a>
 	 */
 	void restore(K key, byte[] value, long timeToLive, TimeUnit unit, boolean replace);
 
@@ -352,7 +352,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/ttl">Redis Documentation: TTL</a>
+	 * @see <a href="https://redis.io/commands/ttl">Redis Documentation: TTL</a>
 	 */
 	@Nullable
 	Long getExpire(K key);
@@ -373,7 +373,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param query must not be {@literal null}.
 	 * @return the results of sort. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 * @see <a href="https://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	@Nullable
 	List<V> sort(SortQuery<K> query);
@@ -383,7 +383,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param query must not be {@literal null}.
 	 * @return the deserialized results of sort. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 * @see <a href="https://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	@Nullable
 	<T> List<T> sort(SortQuery<K> query, RedisSerializer<T> resultSerializer);
@@ -393,7 +393,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param query must not be {@literal null}.
 	 * @return the deserialized results of sort. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 * @see <a href="https://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	@Nullable
 	<T> List<T> sort(SortQuery<K> query, BulkMapper<T, V> bulkMapper);
@@ -403,7 +403,7 @@ public interface RedisOperations<K, V> {
 	 *
 	 * @param query must not be {@literal null}.
 	 * @return the deserialized results of sort. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 * @see <a href="https://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	@Nullable
 	<T, S> List<T> sort(SortQuery<K> query, BulkMapper<T, S> bulkMapper, RedisSerializer<S> resultSerializer);
@@ -414,7 +414,7 @@ public interface RedisOperations<K, V> {
 	 * @param query must not be {@literal null}.
 	 * @param storeKey must not be {@literal null}.
 	 * @return number of values. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sort">Redis Documentation: SORT</a>
+	 * @see <a href="https://redis.io/commands/sort">Redis Documentation: SORT</a>
 	 */
 	@Nullable
 	Long sort(SortQuery<K> query, K storeKey);
@@ -427,7 +427,7 @@ public interface RedisOperations<K, V> {
 	 * Watch given {@code key} for modifications during transaction started with {@link #multi()}.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/watch">Redis Documentation: WATCH</a>
+	 * @see <a href="https://redis.io/commands/watch">Redis Documentation: WATCH</a>
 	 */
 	void watch(K key);
 
@@ -435,14 +435,14 @@ public interface RedisOperations<K, V> {
 	 * Watch given {@code keys} for modifications during transaction started with {@link #multi()}.
 	 *
 	 * @param keys must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/watch">Redis Documentation: WATCH</a>
+	 * @see <a href="https://redis.io/commands/watch">Redis Documentation: WATCH</a>
 	 */
 	void watch(Collection<K> keys);
 
 	/**
 	 * Flushes all the previously {@link #watch(Object)} keys.
 	 *
-	 * @see <a href="http://redis.io/commands/unwatch">Redis Documentation: UNWATCH</a>
+	 * @see <a href="https://redis.io/commands/unwatch">Redis Documentation: UNWATCH</a>
 	 */
 	void unwatch();
 
@@ -451,14 +451,14 @@ public interface RedisOperations<K, V> {
 	 * Commands will be queued and can then be executed by calling {@link #exec()} or rolled back using {@link #discard()}
 	 * <p>
 	 *
-	 * @see <a href="http://redis.io/commands/multi">Redis Documentation: MULTI</a>
+	 * @see <a href="https://redis.io/commands/multi">Redis Documentation: MULTI</a>
 	 */
 	void multi();
 
 	/**
 	 * Discard all commands issued after {@link #multi()}.
 	 *
-	 * @see <a href="http://redis.io/commands/discard">Redis Documentation: DISCARD</a>
+	 * @see <a href="https://redis.io/commands/discard">Redis Documentation: DISCARD</a>
 	 */
 	void discard();
 
@@ -467,7 +467,7 @@ public interface RedisOperations<K, V> {
 	 * If used along with {@link #watch(Object)} the operation will fail if any of watched keys has been modified.
 	 *
 	 * @return List of replies for each executed command.
-	 * @see <a href="http://redis.io/commands/exec">Redis Documentation: EXEC</a>
+	 * @see <a href="https://redis.io/commands/exec">Redis Documentation: EXEC</a>
 	 */
 	List<Object> exec();
 
@@ -510,7 +510,7 @@ public interface RedisOperations<K, V> {
 	 * @param host must not be {@literal null}.
 	 * @param port
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
+	 * @see <a href="https://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
 	 */
 	void slaveOf(String host, int port);
 
@@ -518,7 +518,7 @@ public interface RedisOperations<K, V> {
 	 * Change server into master.
 	 *
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
+	 * @see <a href="https://redis.io/commands/slaveof">Redis Documentation: SLAVEOF</a>
 	 */
 	void slaveOfNoOne();
 
@@ -528,7 +528,7 @@ public interface RedisOperations<K, V> {
 	 * @param destination the channel to publish to, must not be {@literal null}.
 	 * @param message message to publish
 	 * @return the number of clients that received the message
-	 * @see <a href="http://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
+	 * @see <a href="https://redis.io/commands/publish">Redis Documentation: PUBLISH</a>
 	 */
 	void convertAndSend(String destination, Object message);
 

--- a/src/main/java/org/springframework/data/redis/core/SetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/SetOperations.java
@@ -37,7 +37,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sadd">Redis Documentation: SADD</a>
+	 * @see <a href="https://redis.io/commands/sadd">Redis Documentation: SADD</a>
 	 */
 	@Nullable
 	Long add(K key, V... values);
@@ -48,7 +48,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/srem">Redis Documentation: SREM</a>
+	 * @see <a href="https://redis.io/commands/srem">Redis Documentation: SREM</a>
 	 */
 	@Nullable
 	Long remove(K key, Object... values);
@@ -58,7 +58,7 @@ public interface SetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 */
 	@Nullable
 	V pop(K key);
@@ -69,7 +69,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param count number of random members to pop from the set.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/spop">Redis Documentation: SPOP</a>
+	 * @see <a href="https://redis.io/commands/spop">Redis Documentation: SPOP</a>
 	 * @since 2.0
 	 */
 	@Nullable
@@ -82,7 +82,7 @@ public interface SetOperations<K, V> {
 	 * @param value
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/smove">Redis Documentation: SMOVE</a>
+	 * @see <a href="https://redis.io/commands/smove">Redis Documentation: SMOVE</a>
 	 */
 	@Nullable
 	Boolean move(K key, V value, K destKey);
@@ -92,7 +92,7 @@ public interface SetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/scard">Redis Documentation: SCARD</a>
+	 * @see <a href="https://redis.io/commands/scard">Redis Documentation: SCARD</a>
 	 */
 	@Nullable
 	Long size(K key);
@@ -103,7 +103,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param o
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
+	 * @see <a href="https://redis.io/commands/sismember">Redis Documentation: SISMEMBER</a>
 	 */
 	@Nullable
 	Boolean isMember(K key, Object o);
@@ -114,7 +114,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	@Nullable
 	Set<V> intersect(K key, K otherKey);
@@ -125,7 +125,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKeys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 */
 	@Nullable
 	Set<V> intersect(K key, Collection<K> otherKeys);
@@ -135,7 +135,7 @@ public interface SetOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinter">Redis Documentation: SINTER</a>
+	 * @see <a href="https://redis.io/commands/sinter">Redis Documentation: SINTER</a>
 	 * @since 2.2
 	 */
 	@Nullable
@@ -148,7 +148,7 @@ public interface SetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	@Nullable
 	Long intersectAndStore(K key, K otherKey, K destKey);
@@ -160,7 +160,7 @@ public interface SetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	@Nullable
 	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey);
@@ -171,7 +171,7 @@ public interface SetOperations<K, V> {
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 * @since 2.2
 	 */
 	@Nullable
@@ -183,7 +183,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	@Nullable
 	Set<V> union(K key, K otherKey);
@@ -194,7 +194,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKeys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 */
 	@Nullable
 	Set<V> union(K key, Collection<K> otherKeys);
@@ -204,7 +204,7 @@ public interface SetOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunion">Redis Documentation: SUNION</a>
+	 * @see <a href="https://redis.io/commands/sunion">Redis Documentation: SUNION</a>
 	 * @since 2.2
 	 */
 	@Nullable
@@ -217,7 +217,7 @@ public interface SetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	@Nullable
 	Long unionAndStore(K key, K otherKey, K destKey);
@@ -229,7 +229,7 @@ public interface SetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 */
 	@Nullable
 	Long unionAndStore(K key, Collection<K> otherKeys, K destKey);
@@ -240,7 +240,7 @@ public interface SetOperations<K, V> {
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/sunionstore">Redis Documentation: SUNIONSTORE</a>
 	 * @since 2.2
 	 */
 	@Nullable
@@ -252,7 +252,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	@Nullable
 	Set<V> difference(K key, K otherKey);
@@ -263,7 +263,7 @@ public interface SetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param otherKeys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 */
 	@Nullable
 	Set<V> difference(K key, Collection<K> otherKeys);
@@ -273,7 +273,7 @@ public interface SetOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
+	 * @see <a href="https://redis.io/commands/sdiff">Redis Documentation: SDIFF</a>
 	 * @since 2.2
 	 */
 	@Nullable
@@ -286,7 +286,7 @@ public interface SetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	@Nullable
 	Long differenceAndStore(K key, K otherKey, K destKey);
@@ -298,7 +298,7 @@ public interface SetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 */
 	@Nullable
 	Long differenceAndStore(K key, Collection<K> otherKeys, K destKey);
@@ -309,7 +309,7 @@ public interface SetOperations<K, V> {
 	 * @param keys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
+	 * @see <a href="https://redis.io/commands/sdiffstore">Redis Documentation: SDIFFSTORE</a>
 	 * @since 2.2
 	 */
 	@Nullable
@@ -320,7 +320,7 @@ public interface SetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
+	 * @see <a href="https://redis.io/commands/smembers">Redis Documentation: SMEMBERS</a>
 	 */
 	@Nullable
 	Set<V> members(K key);
@@ -330,7 +330,7 @@ public interface SetOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	V randomMember(K key);
 
@@ -341,7 +341,7 @@ public interface SetOperations<K, V> {
 	 * @param count nr of members to return
 	 * @return empty {@link Set} if {@code key} does not exist.
 	 * @throws IllegalArgumentException if count is negative.
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	@Nullable
 	Set<V> distinctRandomMembers(K key, long count);
@@ -353,7 +353,7 @@ public interface SetOperations<K, V> {
 	 * @param count nr of members to return.
 	 * @return empty {@link List} if {@code key} does not exist or {@literal null} when used in pipeline / transaction.
 	 * @throws IllegalArgumentException if count is negative.
-	 * @see <a href="http://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
+	 * @see <a href="https://redis.io/commands/srandmember">Redis Documentation: SRANDMEMBER</a>
 	 */
 	@Nullable
 	List<V> randomMembers(K key, long count);

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -52,7 +52,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param group name of the consumer group.
 	 * @param recordIds record id's to acknowledge.
 	 * @return length of acknowledged records. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	@Nullable
 	Long acknowledge(K key, String group, String... recordIds);
@@ -64,7 +64,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param group name of the consumer group.
 	 * @param recordIds record id's to acknowledge.
 	 * @return length of acknowledged records. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	@Nullable
 	default Long acknowledge(K key, String group, RecordId... recordIds) {
@@ -77,7 +77,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param group name of the consumer group.
 	 * @param record the {@link Record} to acknowledge.
 	 * @return length of acknowledged records. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xack">Redis Documentation: XACK</a>
+	 * @see <a href="https://redis.io/commands/xack">Redis Documentation: XACK</a>
 	 */
 	default Long acknowledge(String group, Record<K, ?> record) {
 		return acknowledge(record.getStream(), group, record.getId());
@@ -89,7 +89,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param key the stream key.
 	 * @param content record content as Map.
 	 * @return the record Id. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	@SuppressWarnings("unchecked")
 	@Nullable
@@ -102,7 +102,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 *
 	 * @param record the record to append.
 	 * @return the record Id. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
 	 */
 	@Nullable
 	@SuppressWarnings("unchecked")
@@ -129,7 +129,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param key the stream key.
 	 * @param recordIds stream record Id's.
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	@Nullable
 	default Long delete(K key, String... recordIds) {
@@ -154,7 +154,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param key the stream key.
 	 * @param recordIds stream record Id's.
 	 * @return the {@link Mono} emitting the number of removed records.
-	 * @see <a href="http://redis.io/commands/xdel">Redis Documentation: XDEL</a>
+	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
 	@Nullable
 	Long delete(K key, RecordId... recordIds);
@@ -206,7 +206,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 *
 	 * @param key the stream key.
 	 * @return length of the stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xlen">Redis Documentation: XLEN</a>
+	 * @see <a href="https://redis.io/commands/xlen">Redis Documentation: XLEN</a>
 	 */
 	@Nullable
 	Long size(K key);
@@ -217,7 +217,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	@Nullable
 	default List<MapRecord<K, HK, HV>> range(K key, Range<String> range) {
@@ -231,7 +231,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	@Nullable
 	List<MapRecord<K, HK, HV>> range(K key, Range<String> range, Limit limit);
@@ -243,7 +243,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	default <V> List<ObjectRecord<K, V>> range(Class<V> targetType, K key, Range<String> range) {
 		return range(targetType, key, range, Limit.unlimited());
@@ -257,7 +257,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrange">Redis Documentation: XRANGE</a>
 	 */
 	default <V> List<ObjectRecord<K, V>> range(Class<V> targetType, K key, Range<String> range, Limit limit) {
 
@@ -271,7 +271,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 *
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	default List<MapRecord<K, HK, HV>> read(StreamOffset<K>... streams) {
@@ -284,7 +284,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param targetType the target type of the payload.
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	default <V> List<ObjectRecord<K, V>> read(Class<V> targetType, StreamOffset<K>... streams) {
 		return read(targetType, StreamReadOptions.empty(), streams);
@@ -296,7 +296,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	List<MapRecord<K, HK, HV>> read(StreamReadOptions readOptions, StreamOffset<K>... streams);
@@ -308,7 +308,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xread">Redis Documentation: XREAD</a>
+	 * @see <a href="https://redis.io/commands/xread">Redis Documentation: XREAD</a>
 	 */
 	@Nullable
 	default <V> List<ObjectRecord<K, V>> read(Class<V> targetType, StreamReadOptions readOptions,
@@ -325,7 +325,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param consumer consumer/group.
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	default List<MapRecord<K, HK, HV>> read(Consumer consumer, StreamOffset<K>... streams) {
@@ -339,7 +339,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param consumer consumer/group.
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	default <V> List<ObjectRecord<K, V>> read(Class<V> targetType, Consumer consumer, StreamOffset<K>... streams) {
@@ -353,7 +353,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	List<MapRecord<K, HK, HV>> read(Consumer consumer, StreamReadOptions readOptions, StreamOffset<K>... streams);
@@ -366,7 +366,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param readOptions read arguments.
 	 * @param streams the streams to read from.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
+	 * @see <a href="https://redis.io/commands/xreadgroup">Redis Documentation: XREADGROUP</a>
 	 */
 	@Nullable
 	default <V> List<ObjectRecord<K, V>> read(Class<V> targetType, Consumer consumer, StreamReadOptions readOptions,
@@ -383,7 +383,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	@Nullable
 	default List<MapRecord<K, HK, HV>> reverseRange(K key, Range<String> range) {
@@ -397,7 +397,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	@Nullable
 	List<MapRecord<K, HK, HV>> reverseRange(K key, Range<String> range, Limit limit);
@@ -409,7 +409,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param key the stream key.
 	 * @param range must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	default <V> List<ObjectRecord<K, V>> reverseRange(Class<V> targetType, K key, Range<String> range) {
 		return reverseRange(targetType, key, range, Limit.unlimited());
@@ -424,7 +424,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param range must not be {@literal null}.
 	 * @param limit must not be {@literal null}.
 	 * @return list with members of the resulting stream. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/xrevrange">Redis Documentation: XREVRANGE</a>
 	 */
 	default <V> List<ObjectRecord<K, V>> reverseRange(Class<V> targetType, K key, Range<String> range, Limit limit) {
 
@@ -439,7 +439,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @param key the stream key.
 	 * @param count length of the stream.
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
+	 * @see <a href="https://redis.io/commands/xtrim">Redis Documentation: XTRIM</a>
 	 */
 	@Nullable
 	Long trim(K key, long count);

--- a/src/main/java/org/springframework/data/redis/core/ValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ValueOperations.java
@@ -40,7 +40,7 @@ public interface ValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	void set(K key, V value);
 
@@ -51,7 +51,7 @@ public interface ValueOperations<K, V> {
 	 * @param value must not be {@literal null}.
 	 * @param timeout the key expiration timeout.
 	 * @param unit must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see <a href="https://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 */
 	void set(K key, V value, long timeout, TimeUnit unit);
 
@@ -62,7 +62,7 @@ public interface ValueOperations<K, V> {
 	 * @param value must not be {@literal null}.
 	 * @param timeout must not be {@literal null}.
 	 * @throws IllegalArgumentException if either {@code key}, {@code value} or {@code timeout} is not present.
-	 * @see <a href="http://redis.io/commands/setex">Redis Documentation: SETEX</a>
+	 * @see <a href="https://redis.io/commands/setex">Redis Documentation: SETEX</a>
 	 * @since 2.1
 	 */
 	default void set(K key, V value, Duration timeout) {
@@ -82,7 +82,7 @@ public interface ValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/setnx">Redis Documentation: SETNX</a>
+	 * @see <a href="https://redis.io/commands/setnx">Redis Documentation: SETNX</a>
 	 */
 	@Nullable
 	Boolean setIfAbsent(K key, V value);
@@ -96,7 +96,7 @@ public interface ValueOperations<K, V> {
 	 * @param unit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 */
 	@Nullable
 	Boolean setIfAbsent(K key, V value, long timeout, TimeUnit unit);
@@ -109,7 +109,7 @@ public interface ValueOperations<K, V> {
 	 * @param timeout must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @throws IllegalArgumentException if either {@code key}, {@code value} or {@code timeout} is not present.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -131,7 +131,7 @@ public interface ValueOperations<K, V> {
 	 * @param value must not be {@literal null}.
 	 * @return command result indicating if the key has been set.
 	 * @throws IllegalArgumentException if either {@code key} or {@code value} is not present.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -146,7 +146,7 @@ public interface ValueOperations<K, V> {
 	 * @param unit must not be {@literal null}.
 	 * @return command result indicating if the key has been set.
 	 * @throws IllegalArgumentException if either {@code key}, {@code value} or {@code timeout} is not present.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -160,7 +160,7 @@ public interface ValueOperations<K, V> {
 	 * @param timeout must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @throws IllegalArgumentException if either {@code key}, {@code value} or {@code timeout} is not present.
-	 * @see <a href="http://redis.io/commands/set">Redis Documentation: SET</a>
+	 * @see <a href="https://redis.io/commands/set">Redis Documentation: SET</a>
 	 * @since 2.1
 	 */
 	@Nullable
@@ -179,7 +179,7 @@ public interface ValueOperations<K, V> {
 	 * Set multiple keys to multiple values using key-value pairs provided in {@code tuple}.
 	 *
 	 * @param map must not be {@literal null}.
-	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 * @see <a href="https://redis.io/commands/mset">Redis Documentation: MSET</a>
 	 */
 	void multiSet(Map<? extends K, ? extends V> map);
 
@@ -189,7 +189,7 @@ public interface ValueOperations<K, V> {
 	 *
 	 * @param map must not be {@literal null}.
 	 * @param {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/mset">Redis Documentation: MSET</a>
+	 * @see <a href="https://redis.io/commands/mset">Redis Documentation: MSET</a>
 	 */
 	@Nullable
 	Boolean multiSetIfAbsent(Map<? extends K, ? extends V> map);
@@ -199,7 +199,7 @@ public interface ValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/get">Redis Documentation: GET</a>
+	 * @see <a href="https://redis.io/commands/get">Redis Documentation: GET</a>
 	 */
 	@Nullable
 	V get(Object key);
@@ -209,7 +209,7 @@ public interface ValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/getset">Redis Documentation: GETSET</a>
+	 * @see <a href="https://redis.io/commands/getset">Redis Documentation: GETSET</a>
 	 */
 	@Nullable
 	V getAndSet(K key, V value);
@@ -219,7 +219,7 @@ public interface ValueOperations<K, V> {
 	 *
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/mget">Redis Documentation: MGET</a>
+	 * @see <a href="https://redis.io/commands/mget">Redis Documentation: MGET</a>
 	 */
 	@Nullable
 	List<V> multiGet(Collection<K> keys);
@@ -230,7 +230,7 @@ public interface ValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/incr">Redis Documentation: INCR</a>
+	 * @see <a href="https://redis.io/commands/incr">Redis Documentation: INCR</a>
 	 */
 	@Nullable
 	Long increment(K key);
@@ -241,7 +241,7 @@ public interface ValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param delta
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
+	 * @see <a href="https://redis.io/commands/incrby">Redis Documentation: INCRBY</a>
 	 */
 	@Nullable
 	Long increment(K key, long delta);
@@ -252,7 +252,7 @@ public interface ValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param delta
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
+	 * @see <a href="https://redis.io/commands/incrbyfloat">Redis Documentation: INCRBYFLOAT</a>
 	 */
 	@Nullable
 	Double increment(K key, double delta);
@@ -263,7 +263,7 @@ public interface ValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/decr">Redis Documentation: DECR</a>
+	 * @see <a href="https://redis.io/commands/decr">Redis Documentation: DECR</a>
 	 */
 	@Nullable
 	Long decrement(K key);
@@ -275,7 +275,7 @@ public interface ValueOperations<K, V> {
 	 * @param delta
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
+	 * @see <a href="https://redis.io/commands/decrby">Redis Documentation: DECRBY</a>
 	 */
 	@Nullable
 	Long decrement(K key, long delta);
@@ -286,7 +286,7 @@ public interface ValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/append">Redis Documentation: APPEND</a>
+	 * @see <a href="https://redis.io/commands/append">Redis Documentation: APPEND</a>
 	 */
 	@Nullable
 	Integer append(K key, String value);
@@ -298,7 +298,7 @@ public interface ValueOperations<K, V> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
+	 * @see <a href="https://redis.io/commands/getrange">Redis Documentation: GETRANGE</a>
 	 */
 	@Nullable
 	String get(K key, long start, long end);
@@ -309,7 +309,7 @@ public interface ValueOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param value
 	 * @param offset
-	 * @see <a href="http://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
+	 * @see <a href="https://redis.io/commands/setrange">Redis Documentation: SETRANGE</a>
 	 */
 	void set(K key, V value, long offset);
 
@@ -318,7 +318,7 @@ public interface ValueOperations<K, V> {
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
+	 * @see <a href="https://redis.io/commands/strlen">Redis Documentation: STRLEN</a>
 	 */
 	@Nullable
 	Long size(K key);
@@ -331,7 +331,7 @@ public interface ValueOperations<K, V> {
 	 * @param value
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
+	 * @see <a href="https://redis.io/commands/setbit">Redis Documentation: SETBIT</a>
 	 */
 	@Nullable
 	Boolean setBit(K key, long offset, boolean value);
@@ -343,7 +343,7 @@ public interface ValueOperations<K, V> {
 	 * @param offset
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.5
-	 * @see <a href="http://redis.io/commands/setbit">Redis Documentation: GETBIT</a>
+	 * @see <a href="https://redis.io/commands/setbit">Redis Documentation: GETBIT</a>
 	 */
 	@Nullable
 	Boolean getBit(K key, long offset);
@@ -356,7 +356,7 @@ public interface ValueOperations<K, V> {
 	 * @param subCommands must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/bitfield">Redis Documentation: BITFIELD</a>
+	 * @see <a href="https://redis.io/commands/bitfield">Redis Documentation: BITFIELD</a>
 	 */
 	@Nullable
 	List<Long> bitField(K key, BitFieldSubCommands subCommands);

--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -55,7 +55,7 @@ public interface ZSetOperations<K, V> {
 	 * @param score the score.
 	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	@Nullable
 	Boolean add(K key, V value, double score);
@@ -66,7 +66,7 @@ public interface ZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param tuples must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zadd">Redis Documentation: ZADD</a>
+	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
 	@Nullable
 	Long add(K key, Set<TypedTuple<V>> tuples);
@@ -77,7 +77,7 @@ public interface ZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param values must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrem">Redis Documentation: ZREM</a>
+	 * @see <a href="https://redis.io/commands/zrem">Redis Documentation: ZREM</a>
 	 */
 	@Nullable
 	Long remove(K key, Object... values);
@@ -89,7 +89,7 @@ public interface ZSetOperations<K, V> {
 	 * @param delta
 	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 */
 	@Nullable
 	Double incrementScore(K key, V value, double delta);
@@ -100,7 +100,7 @@ public interface ZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param o the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
+	 * @see <a href="https://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
 	 */
 	@Nullable
 	Long rank(K key, Object o);
@@ -111,7 +111,7 @@ public interface ZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param o the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
+	 * @see <a href="https://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 */
 	@Nullable
 	Long reverseRank(K key, Object o);
@@ -123,7 +123,7 @@ public interface ZSetOperations<K, V> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	@Nullable
 	Set<V> range(K key, long start, long end);
@@ -135,7 +135,7 @@ public interface ZSetOperations<K, V> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrange">Redis Documentation: ZRANGE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> rangeWithScores(K key, long start, long end);
@@ -147,7 +147,7 @@ public interface ZSetOperations<K, V> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<V> rangeByScore(K key, double min, double max);
@@ -159,7 +159,7 @@ public interface ZSetOperations<K, V> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> rangeByScoreWithScores(K key, double min, double max);
@@ -174,7 +174,7 @@ public interface ZSetOperations<K, V> {
 	 * @param offset
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<V> rangeByScore(K key, double min, double max, long offset, long count);
@@ -189,7 +189,7 @@ public interface ZSetOperations<K, V> {
 	 * @param offset
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> rangeByScoreWithScores(K key, double min, double max, long offset, long count);
@@ -201,7 +201,7 @@ public interface ZSetOperations<K, V> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	@Nullable
 	Set<V> reverseRange(K key, long start, long end);
@@ -213,7 +213,7 @@ public interface ZSetOperations<K, V> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> reverseRangeWithScores(K key, long start, long end);
@@ -225,7 +225,7 @@ public interface ZSetOperations<K, V> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
 	 */
 	@Nullable
 	Set<V> reverseRangeByScore(K key, double min, double max);
@@ -238,7 +238,7 @@ public interface ZSetOperations<K, V> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, double min, double max);
@@ -253,7 +253,7 @@ public interface ZSetOperations<K, V> {
 	 * @param offset
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<V> reverseRangeByScore(K key, double min, double max, long offset, long count);
@@ -268,7 +268,7 @@ public interface ZSetOperations<K, V> {
 	 * @param offset
 	 * @param count
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, double min, double max, long offset, long count);
@@ -280,7 +280,7 @@ public interface ZSetOperations<K, V> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
+	 * @see <a href="https://redis.io/commands/zcount">Redis Documentation: ZCOUNT</a>
 	 */
 	@Nullable
 	Long count(K key, double min, double max);
@@ -291,7 +291,7 @@ public interface ZSetOperations<K, V> {
 	 * @see #zCard(Object)
 	 * @param key
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see <a href="https://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 */
 	@Nullable
 	Long size(K key);
@@ -302,7 +302,7 @@ public interface ZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.3
-	 * @see <a href="http://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
+	 * @see <a href="https://redis.io/commands/zcard">Redis Documentation: ZCARD</a>
 	 */
 	@Nullable
 	Long zCard(K key);
@@ -313,7 +313,7 @@ public interface ZSetOperations<K, V> {
 	 * @param key must not be {@literal null}.
 	 * @param o the value.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
+	 * @see <a href="https://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
 	 */
 	@Nullable
 	Double score(K key, Object o);
@@ -325,7 +325,7 @@ public interface ZSetOperations<K, V> {
 	 * @param start
 	 * @param end
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyrank">Redis Documentation: ZREMRANGEBYRANK</a>
 	 */
 	@Nullable
 	Long removeRange(K key, long start, long end);
@@ -337,7 +337,7 @@ public interface ZSetOperations<K, V> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
+	 * @see <a href="https://redis.io/commands/zremrangebyscore">Redis Documentation: ZREMRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Long removeRangeByScore(K key, double min, double max);
@@ -349,7 +349,7 @@ public interface ZSetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	Long unionAndStore(K key, K otherKey, K destKey);
@@ -361,7 +361,7 @@ public interface ZSetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	Long unionAndStore(K key, Collection<K> otherKeys, K destKey);
@@ -375,7 +375,7 @@ public interface ZSetOperations<K, V> {
 	 * @param aggregate must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	default Long unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
@@ -392,7 +392,7 @@ public interface ZSetOperations<K, V> {
 	 * @param weights must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
+	 * @see <a href="https://redis.io/commands/zunionstore">Redis Documentation: ZUNIONSTORE</a>
 	 */
 	@Nullable
 	Long unionAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
@@ -404,7 +404,7 @@ public interface ZSetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	Long intersectAndStore(K key, K otherKey, K destKey);
@@ -416,7 +416,7 @@ public interface ZSetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @param destKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey);
@@ -430,7 +430,7 @@ public interface ZSetOperations<K, V> {
 	 * @param aggregate must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	default Long intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate) {
@@ -447,7 +447,7 @@ public interface ZSetOperations<K, V> {
 	 * @param weights must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.1
-	 * @see <a href="http://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
+	 * @see <a href="https://redis.io/commands/zinterstore">Redis Documentation: ZINTERSTORE</a>
 	 */
 	@Nullable
 	Long intersectAndStore(K key, Collection<K> otherKeys, K destKey, Aggregate aggregate, Weights weights);
@@ -459,7 +459,7 @@ public interface ZSetOperations<K, V> {
 	 * @param key
 	 * @param options
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="http://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
+	 * @see <a href="https://redis.io/commands/zscan">Redis Documentation: ZSCAN</a>
 	 * @since 1.4
 	 */
 	Cursor<TypedTuple<V>> scan(K key, ScanOptions options);
@@ -472,7 +472,7 @@ public interface ZSetOperations<K, V> {
 	 * @param range must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.7
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	@Nullable
 	Set<V> rangeByLex(K key, Range range);
@@ -487,7 +487,7 @@ public interface ZSetOperations<K, V> {
 	 * @param limit can be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 1.7
-	 * @see <a href="http://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
+	 * @see <a href="https://redis.io/commands/zrangebylex">Redis Documentation: ZRANGEBYLEX</a>
 	 */
 	@Nullable
 	Set<V> rangeByLex(K key, Range range, Limit limit);

--- a/src/main/java/org/springframework/data/redis/core/script/RedisScript.java
+++ b/src/main/java/org/springframework/data/redis/core/script/RedisScript.java
@@ -19,7 +19,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * A script to be executed using the <a href="http://redis.io/commands/eval">Redis scripting support</a> available as of
+ * A script to be executed using the <a href="https://redis.io/commands/eval">Redis scripting support</a> available as of
  * version 2.6
  *
  * @author Jennifer Hickey

--- a/src/main/resources/org/springframework/data/redis/config/spring-redis-1.0.xsd
+++ b/src/main/resources/org/springframework/data/redis/config/spring-redis-1.0.xsd
@@ -8,7 +8,7 @@
     elementFormDefault="qualified"
     attributeFormDefault="unqualified">
 
-  <xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+  <xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="https://www.springframework.org/schema/tool/spring-tool.xsd"/>
 
   <xsd:annotation>
     <xsd:documentation><![CDATA[

--- a/src/main/resources/readme.txt
+++ b/src/main/resources/readme.txt
@@ -1,6 +1,6 @@
 SPRING DATA REDIS $version (March 31, 2014)
 -------------------------------------------
-http://projects.spring.io/spring-data-redis/
+https://projects.spring.io/spring-data-redis/
 
 1. INTRODUCTION
 
@@ -23,6 +23,6 @@ Please see the reference documentation.
 Additionally the blog at https://spring.io/blog as well as sections of interest in the reference documentation.
 
 5. ADDITIONAL RESOURCES
-Spring Data Homepage:			http://projects.spring.io/spring-data-redis/
-Spring Data on Stackoverflow:	http://stackoverflow.com/questions/tagged/spring-data
-Redis Homepage:					http://redis.io
+Spring Data Homepage:			https://projects.spring.io/spring-data-redis/
+Spring Data on Stackoverflow:	https://stackoverflow.com/questions/tagged/spring-data
+Redis Homepage:					https://redis.io


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://blog.springsource.com/2011/04/27/getting-started-redis-spring-cloud-foundry/ (301) with 1 occurrences migrated to:  
  https://spring.io/blog/2011/04/27/getting-started-redis-spring-cloud-foundry/ ([https](https://blog.springsource.com/2011/04/27/getting-started-redis-spring-cloud-foundry/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://static.springsource.org/spring-data/data-keyvalue/examples/retwisj/current/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-keyvalue/examples/retwisj/current/ ([https](https://static.springsource.org/spring-data/data-keyvalue/examples/retwisj/current/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 12 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://en.wikipedia.org/wiki/JSON with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/JSON ([https](https://en.wikipedia.org/wiki/JSON) result 200).
* [ ] http://en.wikipedia.org/wiki/NoSQL with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/NoSQL ([https](https://en.wikipedia.org/wiki/NoSQL) result 200).
* [ ] http://github.com/lettuce-io/lettuce-core with 3 occurrences migrated to:  
  https://github.com/lettuce-io/lettuce-core ([https](https://github.com/lettuce-io/lettuce-core) result 200).
* [ ] http://github.com/mp911de/lettuce with 1 occurrences migrated to:  
  https://github.com/mp911de/lettuce ([https](https://github.com/mp911de/lettuce) result 200).
* [ ] http://github.com/spring-projects/spring-data-keyvalue-examples with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-data-keyvalue-examples ([https](https://github.com/spring-projects/spring-data-keyvalue-examples) result 200).
* [ ] http://github.com/xetorthio/jedis with 5 occurrences migrated to:  
  https://github.com/xetorthio/jedis ([https](https://github.com/xetorthio/jedis) result 200).
* [ ] http://netty.io/ with 1 occurrences migrated to:  
  https://netty.io/ ([https](https://netty.io/) result 200).
* [ ] http://netty.io/wiki/native-transports.html with 1 occurrences migrated to:  
  https://netty.io/wiki/native-transports.html ([https](https://netty.io/wiki/native-transports.html) result 200).
* [ ] http://openjdk.java.net/jeps/290 with 1 occurrences migrated to:  
  https://openjdk.java.net/jeps/290 ([https](https://openjdk.java.net/jeps/290) result 200).
* [ ] http://projects.spring.io/spring-data-redis/ with 4 occurrences migrated to:  
  https://projects.spring.io/spring-data-redis/ ([https](https://projects.spring.io/spring-data-redis/) result 200).
* [ ] http://projects.spring.io/spring-data/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data/ ([https](https://projects.spring.io/spring-data/) result 200).
* [ ] http://projects.spring.io/spring-framework/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-framework/ ([https](https://projects.spring.io/spring-framework/) result 200).
* [ ] http://redis.io with 3 occurrences migrated to:  
  https://redis.io ([https](https://redis.io) result 200).
* [ ] http://redis.io/ with 3 occurrences migrated to:  
  https://redis.io/ ([https](https://redis.io/) result 200).
* [ ] http://redis.io/commands with 8 occurrences migrated to:  
  https://redis.io/commands ([https](https://redis.io/commands) result 200).
* [ ] http://redis.io/commands/append with 8 occurrences migrated to:  
  https://redis.io/commands/append ([https](https://redis.io/commands/append) result 200).
* [ ] http://redis.io/commands/bgrewriteaof with 3 occurrences migrated to:  
  https://redis.io/commands/bgrewriteaof ([https](https://redis.io/commands/bgrewriteaof) result 200).
* [ ] http://redis.io/commands/bgsave with 2 occurrences migrated to:  
  https://redis.io/commands/bgsave ([https](https://redis.io/commands/bgsave) result 200).
* [ ] http://redis.io/commands/bitcount with 8 occurrences migrated to:  
  https://redis.io/commands/bitcount ([https](https://redis.io/commands/bitcount) result 200).
* [ ] http://redis.io/commands/bitfield with 5 occurrences migrated to:  
  https://redis.io/commands/bitfield ([https](https://redis.io/commands/bitfield) result 200).
* [ ] http://redis.io/commands/bitop with 5 occurrences migrated to:  
  https://redis.io/commands/bitop ([https](https://redis.io/commands/bitop) result 200).
* [ ] http://redis.io/commands/bitpos with 4 occurrences migrated to:  
  https://redis.io/commands/bitpos ([https](https://redis.io/commands/bitpos) result 200).
* [ ] http://redis.io/commands/blpop with 8 occurrences migrated to:  
  https://redis.io/commands/blpop ([https](https://redis.io/commands/blpop) result 200).
* [ ] http://redis.io/commands/brpop with 8 occurrences migrated to:  
  https://redis.io/commands/brpop ([https](https://redis.io/commands/brpop) result 200).
* [ ] http://redis.io/commands/brpoplpush with 7 occurrences migrated to:  
  https://redis.io/commands/brpoplpush ([https](https://redis.io/commands/brpoplpush) result 200).
* [ ] http://redis.io/commands/client-getname with 2 occurrences migrated to:  
  https://redis.io/commands/client-getname ([https](https://redis.io/commands/client-getname) result 200).
* [ ] http://redis.io/commands/client-kill with 2 occurrences migrated to:  
  https://redis.io/commands/client-kill ([https](https://redis.io/commands/client-kill) result 200).
* [ ] http://redis.io/commands/client-list with 3 occurrences migrated to:  
  https://redis.io/commands/client-list ([https](https://redis.io/commands/client-list) result 200).
* [ ] http://redis.io/commands/client-setname with 3 occurrences migrated to:  
  https://redis.io/commands/client-setname ([https](https://redis.io/commands/client-setname) result 200).
* [ ] http://redis.io/commands/config-get with 2 occurrences migrated to:  
  https://redis.io/commands/config-get ([https](https://redis.io/commands/config-get) result 200).
* [ ] http://redis.io/commands/config-resetstat with 2 occurrences migrated to:  
  https://redis.io/commands/config-resetstat ([https](https://redis.io/commands/config-resetstat) result 200).
* [ ] http://redis.io/commands/config-set with 2 occurrences migrated to:  
  https://redis.io/commands/config-set ([https](https://redis.io/commands/config-set) result 200).
* [ ] http://redis.io/commands/dbsize with 2 occurrences migrated to:  
  https://redis.io/commands/dbsize ([https](https://redis.io/commands/dbsize) result 200).
* [ ] http://redis.io/commands/decr with 7 occurrences migrated to:  
  https://redis.io/commands/decr ([https](https://redis.io/commands/decr) result 200).
* [ ] http://redis.io/commands/decrby with 7 occurrences migrated to:  
  https://redis.io/commands/decrby ([https](https://redis.io/commands/decrby) result 200).
* [ ] http://redis.io/commands/del with 10 occurrences migrated to:  
  https://redis.io/commands/del ([https](https://redis.io/commands/del) result 200).
* [ ] http://redis.io/commands/discard with 2 occurrences migrated to:  
  https://redis.io/commands/discard ([https](https://redis.io/commands/discard) result 200).
* [ ] http://redis.io/commands/dump with 2 occurrences migrated to:  
  https://redis.io/commands/dump ([https](https://redis.io/commands/dump) result 200).
* [ ] http://redis.io/commands/echo with 2 occurrences migrated to:  
  https://redis.io/commands/echo ([https](https://redis.io/commands/echo) result 200).
* [ ] http://redis.io/commands/eval with 5 occurrences migrated to:  
  https://redis.io/commands/eval ([https](https://redis.io/commands/eval) result 200).
* [ ] http://redis.io/commands/evalsha with 5 occurrences migrated to:  
  https://redis.io/commands/evalsha ([https](https://redis.io/commands/evalsha) result 200).
* [ ] http://redis.io/commands/exec with 2 occurrences migrated to:  
  https://redis.io/commands/exec ([https](https://redis.io/commands/exec) result 200).
* [ ] http://redis.io/commands/exists with 8 occurrences migrated to:  
  https://redis.io/commands/exists ([https](https://redis.io/commands/exists) result 200).
* [ ] http://redis.io/commands/expire with 6 occurrences migrated to:  
  https://redis.io/commands/expire ([https](https://redis.io/commands/expire) result 200).
* [ ] http://redis.io/commands/expireat with 4 occurrences migrated to:  
  https://redis.io/commands/expireat ([https](https://redis.io/commands/expireat) result 200).
* [ ] http://redis.io/commands/flushall with 2 occurrences migrated to:  
  https://redis.io/commands/flushall ([https](https://redis.io/commands/flushall) result 200).
* [ ] http://redis.io/commands/flushdb with 2 occurrences migrated to:  
  https://redis.io/commands/flushdb ([https](https://redis.io/commands/flushdb) result 200).
* [ ] http://redis.io/commands/geoadd with 34 occurrences migrated to:  
  https://redis.io/commands/geoadd ([https](https://redis.io/commands/geoadd) result 200).
* [ ] http://redis.io/commands/geodist with 18 occurrences migrated to:  
  https://redis.io/commands/geodist ([https](https://redis.io/commands/geodist) result 200).
* [ ] http://redis.io/commands/geohash with 12 occurrences migrated to:  
  https://redis.io/commands/geohash ([https](https://redis.io/commands/geohash) result 200).
* [ ] http://redis.io/commands/geopos with 12 occurrences migrated to:  
  https://redis.io/commands/geopos ([https](https://redis.io/commands/geopos) result 200).
* [ ] http://redis.io/commands/georadius with 18 occurrences migrated to:  
  https://redis.io/commands/georadius ([https](https://redis.io/commands/georadius) result 200).
* [ ] http://redis.io/commands/georadiusbymember with 25 occurrences migrated to:  
  https://redis.io/commands/georadiusbymember ([https](https://redis.io/commands/georadiusbymember) result 200).
* [ ] http://redis.io/commands/get with 7 occurrences migrated to:  
  https://redis.io/commands/get ([https](https://redis.io/commands/get) result 200).
* [ ] http://redis.io/commands/getbit with 6 occurrences migrated to:  
  https://redis.io/commands/getbit ([https](https://redis.io/commands/getbit) result 200).
* [ ] http://redis.io/commands/getrange with 7 occurrences migrated to:  
  https://redis.io/commands/getrange ([https](https://redis.io/commands/getrange) result 200).
* [ ] http://redis.io/commands/getset with 7 occurrences migrated to:  
  https://redis.io/commands/getset ([https](https://redis.io/commands/getset) result 200).
* [ ] http://redis.io/commands/hdel with 6 occurrences migrated to:  
  https://redis.io/commands/hdel ([https](https://redis.io/commands/hdel) result 200).
* [ ] http://redis.io/commands/hexists with 3 occurrences migrated to:  
  https://redis.io/commands/hexists ([https](https://redis.io/commands/hexists) result 200).
* [ ] http://redis.io/commands/hexits with 2 occurrences migrated to:  
  https://redis.io/commands/hexits ([https](https://redis.io/commands/hexits) result 200).
* [ ] http://redis.io/commands/hget with 4 occurrences migrated to:  
  https://redis.io/commands/hget ([https](https://redis.io/commands/hget) result 200).
* [ ] http://redis.io/commands/hgetall with 4 occurrences migrated to:  
  https://redis.io/commands/hgetall ([https](https://redis.io/commands/hgetall) result 200).
* [ ] http://redis.io/commands/hincrby with 5 occurrences migrated to:  
  https://redis.io/commands/hincrby ([https](https://redis.io/commands/hincrby) result 200).
* [ ] http://redis.io/commands/hincrbyfloat with 2 occurrences migrated to:  
  https://redis.io/commands/hincrbyfloat ([https](https://redis.io/commands/hincrbyfloat) result 200).
* [ ] http://redis.io/commands/hkeys with 4 occurrences migrated to:  
  https://redis.io/commands/hkeys ([https](https://redis.io/commands/hkeys) result 200).
* [ ] http://redis.io/commands/hlen with 4 occurrences migrated to:  
  https://redis.io/commands/hlen ([https](https://redis.io/commands/hlen) result 200).
* [ ] http://redis.io/commands/hmget with 4 occurrences migrated to:  
  https://redis.io/commands/hmget ([https](https://redis.io/commands/hmget) result 200).
* [ ] http://redis.io/commands/hmset with 3 occurrences migrated to:  
  https://redis.io/commands/hmset ([https](https://redis.io/commands/hmset) result 200).
* [ ] http://redis.io/commands/hscan with 7 occurrences migrated to:  
  https://redis.io/commands/hscan ([https](https://redis.io/commands/hscan) result 200).
* [ ] http://redis.io/commands/hset with 5 occurrences migrated to:  
  https://redis.io/commands/hset ([https](https://redis.io/commands/hset) result 200).
* [ ] http://redis.io/commands/hsetnx with 3 occurrences migrated to:  
  https://redis.io/commands/hsetnx ([https](https://redis.io/commands/hsetnx) result 200).
* [ ] http://redis.io/commands/hstrlen with 1 occurrences migrated to:  
  https://redis.io/commands/hstrlen ([https](https://redis.io/commands/hstrlen) result 200).
* [ ] http://redis.io/commands/hvals with 4 occurrences migrated to:  
  https://redis.io/commands/hvals ([https](https://redis.io/commands/hvals) result 200).
* [ ] http://redis.io/commands/incr with 7 occurrences migrated to:  
  https://redis.io/commands/incr ([https](https://redis.io/commands/incr) result 200).
* [ ] http://redis.io/commands/incrby with 8 occurrences migrated to:  
  https://redis.io/commands/incrby ([https](https://redis.io/commands/incrby) result 200).
* [ ] http://redis.io/commands/incrbyfloat with 7 occurrences migrated to:  
  https://redis.io/commands/incrbyfloat ([https](https://redis.io/commands/incrbyfloat) result 200).
* [ ] http://redis.io/commands/info with 4 occurrences migrated to:  
  https://redis.io/commands/info ([https](https://redis.io/commands/info) result 200).
* [ ] http://redis.io/commands/keys with 6 occurrences migrated to:  
  https://redis.io/commands/keys ([https](https://redis.io/commands/keys) result 200).
* [ ] http://redis.io/commands/lastsave with 2 occurrences migrated to:  
  https://redis.io/commands/lastsave ([https](https://redis.io/commands/lastsave) result 200).
* [ ] http://redis.io/commands/lindex with 8 occurrences migrated to:  
  https://redis.io/commands/lindex ([https](https://redis.io/commands/lindex) result 200).
* [ ] http://redis.io/commands/linsert with 5 occurrences migrated to:  
  https://redis.io/commands/linsert ([https](https://redis.io/commands/linsert) result 200).
* [ ] http://redis.io/commands/llen with 7 occurrences migrated to:  
  https://redis.io/commands/llen ([https](https://redis.io/commands/llen) result 200).
* [ ] http://redis.io/commands/lpop with 8 occurrences migrated to:  
  https://redis.io/commands/lpop ([https](https://redis.io/commands/lpop) result 200).
* [ ] http://redis.io/commands/lpush with 19 occurrences migrated to:  
  https://redis.io/commands/lpush ([https](https://redis.io/commands/lpush) result 200).
* [ ] http://redis.io/commands/lpushx with 6 occurrences migrated to:  
  https://redis.io/commands/lpushx ([https](https://redis.io/commands/lpushx) result 200).
* [ ] http://redis.io/commands/lrange with 7 occurrences migrated to:  
  https://redis.io/commands/lrange ([https](https://redis.io/commands/lrange) result 200).
* [ ] http://redis.io/commands/lrem with 9 occurrences migrated to:  
  https://redis.io/commands/lrem ([https](https://redis.io/commands/lrem) result 200).
* [ ] http://redis.io/commands/lset with 8 occurrences migrated to:  
  https://redis.io/commands/lset ([https](https://redis.io/commands/lset) result 200).
* [ ] http://redis.io/commands/ltrim with 7 occurrences migrated to:  
  https://redis.io/commands/ltrim ([https](https://redis.io/commands/ltrim) result 200).
* [ ] http://redis.io/commands/mget with 6 occurrences migrated to:  
  https://redis.io/commands/mget ([https](https://redis.io/commands/mget) result 200).
* [ ] http://redis.io/commands/migrate with 2 occurrences migrated to:  
  https://redis.io/commands/migrate ([https](https://redis.io/commands/migrate) result 200).
* [ ] http://redis.io/commands/move with 7 occurrences migrated to:  
  https://redis.io/commands/move ([https](https://redis.io/commands/move) result 200).
* [ ] http://redis.io/commands/mset with 8 occurrences migrated to:  
  https://redis.io/commands/mset ([https](https://redis.io/commands/mset) result 200).
* [ ] http://redis.io/commands/msetnx with 5 occurrences migrated to:  
  https://redis.io/commands/msetnx ([https](https://redis.io/commands/msetnx) result 200).
* [ ] http://redis.io/commands/multi with 2 occurrences migrated to:  
  https://redis.io/commands/multi ([https](https://redis.io/commands/multi) result 200).
* [ ] http://redis.io/commands/object with 6 occurrences migrated to:  
  https://redis.io/commands/object ([https](https://redis.io/commands/object) result 200).
* [ ] http://redis.io/commands/persist with 6 occurrences migrated to:  
  https://redis.io/commands/persist ([https](https://redis.io/commands/persist) result 200).
* [ ] http://redis.io/commands/pexpire with 6 occurrences migrated to:  
  https://redis.io/commands/pexpire ([https](https://redis.io/commands/pexpire) result 200).
* [ ] http://redis.io/commands/pexpireat with 4 occurrences migrated to:  
  https://redis.io/commands/pexpireat ([https](https://redis.io/commands/pexpireat) result 200).
* [ ] http://redis.io/commands/pfadd with 6 occurrences migrated to:  
  https://redis.io/commands/pfadd ([https](https://redis.io/commands/pfadd) result 200).
* [ ] http://redis.io/commands/pfcount with 6 occurrences migrated to:  
  https://redis.io/commands/pfcount ([https](https://redis.io/commands/pfcount) result 200).
* [ ] http://redis.io/commands/pfmerge with 5 occurrences migrated to:  
  https://redis.io/commands/pfmerge ([https](https://redis.io/commands/pfmerge) result 200).
* [ ] http://redis.io/commands/ping with 2 occurrences migrated to:  
  https://redis.io/commands/ping ([https](https://redis.io/commands/ping) result 200).
* [ ] http://redis.io/commands/psetex with 4 occurrences migrated to:  
  https://redis.io/commands/psetex ([https](https://redis.io/commands/psetex) result 200).
* [ ] http://redis.io/commands/psubscribe with 3 occurrences migrated to:  
  https://redis.io/commands/psubscribe ([https](https://redis.io/commands/psubscribe) result 200).
* [ ] http://redis.io/commands/pttl with 6 occurrences migrated to:  
  https://redis.io/commands/pttl ([https](https://redis.io/commands/pttl) result 200).
* [ ] http://redis.io/commands/publish with 6 occurrences migrated to:  
  https://redis.io/commands/publish ([https](https://redis.io/commands/publish) result 200).
* [ ] http://redis.io/commands/randomkey with 4 occurrences migrated to:  
  https://redis.io/commands/randomkey ([https](https://redis.io/commands/randomkey) result 200).
* [ ] http://redis.io/commands/rename with 7 occurrences migrated to:  
  https://redis.io/commands/rename ([https](https://redis.io/commands/rename) result 200).
* [ ] http://redis.io/commands/renamenx with 6 occurrences migrated to:  
  https://redis.io/commands/renamenx ([https](https://redis.io/commands/renamenx) result 200).
* [ ] http://redis.io/commands/restore with 4 occurrences migrated to:  
  https://redis.io/commands/restore ([https](https://redis.io/commands/restore) result 200).
* [ ] http://redis.io/commands/rpop with 8 occurrences migrated to:  
  https://redis.io/commands/rpop ([https](https://redis.io/commands/rpop) result 200).
* [ ] http://redis.io/commands/rpoplpush with 7 occurrences migrated to:  
  https://redis.io/commands/rpoplpush ([https](https://redis.io/commands/rpoplpush) result 200).
* [ ] http://redis.io/commands/rpush with 13 occurrences migrated to:  
  https://redis.io/commands/rpush ([https](https://redis.io/commands/rpush) result 200).
* [ ] http://redis.io/commands/rpushx with 6 occurrences migrated to:  
  https://redis.io/commands/rpushx ([https](https://redis.io/commands/rpushx) result 200).
* [ ] http://redis.io/commands/sadd with 9 occurrences migrated to:  
  https://redis.io/commands/sadd ([https](https://redis.io/commands/sadd) result 200).
* [ ] http://redis.io/commands/save with 2 occurrences migrated to:  
  https://redis.io/commands/save ([https](https://redis.io/commands/save) result 200).
* [ ] http://redis.io/commands/scan with 8 occurrences migrated to:  
  https://redis.io/commands/scan ([https](https://redis.io/commands/scan) result 200).
* [ ] http://redis.io/commands/scard with 7 occurrences migrated to:  
  https://redis.io/commands/scard ([https](https://redis.io/commands/scard) result 200).
* [ ] http://redis.io/commands/script-exists with 2 occurrences migrated to:  
  https://redis.io/commands/script-exists ([https](https://redis.io/commands/script-exists) result 200).
* [ ] http://redis.io/commands/script-flush with 2 occurrences migrated to:  
  https://redis.io/commands/script-flush ([https](https://redis.io/commands/script-flush) result 200).
* [ ] http://redis.io/commands/script-kill with 2 occurrences migrated to:  
  https://redis.io/commands/script-kill ([https](https://redis.io/commands/script-kill) result 200).
* [ ] http://redis.io/commands/script-load with 3 occurrences migrated to:  
  https://redis.io/commands/script-load ([https](https://redis.io/commands/script-load) result 200).
* [ ] http://redis.io/commands/sdiff with 13 occurrences migrated to:  
  https://redis.io/commands/sdiff ([https](https://redis.io/commands/sdiff) result 200).
* [ ] http://redis.io/commands/sdiffstore with 13 occurrences migrated to:  
  https://redis.io/commands/sdiffstore ([https](https://redis.io/commands/sdiffstore) result 200).
* [ ] http://redis.io/commands/select with 1 occurrences migrated to:  
  https://redis.io/commands/select ([https](https://redis.io/commands/select) result 200).
* [ ] http://redis.io/commands/set with 24 occurrences migrated to:  
  https://redis.io/commands/set ([https](https://redis.io/commands/set) result 200).
* [ ] http://redis.io/commands/setbit with 7 occurrences migrated to:  
  https://redis.io/commands/setbit ([https](https://redis.io/commands/setbit) result 200).
* [ ] http://redis.io/commands/setex with 9 occurrences migrated to:  
  https://redis.io/commands/setex ([https](https://redis.io/commands/setex) result 200).
* [ ] http://redis.io/commands/setnx with 7 occurrences migrated to:  
  https://redis.io/commands/setnx ([https](https://redis.io/commands/setnx) result 200).
* [ ] http://redis.io/commands/setrange with 8 occurrences migrated to:  
  https://redis.io/commands/setrange ([https](https://redis.io/commands/setrange) result 200).
* [ ] http://redis.io/commands/shutdown with 2 occurrences migrated to:  
  https://redis.io/commands/shutdown ([https](https://redis.io/commands/shutdown) result 200).
* [ ] http://redis.io/commands/sinter with 13 occurrences migrated to:  
  https://redis.io/commands/sinter ([https](https://redis.io/commands/sinter) result 200).
* [ ] http://redis.io/commands/sinterstore with 13 occurrences migrated to:  
  https://redis.io/commands/sinterstore ([https](https://redis.io/commands/sinterstore) result 200).
* [ ] http://redis.io/commands/sismember with 8 occurrences migrated to:  
  https://redis.io/commands/sismember ([https](https://redis.io/commands/sismember) result 200).
* [ ] http://redis.io/commands/slaveof with 4 occurrences migrated to:  
  https://redis.io/commands/slaveof ([https](https://redis.io/commands/slaveof) result 200).
* [ ] http://redis.io/commands/smembers with 7 occurrences migrated to:  
  https://redis.io/commands/smembers ([https](https://redis.io/commands/smembers) result 200).
* [ ] http://redis.io/commands/smove with 8 occurrences migrated to:  
  https://redis.io/commands/smove ([https](https://redis.io/commands/smove) result 200).
* [ ] http://redis.io/commands/sort with 9 occurrences migrated to:  
  https://redis.io/commands/sort ([https](https://redis.io/commands/sort) result 200).
* [ ] http://redis.io/commands/spop with 14 occurrences migrated to:  
  https://redis.io/commands/spop ([https](https://redis.io/commands/spop) result 200).
* [ ] http://redis.io/commands/srandmember with 17 occurrences migrated to:  
  https://redis.io/commands/srandmember ([https](https://redis.io/commands/srandmember) result 200).
* [ ] http://redis.io/commands/srem with 9 occurrences migrated to:  
  https://redis.io/commands/srem ([https](https://redis.io/commands/srem) result 200).
* [ ] http://redis.io/commands/sscan with 5 occurrences migrated to:  
  https://redis.io/commands/sscan ([https](https://redis.io/commands/sscan) result 200).
* [ ] http://redis.io/commands/strlen with 7 occurrences migrated to:  
  https://redis.io/commands/strlen ([https](https://redis.io/commands/strlen) result 200).
* [ ] http://redis.io/commands/subscribe with 3 occurrences migrated to:  
  https://redis.io/commands/subscribe ([https](https://redis.io/commands/subscribe) result 200).
* [ ] http://redis.io/commands/sunion with 13 occurrences migrated to:  
  https://redis.io/commands/sunion ([https](https://redis.io/commands/sunion) result 200).
* [ ] http://redis.io/commands/sunionstore with 13 occurrences migrated to:  
  https://redis.io/commands/sunionstore ([https](https://redis.io/commands/sunionstore) result 200).
* [ ] http://redis.io/commands/time with 2 occurrences migrated to:  
  https://redis.io/commands/time ([https](https://redis.io/commands/time) result 200).
* [ ] http://redis.io/commands/touch with 4 occurrences migrated to:  
  https://redis.io/commands/touch ([https](https://redis.io/commands/touch) result 200).
* [ ] http://redis.io/commands/ttl with 8 occurrences migrated to:  
  https://redis.io/commands/ttl ([https](https://redis.io/commands/ttl) result 200).
* [ ] http://redis.io/commands/type with 6 occurrences migrated to:  
  https://redis.io/commands/type ([https](https://redis.io/commands/type) result 200).
* [ ] http://redis.io/commands/unlink with 10 occurrences migrated to:  
  https://redis.io/commands/unlink ([https](https://redis.io/commands/unlink) result 200).
* [ ] http://redis.io/commands/unwatch with 2 occurrences migrated to:  
  https://redis.io/commands/unwatch ([https](https://redis.io/commands/unwatch) result 200).
* [ ] http://redis.io/commands/watch with 3 occurrences migrated to:  
  https://redis.io/commands/watch ([https](https://redis.io/commands/watch) result 200).
* [ ] http://redis.io/commands/xack with 12 occurrences migrated to:  
  https://redis.io/commands/xack ([https](https://redis.io/commands/xack) result 200).
* [ ] http://redis.io/commands/xadd with 14 occurrences migrated to:  
  https://redis.io/commands/xadd ([https](https://redis.io/commands/xadd) result 200).
* [ ] http://redis.io/commands/xdel with 12 occurrences migrated to:  
  https://redis.io/commands/xdel ([https](https://redis.io/commands/xdel) result 200).
* [ ] http://redis.io/commands/xlen with 7 occurrences migrated to:  
  https://redis.io/commands/xlen ([https](https://redis.io/commands/xlen) result 200).
* [ ] http://redis.io/commands/xrange with 19 occurrences migrated to:  
  https://redis.io/commands/xrange ([https](https://redis.io/commands/xrange) result 200).
* [ ] http://redis.io/commands/xread with 21 occurrences migrated to:  
  https://redis.io/commands/xread ([https](https://redis.io/commands/xread) result 200).
* [ ] http://redis.io/commands/xreadgroup with 19 occurrences migrated to:  
  https://redis.io/commands/xreadgroup ([https](https://redis.io/commands/xreadgroup) result 200).
* [ ] http://redis.io/commands/xrevrange with 19 occurrences migrated to:  
  https://redis.io/commands/xrevrange ([https](https://redis.io/commands/xrevrange) result 200).
* [ ] http://redis.io/commands/xtrim with 8 occurrences migrated to:  
  https://redis.io/commands/xtrim ([https](https://redis.io/commands/xtrim) result 200).
* [ ] http://redis.io/commands/zadd with 14 occurrences migrated to:  
  https://redis.io/commands/zadd ([https](https://redis.io/commands/zadd) result 200).
* [ ] http://redis.io/commands/zcard with 9 occurrences migrated to:  
  https://redis.io/commands/zcard ([https](https://redis.io/commands/zcard) result 200).
* [ ] http://redis.io/commands/zcount with 9 occurrences migrated to:  
  https://redis.io/commands/zcount ([https](https://redis.io/commands/zcount) result 200).
* [ ] http://redis.io/commands/zincrby with 8 occurrences migrated to:  
  https://redis.io/commands/zincrby ([https](https://redis.io/commands/zincrby) result 200).
* [ ] http://redis.io/commands/zinterstore with 24 occurrences migrated to:  
  https://redis.io/commands/zinterstore ([https](https://redis.io/commands/zinterstore) result 200).
* [ ] http://redis.io/commands/zrange with 14 occurrences migrated to:  
  https://redis.io/commands/zrange ([https](https://redis.io/commands/zrange) result 200).
* [ ] http://redis.io/commands/zrangebylex with 16 occurrences migrated to:  
  https://redis.io/commands/zrangebylex ([https](https://redis.io/commands/zrangebylex) result 200).
* [ ] http://redis.io/commands/zrangebyscore with 32 occurrences migrated to:  
  https://redis.io/commands/zrangebyscore ([https](https://redis.io/commands/zrangebyscore) result 200).
* [ ] http://redis.io/commands/zrank with 8 occurrences migrated to:  
  https://redis.io/commands/zrank ([https](https://redis.io/commands/zrank) result 200).
* [ ] http://redis.io/commands/zrem with 11 occurrences migrated to:  
  https://redis.io/commands/zrem ([https](https://redis.io/commands/zrem) result 200).
* [ ] http://redis.io/commands/zremrangebyrank with 8 occurrences migrated to:  
  https://redis.io/commands/zremrangebyrank ([https](https://redis.io/commands/zremrangebyrank) result 200).
* [ ] http://redis.io/commands/zremrangebyscore with 9 occurrences migrated to:  
  https://redis.io/commands/zremrangebyscore ([https](https://redis.io/commands/zremrangebyscore) result 200).
* [ ] http://redis.io/commands/zrevrange with 19 occurrences migrated to:  
  https://redis.io/commands/zrevrange ([https](https://redis.io/commands/zrevrange) result 200).
* [ ] http://redis.io/commands/zrevrangebylex with 6 occurrences migrated to:  
  https://redis.io/commands/zrevrangebylex ([https](https://redis.io/commands/zrevrangebylex) result 200).
* [ ] http://redis.io/commands/zrevrangebyscore with 23 occurrences migrated to:  
  https://redis.io/commands/zrevrangebyscore ([https](https://redis.io/commands/zrevrangebyscore) result 200).
* [ ] http://redis.io/commands/zrevrank with 8 occurrences migrated to:  
  https://redis.io/commands/zrevrank ([https](https://redis.io/commands/zrevrank) result 200).
* [ ] http://redis.io/commands/zscan with 8 occurrences migrated to:  
  https://redis.io/commands/zscan ([https](https://redis.io/commands/zscan) result 200).
* [ ] http://redis.io/commands/zscore with 8 occurrences migrated to:  
  https://redis.io/commands/zscore ([https](https://redis.io/commands/zscore) result 200).
* [ ] http://redis.io/commands/zunionstore with 24 occurrences migrated to:  
  https://redis.io/commands/zunionstore ([https](https://redis.io/commands/zunionstore) result 200).
* [ ] http://redis.io/topics/cluster-spec with 2 occurrences migrated to:  
  https://redis.io/topics/cluster-spec ([https](https://redis.io/topics/cluster-spec) result 200).
* [ ] http://redis.io/topics/cluster-tutorial with 2 occurrences migrated to:  
  https://redis.io/topics/cluster-tutorial ([https](https://redis.io/topics/cluster-tutorial) result 200).
* [ ] http://redis.io/topics/indexes with 2 occurrences migrated to:  
  https://redis.io/topics/indexes ([https](https://redis.io/topics/indexes) result 200).
* [ ] http://redis.io/topics/notifications with 1 occurrences migrated to:  
  https://redis.io/topics/notifications ([https](https://redis.io/topics/notifications) result 200).
* [ ] http://redis.io/topics/pipelining with 1 occurrences migrated to:  
  https://redis.io/topics/pipelining ([https](https://redis.io/topics/pipelining) result 200).
* [ ] http://redis.io/topics/sentinel with 2 occurrences migrated to:  
  https://redis.io/topics/sentinel ([https](https://redis.io/topics/sentinel) result 200).
* [ ] http://redis.io/topics/transactions with 1 occurrences migrated to:  
  https://redis.io/topics/transactions ([https](https://redis.io/topics/transactions) result 200).
* [ ] http://spring.io/ with 1 occurrences migrated to:  
  https://spring.io/ ([https](https://spring.io/) result 200).
* [ ] http://spring.io/blog/ with 1 occurrences migrated to:  
  https://spring.io/blog/ ([https](https://spring.io/blog/) result 200).
* [ ] http://spring.io/guides with 1 occurrences migrated to:  
  https://spring.io/guides ([https](https://spring.io/guides) result 200).
* [ ] http://spring.io/spring-data with 1 occurrences migrated to:  
  https://spring.io/spring-data ([https](https://spring.io/spring-data) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data with 3 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data ([https](https://stackoverflow.com/questions/tagged/spring-data) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data-redis with 2 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data-redis ([https](https://stackoverflow.com/questions/tagged/spring-data-redis) result 200).
* [ ] http://twitter.com/SpringData with 1 occurrences migrated to:  
  https://twitter.com/SpringData ([https](https://twitter.com/SpringData) result 200).
* [ ] http://twitter.com/springdata with 1 occurrences migrated to:  
  https://twitter.com/springdata ([https](https://twitter.com/springdata) result 200).
* [ ] http://www.google.com/search?q=nosoql+acronym with 1 occurrences migrated to:  
  https://www.google.com/search?q=nosoql+acronym ([https](https://www.google.com/search?q=nosoql+acronym) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/tool/spring-tool.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tool/spring-tool.xsd ([https](https://www.springframework.org/schema/tool/spring-tool.xsd) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-data/data-redis/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-redis/docs/current/api/ ([https](https://docs.spring.io/spring-data/data-redis/docs/current/api/) result 301).
* [ ] http://docs.spring.io/spring-data/data-redis/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://www.pivotal.io/ with 1 occurrences migrated to:  
  https://www.pivotal.io/ ([https](https://www.pivotal.io/) result 301).
* [ ] http://www.springframework.org/schema/redis/spring-redis-1.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/redis/spring-redis-1.0.xsd ([https](https://www.springframework.org/schema/redis/spring-redis-1.0.xsd) result 301).
* [ ] http://www.springframework.org/schema/redis/spring-redis.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/redis/spring-redis.xsd ([https](https://www.springframework.org/schema/redis/spring-redis.xsd) result 301).
* [ ] http://download.oracle.com/javase/8/docs/api/java/util/Collection.html with 1 occurrences migrated to:  
  https://download.oracle.com/javase/8/docs/api/java/util/Collection.html ([https](https://download.oracle.com/javase/8/docs/api/java/util/Collection.html) result 302).
* [ ] http://download.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/package-summary.html with 1 occurrences migrated to:  
  https://download.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/package-summary.html ([https](https://download.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/package-summary.html) result 302).
* [ ] http://repo.spring.io/libs-milestone with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* [ ] http://repo.spring.io/libs-snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:1234 with 3 occurrences
* http://www.springframework.org/schema/beans with 10 occurrences
* http://www.springframework.org/schema/p with 4 occurrences
* http://www.springframework.org/schema/redis with 4 occurrences
* http://www.springframework.org/schema/tool with 2 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 6 occurrences