### PR TITLE
DATAREDIS-990 - Propagate SSL configuration to Lettuce driver when using Redis Sentinel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-990-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -1031,6 +1031,10 @@ public class LettuceConnectionFactory
 
 		getRedisPassword().toOptional().ifPresent(redisUri::setPassword);
 		clientConfiguration.getClientName().ifPresent(redisUri::setClientName);
+
+		redisUri.setSsl(clientConfiguration.isUseSsl());
+		redisUri.setVerifyPeer(clientConfiguration.isVerifyPeer());
+		redisUri.setStartTls(clientConfiguration.isStartTls());
 		redisUri.setTimeout(clientConfiguration.getCommandTimeout());
 		redisUri.setDatabase(getDatabase());
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -285,6 +285,68 @@ public class LettuceConnectionFactoryUnitTests {
 		assertThat(connectionFactory.isStartTls()).isTrue();
 	}
 
+	@Test // DATAREDIS-990
+	public void sslShouldBeSetCorrectlyOnSentinelClient() {
+
+		RedisSentinelConfiguration sentinelConfiguration = new RedisSentinelConfiguration("myMaster",
+				Collections.singleton("localhost:1234"));
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(sentinelConfiguration);
+		connectionFactory.setClientResources(getSharedClientResources());
+		connectionFactory.setUseSsl(true);
+		connectionFactory.afterPropertiesSet();
+		ConnectionFactoryTracker.add(connectionFactory);
+
+		AbstractRedisClient client = (AbstractRedisClient) getField(connectionFactory, "client");
+		assertThat(client).isInstanceOf(RedisClient.class);
+
+		RedisURI redisUri = (RedisURI) getField(client, "redisURI");
+
+		assertThat(redisUri.isSsl()).isTrue();
+		assertThat(connectionFactory.isUseSsl()).isTrue();
+		assertThat(redisUri.isVerifyPeer()).isTrue();
+		assertThat(connectionFactory.isVerifyPeer()).isTrue();
+	}
+
+	@Test // DATAREDIS-990
+	public void verifyPeerOptionShouldBeSetCorrectlyOnSentinelClient() {
+
+		RedisSentinelConfiguration sentinelConfiguration = new RedisSentinelConfiguration("myMaster",
+				Collections.singleton("localhost:1234"));
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(sentinelConfiguration);
+		connectionFactory.setClientResources(getSharedClientResources());
+		connectionFactory.setVerifyPeer(false);
+		connectionFactory.afterPropertiesSet();
+		ConnectionFactoryTracker.add(connectionFactory);
+
+		AbstractRedisClient client = (AbstractRedisClient) getField(connectionFactory, "client");
+		assertThat(client).isInstanceOf(RedisClient.class);
+
+		RedisURI redisUri = (RedisURI) getField(client, "redisURI");
+
+		assertThat(redisUri.isVerifyPeer()).isFalse();
+		assertThat(connectionFactory.isVerifyPeer()).isFalse();
+	}
+
+	@Test // DATAREDIS-990
+	public void startTLSOptionShouldBeSetCorrectlyOnSentinelClient() {
+
+		RedisSentinelConfiguration sentinelConfiguration = new RedisSentinelConfiguration("myMaster",
+				Collections.singleton("localhost:1234"));
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(sentinelConfiguration);
+		connectionFactory.setClientResources(getSharedClientResources());
+		connectionFactory.setStartTls(true);
+		connectionFactory.afterPropertiesSet();
+		ConnectionFactoryTracker.add(connectionFactory);
+
+		AbstractRedisClient client = (AbstractRedisClient) getField(connectionFactory, "client");
+		assertThat(client).isInstanceOf(RedisClient.class);
+
+		RedisURI redisUri = (RedisURI) getField(client, "redisURI");
+
+		assertThat(redisUri.isStartTls()).isTrue();
+		assertThat(connectionFactory.isStartTls()).isTrue();
+	}
+
 	@Test // DATAREDIS-537
 	public void sslShouldBeSetCorrectlyOnClusterClient() {
 


### PR DESCRIPTION
We now appropriately set SSL configuration when using the Lettuce driver with Redis Sentinel to enable Sentinel usage with SSL. Using Sentinel with SSL requires Lettuce 5.2 or newer.

---

Related ticket: [DATAREDIS-990](https://jira.spring.io/browse/DATAREDIS-990).
See also: lettuce-io/lettuce-core#1048.