### PR TITLE
DATAREDIS-1027 - Dispose reactive LettuceConnectionProvider on connection factory shutdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-1027-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -299,16 +299,8 @@ public class LettuceConnectionFactory
 
 		resetConnection();
 
-		if (connectionProvider instanceof DisposableBean) {
-			try {
-				((DisposableBean) connectionProvider).destroy();
-			} catch (Exception e) {
-
-				if (log.isWarnEnabled()) {
-					log.warn(connectionProvider + " did not shut down gracefully.", e);
-				}
-			}
-		}
+		dispose(connectionProvider);
+		dispose(reactiveConnectionProvider);
 
 		try {
 			Duration quietPeriod = clientConfiguration.getShutdownQuietPeriod();
@@ -328,6 +320,20 @@ public class LettuceConnectionFactory
 				clusterCommandExecutor.destroy();
 			} catch (Exception ex) {
 				log.warn("Cannot properly close cluster command executor", ex);
+			}
+		}
+	}
+
+	private void dispose(LettuceConnectionProvider connectionProvider) {
+
+		if (connectionProvider instanceof DisposableBean) {
+			try {
+				((DisposableBean) connectionProvider).destroy();
+			} catch (Exception e) {
+
+				if (log.isWarnEnabled()) {
+					log.warn(connectionProvider + " did not shut down gracefully.", e);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
`LettuceConnectionFactory.destroy()` now disposes also the reactive `LettuceConnectionProvider` to free resources of a connection pool.

---

Related ticket: [DATAREDIS-1027](https://jira.spring.io/browse/DATAREDIS-1027).