### PR TITLE
DATAREDIS-1034 - Fix dataraces in RedisTemplate.

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/AbstractOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/AbstractOperations.java
@@ -44,6 +44,7 @@ import org.springframework.util.CollectionUtils;
  * @author Christoph Strobl
  * @author David Liu
  * @author Mark Paluch
+ * @author Denis Zavedeev
  */
 abstract class AbstractOperations<K, V> {
 
@@ -64,7 +65,7 @@ abstract class AbstractOperations<K, V> {
 		protected abstract byte[] inRedis(byte[] rawKey, RedisConnection connection);
 	}
 
-	RedisTemplate<K, V> template;
+	final RedisTemplate<K, V> template;
 
 	AbstractOperations(RedisTemplate<K, V> template) {
 		this.template = template;

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -81,6 +81,7 @@ import org.springframework.util.CollectionUtils;
  * @author Ninad Divadkar
  * @author Anqing Shao
  * @author Mark Paluch
+ * @author Denis Zavedeev
  * @param <K> the Redis key type against which the template works (usually a String)
  * @param <V> the Redis value type against which the template works
  * @see StringRedisTemplate
@@ -102,14 +103,14 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 
 	private @Nullable ScriptExecutor<K> scriptExecutor;
 
-	// cache singleton objects (where possible)
-	private @Nullable ValueOperations<K, V> valueOps;
-	private @Nullable ListOperations<K, V> listOps;
-	private @Nullable SetOperations<K, V> setOps;
-	private @Nullable StreamOperations<K, ?, ?> streamOps;
-	private @Nullable ZSetOperations<K, V> zSetOps;
-	private @Nullable GeoOperations<K, V> geoOps;
-	private @Nullable HyperLogLogOperations<K, V> hllOps;
+	private final ValueOperations<K, V> valueOps = new DefaultValueOperations<>(this);
+	private final ListOperations<K, V> listOps = new DefaultListOperations<>(this);
+	private final SetOperations<K, V> setOps = new DefaultSetOperations<>(this);
+	private final StreamOperations<K, ?, ?> streamOps = new DefaultStreamOperations<>(this, new ObjectHashMapper());
+	private final ZSetOperations<K, V> zSetOps = new DefaultZSetOperations<>(this);
+	private final GeoOperations<K, V> geoOps = new DefaultGeoOperations<>(this);
+	private final HyperLogLogOperations<K, V> hllOps = new DefaultHyperLogLogOperations<>(this);
+	private final ClusterOperations<K, V> clusterOps = new DefaultClusterOperations<>(this);
 
 	/**
 	 * Constructs a new <code>RedisTemplate</code> instance.
@@ -1203,7 +1204,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 */
 	@Override
 	public ClusterOperations<K, V> opsForCluster() {
-		return new DefaultClusterOperations<>(this);
+		return clusterOps;
 	}
 
 	/*
@@ -1212,10 +1213,6 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 */
 	@Override
 	public GeoOperations<K, V> opsForGeo() {
-
-		if (geoOps == null) {
-			geoOps = new DefaultGeoOperations<>(this);
-		}
 		return geoOps;
 	}
 
@@ -1252,10 +1249,6 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 */
 	@Override
 	public HyperLogLogOperations<K, V> opsForHyperLogLog() {
-
-		if (hllOps == null) {
-			hllOps = new DefaultHyperLogLogOperations<>(this);
-		}
 		return hllOps;
 	}
 
@@ -1265,10 +1258,6 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 */
 	@Override
 	public ListOperations<K, V> opsForList() {
-
-		if (listOps == null) {
-			listOps = new DefaultListOperations<>(this);
-		}
 		return listOps;
 	}
 
@@ -1296,10 +1285,6 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 */
 	@Override
 	public SetOperations<K, V> opsForSet() {
-
-		if (setOps == null) {
-			setOps = new DefaultSetOperations<>(this);
-		}
 		return setOps;
 	}
 
@@ -1309,10 +1294,6 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 */
 	@Override
 	public <HK, HV> StreamOperations<K, HK, HV> opsForStream() {
-
-		if (streamOps == null) {
-			streamOps = new DefaultStreamOperations<>(this, new ObjectHashMapper());
-		}
 		return (StreamOperations<K, HK, HV>) streamOps;
 	}
 
@@ -1350,10 +1331,6 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 */
 	@Override
 	public ValueOperations<K, V> opsForValue() {
-
-		if (valueOps == null) {
-			valueOps = new DefaultValueOperations<>(this);
-		}
 		return valueOps;
 	}
 
@@ -1372,10 +1349,6 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 */
 	@Override
 	public ZSetOperations<K, V> opsForZSet() {
-
-		if (zSetOps == null) {
-			zSetOps = new DefaultZSetOperations<>(this);
-		}
 		return zSetOps;
 	}
 


### PR DESCRIPTION
Previously it was possible in multi-threaded environment to:
* get a `null` from `opsFor*` methods in RedisTemplate.
* fail with a `NullPointerException` when working with a not-`null` reference returned from `RedisTemplate.opsFor*` methods.

Introduced changes initialize the fields eagerly to avoid a datarace when accessing them and add a `final` modifier to the `AbstractOperations#template` field.

Please note that these changes still require a client to publish a reference to RedisTemplate safely (getting a reference from an `ApplicationContext` is fine).
Also note that escaping a reference to `this` in `RedisTemplate` initializer should also be ok, because putting a bean into `ApplicationContext` happens-before its subsequent retrieval.

Original pull request: #???.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
