### PR TITLE
DATAREDIS-976 - Integrate Cluster-Specific Lettuce PubSub Connection Code

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/ClusterMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterMessageListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+/**
+ * Listener of messages published in Redis.
+ *
+ */
+public interface ClusterMessageListener extends MessageListener {
+
+	/**
+	 * Boolean flag indicating whether this listener requires keyspace events from Redis
+	 */
+	boolean listensForKeyspaceNotifications();
+}

--- a/src/main/java/org/springframework/data/redis/connection/ClusterMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/redis/connection/ClusterMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterMessageListener.java
@@ -18,6 +18,8 @@ package org.springframework.data.redis.connection;
 /**
  * Listener of messages published in Redis.
  *
+ * @author Bruce Cloud
+ * @since 2.2
  */
 public interface ClusterMessageListener extends MessageListener {
 

--- a/src/main/java/org/springframework/data/redis/connection/ConnectionUtils.java
+++ b/src/main/java/org/springframework/data/redis/connection/ConnectionUtils.java
@@ -23,6 +23,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
  *
  * @author Jennifer Hickey
  * @author Thomas Darimont
+ * @author Bruce Cloud
  */
 public abstract class ConnectionUtils {
 

--- a/src/main/java/org/springframework/data/redis/connection/ConnectionUtils.java
+++ b/src/main/java/org/springframework/data/redis/connection/ConnectionUtils.java
@@ -37,4 +37,14 @@ public abstract class ConnectionUtils {
 	public static boolean isJedis(RedisConnectionFactory connectionFactory) {
 		return connectionFactory instanceof JedisConnectionFactory;
 	}
+	
+	public static boolean isClusterAware(RedisConnectionFactory connectionFactory) {
+		if (connectionFactory instanceof LettuceConnectionFactory) {
+			return ((LettuceConnectionFactory) connectionFactory).isClusterAware();
+		}
+		else if (connectionFactory instanceof JedisConnectionFactory) {
+			return ((JedisConnectionFactory) connectionFactory).isRedisClusterAware();
+		}
+		return false;
+	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
@@ -19,6 +19,7 @@ import io.lettuce.core.ReadFrom;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 
@@ -93,7 +94,8 @@ class ClusterConnectionProvider implements LettuceConnectionProvider, RedisClien
 			}
 		}
 
-		if (connectionType.equals(StatefulRedisPubSubConnection.class)) {
+		if (connectionType.equals(StatefulRedisPubSubConnection.class)
+			|| connectionType.equals(StatefulRedisClusterPubSubConnection.class)) {
 
 			return client.connectPubSubAsync(codec) //
 					.thenApply(connectionType::cast);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Bruce Cloud
  * @since 2.0
  */
 class ClusterConnectionProvider implements LettuceConnectionProvider, RedisClientProvider {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -57,6 +57,7 @@ import org.springframework.util.ObjectUtils;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Bruce Cloud
  * @since 1.7
  */
 public class LettuceClusterConnection extends LettuceConnection implements DefaultedRedisClusterConnection {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSubscription.java
@@ -27,6 +27,8 @@ import org.springframework.data.redis.connection.util.AbstractSubscription;
 /**
  * Message subscription on top of Lettuce cluster support.
  *
+ * @author Bruce Cloud
+ * @since 2.2
  */
 class LettuceClusterSubscription extends AbstractSubscription {
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
 import io.lettuce.core.cluster.pubsub.api.sync.RedisClusterPubSubCommands;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.data.redis.connection.ClusterMessageListener;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.connection.util.AbstractSubscription;
@@ -37,8 +35,6 @@ class LettuceClusterSubscription extends AbstractSubscription {
 	private final LettuceConnectionProvider connectionProvider;
 	private final RedisClusterPubSubCommands<byte[], byte[]> pubsub;
 	private final boolean listensForKeyspaceNotifications;
-	
-	private final Log log = LogFactory.getLog(getClass());
 	
 	LettuceClusterSubscription(MessageListener listener, StatefulRedisClusterPubSubConnection<byte[], byte[]> pubsubConnection,
 			LettuceConnectionProvider connectionProvider) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSubscription.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
+import io.lettuce.core.cluster.pubsub.api.sync.RedisClusterPubSubCommands;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.data.redis.connection.ClusterMessageListener;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.connection.util.AbstractSubscription;
+
+/**
+ * Message subscription on top of Lettuce cluster support.
+ *
+ */
+class LettuceClusterSubscription extends AbstractSubscription {
+
+	private final StatefulRedisClusterPubSubConnection<byte[], byte[]> connection;
+	private final LettuceMessageListener listener;
+	private final LettuceConnectionProvider connectionProvider;
+	private final RedisClusterPubSubCommands<byte[], byte[]> pubsub;
+	private final boolean listensForKeyspaceNotifications;
+	
+	private final Log log = LogFactory.getLog(getClass());
+	
+	LettuceClusterSubscription(MessageListener listener, StatefulRedisClusterPubSubConnection<byte[], byte[]> pubsubConnection,
+			LettuceConnectionProvider connectionProvider) {
+
+		super(listener);
+
+		this.connection = pubsubConnection;
+		
+		this.listener = new LettuceMessageListener(listener);
+		this.listensForKeyspaceNotifications = (listener instanceof ClusterMessageListener
+			&& ((ClusterMessageListener)listener).listensForKeyspaceNotifications());
+		if (listensForKeyspaceNotifications) pubsubConnection.setNodeMessagePropagation(true);
+		
+		this.connectionProvider = connectionProvider;
+		this.pubsub = connection.sync();
+
+		this.connection.addListener(this.listener);
+	}
+
+	protected StatefulRedisPubSubConnection<byte[], byte[]> getNativeConnection() {
+		return connection;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doClose()
+	 */
+	protected void doClose() {
+
+		if (!getChannels().isEmpty()) {
+			pubsub.unsubscribe(new byte[0]);
+		}
+
+		if (!getPatterns().isEmpty()) {
+			pubsub.punsubscribe(new byte[0]);
+		}
+
+		connection.removeListener(this.listener);
+		connectionProvider.release(connection);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doPsubscribe(byte[][])
+	 */
+	protected void doPsubscribe(byte[]... patterns) {
+		
+		if (listensForKeyspaceNotifications) {
+			pubsub.masters().commands().psubscribe(patterns);
+		}
+		else {
+			pubsub.psubscribe(patterns);
+		}
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doPUnsubscribe(boolean, byte[][])
+	 */
+	protected void doPUnsubscribe(boolean all, byte[]... patterns) {
+
+		// ignore `all` flag as Lettuce unsubscribes from all patterns if none provided.
+		pubsub.punsubscribe(patterns);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doSubscribe(byte[][])
+	 */
+	protected void doSubscribe(byte[]... channels) {
+		
+		if (listensForKeyspaceNotifications) {
+			pubsub.masters().commands().subscribe(channels);
+		}
+		else {
+			pubsub.subscribe(channels);
+		}
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doUnsubscribe(boolean, byte[][])
+	 */
+	protected void doUnsubscribe(boolean all, byte[]... channels) {
+
+		// ignore `all` flag as Lettuce unsubscribes from all channels if none provided.
+		pubsub.unsubscribe(channels);
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -84,6 +84,7 @@ import org.springframework.util.ObjectUtils;
  * @author David Liu
  * @author Mark Paluch
  * @author Ninad Divadkar
+ * @author Bruce Cloud
  */
 public class LettuceConnection extends AbstractRedisConnection {
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -95,8 +95,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 	private final int defaultDbIndex;
 	private int dbIndex;
-
-	private final LettuceConnectionProvider connectionProvider;
+	
+	protected final LettuceConnectionProvider connectionProvider;
 	private final @Nullable StatefulConnection<byte[], byte[]> asyncSharedConn;
 	private @Nullable StatefulConnection<byte[], byte[]> asyncDedicatedConn;
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
@@ -16,7 +16,7 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.pubsub.RedisPubSubListener;
-
+import org.springframework.data.redis.connection.ClusterMessageListener;
 import org.springframework.data.redis.connection.DefaultMessage;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.util.Assert;
@@ -33,6 +33,11 @@ class LettuceMessageListener implements RedisPubSubListener<byte[], byte[]> {
 	LettuceMessageListener(MessageListener listener) {
 		Assert.notNull(listener, "MessageListener must not be null!");
 		this.listener = listener;
+	}
+	
+	LettuceMessageListener(ClusterMessageListener listener) {
+		Assert.notNull(listener, "ClusterMessageListener must not be null!");
+		this.listener = (MessageListener)listener;
 	}
 
 	/* 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
@@ -25,6 +25,7 @@ import org.springframework.util.Assert;
  * MessageListener wrapper around Lettuce {@link RedisPubSubListener}.
  *
  * @author Costin Leau
+ * @author Bruce Cloud
  */
 class LettuceMessageListener implements RedisPubSubListener<byte[], byte[]> {
 

--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -70,6 +70,7 @@ import org.springframework.util.ErrorHandler;
  * @author Way Joke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Bruce Cloud
  */
 public class RedisMessageListenerContainer implements InitializingBean, DisposableBean, BeanNameAware, SmartLifecycle {
 


### PR DESCRIPTION
As part of scaling up our cloud infrastructure, we identified the need to migrate to clustered Redis for our services deployment that uses Spring Session.  We are using

Spring Cloud Finchley.SR2
Spring Boot 2.0.5.RELEASE
Spring Session 2.1.4.RELEASE
Spring Data Redis 2.1.5.RELEASE
Lettuce 5.1.4.RELEASE

Testing with the Redis cluster showed that our designated service that processes events from Spring Session was not receiving any session expiration events. Looking closer, Redis keyspace event notification subscriptions required by Spring Session were not being registered on the Redis cluster master nodes.  The subscriptions were present in the cluster slave nodes and were indicated in the info for the connections to the slaves, but were missing from the masters.

We looked into the Spring code and the Lettuce documentation and it appears that some of the code Lettuce uses to handle PubSub with clusters hasn't been integrated yet.  The documentation in question is here https://github.com/lettuce-io/lettuce-core/wiki/Pub-Sub#redis-cluster.

We successfully integrated the Lettuce code into a branch of Spring Data Redis based on the 2.1.5.RELEASE and Spring Session began working as expected -- our service once again was receiving the session expiration events that are based on the Redis keyspace event notifications, and we can see the PubSub subscriptions on the Redis master nodes.

The Lettuce documentation specifies different code paths for user-space versus keyspace notifications from Redis. For our purposes we hard-coded the modifications to work as required by Spring Session (i.e., for keyspace notifications), but this fork has some additional code to expose the necessary flag to differentiate the two cases. A change will be required in Spring Session to utilize this new flag.

Caveats:
I haven't contributed before so I am looking for feedback/guidance.
This code has been tested as part of our branch based on the 2.1.5.RELEASE.  For the fork, I have integrated it into 2.2.0-SNAPSHOT but we haven't tried this upgrade yet.
I am not sure how the unit tests for cluster code work, as I only have a standalone Redis installation in my local dev environment, so I have not attempted to add any unit tests for this functionality.

Thank you