### PR TITLE
DATAREDIS-1005 - Support Eval & EvalSha by JedisClusterConnection

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -326,7 +326,7 @@ public class JedisClusterConnection implements DefaultedRedisClusterConnection {
 	 */
 	@Override
 	public RedisScriptingCommands scriptingCommands() {
-		return JedisClusterScriptingCommands.INSTANCE;
+		return new JedisClusterScriptingCommands(this);
 	}
 
 	private JedisClusterKeyCommands doGetKeyCommands() {


### PR DESCRIPTION
Added Eval & EvalSha Redis commands to JedisClusterScriptingCommands 

---
Related ticket: [DATAREDIS-1005](https://jira.spring.io/browse/DATAREDIS-1005)