### PR TITLE
DATAREDIS-992 - '&' instead of '&&'.

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/AbstractOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/AbstractOperations.java
@@ -178,7 +178,7 @@ abstract class AbstractOperations<K, V> {
 	@SuppressWarnings("unchecked")
 	<HV> byte[] rawHashValue(HV value) {
 
-		if (hashValueSerializer() == null & value instanceof byte[]) {
+		if (hashValueSerializer() == null && value instanceof byte[]) {
 			return (byte[]) value;
 		}
 		return hashValueSerializer().serialize(value);


### PR DESCRIPTION
Bitwise AND was used instead of logical AND.