### PR TITLE
DATAREDIS-1009 - Make StreamMessageListenerContainerOptions.builder public

### DIFF
--- a/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
@@ -504,7 +504,7 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 		/**
 		 * @return a new builder for {@link StreamMessageListenerContainerOptions}.
 		 */
-		static StreamMessageListenerContainerOptionsBuilder<String, MapRecord<String, String, String>> builder() {
+		public static StreamMessageListenerContainerOptionsBuilder<String, MapRecord<String, String, String>> builder() {
 			return new StreamMessageListenerContainerOptionsBuilder<>().serializer(StringRedisSerializer.UTF_8);
 		}
 


### PR DESCRIPTION
When I try to use the builder, I get "the method builder is not visible

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
