### PR TITLE
 DATAREDIS-678 Lock only given cache key (Work in progress)

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
@@ -123,7 +123,7 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 
 
 		byte[] lockName = ByteBuffer.allocate(name.length() + key.length)
-			.put(name.getBytes(StandardCharsets.UTF_8))
+			.put(key.getBytes(StandardCharsets.UTF_8))
 			.put(value)
 			.array();
 


### PR DESCRIPTION
This is a Work-in-progress proposal for fixing [DATAREDIS-678](https://jira.spring.io/projects/DATAREDIS/issues/DATAREDIS-678?filter=allopenissues).

This PR addresses locking of only keys and I believe it solves it correctly.

However as I don't understand well the implementation, I am not sure about fixing correctly the unlocks:

```
/*
	 * (non-Javadoc)
	 * @see org.springframework.data.redis.cache.RedisCacheWriter#clean(java.lang.String, byte[])
	 */
	@Override
	public void clean(String name, byte[] pattern) {

		Assert.notNull(name, "Name must not be null!");
		Assert.notNull(pattern, "Pattern must not be null!");

		execute(name, connection -> {

			boolean wasLocked = false;

			try {

				if (isLockingCacheWriter()) {
					doLock(name, connection);
					wasLocked = true;
				}

				byte[][] keys = Optional.ofNullable(connection.keys(pattern)).orElse(Collections.emptySet())
						.toArray(new byte[0][]);

				if (keys.length > 0) {
					connection.del(keys);
				}
			} finally {

				if (wasLocked && isLockingCacheWriter()) {
					doUnlock(name, connection);
				}
			}

			return "OK";
		});
	}
```

As the clean doesn't work with the cache key, I am not sure, about how to implement this correctly.