### PR TITLE
 DATAREDIS-976 - Allow extension of Lettuce Connection and Subscription classes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-976-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/ClusterConnectionProvider.java
@@ -19,6 +19,7 @@ import io.lettuce.core.ReadFrom;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 
@@ -33,6 +34,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Bruce Cloud
  * @since 2.0
  */
 class ClusterConnectionProvider implements LettuceConnectionProvider, RedisClientProvider {
@@ -93,7 +95,8 @@ class ClusterConnectionProvider implements LettuceConnectionProvider, RedisClien
 			}
 		}
 
-		if (connectionType.equals(StatefulRedisPubSubConnection.class)) {
+		if (connectionType.equals(StatefulRedisPubSubConnection.class)
+			|| connectionType.equals(StatefulRedisClusterPubSubConnection.class)) {
 
 			return client.connectPubSubAsync(codec) //
 					.thenApply(connectionType::cast);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -23,6 +23,7 @@ import io.lettuce.core.cluster.SlotHash;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
 import io.lettuce.core.cluster.models.partitions.Partitions;
+import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
 import lombok.RequiredArgsConstructor;
 
 import java.time.Duration;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -22,8 +22,6 @@ import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.SlotHash;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
-import io.lettuce.core.cluster.models.partitions.Partitions;
-import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
 import lombok.RequiredArgsConstructor;
 
 import java.time.Duration;
@@ -55,6 +53,9 @@ import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
 /**
+ * {@code RedisClusterConnection} implementation on top of <a href="https://github.com/mp911de/lettuce">Lettuce</a>
+ * Redis client.
+ *
  * @author Christoph Strobl
  * @author Mark Paluch
  * @since 1.7

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -1254,7 +1254,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 		private final LettucePool pool;
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnection(java.lang.Class)
 		 */
@@ -1263,7 +1263,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 			return connectionType.cast(pool.getResource());
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#getConnectionAsync(java.lang.Class)
 		 */
@@ -1272,7 +1272,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 			throw new UnsupportedOperationException("Async operations not supported!");
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider#release(io.lettuce.core.api.StatefulConnection)
 		 */

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -879,7 +879,21 @@ public class LettuceConnection extends AbstractRedisConnection {
 	}
 
 	private LettuceSubscription initSubscription(MessageListener listener) {
-		return new LettuceSubscription(listener, switchToPubSub(), connectionProvider);
+		return doCreateSubscription(listener, switchToPubSub(), connectionProvider);
+	}
+
+	/**
+	 * Customization hook to create a {@link LettuceSubscription}.
+	 *
+	 * @param listener the {@link MessageListener} to notify.
+	 * @param connection Pub/Sub connection.
+	 * @param connectionProvider the {@link LettuceConnectionProvider} for connection release.
+	 * @return a {@link LettuceSubscription}.
+	 * @since 2.2
+	 */
+	protected LettuceSubscription doCreateSubscription(MessageListener listener,
+			StatefulRedisPubSubConnection<byte[], byte[]> connection, LettuceConnectionProvider connectionProvider) {
+		return new LettuceSubscription(listener, connection, connectionProvider);
 	}
 
 	void pipeline(LettuceResult result) {
@@ -1250,7 +1264,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 	}
 
 	@RequiredArgsConstructor
-	private class LettucePoolConnectionProvider implements LettuceConnectionProvider {
+	static class LettucePoolConnectionProvider implements LettuceConnectionProvider {
 
 		private final LettucePool pool;
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceMessageListener.java
@@ -35,7 +35,7 @@ class LettuceMessageListener implements RedisPubSubListener<byte[], byte[]> {
 		this.listener = listener;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see io.lettuce.core.pubsub.RedisPubSubListener#message(java.lang.Object, java.lang.Object)
 	 */
@@ -43,7 +43,7 @@ class LettuceMessageListener implements RedisPubSubListener<byte[], byte[]> {
 		listener.onMessage(new DefaultMessage(channel, message), null);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see io.lettuce.core.pubsub.RedisPubSubListener#message(java.lang.Object, java.lang.Object, java.lang.Object)
 	 */
@@ -51,25 +51,25 @@ class LettuceMessageListener implements RedisPubSubListener<byte[], byte[]> {
 		listener.onMessage(new DefaultMessage(channel, message), pattern);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see io.lettuce.core.pubsub.RedisPubSubListener#subscribed(java.lang.Object, long)
 	 */
 	public void subscribed(byte[] channel, long count) {}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see io.lettuce.core.pubsub.RedisPubSubListener#psubscribed(java.lang.Object, long)
 	 */
 	public void psubscribed(byte[] pattern, long count) {}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see io.lettuce.core.pubsub.RedisPubSubListener#unsubscribed(java.lang.Object, long)
 	 */
 	public void unsubscribed(byte[] channel, long count) {}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see io.lettuce.core.pubsub.RedisPubSubListener#punsubscribed(java.lang.Object, long)
 	 */

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
@@ -28,15 +28,23 @@ import org.springframework.data.redis.connection.util.AbstractSubscription;
  * @author Mark Paluch
  * @author Christoph Strobl
  */
-class LettuceSubscription extends AbstractSubscription {
+public class LettuceSubscription extends AbstractSubscription {
 
 	private final StatefulRedisPubSubConnection<byte[], byte[]> connection;
 	private final LettuceMessageListener listener;
 	private final LettuceConnectionProvider connectionProvider;
 	private final RedisPubSubCommands<byte[], byte[]> pubsub;
 
-	LettuceSubscription(MessageListener listener, StatefulRedisPubSubConnection<byte[], byte[]> pubsubConnection,
-			LettuceConnectionProvider connectionProvider) {
+	/**
+	 * Creates a new {@link LettuceSubscription} given {@link MessageListener}, {@link StatefulRedisPubSubConnection}, and
+	 * {@link LettuceConnectionProvider}.
+	 *
+	 * @param listener the listener to notify, must not be {@literal null}.
+	 * @param pubsubConnection must not be {@literal null}.
+	 * @param connectionProvider must not be {@literal null}.
+	 */
+	protected LettuceSubscription(MessageListener listener,
+			StatefulRedisPubSubConnection<byte[], byte[]> pubsubConnection, LettuceConnectionProvider connectionProvider) {
 
 		super(listener);
 
@@ -52,25 +60,25 @@ class LettuceSubscription extends AbstractSubscription {
 		return connection;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doClose()
 	 */
 	protected void doClose() {
 
 		if (!getChannels().isEmpty()) {
-			pubsub.unsubscribe(new byte[0]);
+			doUnsubscribe(true, new byte[0]);
 		}
 
 		if (!getPatterns().isEmpty()) {
-			pubsub.punsubscribe(new byte[0]);
+			doPUnsubscribe(true, new byte[0]);
 		}
 
 		connection.removeListener(this.listener);
 		connectionProvider.release(connection);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doPsubscribe(byte[][])
 	 */
@@ -78,7 +86,7 @@ class LettuceSubscription extends AbstractSubscription {
 		pubsub.psubscribe(patterns);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doPUnsubscribe(boolean, byte[][])
 	 */
@@ -88,7 +96,7 @@ class LettuceSubscription extends AbstractSubscription {
 		pubsub.punsubscribe(patterns);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doSubscribe(byte[][])
 	 */
@@ -96,7 +104,7 @@ class LettuceSubscription extends AbstractSubscription {
 		pubsub.subscribe(channels);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doUnsubscribe(boolean, byte[][])
 	 */

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
@@ -48,6 +48,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.redis.connection.ClusterCommandExecutor;
 import org.springframework.data.redis.connection.ClusterNodeResourceProvider;
+import org.springframework.data.redis.connection.ClusterTopologyProvider;
 import org.springframework.data.redis.connection.RedisClusterCommands.AddSlots;
 import org.springframework.data.redis.connection.RedisClusterNode;
 
@@ -67,6 +68,7 @@ public class LettuceClusterConnectionUnitTests {
 	static final byte[] KEY_3_BYTES = KEY_3.getBytes();
 
 	@Mock RedisClusterClient clusterMock;
+	@Mock ClusterTopologyProvider topologyProviderMock;
 
 	@Mock LettuceConnectionProvider connectionProviderMock;
 	@Mock ClusterCommandExecutor executorMock;
@@ -363,7 +365,7 @@ public class LettuceClusterConnectionUnitTests {
 		when(sharedConnectionMock.sync()).thenReturn(sync);
 
 		LettuceClusterConnection connection = new LettuceClusterConnection(sharedConnectionMock, connectionProviderMock,
-				clusterMock, executorMock, Duration.ZERO);
+				topologyProviderMock, executorMock, Duration.ZERO);
 
 		connection.keyCommands().del(KEY_1_BYTES);
 
@@ -381,7 +383,7 @@ public class LettuceClusterConnectionUnitTests {
 		when(dedicatedConnection.sync()).thenReturn(sync);
 
 		LettuceClusterConnection connection = new LettuceClusterConnection(sharedConnectionMock, connectionProviderMock,
-				clusterMock, executorMock, Duration.ZERO);
+				topologyProviderMock, executorMock, Duration.ZERO);
 
 		connection.listCommands().bLPop(1, KEY_1_BYTES);
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyspaceNotificationsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyspaceNotificationsTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.SetArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.cluster.SlotHash;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.springframework.data.redis.ConnectionFactoryTracker;
+import org.springframework.data.redis.connection.ClusterCommandExecutor;
+import org.springframework.data.redis.connection.ClusterTopologyProvider;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.connection.RedisClusterConnection;
+import org.springframework.data.redis.connection.RedisConfiguration;
+import org.springframework.data.redis.test.util.RedisClusterRule;
+import org.springframework.lang.Nullable;
+
+/**
+ * Integration tests to listen for keyspace notifications.
+ *
+ * @author Mark Paluch
+ */
+public class LettuceClusterKeyspaceNotificationsTests {
+
+	@ClassRule public static RedisClusterRule clusterRule = new RedisClusterRule();
+
+	CustomLettuceConnectionFactory factory;
+	String keyspaceConfig;
+
+	// maps to 127.0.0.1:7381/slot hash 13477
+	String key = "10923";
+
+	@Before
+	public void before() {
+
+		factory = new CustomLettuceConnectionFactory(clusterRule.getConfiguration());
+		factory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		ConnectionFactoryTracker.add(factory);
+		factory.afterPropertiesSet();
+
+		// enable keyspace events on a specific node.
+		withConnection("127.0.0.1", 7381, commands -> {
+
+			keyspaceConfig = commands.configGet("*").get("notify-keyspace-events");
+			commands.configSet("notify-keyspace-events", "KEx");
+		});
+
+		assertThat(SlotHash.getSlot(key)).isEqualTo(13477);
+	}
+
+	@After
+	public void tearDown() {
+
+		// Restore previous settings.
+		withConnection("127.0.0.1", 7381, commands -> {
+			commands.configSet("notify-keyspace-events", keyspaceConfig);
+		});
+	}
+
+	@Test // DATAREDIS-976
+	public void shouldListenForKeyspaceNotifications() throws Exception {
+
+		CompletableFuture<String> expiry = new CompletableFuture<>();
+
+		RedisClusterConnection connection = factory.getClusterConnection();
+
+		connection.pSubscribe((message, pattern) -> {
+			expiry.complete(new String(message.getBody()) + ":" + new String(message.getChannel()));
+		}, "__keyspace*@*".getBytes());
+
+		withConnection("127.0.0.1", 7381, commands -> {
+			commands.set(key, "foo", SetArgs.Builder.px(1));
+		});
+
+		assertThat(expiry.get(2, TimeUnit.SECONDS)).isEqualTo("expired:__keyspace@0__:10923");
+
+		connection.getSubscription().close();
+		connection.close();
+	}
+
+	private void withConnection(String hostname, int port, Consumer<RedisCommands<String, String>> commandsConsumer) {
+
+		RedisClient client = RedisClient.create(LettuceTestClientResources.getSharedClientResources(),
+				RedisURI.create(hostname, port));
+
+		StatefulRedisConnection<String, String> connection = client.connect();
+		commandsConsumer.accept(connection.sync());
+
+		connection.close();
+		client.shutdownAsync();
+	}
+
+	static class CustomLettuceConnectionFactory extends LettuceConnectionFactory {
+
+		CustomLettuceConnectionFactory(RedisConfiguration redisConfiguration) {
+			super(redisConfiguration);
+		}
+
+		@Override
+		protected LettuceClusterConnection doCreateLettuceClusterConnection(
+				StatefulRedisClusterConnection<byte[], byte[]> sharedConnection, LettuceConnectionProvider connectionProvider,
+				ClusterTopologyProvider topologyProvider, ClusterCommandExecutor clusterCommandExecutor,
+				Duration commandTimeout) {
+			return new CustomLettuceClusterConnection(sharedConnection, connectionProvider, topologyProvider,
+					clusterCommandExecutor, commandTimeout);
+		}
+	}
+
+	static class CustomLettuceClusterConnection extends LettuceClusterConnection {
+
+		CustomLettuceClusterConnection(@Nullable StatefulRedisClusterConnection<byte[], byte[]> sharedConnection,
+				LettuceConnectionProvider connectionProvider, ClusterTopologyProvider clusterTopologyProvider,
+				ClusterCommandExecutor executor, Duration timeout) {
+			super(sharedConnection, connectionProvider, clusterTopologyProvider, executor, timeout);
+		}
+
+		@Override
+		protected LettuceSubscription doCreateSubscription(MessageListener listener,
+				StatefulRedisPubSubConnection<byte[], byte[]> connection, LettuceConnectionProvider connectionProvider) {
+			return new CustomLettuceSubscription(listener, (StatefulRedisClusterPubSubConnection<byte[], byte[]>) connection,
+					connectionProvider);
+		}
+	}
+
+	/**
+	 * Customized {@link LettuceSubscription}. Enables
+	 * {@link StatefulRedisClusterPubSubConnection#setNodeMessagePropagation(boolean)} and uses
+	 * {@link io.lettuce.core.cluster.api.sync.NodeSelection} to subscribe to all master nodes.
+	 */
+	static class CustomLettuceSubscription extends LettuceSubscription {
+
+		private final StatefulRedisClusterPubSubConnection<byte[], byte[]> connection;
+
+		CustomLettuceSubscription(MessageListener listener, StatefulRedisClusterPubSubConnection<byte[], byte[]> connection,
+				LettuceConnectionProvider connectionProvider) {
+			super(listener, connection, connectionProvider);
+			this.connection = connection;
+
+			// Must be enabled for keyspace notification propagation
+			this.connection.setNodeMessagePropagation(true);
+		}
+
+		@Override
+		protected void doPsubscribe(byte[]... patterns) {
+			connection.sync().all().commands().psubscribe(patterns);
+		}
+
+		@Override
+		protected void doPUnsubscribe(boolean all, byte[]... patterns) {
+			connection.sync().all().commands().punsubscribe();
+		}
+
+		@Override
+		protected void doSubscribe(byte[]... channels) {
+			connection.sync().all().commands().subscribe(channels);
+		}
+
+		@Override
+		protected void doUnsubscribe(boolean all, byte[]... channels) {
+			connection.sync().all().commands().unsubscribe();
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/redis/test/util/RedisClusterRule.java
+++ b/src/test/java/org/springframework/data/redis/test/util/RedisClusterRule.java
@@ -23,6 +23,7 @@ import org.junit.Assume;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConfiguration;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.jedis.JedisConverters;
 
@@ -61,6 +62,10 @@ public class RedisClusterRule extends ExternalResource {
 	@Override
 	public void before() {
 		Assume.assumeThat(mode, is("cluster"));
+	}
+
+	public RedisConfiguration getConfiguration() {
+		return this.clusterConfig;
 	}
 
 	private void init() {


### PR DESCRIPTION
`LettuceConnection`, `LettuceClusterConnection`, and `LettuceSubscription` can now be properly subclassed so they can be extended and created by `LettuceConnectionFactory`.

LettuceConnectionFactory provides template methods `doCreateLettuceConnection` and `doCreateLettuceClusterConnection`.

---

Original pull request: #450.