### PR TITLE
DATAREDIS-955 - Fix collection initialization when reading nested structures with same name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-955-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/convert/Bucket.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/Bucket.java
@@ -178,7 +178,7 @@ public class Bucket {
 			return keySet();
 		}
 
-		Pattern pattern = Pattern.compile("(" + Pattern.quote(path) + ")\\.\\[.*?\\]");
+		Pattern pattern = Pattern.compile("^(" + Pattern.quote(path) + ")\\.\\[.*?\\]");
 
 		Set<String> keys = new LinkedHashSet<>();
 		for (Map.Entry<String, byte[]> entry : data.entrySet()) {

--- a/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
@@ -229,4 +229,15 @@ public class ConversionTestEntities {
 
 		UUID uuid;
 	}
+
+	static class Outer {
+
+		List<Inner> inners;
+		List<String> values;
+	}
+
+	static class Inner {
+		
+		List<String> values;
+	}
 }

--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -1863,6 +1863,32 @@ public class MappingRedisConverterUnitTests {
 		assertThat(write(source).getBucket(), isBucket().containingUtf8String("uuid", source.uuid.toString()));
 	}
 
+	@Test // DATAREDIS-955
+	public void readInnerListShouldNotInfluenceOuterWithSameName() {
+
+		Map<String, String> source = new LinkedHashMap<>();
+		source.put("inners.[0].values.[0]", "i-1");
+		source.put("inners.[0].values.[1]", "i-2");
+		source.put("values.[0]", "o-1");
+		source.put("values.[1]", "o-2");
+
+		Outer outer = read(Outer.class, source);
+		assertThat(outer.values, is(equalTo(Arrays.asList("o-1", "o-2"))));
+		assertThat(outer.inners.get(0).values, is(equalTo(Arrays.asList("i-1", "i-2"))));
+	}
+
+	@Test // DATAREDIS-955
+	public void readInnerListShouldNotInfluenceOuterWithSameNameWhenNull() {
+
+		Map<String, String> source = new LinkedHashMap<>();
+		source.put("inners.[0].values.[0]", "i-1");
+		source.put("inners.[0].values.[1]", "i-2");
+
+		Outer outer = read(Outer.class, source);
+		assertThat(outer.values, is(nullValue()));
+		assertThat(outer.inners.get(0).values, is(equalTo(Arrays.asList("i-1", "i-2"))));
+	}
+
 	private RedisData write(Object source) {
 
 		RedisData rdo = new RedisData();


### PR DESCRIPTION
We now make sure to not falsely populate instances with null values from nested structures.