### PR TITLE
DATAREDIS-588 - Use JedisCluster.psetex(…) instead dispatching to a node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-588-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStringCommands.java
@@ -33,7 +33,6 @@ import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.RedisStringCommands;
 import org.springframework.data.redis.connection.convert.Converters;
-import org.springframework.data.redis.connection.jedis.JedisClusterConnection.JedisClusterCommandCallback;
 import org.springframework.data.redis.connection.jedis.JedisClusterConnection.JedisMultiKeyClusterCommandCallback;
 import org.springframework.data.redis.connection.lettuce.LettuceConverters;
 import org.springframework.data.redis.core.types.Expiration;
@@ -189,11 +188,11 @@ class JedisClusterStringCommands implements RedisStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		return Converters.stringToBoolean(connection.getClusterCommandExecutor()
-				.executeCommandOnSingleNode(
-						(JedisClusterCommandCallback<String>) client -> client.psetex(key, milliseconds, value),
-						connection.getTopologyProvider().getTopology().getKeyServingMasterNode(key))
-				.getValue());
+		try {
+			return Converters.stringToBoolean(connection.getCluster().psetex(key, milliseconds, value));
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
+		}
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -533,11 +533,15 @@ abstract public class JedisConverters extends Converters {
 
 		SetParams paramsToUse = params == null ? SetParams.setParams() : params;
 
-		if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
-			return paramsToUse.px(expiration.getExpirationTime());
+		if (!expiration.isPersistent()) {
+			if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
+				return paramsToUse.px(expiration.getExpirationTime());
+			}
+
+			return paramsToUse.ex((int) expiration.getExpirationTime());
 		}
 
-		return paramsToUse.ex((int) expiration.getExpirationTime());
+		return params;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -1836,9 +1836,9 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
 		clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.persistent(), SetOption.ifPresent());
 
-		assertThat(nativeConnection.exists(KEY_1_BYTES), is(true));
-		assertThat(clusterConnection.get(KEY_1_BYTES), is(VALUE_2_BYTES));
-		assertThat(nativeConnection.ttl(KEY_1_BYTES), is(-1L));
+		assertThat(nativeConnection.exists(KEY_1_BYTES)).isTrue();
+		assertThat(clusterConnection.get(KEY_1_BYTES)).isEqualTo(VALUE_2_BYTES);
+		assertThat(nativeConnection.ttl(KEY_1_BYTES)).isEqualTo(-1L);
 	}
 
 	@Test // DATAREDIS-315

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -1830,11 +1830,15 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.ttl(KEY_1_BYTES)).isEqualTo(-1L);
 	}
 
-	@Test(expected = UnsupportedOperationException.class) // DATAREDIS-316
+	@Test // DATAREDIS-316, DATAREDIS-588
 	public void setWithOptionIfPresentShouldWorkCorrectly() {
 
 		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
 		clusterConnection.set(KEY_1_BYTES, VALUE_2_BYTES, Expiration.persistent(), SetOption.ifPresent());
+
+		assertThat(nativeConnection.exists(KEY_1_BYTES), is(true));
+		assertThat(clusterConnection.get(KEY_1_BYTES), is(VALUE_2_BYTES));
+		assertThat(nativeConnection.ttl(KEY_1_BYTES), is(-1L));
 	}
 
 	@Test // DATAREDIS-315


### PR DESCRIPTION
We now use `JedisCluster`'s `psetex` command instead of looking up the topology and dispatching the command ourselves.

Simplify `SET` command usage with Jedis using various expiry and presence/absence flags to use consistently `SetParams`.

---

Related ticket: [DATAREDIS-588](https://jira.spring.io/browse/DATAREDIS-588).

