### PR TITLE
DATAREDIS-1041 - Add cache name after key prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1041-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
@@ -153,7 +153,8 @@ public class RedisCacheConfiguration {
 
 		Assert.notNull(prefix, "Prefix must not be null!");
 
-		return computePrefixWith((cacheName) -> prefix);
+		return computePrefixWith((cacheName) -> CacheKeyPrefix.simple().compute(prefix)
+				+ CacheKeyPrefix.simple().compute(cacheName));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Dmitriy Poboyko
  * @since 2.0
  */
 public class RedisCacheConfiguration {

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheConfigurationUnitTests.java
@@ -27,6 +27,7 @@ import org.springframework.lang.Nullable;
  * Unit tests for {@link RedisCacheConfiguration}.
  *
  * @author Mark Paluch
+ * @author Dmitriy Poboyko
  */
 public class RedisCacheConfigurationUnitTests {
 

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheConfigurationUnitTests.java
@@ -55,6 +55,15 @@ public class RedisCacheConfigurationUnitTests {
 		assertThat(config.getConversionService().canConvert(DomainType.class, String.class)).isTrue();
 	}
 
+	@Test // DATAREDIS-1041
+	public void shouldAppendCacheNameAfterKeyPrefix() {
+
+		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+				.prefixKeysWith("prefix");
+
+		assertThat(config.getKeyPrefixFor("cacheName")).isEqualTo("prefix::cacheName::");
+	}
+
 	private static class DomainType {
 
 	}


### PR DESCRIPTION
This fixes cache eviction while using @CacheEvict with a cache name and allEntries set to "true". With a key prefix specified in RedisConfiguration all the caches were evicted disregarding the name.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
