### PR TITLE
 DATAREDIS-950,  DATAREDIS-953 - Fix ClassCastException on shared Lettuce Cluster connection validation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-950-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -1160,7 +1160,7 @@ public class LettuceConnectionFactory
 						}
 
 						if (connection instanceof StatefulRedisClusterConnection) {
-							((StatefulRedisConnection) connection).sync().ping();
+							((StatefulRedisClusterConnection) connection).sync().ping();
 						}
 						valid = true;
 					} catch (Exception e) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -1170,12 +1170,7 @@ public class LettuceConnectionFactory
 
 				if (!valid) {
 
-					if (connection != null) {
-						connectionProvider.release(connection);
-					}
-
 					log.warn("Validation of shared connection failed. Creating a new connection.");
-
 					resetConnection();
 					this.connection = getNativeConnection();
 				}


### PR DESCRIPTION
Also part of the PR is DATAREDIS-953 - Release connection after failed validation only once.
We now release a connection after a failed validation only once. Previously, a connection was released twice which caused a failure if the connection was obtained from a pool.

---

Related tickets: [DATAREDIS-950](https://jira.spring.io/browse/DATAREDIS-950), [DATAREDIS-953](https://jira.spring.io/browse/DATAREDIS-953).