### PR TITLE
DATAREDIS-1035 - Fix confusing/incorrect JavaDoc of RedisKeyExpiredEvent

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
@@ -24,7 +24,7 @@ import org.springframework.lang.Nullable;
 
 /**
  * {@link RedisKeyExpiredEvent} is Redis specific {@link ApplicationEvent} published when a specific key in Redis
- * expires. It might but must not hold the expired value itself next to the key.
+ * expires. It might hold the expired value itself next to the key, but is not required to do so.
  *
  * @author Christoph Strobl
  * @author Mark Paluch


### PR DESCRIPTION
The JavaDoc of RedisKeyExpiredEvent used the phrase "must not", when it should say "does not have to" or "need not". Rephrase the JavaDoc to be less confusing to native speakers.