### PR TITLE
DATAREDIS-1000 - Fix raw/byte array serialization via RedisSerializationContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-1000-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/serializer/ByteArrayRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/ByteArrayRedisSerializer.java
@@ -21,8 +21,9 @@ import org.springframework.lang.Nullable;
  * Raw {@link RedisSerializer} using {@code byte[]}.
  *
  * @author Mark Paluch
+ * @since 2.2
  */
-enum RawRedisSerializer implements RedisSerializer<byte[]> {
+enum ByteArrayRedisSerializer implements RedisSerializer<byte[]> {
 
 	INSTANCE;
 

--- a/src/main/java/org/springframework/data/redis/serializer/RawRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RawRedisSerializer.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.redis.stream;
+package org.springframework.data.redis.serializer;
 
-import org.springframework.data.redis.serializer.RedisSerializer;
-import org.springframework.data.redis.serializer.SerializationException;
 import org.springframework.lang.Nullable;
 
 /**
+ * Raw {@link RedisSerializer} using {@code byte[]}.
+ *
  * @author Mark Paluch
  */
 enum RawRedisSerializer implements RedisSerializer<byte[]> {

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
@@ -79,12 +79,23 @@ public interface RedisSerializationContext<K, V> {
 	}
 
 	/**
-	 * Creates a new {@link RedisSerializationContext} using a {@link SerializationPair#raw()} serialization pair.
+	 * Creates a new {@link RedisSerializationContext} using a {@link SerializationPair#raw() ByteBuffer} serialization
+	 * pair.
 	 *
 	 * @return
 	 */
-	static RedisSerializationContext<byte[], byte[]> raw() {
-		return just(SerializationPair.raw());
+	static RedisSerializationContext<ByteBuffer, ByteBuffer> raw() {
+		return just(RedisSerializerToSerializationPairAdapter.raw());
+	}
+
+	/**
+	 * Creates a new {@link RedisSerializationContext} using a {@link RedisSerializer#raw() byte[]} serialization.
+	 *
+	 * @return
+	 * @since 2.2
+	 */
+	static RedisSerializationContext<byte[], byte[]> byteArray() {
+		return just(RedisSerializerToSerializationPairAdapter.byteArray());
 	}
 
 	/**
@@ -207,7 +218,7 @@ public interface RedisSerializationContext<K, V> {
 		 *
 		 * @return a pass through {@link SerializationPair}.
 		 */
-		static <T> SerializationPair<T> raw() {
+		static SerializationPair<ByteBuffer> raw() {
 			return RedisSerializerToSerializationPairAdapter.raw();
 		}
 

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializationContext.java
@@ -79,23 +79,36 @@ public interface RedisSerializationContext<K, V> {
 	}
 
 	/**
-	 * Creates a new {@link RedisSerializationContext} using a {@link SerializationPair#raw() ByteBuffer} serialization
+	 * Creates a new {@link RedisSerializationContext} using a {@link RedisSerializer#byteArray() byte[]} serialization
 	 * pair.
 	 *
-	 * @return
+	 * @return new instance of {@link RedisSerializationContext}.
+	 * @deprecated since 2.2. Please use {@link #byteArray()} instead.
 	 */
-	static RedisSerializationContext<ByteBuffer, ByteBuffer> raw() {
-		return just(RedisSerializerToSerializationPairAdapter.raw());
+	@Deprecated
+	static RedisSerializationContext<byte[], byte[]> raw() {
+		return byteArray();
 	}
 
 	/**
-	 * Creates a new {@link RedisSerializationContext} using a {@link RedisSerializer#raw() byte[]} serialization.
+	 * Creates a new {@link RedisSerializationContext} using a {@link RedisSerializer#byteArray() byte[]} serialization.
 	 *
-	 * @return
+	 * @return new instance of {@link RedisSerializationContext}.
 	 * @since 2.2
 	 */
 	static RedisSerializationContext<byte[], byte[]> byteArray() {
 		return just(RedisSerializerToSerializationPairAdapter.byteArray());
+	}
+
+	/**
+	 * Creates a new {@link RedisSerializationContext} using a {@link SerializationPair#byteBuffer() ByteBuffer}
+	 * serialization.
+	 *
+	 * @return new instance of {@link RedisSerializationContext}.
+	 * @since 2.2
+	 */
+	static RedisSerializationContext<ByteBuffer, ByteBuffer> byteBuffer() {
+		return just(RedisSerializerToSerializationPairAdapter.byteBuffer());
 	}
 
 	/**
@@ -217,9 +230,26 @@ public interface RedisSerializationContext<K, V> {
 		 * Creates a pass through {@link SerializationPair} to pass-thru {@link ByteBuffer} objects.
 		 *
 		 * @return a pass through {@link SerializationPair}.
+		 * @deprecated since 2.2. Please use either {@link #byteArray()} or {@link #byteBuffer()}.
 		 */
-		static SerializationPair<ByteBuffer> raw() {
+		static <T> SerializationPair<T> raw() {
 			return RedisSerializerToSerializationPairAdapter.raw();
+		}
+
+		/**
+		 * @return
+		 * @since 2.2
+		 */
+		static SerializationPair<byte[]> byteArray() {
+			return RedisSerializerToSerializationPairAdapter.byteArray();
+		}
+
+		/**
+		 * @return
+		 * @since 2.2
+		 */
+		static SerializationPair<ByteBuffer> byteBuffer() {
+			return RedisSerializerToSerializationPairAdapter.byteBuffer();
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
@@ -92,6 +92,16 @@ public interface RedisSerializer<T> {
 		return StringRedisSerializer.UTF_8;
 	}
 
+	/**
+	 * Obtain a raw {@link RedisSerializer} that passes thru {@code byte[]}.
+	 *
+	 * @return never {@literal null}.
+	 * @since 2.2
+	 */
+	static RedisSerializer<byte[]> raw() {
+		return RawRedisSerializer.INSTANCE;
+	}
+
 	default boolean canSerialize(Class<?> type) {
 		return ClassUtils.isAssignable(getTargetType(), type);
 	}

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
@@ -93,13 +93,13 @@ public interface RedisSerializer<T> {
 	}
 
 	/**
-	 * Obtain a raw {@link RedisSerializer} that passes thru {@code byte[]}.
+	 * Obtain a {@link RedisSerializer} that passes thru {@code byte[]}.
 	 *
 	 * @return never {@literal null}.
 	 * @since 2.2
 	 */
-	static RedisSerializer<byte[]> raw() {
-		return RawRedisSerializer.INSTANCE;
+	static RedisSerializer<byte[]> byteArray() {
+		return ByteArrayRedisSerializer.INSTANCE;
 	}
 
 	default boolean canSerialize(Class<?> type) {

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializerToSerializationPairAdapter.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializerToSerializationPairAdapter.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.serializer;
 
+import java.nio.ByteBuffer;
+
 import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -31,16 +33,23 @@ class RedisSerializerToSerializationPairAdapter<T> implements SerializationPair<
 	private final static RedisSerializerToSerializationPairAdapter<?> RAW = new RedisSerializerToSerializationPairAdapter<>(
 			null);
 
+	private final static RedisSerializerToSerializationPairAdapter<byte[]> BYTE_ARRAY = new RedisSerializerToSerializationPairAdapter<>(
+			RedisSerializer.raw());
+
 	private final DefaultSerializationPair pair;
 
-	protected RedisSerializerToSerializationPairAdapter(@Nullable RedisSerializer<T> serializer) {
-		pair = new DefaultSerializationPair(new DefaultRedisElementReader<>(serializer),
+	RedisSerializerToSerializationPairAdapter(@Nullable RedisSerializer<T> serializer) {
+		pair = new DefaultSerializationPair<>(new DefaultRedisElementReader<>(serializer),
 				new DefaultRedisElementWriter<>(serializer));
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <T> SerializationPair<T> raw() {
+	static SerializationPair<ByteBuffer> raw() {
 		return (SerializationPair) RAW;
+	}
+
+	static SerializationPair<byte[]> byteArray() {
+		return BYTE_ARRAY;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializerToSerializationPairAdapter.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializerToSerializationPairAdapter.java
@@ -30,11 +30,11 @@ import org.springframework.util.Assert;
  */
 class RedisSerializerToSerializationPairAdapter<T> implements SerializationPair<T> {
 
-	private final static RedisSerializerToSerializationPairAdapter<?> RAW = new RedisSerializerToSerializationPairAdapter<>(
+	private final static RedisSerializerToSerializationPairAdapter<?> BYTE_BUFFER = new RedisSerializerToSerializationPairAdapter<>(
 			null);
 
 	private final static RedisSerializerToSerializationPairAdapter<byte[]> BYTE_ARRAY = new RedisSerializerToSerializationPairAdapter<>(
-			RedisSerializer.raw());
+			RedisSerializer.byteArray());
 
 	private final DefaultSerializationPair pair;
 
@@ -43,13 +43,30 @@ class RedisSerializerToSerializationPairAdapter<T> implements SerializationPair<
 				new DefaultRedisElementWriter<>(serializer));
 	}
 
+	/**
+	 * @return the {@link RedisSerializerToSerializationPairAdapter} for {@link ByteBuffer}.
+	 * @deprecated since 2.2. Please use {@link #byteBuffer()} instead.
+	 */
 	@SuppressWarnings("unchecked")
-	static SerializationPair<ByteBuffer> raw() {
-		return (SerializationPair) RAW;
+	@Deprecated
+	static <T> SerializationPair<T> raw() {
+		return (SerializationPair) byteBuffer();
 	}
 
+	/**
+	 * @return the {@link RedisSerializerToSerializationPairAdapter} for {@link byte[]}.
+	 * @since 2.2
+	 */
 	static SerializationPair<byte[]> byteArray() {
 		return BYTE_ARRAY;
+	}
+
+	/**
+	 * @return the {@link RedisSerializerToSerializationPairAdapter} for {@link ByteBuffer}.
+	 * @since 2.2
+	 */
+	static SerializationPair<ByteBuffer> byteBuffer() {
+		return (SerializationPair) BYTE_BUFFER;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
@@ -722,8 +722,8 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 
 			if (this.hashMapper == null) {
 
-				hashKeySerializer(RawRedisSerializer.INSTANCE);
-				hashValueSerializer(RawRedisSerializer.INSTANCE);
+				hashKeySerializer(RedisSerializer.raw());
+				hashValueSerializer(RedisSerializer.raw());
 				return (StreamMessageListenerContainerOptionsBuilder) objectMapper(new ObjectHashMapper());
 			}
 

--- a/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
@@ -710,7 +710,7 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 		/**
 		 * Configure a hash target type. Changes the emitted {@link Record} type to {@link ObjectRecord}.
 		 *
-		 * @param pair must not be {@literal null}.
+		 * @param targetType must not be {@literal null}.
 		 * @return {@code this} {@link StreamMessageListenerContainerOptionsBuilder}.
 		 */
 		@SuppressWarnings("unchecked")
@@ -722,8 +722,8 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 
 			if (this.hashMapper == null) {
 
-				hashKeySerializer(RedisSerializer.raw());
-				hashValueSerializer(RedisSerializer.raw());
+				hashKeySerializer(RedisSerializer.byteArray());
+				hashValueSerializer(RedisSerializer.byteArray());
 				return (StreamMessageListenerContainerOptionsBuilder) objectMapper(new ObjectHashMapper());
 			}
 

--- a/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
@@ -119,7 +119,7 @@ abstract public class ReactiveOperationsTestParams {
 				RedisSerializationContext.<String, Double> newSerializationContext(jdkSerializationRedisSerializer)
 						.key(stringRedisSerializer).value(doubleToStringSerializer).build());
 
-		ReactiveRedisTemplate<byte[], byte[]> rawTemplate = new ReactiveRedisTemplate<>(lettuceConnectionFactory,
+		ReactiveRedisTemplate<ByteBuffer, ByteBuffer> rawTemplate = new ReactiveRedisTemplate<>(lettuceConnectionFactory,
 				RedisSerializationContext.raw());
 
 		ReactiveRedisTemplate<String, Person> personTemplate = new ReactiveRedisTemplate(lettuceConnectionFactory,

--- a/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveOperationsTestParams.java
@@ -120,7 +120,7 @@ abstract public class ReactiveOperationsTestParams {
 						.key(stringRedisSerializer).value(doubleToStringSerializer).build());
 
 		ReactiveRedisTemplate<ByteBuffer, ByteBuffer> rawTemplate = new ReactiveRedisTemplate<>(lettuceConnectionFactory,
-				RedisSerializationContext.raw());
+				RedisSerializationContext.byteBuffer());
 
 		ReactiveRedisTemplate<String, Person> personTemplate = new ReactiveRedisTemplate(lettuceConnectionFactory,
 				RedisSerializationContext.fromSerializer(jdkSerializationRedisSerializer));

--- a/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
@@ -111,6 +111,32 @@ public class RedisSerializationContextUnitTests {
 		assertThat(deserialized).isEqualTo(42);
 	}
 
+	@Test // DATAREDIS-1000
+	public void shouldEncodeAndDecodeRawByteBufferValue() {
+
+		RedisSerializationContext<ByteBuffer, ByteBuffer> serializationContext = RedisSerializationContext
+				.raw();
+
+		ByteBuffer deserialized = serializationContext.getValueSerializationPair()
+				.read(serializationContext.getValueSerializationPair()
+						.write(ByteBuffer.wrap("hello".getBytes())));
+
+		assertThat(deserialized).isEqualTo(ByteBuffer.wrap("hello".getBytes()));
+	}
+
+	@Test // DATAREDIS-1000
+	public void shouldEncodeAndDecodeByteArrayValue() {
+
+		RedisSerializationContext<byte[], byte[]> serializationContext = RedisSerializationContext
+				.byteArray();
+
+		byte[] deserialized = serializationContext.getValueSerializationPair()
+				.read(serializationContext.getValueSerializationPair()
+						.write("hello".getBytes()));
+
+		assertThat(deserialized).isEqualTo("hello".getBytes());
+	}
+
 	private RedisSerializationContext<String, Long> createSerializationContext() {
 
 		return RedisSerializationContext.<String, Long> newSerializationContext() //

--- a/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
@@ -115,7 +115,7 @@ public class RedisSerializationContextUnitTests {
 	public void shouldEncodeAndDecodeRawByteBufferValue() {
 
 		RedisSerializationContext<ByteBuffer, ByteBuffer> serializationContext = RedisSerializationContext
-				.raw();
+				.byteBuffer();
 
 		ByteBuffer deserialized = serializationContext.getValueSerializationPair()
 				.read(serializationContext.getValueSerializationPair()


### PR DESCRIPTION
We now use the correct generic parameters for raw serialization via `RedisSerializationContext` returning `ByteBuffer`.

Introduce `RedisSerializer.raw()` and cleanups.

---

Related ticket: [DATAREDIS-1000](https://jira.spring.io/browse/DATAREDIS-1000).