### PR TITLE
DATAREDIS-973 - Fix database selection using Lettuce

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-973-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -25,9 +25,11 @@ import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.reactive.BaseRedisReactiveCommands;
+import reactor.test.StepVerifier;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.function.Consumer;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.After;
@@ -35,14 +37,15 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.connection.DefaultStringRedisConnection;
 import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
 import org.springframework.data.redis.connection.StringRedisConnection;
 
 /**
@@ -131,28 +134,86 @@ public class LettuceConnectionFactoryTests {
 		assertSame(connection.getNativeConnection(), conn2.getNativeConnection());
 	}
 
-	@Test
+	@Test // DATAREDIS-973
 	public void testSelectDb() {
 
-		LettuceConnectionFactory factory2 = new LettuceConnectionFactory(SettingsUtils.getHost(), SettingsUtils.getPort());
-		factory2.setClientResources(LettuceTestClientResources.getSharedClientResources());
-		factory2.setShutdownTimeout(0);
-		factory2.setDatabase(1);
-		factory2.afterPropertiesSet();
+		// put an item in database 0
+		connection.set("sometestkey", "sometestvalue");
+
+		LettuceConnectionFactory sharingConnectionFactory = newConnectionFactory(cf -> {});
+		runSelectDbTest(sharingConnectionFactory);
+
+		LettuceConnectionFactory nonSharingConnectionFactory = newConnectionFactory(
+				cf -> cf.setShareNativeConnection(false));
+		runSelectDbTest(nonSharingConnectionFactory);
+	}
+
+	private void runSelectDbTest(LettuceConnectionFactory factory2) {
 
 		ConnectionFactoryTracker.add(factory2);
 
-		StringRedisConnection connection2 = new DefaultStringRedisConnection(factory2.getConnection());
-		connection2.flushDb();
+		StringRedisConnection separateDatabase = new DefaultStringRedisConnection(factory2.getConnection());
+		separateDatabase.flushDb();
+
 		// put an item in database 0
 		connection.set("sometestkey", "sometestvalue");
+
 		try {
 			// there should still be nothing in database 1
-			assertEquals(Long.valueOf(0), connection2.dbSize());
+			assertEquals(Long.valueOf(0), separateDatabase.dbSize());
 		} finally {
-			connection2.close();
+			separateDatabase.close();
 			factory2.destroy();
 		}
+	}
+
+	@Test // DATAREDIS-973
+	public void testSelectDbReactive() {
+
+		LettuceConnectionFactory sharingConnectionFactory = newConnectionFactory(cf -> {});
+		runSelectDbReactiveTest(sharingConnectionFactory);
+
+		LettuceConnectionFactory nonSharingConnectionFactory = newConnectionFactory(
+				cf -> cf.setShareNativeConnection(false));
+		runSelectDbTest(nonSharingConnectionFactory);
+	}
+
+	private void runSelectDbReactiveTest(LettuceConnectionFactory factory2) {
+
+		ConnectionFactoryTracker.add(factory2);
+
+		LettuceReactiveRedisConnection separateDatabase = factory2.getReactiveConnection();
+
+		separateDatabase.serverCommands().flushDb() //
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+
+		// put an item in database 0
+		connection.set("sometestkey", "sometestvalue");
+
+		try {
+			// there should still be nothing in database 1
+			separateDatabase.serverCommands().dbSize() //
+					.as(StepVerifier::create).expectNext(0L) //
+					.verifyComplete();
+		} finally {
+			separateDatabase.close();
+			factory2.destroy();
+		}
+	}
+
+	private static LettuceConnectionFactory newConnectionFactory(Consumer<LettuceConnectionFactory> customizer) {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(SettingsUtils.getHost(),
+				SettingsUtils.getPort());
+		connectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		connectionFactory.setShutdownTimeout(0);
+		connectionFactory.setDatabase(1);
+		customizer.accept(connectionFactory);
+		connectionFactory.afterPropertiesSet();
+
+		return connectionFactory;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -394,11 +455,10 @@ public class LettuceConnectionFactoryTests {
 		LettuceClientConfiguration configuration = LettuceTestClientConfiguration.builder().readFrom(ReadFrom.SLAVE)
 				.build();
 
-		RedisStaticMasterReplicaConfiguration elastiCache = new RedisStaticMasterReplicaConfiguration(SettingsUtils.getHost())
-				.node(SettingsUtils.getHost(), SettingsUtils.getPort() + 1);
+		RedisStaticMasterReplicaConfiguration elastiCache = new RedisStaticMasterReplicaConfiguration(
+				SettingsUtils.getHost()).node(SettingsUtils.getHost(), SettingsUtils.getPort() + 1);
 
-		LettuceConnectionFactory factory = new LettuceConnectionFactory(elastiCache,
-				configuration);
+		LettuceConnectionFactory factory = new LettuceConnectionFactory(elastiCache, configuration);
 		factory.afterPropertiesSet();
 
 		RedisConnection connection = factory.getConnection();
@@ -422,8 +482,8 @@ public class LettuceConnectionFactoryTests {
 		LettuceClientConfiguration configuration = LettuceTestClientConfiguration.builder().readFrom(ReadFrom.MASTER)
 				.build();
 
-		RedisStaticMasterReplicaConfiguration elastiCache = new RedisStaticMasterReplicaConfiguration(SettingsUtils.getHost(),
-				SettingsUtils.getPort() + 1);
+		RedisStaticMasterReplicaConfiguration elastiCache = new RedisStaticMasterReplicaConfiguration(
+				SettingsUtils.getHost(), SettingsUtils.getPort() + 1);
 
 		LettuceConnectionFactory factory = new LettuceConnectionFactory(elastiCache, configuration);
 		factory.afterPropertiesSet();


### PR DESCRIPTION
We now correctly set the requested database using `RedisURI` so the driver performs the database selection. We no longer need to call select ourselves and this fixes the issue with reactive database selection.

For shared connections (pooled and single shared connection) we now no longer call select. This can leave connections with a different database associated.

---

Related ticket: [DATAREDIS-973](https://jira.spring.io/browse/DATAREDIS-973).

Should be backported to 2.1.x.