### PR TITLE
DATAREDIS-1001 - Fix java.util.Date hash mapping when flattening out entries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+			<version>${jackson}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-1001-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/test/java/org/springframework/data/redis/mapping/AbstractHashMapperTest.java
+++ b/src/test/java/org/springframework/data/redis/mapping/AbstractHashMapperTest.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.mapping;
 
+import static org.hamcrest.core.IsEqual.*;
 import static org.junit.Assert.*;
 
 import java.util.Map;
@@ -42,7 +43,7 @@ public abstract class AbstractHashMapperTest {
 
 		HashMapper mapper = mapperFor(o.getClass());
 		Map hash = mapper.toHash(o);
-		assertThat(mapper.fromHash(hash), IsEqual.equalTo(o));
+		assertThat(mapper.fromHash(hash), equalTo(o));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperTests.java
@@ -97,5 +97,4 @@ public class Jackson2HashMapperTests {
 		Person result = (Person) mapper.fromHash(template.<String, Object> opsForHash().entries("JON-SNOW"));
 		Assert.assertThat(result, Is.is(jon));
 	}
-
 }

--- a/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
@@ -17,8 +17,11 @@ package org.springframework.data.redis.mapping;
 
 import lombok.Data;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -165,9 +168,12 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 	@Test // DATAREDIS-1001
 	public void dateValueShouldBeTreatedCorrectly() {
 
-		WithDate source = new WithDate();
+		WithDates source = new WithDates();
 		source.string = "id-1";
 		source.date = new Date(1561543964015L);
+		source.calendar = Calendar.getInstance();
+		source.localDate = LocalDate.parse("2018-01-02");
+		source.localDateTime = LocalDateTime.parse("2018-01-02T12:13:14");
 
 		assertBackAndForwardMapping(source);
 	}
@@ -187,9 +193,12 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 	}
 
 	@Data
-	static class WithDate {
+	static class WithDates {
 
 		private String string;
 		private Date date;
+		private Calendar calendar;
+		private LocalDate localDate;
+		private LocalDateTime localDateTime;
 	}
 }

--- a/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
@@ -20,6 +20,7 @@ import lombok.Data;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -161,6 +162,16 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		assertBackAndForwardMapping(outer);
 	}
 
+	@Test // DATAREDIS-1001
+	public void dateValueShouldBeTreatedCorrectly() {
+
+		WithDate source = new WithDate();
+		source.string = "id-1";
+		source.date = new Date(1561543964015L);
+
+		assertBackAndForwardMapping(source);
+	}
+
 	@Data
 	public static class WithList {
 		List<String> strings;
@@ -173,5 +184,12 @@ public class Jackson2HashMapperUnitTests extends AbstractHashMapperTest {
 		Map<String, String> strings;
 		Map<String, Object> objects;
 		Map<String, Person> persons;
+	}
+
+	@Data
+	static class WithDate {
+
+		private String string;
+		private Date date;
 	}
 }


### PR DESCRIPTION
The `AsArrayTypeDeserializer` causes `Date` values to be rendered as an array like `[java.util.Date, 1561543964015`].  Therefore they are skipped when flattening and if not skipped cannot be read back.

We now register an error handler along with a custom deserializer aware of the used date format to write and read date values without having to store an array.