### PR TITLE
DATAREDIS-1031 - Fix reactive pExpire/pExpireAt to invoke correct command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAREDIS-1031-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveKeyCommands.java
@@ -131,7 +131,7 @@ public interface ReactiveKeyCommands {
 	 * Find all keys matching the given {@literal pattern}.<br />
 	 * It is recommended to use {@link #scan(ScanOptions)} to iterate over the keyspace as {@link #keys(Publisher)} is a
 	 * non-interruptible and expensive Redis operation.
-	 * 
+	 *
 	 * @param patterns must not be {@literal null}.
 	 * @return
 	 * @see <a href="https://redis.io/commands/keys">Redis Documentation: KEYS</a>
@@ -462,7 +462,7 @@ public interface ReactiveKeyCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(timeout, "Timeout must not be null!");
 
-		return expire(Mono.just(new ExpireCommand(key, timeout))).next().map(BooleanResponse::getOutput);
+		return pExpire(Mono.just(new ExpireCommand(key, timeout))).next().map(BooleanResponse::getOutput);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommands.java
@@ -262,7 +262,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getTimeout(), "Timeout must not be null!");
 
-			return cmd.pexpire(command.getKey(), command.getTimeout().getSeconds())
+			return cmd.pexpire(command.getKey(), command.getTimeout().toMillis())
 					.map(value -> new BooleanResponse<>(command, value));
 		}));
 	}
@@ -294,7 +294,7 @@ class LettuceReactiveKeyCommands implements ReactiveKeyCommands {
 			Assert.notNull(command.getKey(), "Key must not be null!");
 			Assert.notNull(command.getExpireAt(), "Expire at must not be null!");
 
-			return cmd.expireat(command.getKey(), command.getExpireAt().toEpochMilli())
+			return cmd.pexpireat(command.getKey(), command.getExpireAt().toEpochMilli())
 					.map(value -> new BooleanResponse<>(command, value));
 		}));
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveKeyCommandsTests.java
@@ -278,7 +278,7 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 		assertThat(nativeCommands.ttl(KEY_1)).isGreaterThan(8L);
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-1031
 	public void shouldPreciseExpireKeysCorrectly() {
 
 		nativeCommands.set(KEY_1, VALUE_1);
@@ -288,10 +288,10 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 				.expectComplete() //
 				.verify();
 
-		assertThat(nativeCommands.ttl(KEY_1)).isGreaterThan(8L);
+		assertThat(nativeCommands.ttl(KEY_1)).isGreaterThan(8).isLessThan(11);
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-1031
 	public void shouldExpireAtKeysCorrectly() {
 
 		nativeCommands.set(KEY_1, VALUE_1);
@@ -302,10 +302,10 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 				.expectComplete() //
 				.verify();
 
-		assertThat(nativeCommands.ttl(KEY_1)).isGreaterThan(8L);
+		assertThat(nativeCommands.ttl(KEY_1)).isGreaterThan(8).isLessThan(11);
 	}
 
-	@Test // DATAREDIS-602
+	@Test // DATAREDIS-602, DATAREDIS-1031
 	public void shouldPreciseExpireAtKeysCorrectly() {
 
 		nativeCommands.set(KEY_1, VALUE_1);
@@ -316,7 +316,7 @@ public class LettuceReactiveKeyCommandsTests extends LettuceReactiveCommandsTest
 				.expectComplete() //
 				.verify();
 
-		assertThat(nativeCommands.ttl(KEY_1)).isGreaterThan(8L);
+		assertThat(nativeCommands.ttl(KEY_1)).isGreaterThan(8).isLessThan(11);
 	}
 
 	@Test // DATAREDIS-602


### PR DESCRIPTION
We now invoke the correct `PEXPIRE(AT)` command. Previously, we invoked `EXPIRE`/`EXPIREAT` commands resulting in the wrong command being called.

---

Related ticket: [DATAREDIS-1031](https://jira.spring.io/browse/DATAREDIS-1031).