### PR TITLE
DATAREDIS-575 - Support client name for JedisCluster.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-575-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -427,10 +427,12 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 
 		int connectTimeout = getConnectTimeout();
 		int readTimeout = getReadTimeout();
+		String password = getPassword();
+		String clientName = getClientName();
 
-		return StringUtils.hasText(getPassword())
-				? new JedisCluster(hostAndPort, connectTimeout, readTimeout, redirects, getPassword(), poolConfig)
-				: new JedisCluster(hostAndPort, connectTimeout, readTimeout, redirects, poolConfig);
+		return new JedisCluster(hostAndPort, connectTimeout, readTimeout, redirects,
+				StringUtils.hasText(password) ? password : null, StringUtils.hasText(clientName) ? clientName : null,
+				poolConfig);
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
@@ -23,6 +23,7 @@ import redis.clients.jedis.JedisShardInfo;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.data.redis.SettingsUtils;
+import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 
 /**
@@ -64,5 +65,18 @@ public class JedisConnectionFactoryIntegrationTests {
 		factory.afterPropertiesSet();
 
 		assertThat(factory.getConnection().ping(), equalTo("PONG"));
+	}
+
+	@Test // DATAREDIS-575
+	public void connectionAppliesClientName() {
+
+		factory = new JedisConnectionFactory(
+				new RedisStandaloneConfiguration(SettingsUtils.getHost(), SettingsUtils.getPort()),
+				JedisClientConfiguration.builder().clientName("clientName").build());
+		factory.afterPropertiesSet();
+
+		RedisConnection connection = factory.getConnection();
+
+		assertThat(connection.getClientName(), equalTo("clientName"));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
-import static org.hamcrest.core.IsEqual.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import redis.clients.jedis.JedisShardInfo;
 
 import org.junit.After;
 import org.junit.Test;
+
 import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
@@ -53,18 +53,18 @@ public class JedisConnectionFactoryIntegrationTests {
 		factory.setPort(1234);
 		factory.afterPropertiesSet();
 
-		assertThat(factory.getConnection().ping(), equalTo("PONG"));
+		assertThat(factory.getConnection().ping()).isEqualTo("PONG");
 	}
 
 	@Test // DATAREDIS-574
-	public void shouldInitiaizeWithStandaloneConfiguration() {
+	public void shouldInitializeWithStandaloneConfiguration() {
 
 		factory = new JedisConnectionFactory(
 				new RedisStandaloneConfiguration(SettingsUtils.getHost(), SettingsUtils.getPort()),
 				JedisClientConfiguration.defaultConfiguration());
 		factory.afterPropertiesSet();
 
-		assertThat(factory.getConnection().ping(), equalTo("PONG"));
+		assertThat(factory.getConnection().ping()).isEqualTo("PONG");
 	}
 
 	@Test // DATAREDIS-575
@@ -77,6 +77,6 @@ public class JedisConnectionFactoryIntegrationTests {
 
 		RedisConnection connection = factory.getConnection();
 
-		assertThat(connection.getClientName(), equalTo("clientName"));
+		assertThat(connection.getClientName()).isEqualTo("clientName");
 	}
 }


### PR DESCRIPTION
We now support setting the client name using `JedisCluster`.

---

Related ticket: [DATAREDIS-575](https://jira.spring.io/browse/DATAREDIS-575).