### PR TITLE
DATAREDIS-1033 - Add Kotlin Flow based extensions

### DIFF
--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensions.kt
@@ -15,12 +15,19 @@
  */
 package org.springframework.data.redis.core
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
+import kotlinx.coroutines.reactor.asFlux
+import org.springframework.data.geo.Circle
 import org.springframework.data.geo.Distance
+import org.springframework.data.geo.GeoResult
 import org.springframework.data.geo.Metric
 import org.springframework.data.geo.Point
-import org.springframework.data.redis.connection.RedisGeoCommands
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoRadiusCommandArgs
 
 /**
  * Coroutines variant of [ReactiveGeoOperations.add].
@@ -37,7 +44,7 @@ suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, p
  * @author Mark Paluch
  * @since 2.2
  */
-suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, location: RedisGeoCommands.GeoLocation<M>): Long =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, location: GeoLocation<M>): Long =
 		add(key, location).awaitSingle()
 
 /**
@@ -55,8 +62,18 @@ suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, m
  * @author Mark Paluch
  * @since 2.2
  */
-suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, locations: Iterable<RedisGeoCommands.GeoLocation<M>>): Long =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, locations: Iterable<GeoLocation<M>>): Long =
 		add(key, locations).awaitSingle()
+
+/**
+ * Coroutines [Flow] variant of [ReactiveGeoOperations.add].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.add(key: K, locations: Flow<Collection<GeoLocation<M>>>): Flow<Long> =
+		add(key, locations.asFlux()).asFlow()
 
 /**
  * Coroutines variant of [ReactiveGeoOperations.distance].
@@ -114,6 +131,37 @@ suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.positionAndAwait(key:
  */
 suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.positionAndAwait(key: K, vararg members: M): List<Point> =
 		position(key, *members).awaitSingle()
+
+/**
+ * Coroutines [Flow] variant of [ReactiveGeoOperations.radius].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.radiusAsFlow(key: K, within: Circle, args: GeoRadiusCommandArgs? = null): Flow<GeoResult<GeoLocation<M>>> =
+		(if (args != null) radius(key, within, args) else radius(key, within)).asFlow()
+
+
+/**
+ * Coroutines [Flow] variant of [ReactiveGeoOperations.radius].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.radiusAsFlow(key: K, member: M, radius: Double): Flow<GeoResult<GeoLocation<M>>> =
+		radius(key, member, radius).asFlow()
+
+/**
+ * Coroutines [Flow] variant of [ReactiveGeoOperations.radius].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.radiusAsFlow(key: K, member: M, distance: Distance, args: GeoRadiusCommandArgs? = null): Flow<GeoResult<GeoLocation<M>>> =
+		(if (args != null) radius(key, member, distance, args) else radius(key, member, distance)).asFlow()
 
 /**
  * Coroutines variant of [ReactiveGeoOperations.remove].

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensions.kt
@@ -28,7 +28,7 @@ import org.springframework.data.redis.connection.RedisGeoCommands
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, point: Point, member: M): Long =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, point: Point, member: M): Long =
 		add(key, point, member).awaitSingle()
 
 /**
@@ -37,7 +37,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, location: RedisGeoCommands.GeoLocation<M>): Long =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, location: RedisGeoCommands.GeoLocation<M>): Long =
 		add(key, location).awaitSingle()
 
 /**
@@ -46,7 +46,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, memberCoordinateMap: Map<M, Point>): Long =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, memberCoordinateMap: Map<M, Point>): Long =
 		add(key, memberCoordinateMap).awaitSingle()
 
 /**
@@ -55,7 +55,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, locations: Iterable<RedisGeoCommands.GeoLocation<M>>): Long =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.addAndAwait(key: K, locations: Iterable<RedisGeoCommands.GeoLocation<M>>): Long =
 		add(key, locations).awaitSingle()
 
 /**
@@ -65,7 +65,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M): Distance? =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M): Distance? =
 		distance(key, member1, member2).awaitFirstOrNull()
 
 /**
@@ -75,7 +75,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M, metric: Metric): Distance? =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.distanceAndAwait(key: K, member1: M, member2: M, metric: Metric): Distance? =
 		distance(key, member1, member2, metric).awaitFirstOrNull()
 
 /**
@@ -85,7 +85,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.hashAndAwait(key: K, member: M): String? =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.hashAndAwait(key: K, member: M): String? =
 		hash(key, member).awaitFirstOrNull()
 
 /**
@@ -94,7 +94,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.hashAndAwait(key: K, vararg member: M): List<String> =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.hashAndAwait(key: K, vararg member: M): List<String> =
 		hash(key, *member).awaitSingle()
 
 /**
@@ -103,7 +103,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.positionAndAwait(key: K, member: M): Point? =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.positionAndAwait(key: K, member: M): Point? =
 		position(key, member).awaitFirstOrNull()
 
 /**
@@ -112,7 +112,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.positionAndAwait(key: K, vararg members: M): List<Point> =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.positionAndAwait(key: K, vararg members: M): List<Point> =
 		position(key, *members).awaitSingle()
 
 /**
@@ -121,7 +121,7 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.removeAndAwait(key: K, vararg member: M): Long =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.removeAndAwait(key: K, vararg member: M): Long =
 		remove(key, *member).awaitSingle()
 
 /**
@@ -130,5 +130,5 @@ suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified M : Any> ReactiveGeoOperations<K, M>.deleteAndAwait(key: K): Boolean =
+suspend fun <K : Any, M : Any> ReactiveGeoOperations<K, M>.deleteAndAwait(key: K): Boolean =
 		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensions.kt
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.redis.core
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 
@@ -54,6 +57,16 @@ suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.mult
  */
 suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.incrementAndAwait(key: H, hashKey: HK, delta: Long): Long =
 		increment(key, hashKey, delta).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.keys].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.keysAsFlow(key: H): Flow<HK> =
+		keys(key).asFlow()
 
 /**
  * Coroutines variant of [ReactiveHashOperations.increment].
@@ -99,6 +112,36 @@ suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.putA
  */
 suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.putIfAbsentAndAwait(key: H, hashKey: HK, hashValue: HV): Boolean =
 		putIfAbsent(key, hashKey, hashValue).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.values].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.valuesAsFlow(key: H): Flow<HV> =
+		values(key).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.entries].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.entriesAsFlow(key: H): Flow<Map.Entry<HK, HV>> =
+		entries(key).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.scan].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.scanAsFlow(key: H, options: ScanOptions = ScanOptions.NONE): Flow<Map.Entry<HK, HV>> =
+		scan(key, options).asFlow()
 
 /**
  * Coroutines variant of [ReactiveHashOperations.remove].

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensions.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.reactive.awaitSingle
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.hasKeyAndAwait(key: H, hashKey: HK): Boolean =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.hasKeyAndAwait(key: H, hashKey: HK): Boolean =
 		hasKey(key, hashKey).awaitSingle()
 
 /**
@@ -34,7 +34,7 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.getAndAwait(key: H, hashKey: HK): HV? =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.getAndAwait(key: H, hashKey: HK): HV? =
 		get(key, hashKey).awaitFirstOrNull()
 
 /**
@@ -43,7 +43,7 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.multiGetAndAwait(key: H, vararg hashKeys: HK): List<HV?> =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.multiGetAndAwait(key: H, vararg hashKeys: HK): List<HV?> =
 		multiGet(key, hashKeys.toCollection(ArrayList())).awaitSingle()
 
 /**
@@ -52,7 +52,7 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.incrementAndAwait(key: H, hashKey: HK, delta: Long): Long =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.incrementAndAwait(key: H, hashKey: HK, delta: Long): Long =
 		increment(key, hashKey, delta).awaitSingle()
 
 /**
@@ -61,7 +61,7 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.incrementAndAwait(key: H, hashKey: HK, delta: Double): Double =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.incrementAndAwait(key: H, hashKey: HK, delta: Double): Double =
 		increment(key, hashKey, delta).awaitSingle()
 
 /**
@@ -70,7 +70,7 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.sizeAndAwait(key: H): Long =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.sizeAndAwait(key: H): Long =
 		size(key).awaitSingle()
 
 /**
@@ -79,7 +79,7 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.putAllAndAwait(key: H, map: Map<HK, HV>): Boolean =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.putAllAndAwait(key: H, map: Map<HK, HV>): Boolean =
 		putAll(key, map).awaitSingle()
 
 /**
@@ -88,7 +88,7 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.putAndAwait(key: H, hashKey: HK, hashValue: HV): Boolean =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.putAndAwait(key: H, hashKey: HK, hashValue: HV): Boolean =
 		put(key, hashKey, hashValue).awaitSingle()
 
 /**
@@ -97,7 +97,7 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.putIfAbsentAndAwait(key: H, hashKey: HK, hashValue: HV): Boolean =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.putIfAbsentAndAwait(key: H, hashKey: HK, hashValue: HV): Boolean =
 		putIfAbsent(key, hashKey, hashValue).awaitSingle()
 
 /**
@@ -106,7 +106,7 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.removeAndAwait(key: H, vararg hashKeys: Any): Long =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.removeAndAwait(key: H, vararg hashKeys: Any): Long =
 		remove(key, *hashKeys).awaitSingle()
 
 /**
@@ -115,5 +115,5 @@ suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified H : Any, reified HK : Any, reified HV : Any> ReactiveHashOperations<H, HK, HV>.deleteAndAwait(key: H): Boolean =
+suspend fun <H : Any, HK : Any, HV : Any> ReactiveHashOperations<H, HK, HV>.deleteAndAwait(key: H): Boolean =
 		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveHyperLogLogOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveHyperLogLogOperationsExtensions.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.reactive.awaitSingle
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperations<K, V>.addAndAwait(key: K, vararg values: V): Long =
+suspend fun <K : Any, V : Any> ReactiveHyperLogLogOperations<K, V>.addAndAwait(key: K, vararg values: V): Long =
 		add(key, *values).awaitSingle()
 
 /**
@@ -32,7 +32,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperati
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperations<K, V>.sizeAndAwait(vararg keys: K): Long =
+suspend fun <K : Any, V : Any> ReactiveHyperLogLogOperations<K, V>.sizeAndAwait(vararg keys: K): Long =
 		size(*keys).awaitSingle()
 
 /**
@@ -41,7 +41,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperati
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperations<K, V>.unionAndAwait(destination: K, vararg sourceKeys: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveHyperLogLogOperations<K, V>.unionAndAwait(destination: K, vararg sourceKeys: K): Boolean =
 		union(destination, *sourceKeys).awaitSingle()
 
 /**
@@ -50,5 +50,5 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperati
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveHyperLogLogOperations<K, V>.deleteAndAwait(key: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveHyperLogLogOperations<K, V>.deleteAndAwait(key: K): Boolean =
 		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensions.kt
@@ -15,9 +15,22 @@
  */
 package org.springframework.data.redis.core
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 import java.time.Duration
+
+/**
+ * Coroutines variant of [ReactiveListOperations.range].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveListOperations<K, V>.rangeAsFlow(key: K, start: Long, end: Long): Flow<V> =
+		range(key, start, end).asFlow()
 
 /**
  * Coroutines variant of [ReactiveListOperations.trim].

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensions.kt
@@ -25,7 +25,7 @@ import java.time.Duration
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.trimAndAwait(key: K, start: Long, end: Long): Boolean =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.trimAndAwait(key: K, start: Long, end: Long): Boolean =
 		trim(key, start, end).awaitSingle()
 
 /**
@@ -34,7 +34,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.sizeAndAwait(key: K): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.sizeAndAwait(key: K): Long =
 		size(key).awaitSingle()
 
 /**
@@ -43,7 +43,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushAndAwait(key: K, value: V): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.leftPushAndAwait(key: K, value: V): Long =
 		leftPush(key, value).awaitSingle()
 
 /**
@@ -52,7 +52,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushAllAndAwait(key: K, vararg values: V): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.leftPushAllAndAwait(key: K, vararg values: V): Long =
 		leftPushAll(key, *values).awaitSingle()
 
 /**
@@ -61,7 +61,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushAllAndAwait(key: K, values: Collection<V>): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.leftPushAllAndAwait(key: K, values: Collection<V>): Long =
 		leftPushAll(key, values).awaitSingle()
 
 /**
@@ -70,7 +70,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushIfPresentAndAwait(key: K, value: V): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.leftPushIfPresentAndAwait(key: K, value: V): Long =
 		leftPushIfPresent(key, value).awaitSingle()
 
 /**
@@ -79,7 +79,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPushAndAwait(key: K, pivot: V, value: V): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.leftPushAndAwait(key: K, pivot: V, value: V): Long =
 		leftPush(key, pivot, value).awaitSingle()
 
 /**
@@ -88,7 +88,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushAndAwait(key: K, value: V): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.rightPushAndAwait(key: K, value: V): Long =
 		rightPush(key, value).awaitSingle()
 
 /**
@@ -97,7 +97,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushAllAndAwait(key: K, vararg values: V): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.rightPushAllAndAwait(key: K, vararg values: V): Long =
 		rightPushAll(key, *values).awaitSingle()
 
 /**
@@ -106,7 +106,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushAllAndAwait(key: K, values: Collection<V>): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.rightPushAllAndAwait(key: K, values: Collection<V>): Long =
 		rightPushAll(key, values).awaitSingle()
 
 /**
@@ -115,7 +115,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushIfPresentAndAwait(key: K, value: V): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.rightPushIfPresentAndAwait(key: K, value: V): Long =
 		rightPushIfPresent(key, value).awaitSingle()
 
 /**
@@ -124,7 +124,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPushAndAwait(key: K, pivot: V, value: V): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.rightPushAndAwait(key: K, pivot: V, value: V): Long =
 		rightPush(key, pivot, value).awaitSingle()
 
 /**
@@ -133,7 +133,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.setAndAwait(key: K, index: Long, value: V): Boolean =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.setAndAwait(key: K, index: Long, value: V): Boolean =
 		set(key, index, value).awaitSingle()
 
 /**
@@ -142,7 +142,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.removeAndAwait(key: K, count: Long, value: V): Long =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.removeAndAwait(key: K, count: Long, value: V): Long =
 		remove(key, count, value).awaitSingle()
 
 /**
@@ -151,7 +151,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.indexAndAwait(key: K, index: Long): V? =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.indexAndAwait(key: K, index: Long): V? =
 		index(key, index).awaitFirstOrNull()
 
 /**
@@ -160,7 +160,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPopAndAwait(key: K): V? =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.leftPopAndAwait(key: K): V? =
 		leftPop(key).awaitFirstOrNull()
 
 /**
@@ -169,7 +169,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.leftPopAndAwait(key: K, timeout: Duration): V? =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.leftPopAndAwait(key: K, timeout: Duration): V? =
 		leftPop(key, timeout).awaitFirstOrNull()
 
 /**
@@ -178,7 +178,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPopAndAwait(key: K): V? =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.rightPopAndAwait(key: K): V? =
 		rightPop(key).awaitFirstOrNull()
 
 /**
@@ -187,7 +187,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.rightPopAndAwait(key: K, timeout: Duration): V? =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.rightPopAndAwait(key: K, timeout: Duration): V? =
 		rightPop(key, timeout).awaitFirstOrNull()
 
 /**
@@ -196,5 +196,5 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveListOperations<K, V>.deleteAndAwait(key: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveListOperations<K, V>.deleteAndAwait(key: K): Boolean =
 		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensions.kt
@@ -15,11 +15,51 @@
  */
 package org.springframework.data.redis.core
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.asPublisher
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 import org.springframework.data.redis.connection.DataType
+import org.springframework.data.redis.connection.ReactiveRedisConnection
+import org.springframework.data.redis.connection.ReactiveSubscription.*
+import org.springframework.data.redis.core.script.RedisScript
+import org.springframework.data.redis.listener.Topic
+import org.springframework.data.redis.serializer.RedisElementReader
+import org.springframework.data.redis.serializer.RedisElementWriter
 import java.time.Duration
 import java.time.Instant
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.execute].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any, T : Any> ReactiveRedisOperations<K, V>.executeAsFlow(action: (ReactiveRedisConnection) -> Flow<T>): Flow<T> =
+		execute { action(it).asPublisher() }.asFlow()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.execute].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any, T : Any> ReactiveRedisOperations<K, V>.executeAsFlow(script: RedisScript<T>, keys: List<K> = emptyList(), args: List<*> = emptyList<Any>()): Flow<T> =
+		execute(script, keys, args).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.execute].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any, T : Any> ReactiveRedisOperations<K, V>.executeAsFlow(script: RedisScript<T>, keys: List<K> = emptyList(), args: List<*> = emptyList<Any>(), argsWriter: RedisElementWriter<*>, resultReader: RedisElementReader<T>): Flow<T> =
+		execute(script, keys, args, argsWriter, resultReader).asFlow()
 
 /**
  * Coroutines variant of [ReactiveRedisOperations.convertAndSend].
@@ -29,6 +69,36 @@ import java.time.Instant
  */
 suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.sendAndAwait(destination: String, message: V): Long =
 		convertAndSend(destination, message).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.listenToChannel].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.listenToChannelAsFlow(vararg channels: String): Flow<Message<String, V>> =
+		listenToChannel(*channels).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.listenToPattern].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.listenToPatternAsFlow(vararg patterns: String): Flow<Message<String, V>> =
+		listenToPattern(*patterns).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.listenTo].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.listenToAsFlow(vararg topics: Topic): Flow<Message<String, V>> =
+		listenTo(*topics).asFlow()
 
 /**
  * Coroutines variant of [ReactiveRedisOperations.hasKey].
@@ -47,6 +117,26 @@ suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.hasKeyAndAwait(key:
  */
 suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.typeAndAwait(key: K): DataType =
 		type(key).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.keys].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.keysAsFlow(pattern: K): Flow<K> =
+		keys(pattern).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.scan].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.scanAsFlow(options: ScanOptions = ScanOptions.NONE): Flow<K> =
+		scan(options).asFlow()
 
 /**
  * Coroutines variant of [ReactiveRedisOperations.randomKey].

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensions.kt
@@ -27,7 +27,7 @@ import java.time.Instant
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.sendAndAwait(destination: String, message: V): Long =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.sendAndAwait(destination: String, message: V): Long =
 		convertAndSend(destination, message).awaitSingle()
 
 /**
@@ -36,7 +36,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.hasKeyAndAwait(key: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.hasKeyAndAwait(key: K): Boolean =
 		hasKey(key).awaitSingle()
 
 /**
@@ -45,7 +45,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.typeAndAwait(key: K): DataType =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.typeAndAwait(key: K): DataType =
 		type(key).awaitSingle()
 
 /**
@@ -54,7 +54,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.randomKeyAndAwait(): K? =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.randomKeyAndAwait(): K? =
 		randomKey().awaitFirstOrNull()
 
 /**
@@ -63,7 +63,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.renameAndAwait(oldKey: K, newKey: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.renameAndAwait(oldKey: K, newKey: K): Boolean =
 		rename(oldKey, newKey).awaitSingle()
 
 /**
@@ -72,7 +72,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.renameIfAbsentAndAwait(oldKey: K, newKey: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.renameIfAbsentAndAwait(oldKey: K, newKey: K): Boolean =
 		renameIfAbsent(oldKey, newKey).awaitSingle()
 
 /**
@@ -81,7 +81,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.deleteAndAwait(vararg key: K): Long =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.deleteAndAwait(vararg key: K): Long =
 		delete(*key).awaitSingle()
 
 /**
@@ -90,7 +90,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.unlinkAndAwait(vararg key: K): Long =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.unlinkAndAwait(vararg key: K): Long =
 		unlink(*key).awaitSingle()
 
 /**
@@ -99,7 +99,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.expireAndAwait(key: K, timeout: Duration): Boolean =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.expireAndAwait(key: K, timeout: Duration): Boolean =
 		expire(key, timeout).awaitSingle()
 
 /**
@@ -108,7 +108,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.expireAtAndAwait(key: K, expireAt: Instant): Boolean = expireAt(key, expireAt).awaitSingle()
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.expireAtAndAwait(key: K, expireAt: Instant): Boolean = expireAt(key, expireAt).awaitSingle()
 
 
 /**
@@ -117,7 +117,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.persistAndAwait(key: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.persistAndAwait(key: K): Boolean =
 		persist(key).awaitSingle()
 
 /**
@@ -126,7 +126,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.moveAndAwait(key: K, dbIndex: Int): Boolean = move(key, dbIndex).awaitSingle()
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.moveAndAwait(key: K, dbIndex: Int): Boolean = move(key, dbIndex).awaitSingle()
 
 /**
  * Coroutines variant of [ReactiveRedisOperations.getExpire].
@@ -134,4 +134,4 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveRedisOperations<K, V>.getExpireAndAwait(key: K): Duration? = getExpire(key).awaitFirstOrNull()
+suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.getExpireAndAwait(key: K): Duration? = getExpire(key).awaitFirstOrNull()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensions.kt
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.redis.core
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 
@@ -46,6 +49,16 @@ suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.popAndAwait(key: K): 
 		pop(key).awaitFirstOrNull()
 
 /**
+ * Coroutines variant of [ReactiveSetOperations.pop].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.popAsFlow(key: K, count: Long): Flow<V> =
+		pop(key, count).asFlow()
+
+/**
  * Coroutines variant of [ReactiveSetOperations.move].
  *
  * @author Mark Paluch
@@ -73,6 +86,36 @@ suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.isMemberAndAwait(key:
 		isMember(key, value).awaitSingle()
 
 /**
+ * Coroutines variant of [ReactiveSetOperations.intersect].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.intersectAsFlow(key: K, otherKey: K): Flow<V> =
+		intersect(key, otherKey).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.intersect].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.intersectAsFlow(key: K, otherKeys: Collection<K>): Flow<V> =
+		intersect(key, otherKeys).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.intersect].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.intersectAsFlow(otherKeys: Collection<K>): Flow<V> =
+		intersect(otherKeys).asFlow()
+
+/**
  * Coroutines variant of [ReactiveSetOperations.intersectAndStore].
  *
  * @author Mark Paluch
@@ -89,6 +132,36 @@ suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.intersectAndStoreAndA
  */
 suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.intersectAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
 		intersectAndStore(keys, destKey).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.union].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.unionAsFlow(key: K, otherKey: K): Flow<V> =
+		union(key, otherKey).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.union].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.unionAsFlow(key: K, otherKeys: Collection<K>): Flow<V> =
+		union(key, otherKeys).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.union].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.unionAsFlow(otherKeys: Collection<K>): Flow<V> =
+		union(otherKeys).asFlow()
 
 /**
  * Coroutines variant of [ReactiveSetOperations.unionAndStore].
@@ -109,6 +182,36 @@ suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.unionAndStoreAndAwait
 		unionAndStore(keys, destKey).awaitSingle()
 
 /**
+ * Coroutines variant of [ReactiveSetOperations.difference].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.differenceAsFlow(key: K, otherKey: K): Flow<V> =
+		difference(key, otherKey).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.difference].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.differenceAsFlow(key: K, otherKeys: Collection<K>): Flow<V> =
+		difference(key, otherKeys).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.difference].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.differenceAsFlow(otherKeys: Collection<K>): Flow<V> =
+		difference(otherKeys).asFlow()
+
+/**
  * Coroutines variant of [ReactiveSetOperations.differenceAndStore].
  *
  * @author Mark Paluch
@@ -127,6 +230,25 @@ suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.differenceAndStoreAnd
 		differenceAndStore(keys, destKey).awaitSingle()
 
 /**
+ * Coroutines variant of [ReactiveSetOperations.members].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.membersAsFlow(key: K): Flow<V> =
+		members(key).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveHashOperations.scan].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.scanAsFlow(key: K, options: ScanOptions = ScanOptions.NONE): Flow<V> =
+		scan(key, options).asFlow()
+/**
  * Coroutines variant of [ReactiveSetOperations.randomMember].
  *
  * @author Mark Paluch
@@ -134,6 +256,26 @@ suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.differenceAndStoreAnd
  */
 suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.randomMemberAndAwait(key: K): V? =
 		randomMember(key).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.distinctRandomMembers].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.distinctRandomMembersAsFlow(key: K, count: Long): Flow<V> =
+		distinctRandomMembers(key, count).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveSetOperations.randomMembers].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveSetOperations<K, V>.randomMembersAsFlow(key: K, count: Long): Flow<V> =
+		randomMembers(key, count).asFlow()
 
 /**
  * Coroutines variant of [ReactiveSetOperations.delete].

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensions.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.reactive.awaitSingle
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.addAndAwait(key: K, vararg values: V): Long =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.addAndAwait(key: K, vararg values: V): Long =
 		add(key, *values).awaitSingle()
 
 /**
@@ -33,7 +33,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.removeAndAwait(key: K, vararg values: V): Long =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.removeAndAwait(key: K, vararg values: V): Long =
 		remove(key, *values).awaitSingle()
 
 /**
@@ -42,7 +42,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.popAndAwait(key: K): V? =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.popAndAwait(key: K): V? =
 		pop(key).awaitFirstOrNull()
 
 /**
@@ -51,7 +51,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.moveAndAwait(sourceKey: K, value: V, destKey: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.moveAndAwait(sourceKey: K, value: V, destKey: K): Boolean =
 		move(sourceKey, value, destKey).awaitSingle()
 
 /**
@@ -60,7 +60,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.sizeAndAwait(key: K): Long =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.sizeAndAwait(key: K): Long =
 		size(key).awaitSingle()
 
 /**
@@ -69,7 +69,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.isMemberAndAwait(key: K, value: V): Boolean =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.isMemberAndAwait(key: K, value: V): Boolean =
 		isMember(key, value).awaitSingle()
 
 /**
@@ -78,7 +78,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
 		intersectAndStore(key, otherKey, destKey).awaitSingle()
 
 /**
@@ -87,7 +87,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.intersectAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.intersectAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
 		intersectAndStore(keys, destKey).awaitSingle()
 
 /**
@@ -96,7 +96,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
 		unionAndStore(key, otherKey, destKey).awaitSingle()
 
 /**
@@ -105,7 +105,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.unionAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.unionAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
 		unionAndStore(keys, destKey).awaitSingle()
 
 /**
@@ -114,7 +114,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.differenceAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.differenceAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
 		differenceAndStore(key, otherKey, destKey).awaitSingle()
 
 /**
@@ -123,7 +123,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.differenceAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.differenceAndStoreAndAwait(keys: Collection<K>, destKey: K): Long =
 		differenceAndStore(keys, destKey).awaitSingle()
 
 /**
@@ -132,7 +132,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.randomMemberAndAwait(key: K): V? =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.randomMemberAndAwait(key: K): V? =
 		randomMember(key).awaitFirstOrNull()
 
 /**
@@ -141,7 +141,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveSetOperations<K, V>.deleteAndAwait(key: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveSetOperations<K, V>.deleteAndAwait(key: K): Boolean =
 		delete(key).awaitSingle()
 
 

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
@@ -24,7 +24,7 @@ import org.springframework.data.redis.connection.stream.*
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(key: K, group: String, vararg recordIds: String): Long =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(key: K, group: String, vararg recordIds: String): Long =
 		acknowledge(key, group, *recordIds).awaitSingle()
 
 /**
@@ -33,7 +33,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(key: K, group: String, vararg recordIds: RecordId): Long =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(key: K, group: String, vararg recordIds: RecordId): Long =
 		acknowledge(key, group, *recordIds).awaitSingle()
 
 /**
@@ -42,7 +42,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(group: String, record: Record<K, *>): Long =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(group: String, record: Record<K, *>): Long =
 		acknowledge(group, record).awaitSingle()
 
 /**
@@ -51,7 +51,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.addAndAwait(record: MapRecord<K, HK, HV>): RecordId =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.addAndAwait(record: MapRecord<K, HK, HV>): RecordId =
 		add(record).awaitSingle()
 
 /**
@@ -60,7 +60,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.addAndAwait(record: Record<K, *>): RecordId =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.addAndAwait(record: Record<K, *>): RecordId =
 		add(record).awaitSingle()
 
 /**
@@ -69,7 +69,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteAndAwait(key: K, vararg recordIds: String): Long =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteAndAwait(key: K, vararg recordIds: String): Long =
 		delete(key, *recordIds).awaitSingle()
 
 /**
@@ -78,7 +78,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteAndAwait(record: Record<K, *>): Long =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteAndAwait(record: Record<K, *>): Long =
 		delete(record).awaitSingle()
 
 /**
@@ -87,7 +87,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteAndAwait(key: K, vararg recordIds: RecordId): Long =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteAndAwait(key: K, vararg recordIds: RecordId): Long =
 		delete(key, *recordIds).awaitSingle()
 
 /**
@@ -96,7 +96,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.createGroupAndAwait(key: K, group: String): String =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.createGroupAndAwait(key: K, group: String): String =
 		createGroup(key, group).awaitSingle()
 
 /**
@@ -105,7 +105,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.createGroupAndAwait(key: K, readOffset: ReadOffset, group: String): String =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.createGroupAndAwait(key: K, readOffset: ReadOffset, group: String): String =
 		createGroup(key, readOffset, group).awaitSingle()
 
 /**
@@ -114,7 +114,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteConsumerAndAwait(key: K, consumer: Consumer): String =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.deleteConsumerAndAwait(key: K, consumer: Consumer): String =
 		deleteConsumer(key, consumer).awaitSingle()
 
 /**
@@ -123,7 +123,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.destroyGroupAndAwait(key: K, group: String): String =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.destroyGroupAndAwait(key: K, group: String): String =
 		destroyGroup(key, group).awaitSingle()
 
 /**
@@ -132,7 +132,7 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.sizeAndAwait(key: K): Long =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.sizeAndAwait(key: K): Long =
 		size(key).awaitSingle()
 
 /**
@@ -141,5 +141,5 @@ suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> Reactiv
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified HK : Any, reified HV : Any> ReactiveStreamOperations<K, HK, HV>.trimAndAwait(key: K, count: Long): Long =
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.trimAndAwait(key: K, count: Long): Long =
 		trim(key, count).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
@@ -15,7 +15,13 @@
  */
 package org.springframework.data.redis.core
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.asPublisher
 import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.data.domain.Range
+import org.springframework.data.redis.connection.RedisZSetCommands.*
 import org.springframework.data.redis.connection.stream.*
 
 /**
@@ -44,6 +50,16 @@ suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.ac
  */
 suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.acknowledgeAndAwait(group: String, record: Record<K, *>): Long =
 		acknowledge(group, record).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.add].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.add(key: K, bodyFlow: Flow<Map<HK, HV>>): Flow<RecordId> =
+		add(key, bodyFlow.asPublisher()).asFlow()
 
 /**
  * Coroutines variant of [ReactiveStreamOperations.add].
@@ -134,6 +150,128 @@ suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.de
  */
 suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.sizeAndAwait(key: K): Long =
 		size(key).awaitSingle()
+
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.range].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.rangeAsFlow(key: K, range: Range<String>, limit: Limit = Limit.unlimited()): Flow<MapRecord<K, HK, HV>>
+		= range(key, range, limit).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.range].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+inline fun <K : Any, reified V : Any> ReactiveStreamOperations<K, *, *>.rangeWithTypeAsFlow(key: K, range: Range<String>, limit: Limit = Limit.unlimited()): Flow<ObjectRecord<K, V>>
+		= range(V::class.java, key, range, limit).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.read].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.readAsFlow(vararg stream: StreamOffset<K>): Flow<MapRecord<K, HK, HV>> =
+		read(*stream).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.read].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.readAsFlow(readOptions: StreamReadOptions, vararg stream: StreamOffset<K>): Flow<MapRecord<K, HK, HV>> =
+		read(readOptions, *stream).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.read].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+inline fun <K : Any, reified V : Any> ReactiveStreamOperations<K, *, *>.readWithTypeAsFlow(vararg stream: StreamOffset<K>): Flow<ObjectRecord<K, V>> =
+		read(V::class.java, *stream).asFlow()
+
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.read].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+inline fun <K : Any, reified V : Any> ReactiveStreamOperations<K, *, *>.readWithTypeAsFlow(readOptions: StreamReadOptions, vararg stream: StreamOffset<K>): Flow<ObjectRecord<K, V>> =
+		read(V::class.java, readOptions, *stream).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.read].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.readAsFlow(consumer: Consumer, vararg stream: StreamOffset<K>): Flow<MapRecord<K, HK, HV>> =
+		read(consumer, *stream).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.read].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.readAsFlow(consumer: Consumer, readOptions: StreamReadOptions, vararg stream: StreamOffset<K>): Flow<MapRecord<K, HK, HV>> =
+		read(consumer, readOptions, *stream).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.read].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+inline fun <K : Any, reified V : Any> ReactiveStreamOperations<K, *, *>.readWithTypeAsFlow(consumer: Consumer, vararg stream: StreamOffset<K>): Flow<ObjectRecord<K, V>> =
+		read(V::class.java, consumer, *stream).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.read].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+inline fun <K : Any, reified V : Any> ReactiveStreamOperations<K, *, *>.readWithTypeAsFlow(consumer: Consumer, readOptions: StreamReadOptions, vararg stream: StreamOffset<K>): Flow<ObjectRecord<K, V>> =
+		read(V::class.java, consumer, readOptions, *stream).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.reverseRange].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.reverseRangeAsFlow(key: K, range: Range<String>, limit: Limit = Limit.unlimited()): Flow<MapRecord<K, HK, HV>>
+		= reverseRange(key, range, limit).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.reverseRange].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+inline fun <K : Any, reified V : Any> ReactiveStreamOperations<K, *, *>.reverseRangeWithTypeAsFlow(key: K, range: Range<String>, limit: Limit = Limit.unlimited()): Flow<ObjectRecord<K, V>> =
+		reverseRange(V::class.java, key, range, limit).asFlow()
 
 /**
  * Coroutines variant of [ReactiveStreamOperations.trim].

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensions.kt
@@ -26,7 +26,7 @@ import java.time.Duration
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setAndAwait(key: K, value: V): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.setAndAwait(key: K, value: V): Boolean =
 		set(key, value).awaitSingle()
 
 /**
@@ -35,7 +35,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setAndAwait(key: K, value: V, timeout: Duration): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.setAndAwait(key: K, value: V, timeout: Duration): Boolean =
 		set(key, value, timeout).awaitSingle()
 
 /**
@@ -44,7 +44,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setIfAbsentAndAwait(key: K, value: V): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.setIfAbsentAndAwait(key: K, value: V): Boolean =
 		setIfAbsent(key, value).awaitSingle()
 
 /**
@@ -53,7 +53,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setIfAbsentAndAwait(key: K, value: V, timeout: Duration): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.setIfAbsentAndAwait(key: K, value: V, timeout: Duration): Boolean =
 		setIfAbsent(key, value, timeout).awaitSingle()
 
 /**
@@ -62,7 +62,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setIfPresentAndAwait(key: K, value: V): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.setIfPresentAndAwait(key: K, value: V): Boolean =
 		setIfPresent(key, value).awaitSingle()
 
 /**
@@ -71,7 +71,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setIfPresentAndAwait(key: K, value: V, timeout: Duration): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.setIfPresentAndAwait(key: K, value: V, timeout: Duration): Boolean =
 		setIfPresent(key, value, timeout).awaitSingle()
 
 /**
@@ -80,7 +80,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.multiSetAndAwait(map: Map<K, V>): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.multiSetAndAwait(map: Map<K, V>): Boolean =
 		multiSet(map).awaitSingle()
 
 /**
@@ -89,7 +89,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.multiSetIfAbsentAndAwait(map: Map<K, V>): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.multiSetIfAbsentAndAwait(map: Map<K, V>): Boolean =
 		multiSetIfAbsent(map).awaitSingle()
 
 /**
@@ -98,7 +98,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.getAndAwait(key: K): V? =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.getAndAwait(key: K): V? =
 		get(key).awaitFirstOrNull()
 
 /**
@@ -108,7 +108,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.getAndSetAndAwait(key: K, value: V): V? =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.getAndSetAndAwait(key: K, value: V): V? =
 		getAndSet(key, value).awaitFirstOrNull()
 
 /**
@@ -117,7 +117,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.multiGetAndAwait(vararg keys: K): List<V?> =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.multiGetAndAwait(vararg keys: K): List<V?> =
 		multiGet(keys.toCollection(ArrayList())).awaitSingle()
 
 /**
@@ -126,7 +126,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.multiGetAndAwait(keys: Collection<K>): List<V?> =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.multiGetAndAwait(keys: Collection<K>): List<V?> =
 		multiGet(keys).awaitSingle()
 
 /**
@@ -135,7 +135,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.incrementAndAwait(key: K): Long =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.incrementAndAwait(key: K): Long =
 		increment(key).awaitSingle()
 
 /**
@@ -144,7 +144,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.incrementAndAwait(key: K, delta: Long): Long =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.incrementAndAwait(key: K, delta: Long): Long =
 		increment(key, delta).awaitSingle()
 
 /**
@@ -153,7 +153,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.incrementAndAwait(key: K, delta: Double): Double =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.incrementAndAwait(key: K, delta: Double): Double =
 		increment(key, delta).awaitSingle()
 
 /**
@@ -162,7 +162,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.decrementAndAwait(key: K): Long =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.decrementAndAwait(key: K): Long =
 		decrement(key).awaitSingle()
 
 /**
@@ -171,7 +171,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.decrementAndAwait(key: K, delta: Long): Long =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.decrementAndAwait(key: K, delta: Long): Long =
 		decrement(key, delta).awaitSingle()
 
 /**
@@ -180,7 +180,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.appendAndAwait(key: K, value: String): Long =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.appendAndAwait(key: K, value: String): Long =
 		append(key, value).awaitSingle()
 
 /**
@@ -189,7 +189,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.getAndAwait(key: K, start: Long, end: Long): String? =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.getAndAwait(key: K, start: Long, end: Long): String? =
 		get(key, start, end).awaitFirstOrNull()
 
 /**
@@ -198,7 +198,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setAndAwait(key: K, value: V, offset: Long): Long =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.setAndAwait(key: K, value: V, offset: Long): Long =
 		set(key, value, offset).awaitSingle()
 
 /**
@@ -208,7 +208,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Christoph Strobl
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.sizeAndAwait(key: K): Long =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.sizeAndAwait(key: K): Long =
 		size(key).awaitSingle()
 
 /**
@@ -217,7 +217,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.setBitAndAwait(key: K, offset: Long, value: Boolean): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.setBitAndAwait(key: K, offset: Long, value: Boolean): Boolean =
 		setBit(key, offset, value).awaitSingle()
 
 /**
@@ -226,7 +226,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.getBitAndAwait(key: K, offset: Long): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.getBitAndAwait(key: K, offset: Long): Boolean =
 		getBit(key, offset).awaitSingle()
 
 /**
@@ -235,7 +235,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.bitFieldAndAwait(key: K, commands: BitFieldSubCommands): List<Long?> =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.bitFieldAndAwait(key: K, commands: BitFieldSubCommands): List<Long?> =
 		bitField(key, commands).awaitSingle()
 
 /**
@@ -244,5 +244,5 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K,
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveValueOperations<K, V>.deleteAndAwait(key: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveValueOperations<K, V>.deleteAndAwait(key: K): Boolean =
 		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensions.kt
@@ -26,7 +26,7 @@ import org.springframework.data.redis.connection.RedisZSetCommands
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.addAndAwait(key: K, value: V, score: Double): Boolean =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.addAndAwait(key: K, value: V, score: Double): Boolean =
 		add(key, value, score).awaitSingle()
 
 /**
@@ -35,7 +35,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.addAllAndAwait(key: K, values: Collection<ZSetOperations.TypedTuple<V>>): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.addAllAndAwait(key: K, values: Collection<ZSetOperations.TypedTuple<V>>): Long =
 		addAll(key, values).awaitSingle()
 
 /**
@@ -44,7 +44,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.removeAndAwait(key: K, vararg values: Any): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.removeAndAwait(key: K, vararg values: Any): Long =
 		remove(key, *values).awaitSingle()
 
 /**
@@ -53,7 +53,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.incrementScoreAndAwait(key: K, value: V, score: Double): Double =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.incrementScoreAndAwait(key: K, value: V, score: Double): Double =
 		incrementScore(key, value, score).awaitSingle()
 
 /**
@@ -62,7 +62,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.rankAndAwait(key: K, value: V): Long? =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.rankAndAwait(key: K, value: V): Long? =
 		rank(key, value).awaitFirstOrNull()
 
 /**
@@ -71,7 +71,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.reverseRankAndAwait(key: K, value: V): Long? =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.reverseRankAndAwait(key: K, value: V): Long? =
 		reverseRank(key, value).awaitFirstOrNull()
 
 /**
@@ -80,7 +80,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.countAndAwait(key: K, range: Range<Double>): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.countAndAwait(key: K, range: Range<Double>): Long =
 		count(key, range).awaitSingle()
 
 /**
@@ -89,7 +89,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.scoreAndAwait(key: K, value: V): Double? =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.scoreAndAwait(key: K, value: V): Double? =
 		score(key, value).awaitFirstOrNull()
 
 /**
@@ -98,7 +98,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.removeRangeAndAwait(key: K, range: Range<Long>): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.removeRangeAndAwait(key: K, range: Range<Long>): Long =
 		removeRange(key, range).awaitSingle()
 
 /**
@@ -107,7 +107,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.removeRangeByScoreAndAwait(key: K, range: Range<Double>): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.removeRangeByScoreAndAwait(key: K, range: Range<Double>): Long =
 		removeRangeByScore(key, range).awaitSingle()
 
 /**
@@ -116,7 +116,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
 		unionAndStore(key, otherKey, destKey).awaitSingle()
 
 /**
@@ -125,7 +125,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K): Long =
 		unionAndStore(key, otherKeys, destKey).awaitSingle()
 
 /**
@@ -134,7 +134,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate): Long =
 		unionAndStore(key, otherKeys, destKey, aggregate).awaitSingle()
 
 /**
@@ -143,7 +143,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate, weights: RedisZSetCommands.Weights): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.unionAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate, weights: RedisZSetCommands.Weights): Long =
 		unionAndStore(key, otherKeys, destKey, aggregate, weights).awaitSingle()
 
 /**
@@ -152,7 +152,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKey: K, destKey: K): Long =
 		intersectAndStore(key, otherKey, destKey).awaitSingle()
 
 /**
@@ -161,7 +161,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K): Long =
 		intersectAndStore(key, otherKeys, destKey).awaitSingle()
 
 /**
@@ -170,7 +170,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate): Long =
 		intersectAndStore(key, otherKeys, destKey, aggregate).awaitSingle()
 
 /**
@@ -179,7 +179,7 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate, weights: RedisZSetCommands.Weights): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.intersectAndStoreAndAwait(key: K, otherKeys: Collection<K>, destKey: K, aggregate: RedisZSetCommands.Aggregate, weights: RedisZSetCommands.Weights): Long =
 		intersectAndStore(key, otherKeys, destKey, aggregate, weights).awaitSingle()
 
 /**
@@ -188,5 +188,5 @@ suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend inline fun <reified K : Any, reified V : Any> ReactiveZSetOperations<K, V>.deleteAndAwait(key: K): Boolean =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.deleteAndAwait(key: K): Boolean =
 		delete(key).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensions.kt
@@ -15,10 +15,15 @@
  */
 package org.springframework.data.redis.core
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 import org.springframework.data.domain.Range
 import org.springframework.data.redis.connection.RedisZSetCommands
+import org.springframework.data.redis.connection.RedisZSetCommands.Limit
+import org.springframework.data.redis.core.ZSetOperations.*
 
 /**
  * Coroutines variant of [ReactiveZSetOperations.add].
@@ -35,7 +40,7 @@ suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.addAndAwait(key: K, 
  * @author Mark Paluch
  * @since 2.2
  */
-suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.addAllAndAwait(key: K, values: Collection<ZSetOperations.TypedTuple<V>>): Long =
+suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.addAllAndAwait(key: K, values: Collection<TypedTuple<V>>): Long =
 		addAll(key, values).awaitSingle()
 
 /**
@@ -73,6 +78,86 @@ suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.rankAndAwait(key: K,
  */
 suspend fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.reverseRankAndAwait(key: K, value: V): Long? =
 		reverseRank(key, value).awaitFirstOrNull()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.range].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.rangeAsFlow(key: K, range: Range<Long>): Flow<V> =
+		range(key, range).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.rangeWithScores].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.rangeWithScoresAsFlow(key: K, range: Range<Long>): Flow<TypedTuple<V>> =
+		rangeWithScores(key, range).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.rangeByScore].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.rangeByScoreAsFlow(key: K, range: Range<Double>, limit: Limit? = null): Flow<V> =
+		(if (limit == null) rangeByScore(key, range) else rangeByScore(key, range, limit)).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.rangeByScoreWithScores].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.rangeByScoreWithScoresAsFlow(key: K, range: Range<Double>, limit: Limit? = null): Flow<TypedTuple<V>> =
+		(if (limit == null) rangeByScoreWithScores(key, range) else rangeByScoreWithScores(key, range, limit)).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.reverseRange].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.reverseRangeAsFlow(key: K, range: Range<Long>): Flow<V> =
+		reverseRange(key, range).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.reverseRangeWithScores].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.reverseRangeWithScoresAsFlow(key: K, range: Range<Long>): Flow<TypedTuple<V>> =
+		reverseRangeWithScores(key, range).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.reverseRangeByScore].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.reverseRangeByScoreAsFlow(key: K, range: Range<Double>, limit: Limit? = null): Flow<V> =
+		(if (limit == null) reverseRangeByScore(key, range) else reverseRangeByScore(key, range, limit)).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveZSetOperations.reverseRangeByScoreWithScores].
+ *
+ * @author Sebastien Deleuze
+ * @since 2.2
+ */
+@ExperimentalCoroutinesApi
+fun <K : Any, V : Any> ReactiveZSetOperations<K, V>.reverseRangeByScoreWithScoresAsFlow(key: K, range: Range<Double>, limit: Limit? = null): Flow<TypedTuple<V>> =
+		(if (limit == null) reverseRangeByScoreWithScores(key, range) else reverseRangeByScoreWithScores(key, range, limit)).asFlow()
 
 /**
  * Coroutines variant of [ReactiveZSetOperations.count].

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveGeoOperationsExtensionsUnitTests.kt
@@ -18,17 +18,26 @@ package org.springframework.data.redis.core
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.reactivestreams.Publisher
+import org.springframework.data.geo.Circle
 import org.springframework.data.geo.Distance
+import org.springframework.data.geo.GeoResult
 import org.springframework.data.geo.Metrics
 import org.springframework.data.geo.Point
 import org.springframework.data.redis.connection.RedisGeoCommands
+import org.springframework.data.redis.connection.RedisGeoCommands.*
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 /**
- * Unit tests for [ReactiveGeoOperationsExtensions].
+ * Unit tests for `ReactiveGeoOperationsExtensions`.
  *
  * @author Mark Paluch
  * @author Christoph Strobl
@@ -54,14 +63,14 @@ class ReactiveGeoOperationsExtensionsUnitTests {
 	fun addGeoLocation() {
 
 		val operations = mockk<ReactiveGeoOperations<String, String>>()
-		every { operations.add(any(), any<RedisGeoCommands.GeoLocation<String>>()) } returns Mono.just(1)
+		every { operations.add(any(), any<GeoLocation<String>>()) } returns Mono.just(1)
 
 		runBlocking {
-			assertThat(operations.addAndAwait("foo", RedisGeoCommands.GeoLocation("bar", Point(1.0, 2.0)))).isEqualTo(1)
+			assertThat(operations.addAndAwait("foo", GeoLocation("bar", Point(1.0, 2.0)))).isEqualTo(1)
 		}
 
 		verify {
-			operations.add("foo", RedisGeoCommands.GeoLocation("bar", Point(1.0, 2.0)))
+			operations.add("foo", GeoLocation("bar", Point(1.0, 2.0)))
 		}
 	}
 
@@ -84,14 +93,30 @@ class ReactiveGeoOperationsExtensionsUnitTests {
 	fun addGeoLocationList() {
 
 		val operations = mockk<ReactiveGeoOperations<String, String>>()
-		every { operations.add(any(), any<List<RedisGeoCommands.GeoLocation<String>>>()) } returns Mono.just(1)
+		every { operations.add(any(), any<List<GeoLocation<String>>>()) } returns Mono.just(1)
 
 		runBlocking {
-			assertThat(operations.addAndAwait("foo", listOf(RedisGeoCommands.GeoLocation("bar", Point(1.0, 2.0))))).isEqualTo(1)
+			assertThat(operations.addAndAwait("foo", listOf(GeoLocation("bar", Point(1.0, 2.0))))).isEqualTo(1)
 		}
 
 		verify {
-			operations.add("foo", listOf(RedisGeoCommands.GeoLocation("bar", Point(1.0, 2.0))))
+			operations.add("foo", listOf(GeoLocation("bar", Point(1.0, 2.0))))
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun addGeoLocationFlow() {
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		every { operations.add(any(), any<Publisher<List<GeoLocation<String>>>>()) } returns Flux.just(1)
+		val flow = flow { emit(listOf(GeoLocation("bar", Point(1.0, 2.0)))) }
+
+		runBlocking {
+			assertThat(operations.add("foo", flow).toList()).contains(1)
+		}
+
+		verify {
+			operations.add("foo", any<Publisher<List<GeoLocation<String>>>>())
 		}
 	}
 
@@ -243,6 +268,95 @@ class ReactiveGeoOperationsExtensionsUnitTests {
 
 		verify {
 			operations.position("foo", "bar", "baz")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun radiusAsFlowCircle() {
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		val result = GeoResult(GeoLocation("bar", Point(1.0, 2.0)), Distance(1.0))
+		val circle = Circle(1.0, 2.0, 3.0)
+		every { operations.radius(any(), any()) } returns Flux.just(result)
+
+		runBlocking {
+			assertThat(operations.radiusAsFlow("foo", circle).toList()).contains(result)
+		}
+
+		verify {
+			operations.radius("foo", circle)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun radiusAsFlowCircleAndArgs() {
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		val result = GeoResult(GeoLocation("bar", Point(1.0, 2.0)), Distance(1.0))
+		val circle = Circle(1.0, 2.0, 3.0)
+		val args = GeoRadiusCommandArgs.newGeoRadiusArgs()
+		every { operations.radius(any(), any(), args) } returns Flux.just(result)
+
+		runBlocking {
+			assertThat(operations.radiusAsFlow("foo", circle, args).toList()).contains(result)
+		}
+
+		verify {
+			operations.radius("foo", circle, args)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun radiusAsFlowMemberAndRadius() {
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		val result = GeoResult(GeoLocation("bar", Point(1.0, 2.0)), Distance(1.0))
+
+		every { operations.radius(any(), any(), any<Double>()) } returns Flux.just(result)
+
+		runBlocking {
+			assertThat(operations.radiusAsFlow("foo", "bar", 1.0).toList()).contains(result)
+		}
+
+		verify {
+			operations.radius("foo", "bar", 1.0)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun radiusAsFlowDistance() {
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		val result = GeoResult(GeoLocation("bar", Point(1.0, 2.0)), Distance(1.0))
+		val distance = Distance(2.0)
+
+		every { operations.radius(any(), any(), any<Distance>()) } returns Flux.just(result)
+
+		runBlocking {
+			assertThat(operations.radiusAsFlow("foo", "bar", distance).toList()).contains(result)
+		}
+
+		verify {
+			operations.radius("foo", "bar", distance)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun radiusAsFlowDistanceAndArgs() {
+		val operations = mockk<ReactiveGeoOperations<String, String>>()
+		val result = GeoResult(GeoLocation("bar", Point(1.0, 2.0)), Distance(1.0))
+		val distance = Distance(2.0)
+		val args = GeoRadiusCommandArgs.newGeoRadiusArgs()
+
+		every { operations.radius(any(), any(), any(), any()) } returns Flux.just(result)
+
+		runBlocking {
+			assertThat(operations.radiusAsFlow("foo", "bar", distance, args).toList()).contains(result)
+		}
+
+		verify {
+			operations.radius("foo", "bar", distance, args)
 		}
 	}
 

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveHashOperationsExtensionsUnitTests.kt
@@ -18,13 +18,16 @@ package org.springframework.data.redis.core
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 /**
- * Unit tests for [ReactiveHashOperationsExtensions].
+ * Unit tests for `ReactiveHashOperationsExtensions`.
  *
  * @author Mark Paluch
  * @author Christoph Strobl
@@ -106,6 +109,21 @@ class ReactiveHashOperationsExtensionsUnitTests {
 		}
 	}
 
+	@Test
+	@ExperimentalCoroutinesApi
+	fun keys() {
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.keys(any()) } returns Flux.just("bar", "baz")
+
+		runBlocking {
+			assertThat(operations.keysAsFlow("foo").toList()).contains("bar", "baz")
+		}
+
+		verify {
+			operations.keys("foo")
+		}
+	}
+
 	@Test // DATAREDIS-937
 	fun incrementDouble() {
 
@@ -178,6 +196,56 @@ class ReactiveHashOperationsExtensionsUnitTests {
 
 		verify {
 			operations.putIfAbsent("foo", "bar", "baz")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun values() {
+
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.values(any()) } returns Flux.just("bar", "baz")
+
+		runBlocking {
+			assertThat(operations.valuesAsFlow("foo").toList()).contains("bar","baz")
+		}
+
+		verify {
+			operations.values("foo")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun entries() {
+
+		val entry = java.util.AbstractMap.SimpleEntry("bar", "baz")
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.entries(any()) } returns Flux.just(entry)
+
+		runBlocking {
+			assertThat(operations.entriesAsFlow("foo").toList()).contains(entry)
+		}
+
+		verify {
+			operations.entries("foo")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun scan() {
+
+		val entry = java.util.AbstractMap.SimpleEntry("bar", "baz")
+		val operations = mockk<ReactiveHashOperations<String, String, String>>()
+		every { operations.scan(any(), any()) } returns Flux.just(entry)
+
+		runBlocking {
+			assertThat(operations.scanAsFlow("foo").toList()).contains(entry)
+		}
+
+		verify {
+			operations.scan("foo", ScanOptions.NONE)
 		}
 	}
 

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveHyperLogLogOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveHyperLogLogOperationsExtensionsUnitTests.kt
@@ -24,7 +24,7 @@ import org.junit.Test
 import reactor.core.publisher.Mono
 
 /**
- * Unit tests for [ReactiveHyperLogLogOperationsExtensions]
+ * Unit tests for `ReactiveHyperLogLogOperationsExtensions`
  *
  * @author Mark Paluch
  */

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveListOperationsExtensionsUnitTests.kt
@@ -18,18 +18,37 @@ package org.springframework.data.redis.core
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.time.Duration
 
 /**
- * Unit tests for [ReactiveListOperationsExtensions]
+ * Unit tests for `ReactiveListOperationsExtensions`
  *
  * @author Mark Paluch
  */
 class ReactiveListOperationsExtensionsUnitTests {
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun range() {
+
+		val operations = mockk<ReactiveListOperations<String, String>>()
+		every { operations.range(any(), any(), any()) } returns Flux.just("foo", "bar")
+
+		runBlocking {
+			assertThat(operations.rangeAsFlow("foo", 2, 3).toList()).contains("foo", "bar")
+		}
+
+		verify {
+			operations.range("foo", 2, 3)
+		}
+	}
 
 	@Test // DATAREDIS-937
 	fun trim() {

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveSetOperationsExtensionsUnitTests.kt
@@ -18,13 +18,16 @@ package org.springframework.data.redis.core
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 /**
- * Unit tests for [ReactiveSetOperationsExtensions].
+ * Unit tests for `ReactiveSetOperationsExtensions`.
  *
  * @author Mark Paluch
  * @author Christoph Strobl
@@ -73,6 +76,22 @@ class ReactiveSetOperationsExtensionsUnitTests {
 
 		verify {
 			operations.pop("foo")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `pop as Flow`() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.pop(any(), any()) } returns Flux.just("bar")
+
+		runBlocking {
+			assertThat(operations.popAsFlow("foo", 1).toList()).contains("bar")
+		}
+
+		verify {
+			operations.pop("foo", 1)
 		}
 	}
 
@@ -136,6 +155,51 @@ class ReactiveSetOperationsExtensionsUnitTests {
 		}
 	}
 
+	@Test
+	@ExperimentalCoroutinesApi
+	fun intersect() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.intersect("foo", "bar") } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.intersectAsFlow("foo", "bar").toList()).contains("baz")
+		}
+
+		verify {
+			operations.intersect("foo", "bar")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `intersect with key and collection`() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.intersect("foo", listOf("bar")) } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.intersectAsFlow("foo", listOf("bar")).toList()).contains("baz")
+		}
+
+		verify {
+			operations.intersect("foo", listOf("bar"))
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `intersect with collection`() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.intersect(listOf("bar")) } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.intersectAsFlow(listOf("bar")).toList()).contains("baz")
+		}
+
+		verify {
+			operations.intersect(listOf("bar"))
+		}
+	}
+
 	@Test // DATAREDIS-937
 	fun intersectAndStore() {
 
@@ -163,6 +227,51 @@ class ReactiveSetOperationsExtensionsUnitTests {
 
 		verify {
 			operations.intersectAndStore(listOf("foo", "bar"), "baz")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun union() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.union("foo", "bar") } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.unionAsFlow("foo", "bar").toList()).contains("baz")
+		}
+
+		verify {
+			operations.union("foo", "bar")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `union with key and collection`() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.union("foo", listOf("bar")) } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.unionAsFlow("foo", listOf("bar")).toList()).contains("baz")
+		}
+
+		verify {
+			operations.union("foo", listOf("bar"))
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `union with collection`() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.union(listOf("bar")) } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.unionAsFlow(listOf("bar")).toList()).contains("baz")
+		}
+
+		verify {
+			operations.union(listOf("bar"))
 		}
 	}
 
@@ -196,6 +305,51 @@ class ReactiveSetOperationsExtensionsUnitTests {
 		}
 	}
 
+	@Test
+	@ExperimentalCoroutinesApi
+	fun difference() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.difference("foo", "bar") } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.differenceAsFlow("foo", "bar").toList()).contains("baz")
+		}
+
+		verify {
+			operations.difference("foo", "bar")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `difference with key and collection`() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.difference("foo", listOf("bar")) } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.differenceAsFlow("foo", listOf("bar")).toList()).contains("baz")
+		}
+
+		verify {
+			operations.difference("foo", listOf("bar"))
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `difference with collection`() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.difference(listOf("bar")) } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.differenceAsFlow(listOf("bar")).toList()).contains("baz")
+		}
+
+		verify {
+			operations.difference(listOf("bar"))
+		}
+	}
+
 	@Test // DATAREDIS-937
 	fun differenceAndStore() {
 
@@ -226,6 +380,37 @@ class ReactiveSetOperationsExtensionsUnitTests {
 		}
 	}
 
+	@Test
+	@ExperimentalCoroutinesApi
+	fun members() {
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.members("foo") } returns Flux.just("baz")
+
+		runBlocking {
+			assertThat(operations.membersAsFlow("foo").toList()).contains("baz")
+		}
+
+		verify {
+			operations.members("foo")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun scan() {
+
+		val operations =  mockk<ReactiveSetOperations<String, String>>()
+		every { operations.scan(any(), any()) } returns Flux.just("bar")
+
+		runBlocking {
+			assertThat(operations.scanAsFlow("foo").toList()).contains("bar")
+		}
+
+		verify {
+			operations.scan("foo", ScanOptions.NONE)
+		}
+	}
+
 	@Test // DATAREDIS-937
 	fun randomMember() {
 
@@ -253,6 +438,38 @@ class ReactiveSetOperationsExtensionsUnitTests {
 
 		verify {
 			operations.randomMember("foo")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun distinctRandomMembers() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.distinctRandomMembers(any(), any()) } returns Flux.just("bar")
+
+		runBlocking {
+			assertThat(operations.distinctRandomMembersAsFlow("foo", 1).toList()).contains("bar")
+		}
+
+		verify {
+			operations.distinctRandomMembers("foo", 1)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun randomMembers() {
+
+		val operations = mockk<ReactiveSetOperations<String, String>>()
+		every { operations.randomMembers(any(), any()) } returns Flux.just("bar")
+
+		runBlocking {
+			assertThat(operations.randomMembersAsFlow("foo", 1).toList()).contains("bar")
+		}
+
+		verify {
+			operations.randomMembers("foo", 1)
 		}
 	}
 

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensionsUnitTests.kt
@@ -18,14 +18,21 @@ package org.springframework.data.redis.core
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.reactivestreams.Publisher
+import org.springframework.data.domain.Range
+import org.springframework.data.redis.connection.RedisZSetCommands.Limit
 import org.springframework.data.redis.connection.stream.*
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 /**
- * Unit tests for [ReactiveStreamOperationsExtensions].
+ * Unit tests for `ReactiveStreamOperationsExtensions`.
  *
  * @author Mark Paluch
  */
@@ -82,15 +89,35 @@ class ReactiveStreamOperationsExtensionsUnitTests {
 
 		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
 		val record = MapRecord.create("foo", mapOf("a" to "b"))
-		val redordId = RecordId.of("0-0")
-		every { operations.add(record) } returns Mono.just(redordId)
+		val recordId = RecordId.of("0-0")
+		every { operations.add(record) } returns Mono.just(recordId)
 
 		runBlocking {
-			assertThat(operations.addAndAwait(record)).isEqualTo(redordId)
+			assertThat(operations.addAndAwait(record)).isEqualTo(recordId)
 		}
 
 		verify {
 			operations.add(record)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `add as Flow`() {
+
+		val map = mapOf("a" to "b")
+		val bodyPublisher = Mono.just(map)
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		val recordId = RecordId.of("0-0")
+		every { operations.add(any(), any<Publisher<Map<String, String>>>()) } returns Flux.just(recordId)
+
+		runBlocking {
+			val bodyFlow = flow { emit(map) }
+			assertThat(operations.add("foo", bodyFlow).toList()).contains(recordId)
+		}
+
+		verify {
+			operations.add("foo", any<Publisher<Map<String, String>>>())
 		}
 	}
 
@@ -230,6 +257,230 @@ class ReactiveStreamOperationsExtensionsUnitTests {
 
 		verify {
 			operations.size("foo")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun range() {
+
+		val record = MapRecord.create("foo", mapOf("a" to "b"))
+		val range = Range.just("bar")
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.range(any(), any(), any()) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.rangeAsFlow("foo", range).toList()).contains(record)
+		}
+
+		verify {
+			operations.range("foo", range, Limit.unlimited())
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun rangeWithType() {
+
+		val record = ObjectRecord.create("a", "b")
+		val range = Range.just("bar")
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.range(any<Class<*>>(), any(), any(), any()) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.rangeWithTypeAsFlow<String, String>("foo", range).toList()).contains(record)
+		}
+
+		verify {
+			operations.range(String::class.java, "foo", range, Limit.unlimited())
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `read with StreamOffset vararg`() {
+		val offset1 = StreamOffset.create("foo", ReadOffset.lastConsumed())
+		val offset2 = StreamOffset.create("bar", ReadOffset.lastConsumed())
+		val record = MapRecord.create("foo", mapOf("a" to "b"))
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.read(offset1, offset2) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.readAsFlow(offset1, offset2).toList()).contains(record)
+		}
+
+		verify {
+			operations.read(offset1, offset2)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `read with options and StreamOffset vararg` () {
+		val offset1 = StreamOffset.create("foo", ReadOffset.lastConsumed())
+		val offset2 = StreamOffset.create("bar", ReadOffset.lastConsumed())
+		val options = StreamReadOptions.empty()
+		val record = MapRecord.create("foo", mapOf("a" to "b"))
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.read(options, offset1, offset2) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.readAsFlow(options, offset1, offset2).toList()).contains(record)
+		}
+
+		verify {
+			operations.read(options, offset1, offset2)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `read with type and StreamOffset vararg`() {
+		val offset1 = StreamOffset.create("foo", ReadOffset.lastConsumed())
+		val offset2 = StreamOffset.create("bar", ReadOffset.lastConsumed())
+		val record = ObjectRecord.create("a", "b")
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.read(String::class.java, offset1, offset2) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.readWithTypeAsFlow<String, String>(offset1, offset2).toList()).contains(record)
+		}
+
+		verify {
+			operations.read(String::class.java, offset1, offset2)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `read with type, options and StreamOffset vararg` () {
+		val offset1 = StreamOffset.create("foo", ReadOffset.lastConsumed())
+		val offset2 = StreamOffset.create("bar", ReadOffset.lastConsumed())
+		val options = StreamReadOptions.empty()
+		val record = ObjectRecord.create("a", "b")
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.read(String::class.java, options, offset1, offset2) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.readWithTypeAsFlow<String, String>(options, offset1, offset2).toList()).contains(record)
+		}
+
+		verify {
+			operations.read(String::class.java, options, offset1, offset2)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `read with consumer and StreamOffset vararg`() {
+		val consumer = Consumer.from("a", "b")
+		val offset1 = StreamOffset.create("foo", ReadOffset.lastConsumed())
+		val offset2 = StreamOffset.create("bar", ReadOffset.lastConsumed())
+		val record = MapRecord.create("foo", mapOf("a" to "b"))
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.read(consumer, offset1, offset2) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.readAsFlow(consumer, offset1, offset2).toList()).contains(record)
+		}
+
+		verify {
+			operations.read(consumer, offset1, offset2)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `read with consumer, options and StreamOffset vararg`() {
+		val consumer = Consumer.from("a", "b")
+		val offset1 = StreamOffset.create("foo", ReadOffset.lastConsumed())
+		val offset2 = StreamOffset.create("bar", ReadOffset.lastConsumed())
+		val options = StreamReadOptions.empty()
+		val record = MapRecord.create("foo", mapOf("a" to "b"))
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.read(consumer, options, offset1, offset2) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.readAsFlow(consumer, options, offset1, offset2).toList()).contains(record)
+		}
+
+		verify {
+			operations.read(consumer, options, offset1, offset2)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `read with type, consumer and StreamOffset vararg`() {
+		val consumer = Consumer.from("a", "b")
+		val offset1 = StreamOffset.create("foo", ReadOffset.lastConsumed())
+		val offset2 = StreamOffset.create("bar", ReadOffset.lastConsumed())
+		val record = ObjectRecord.create("a", "b")
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.read(String::class.java, consumer, offset1, offset2) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.readWithTypeAsFlow<String, String>(consumer, offset1, offset2).toList()).contains(record)
+		}
+
+		verify {
+			operations.read(String::class.java, consumer, offset1, offset2)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun `read with type, consumer, options and StreamOffset vararg`() {
+		val consumer = Consumer.from("a", "b")
+		val offset1 = StreamOffset.create("foo", ReadOffset.lastConsumed())
+		val offset2 = StreamOffset.create("bar", ReadOffset.lastConsumed())
+		val options = StreamReadOptions.empty()
+		val record = ObjectRecord.create("a", "b")
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.read(String::class.java, consumer, options, offset1, offset2) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.readWithTypeAsFlow<String, String>(consumer, options, offset1, offset2).toList()).contains(record)
+		}
+
+		verify {
+			operations.read(String::class.java, consumer, options, offset1, offset2)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun reverseRange() {
+
+		val record = MapRecord.create("foo", mapOf("a" to "b"))
+		val range = Range.just("bar")
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.reverseRange(any(), any(), any()) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.reverseRangeAsFlow("foo", range).toList()).contains(record)
+		}
+
+		verify {
+			operations.reverseRange("foo", range, Limit.unlimited())
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun reverseRangeWithType() {
+
+		val record = ObjectRecord.create("a", "b")
+		val range = Range.just("bar")
+		val operations = mockk<ReactiveStreamOperations<String, String, String>>()
+		every { operations.reverseRange(any<Class<*>>(), any(), any(), any()) } returns Flux.just(record)
+
+		runBlocking {
+			assertThat(operations.reverseRangeWithTypeAsFlow<String, String>("foo", range).toList()).contains(record)
+		}
+
+		verify {
+			operations.reverseRange(String::class.java, "foo", range, Limit.unlimited())
 		}
 	}
 

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveValueOperationsExtensionsUnitTests.kt
@@ -26,7 +26,7 @@ import reactor.core.publisher.Mono
 import java.time.Duration
 
 /**
- * Unit tests for [ReactiveValueOperationsExtensions].
+ * Unit tests for `ReactiveValueOperationsExtensions`.
  *
  * @author Mark Paluch
  * @author Christoph Strobl

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveZSetOperationsExtensionsUnitTests.kt
@@ -18,16 +18,20 @@ package org.springframework.data.redis.core
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.springframework.data.domain.Range
 import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate
 import org.springframework.data.redis.connection.RedisZSetCommands.Weights
+import org.springframework.data.redis.core.ZSetOperations.*
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 /**
- * Unit tests for [ReactiveZSetOperationsExtensions].
+ * Unit tests for `ReactiveZSetOperationsExtensions`.
  *
  * @author Mark Paluch
  * @author Christoph Strobl
@@ -151,6 +155,146 @@ class ReactiveZSetOperationsExtensionsUnitTests {
 
 		verify {
 			operations.reverseRank("foo", "bar")
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun range() {
+
+		val range = Range.unbounded<Long>()
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.range(any(), any()) } returns Flux.just("bar")
+
+		runBlocking {
+			assertThat(operations.rangeAsFlow("foo", range).toList()).contains("bar")
+		}
+
+		verify {
+			operations.range("foo", range)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun rangeWithScores() {
+
+		val tuple = mockk<TypedTuple<String>>(relaxed = true)
+		val range = Range.unbounded<Long>()
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.rangeWithScores(any(), any()) } returns Flux.just(tuple)
+
+		runBlocking {
+			assertThat(operations.rangeWithScoresAsFlow("foo", range).toList()).contains(tuple)
+		}
+
+		verify {
+			operations.rangeWithScores("foo", range)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun rangeByScore() {
+
+		val range = Range.unbounded<Double>()
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.rangeByScore(any(), any()) } returns Flux.just("bar")
+
+		runBlocking {
+			assertThat(operations.rangeByScoreAsFlow("foo", range).toList()).contains("bar")
+		}
+
+		verify {
+			operations.rangeByScore("foo", range)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun rangeByScoreWithScores() {
+
+		val tuple = mockk<TypedTuple<String>>(relaxed = true)
+		val range = Range.unbounded<Double>()
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.rangeByScoreWithScores(any(), any()) } returns Flux.just(tuple)
+
+		runBlocking {
+			assertThat(operations.rangeByScoreWithScoresAsFlow("foo", range).toList()).contains(tuple)
+		}
+
+		verify {
+			operations.rangeByScoreWithScores("foo", range)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun reverseRange() {
+
+		val range = Range.unbounded<Long>()
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.reverseRange(any(), any()) } returns Flux.just("bar")
+
+		runBlocking {
+			assertThat(operations.reverseRangeAsFlow("foo", range).toList()).contains("bar")
+		}
+
+		verify {
+			operations.reverseRange("foo", range)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun reverseRangeWithScores() {
+
+		val tuple = mockk<TypedTuple<String>>(relaxed = true)
+		val range = Range.unbounded<Long>()
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.reverseRangeWithScores(any(), any()) } returns Flux.just(tuple)
+
+		runBlocking {
+			assertThat(operations.reverseRangeWithScoresAsFlow("foo", range).toList()).contains(tuple)
+		}
+
+		verify {
+			operations.reverseRangeWithScores("foo", range)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun reverseRangeByScore() {
+
+		val range = Range.unbounded<Double>()
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.reverseRangeByScore(any(), any()) } returns Flux.just("bar")
+
+		runBlocking {
+			assertThat(operations.reverseRangeByScoreAsFlow("foo", range).toList()).contains("bar")
+		}
+
+		verify {
+			operations.reverseRangeByScore("foo", range)
+		}
+	}
+
+	@Test
+	@ExperimentalCoroutinesApi
+	fun reverseRangeByScoreWithScores() {
+
+		val tuple = mockk<TypedTuple<String>>(relaxed = true)
+		val range = Range.unbounded<Double>()
+		val operations = mockk<ReactiveZSetOperations<String, String>>()
+		every { operations.reverseRangeByScoreWithScores(any(), any()) } returns Flux.just(tuple)
+
+		runBlocking {
+			assertThat(operations.reverseRangeByScoreWithScoresAsFlow("foo", range).toList()).contains(tuple)
+		}
+
+		verify {
+			operations.reverseRangeByScoreWithScores("foo", range)
 		}
 	}
 


### PR DESCRIPTION
It took some time, but here is my PR for `Flow` based extension for Redis. 

Side note: I am not sure it is expected to have `sendAndAwait` instead of `convertSendAndAwait` here:
```
suspend fun <K : Any, V : Any> ReactiveRedisOperations<K, V>.sendAndAwait(destination: String, message: V): Long =
		convertAndSend(destination, message).awaitSingle()
```