### PR TITLE
DATAREDIS-1052 - Improve atomic operation in DefaultRedisCacheWriter.

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
@@ -15,18 +15,16 @@
  */
 package org.springframework.data.redis.cache;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
+import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -45,6 +43,7 @@ import org.springframework.util.Assert;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Joongsoo Park
  * @since 2.0
  */
 class DefaultRedisCacheWriter implements RedisCacheWriter {
@@ -84,7 +83,7 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		execute(name, connection -> {
+		execute(connection -> {
 
 			if (shouldExpireWithin(ttl)) {
 				connection.set(key, value, Expiration.from(ttl.toMillis(), TimeUnit.MILLISECONDS), SetOption.upsert());
@@ -106,7 +105,7 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(name, "Name must not be null!");
 		Assert.notNull(key, "Key must not be null!");
 
-		return execute(name, connection -> connection.get(key));
+		return execute(connection -> connection.get(key));
 	}
 
 	/*
@@ -120,28 +119,23 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		return execute(name, connection -> {
+		return execute(connection -> {
+			boolean shouldExpireWithin = shouldExpireWithin(ttl);
+			Long ttlMillis = shouldExpireWithin ? ttl.toMillis() : null;
 
-			if (isLockingCacheWriter()) {
-				doLock(name, connection);
-			}
-
-			try {
-				if (connection.setNX(key, value)) {
-
-					if (shouldExpireWithin(ttl)) {
-						connection.pExpire(key, ttl.toMillis());
-					}
-					return null;
-				}
-
-				return connection.get(key);
-			} finally {
-
-				if (isLockingCacheWriter()) {
-					doUnlock(name, connection);
-				}
-			}
+			return connection.eval((
+							"if (redis.call('setNX', KEYS[1], ARGV[1]) == 1) then " +
+								"if (ARGV[2] == 'true') then " +
+									"redis.call('pExpire', KEYS[1], ARGV[3]); " +
+								"end; " +
+								"return nil; " +
+							"else " +
+								"return redis.call('get', KEYS[1]); " +
+							"end;"
+					).getBytes(), ReturnType.VALUE, 1, key, value,
+					String.valueOf(shouldExpireWithin).getBytes(),
+					String.valueOf(ttlMillis).getBytes()
+			);
 		});
 	}
 
@@ -155,7 +149,7 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(name, "Name must not be null!");
 		Assert.notNull(key, "Key must not be null!");
 
-		execute(name, connection -> connection.del(key));
+		execute(connection -> connection.del(key));
 	}
 
 	/*
@@ -168,62 +162,26 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(name, "Name must not be null!");
 		Assert.notNull(pattern, "Pattern must not be null!");
 
-		execute(name, connection -> {
-
-			boolean wasLocked = false;
-
-			try {
-
-				if (isLockingCacheWriter()) {
-					doLock(name, connection);
-					wasLocked = true;
-				}
-
+		execute(connection -> {
+			if (isLockingCacheWriter()) {
+				connection.eval((
+						"local k = unpack(redis.call('keys', ARGV[1])); " +
+						"if (k ~= nil) then " +
+							"return redis.call('del', k); " +
+						"end; " +
+						"return 0;"
+				).getBytes(), ReturnType.INTEGER, 0, pattern);
+			} else {
 				byte[][] keys = Optional.ofNullable(connection.keys(pattern)).orElse(Collections.emptySet())
 						.toArray(new byte[0][]);
 
 				if (keys.length > 0) {
 					connection.del(keys);
 				}
-			} finally {
-
-				if (wasLocked && isLockingCacheWriter()) {
-					doUnlock(name, connection);
-				}
 			}
 
 			return "OK";
 		});
-	}
-
-	/**
-	 * Explicitly set a write lock on a cache.
-	 *
-	 * @param name the name of the cache to lock.
-	 */
-	void lock(String name) {
-		execute(name, connection -> doLock(name, connection));
-	}
-
-	/**
-	 * Explicitly remove a write lock from a cache.
-	 *
-	 * @param name the name of the cache to unlock.
-	 */
-	void unlock(String name) {
-		executeLockFree(connection -> doUnlock(name, connection));
-	}
-
-	private Boolean doLock(String name, RedisConnection connection) {
-		return connection.setNX(createCacheLockKey(name), new byte[0]);
-	}
-
-	private Long doUnlock(String name, RedisConnection connection) {
-		return connection.del(createCacheLockKey(name));
-	}
-
-	boolean doCheckLock(String name, RedisConnection connection) {
-		return connection.exists(createCacheLockKey(name));
 	}
 
 	/**
@@ -233,55 +191,17 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		return !sleepTime.isZero() && !sleepTime.isNegative();
 	}
 
-	private <T> T execute(String name, Function<RedisConnection, T> callback) {
+	private <T> T execute(Function<RedisConnection, T> callback) {
 
 		RedisConnection connection = connectionFactory.getConnection();
 		try {
-
-			checkAndPotentiallyWaitUntilUnlocked(name, connection);
 			return callback.apply(connection);
 		} finally {
 			connection.close();
 		}
 	}
 
-	private void executeLockFree(Consumer<RedisConnection> callback) {
-
-		RedisConnection connection = connectionFactory.getConnection();
-
-		try {
-			callback.accept(connection);
-		} finally {
-			connection.close();
-		}
-	}
-
-	private void checkAndPotentiallyWaitUntilUnlocked(String name, RedisConnection connection) {
-
-		if (!isLockingCacheWriter()) {
-			return;
-		}
-
-		try {
-
-			while (doCheckLock(name, connection)) {
-				Thread.sleep(sleepTime.toMillis());
-			}
-		} catch (InterruptedException ex) {
-
-			// Re-interrupt current thread, to allow other participants to react.
-			Thread.currentThread().interrupt();
-
-			throw new PessimisticLockingFailureException(String.format("Interrupted while waiting to unlock cache %s", name),
-					ex);
-		}
-	}
-
 	private static boolean shouldExpireWithin(@Nullable Duration ttl) {
 		return ttl != null && !ttl.isZero() && !ttl.isNegative();
-	}
-
-	private static byte[] createCacheLockKey(String name) {
-		return (name + "~lock").getBytes(StandardCharsets.UTF_8);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
@@ -29,34 +29,22 @@ import org.springframework.util.Assert;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Joongsoo Park
  * @since 2.0
  */
 public interface RedisCacheWriter {
 
 	/**
-	 * Create new {@link RedisCacheWriter} without locking behavior.
+	 * Create new {@link RedisCacheWriter}
 	 *
 	 * @param connectionFactory must not be {@literal null}.
 	 * @return new instance of {@link DefaultRedisCacheWriter}.
 	 */
-	static RedisCacheWriter nonLockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
+	static RedisCacheWriter newDefaultRedisCacheWriter(RedisConnectionFactory connectionFactory) {
 
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
 
 		return new DefaultRedisCacheWriter(connectionFactory);
-	}
-
-	/**
-	 * Create new {@link RedisCacheWriter} with locking behavior.
-	 *
-	 * @param connectionFactory must not be {@literal null}.
-	 * @return new instance of {@link DefaultRedisCacheWriter}.
-	 */
-	static RedisCacheWriter lockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
-
-		Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
-
-		return new DefaultRedisCacheWriter(connectionFactory, Duration.ofMillis(50));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
@@ -87,7 +87,7 @@ public class DefaultRedisCacheWriterTests {
 	@Test // DATAREDIS-481
 	public void putShouldAddEternalEntry() {
 
-		nonLockingRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
+		newDefaultRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
 
 		doWithConnection(connection -> {
 			assertThat(connection.get(binaryCacheKey)).isEqualTo(binaryCacheValue);
@@ -98,7 +98,7 @@ public class DefaultRedisCacheWriterTests {
 	@Test // DATAREDIS-481
 	public void putShouldAddExpiringEntry() {
 
-		nonLockingRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue,
+		newDefaultRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue,
 				Duration.ofSeconds(1));
 
 		doWithConnection(connection -> {
@@ -112,7 +112,7 @@ public class DefaultRedisCacheWriterTests {
 
 		doWithConnection(connection -> connection.set(binaryCacheKey, "foo".getBytes()));
 
-		nonLockingRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
+		newDefaultRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
 
 		doWithConnection(connection -> {
 			assertThat(connection.get(binaryCacheKey)).isEqualTo(binaryCacheValue);
@@ -126,7 +126,7 @@ public class DefaultRedisCacheWriterTests {
 		doWithConnection(connection -> connection.set(binaryCacheKey, "foo".getBytes(),
 				Expiration.from(1, TimeUnit.MINUTES), SetOption.upsert()));
 
-		nonLockingRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue,
+		newDefaultRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue,
 				Duration.ofSeconds(5));
 
 		doWithConnection(connection -> {
@@ -140,19 +140,19 @@ public class DefaultRedisCacheWriterTests {
 
 		doWithConnection(connection -> connection.set(binaryCacheKey, binaryCacheValue));
 
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).get(CACHE_NAME, binaryCacheKey))
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).get(CACHE_NAME, binaryCacheKey))
 				.isEqualTo(binaryCacheValue);
 	}
 
 	@Test // DATAREDIS-481
 	public void getShouldReturnNullWhenKeyDoesNotExist() {
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).get(CACHE_NAME, binaryCacheKey)).isNull();
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).get(CACHE_NAME, binaryCacheKey)).isNull();
 	}
 
 	@Test // DATAREDIS-481
 	public void putIfAbsentShouldAddEternalEntryWhenKeyDoesNotExist() {
 
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, binaryCacheValue,
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, binaryCacheValue,
 				Duration.ZERO)).isNull();
 
 		doWithConnection(connection -> {
@@ -165,7 +165,7 @@ public class DefaultRedisCacheWriterTests {
 
 		doWithConnection(connection -> connection.set(binaryCacheKey, binaryCacheValue));
 
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, "foo".getBytes(),
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, "foo".getBytes(),
 				Duration.ZERO)).isEqualTo(binaryCacheValue);
 
 		doWithConnection(connection -> {
@@ -176,7 +176,7 @@ public class DefaultRedisCacheWriterTests {
 	@Test // DATAREDIS-481
 	public void putIfAbsentShouldAddExpiringEntryWhenKeyDoesNotExist() {
 
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, binaryCacheValue,
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, binaryCacheValue,
 				Duration.ofSeconds(5))).isNull();
 
 		doWithConnection(connection -> {
@@ -189,7 +189,7 @@ public class DefaultRedisCacheWriterTests {
 
 		doWithConnection(connection -> connection.set(binaryCacheKey, binaryCacheValue));
 
-		nonLockingRedisCacheWriter(connectionFactory).remove(CACHE_NAME, binaryCacheKey);
+		newDefaultRedisCacheWriter(connectionFactory).remove(CACHE_NAME, binaryCacheKey);
 
 		doWithConnection(connection -> assertThat(connection.exists(binaryCacheKey)).isFalse());
 	}
@@ -202,7 +202,7 @@ public class DefaultRedisCacheWriterTests {
 			connection.set("foo".getBytes(), "bar".getBytes());
 		});
 
-		nonLockingRedisCacheWriter(connectionFactory).clean(CACHE_NAME,
+		newDefaultRedisCacheWriter(connectionFactory).clean(CACHE_NAME,
 				(CACHE_NAME + "::*").getBytes(Charset.forName("UTF-8")));
 
 		doWithConnection(connection -> {


### PR DESCRIPTION
issue : https://jira.spring.io/browse/DATAREDIS-1052

Hi. i'm joongsoo.

`lockingCacheWriter` using spin wait like spin lock.
It is send very many request to redis.
And existing code is not atomic. It is check exists lock and do acquire lock, but not check is acquired lock.

If using lua script. it is guarantees to atomic. and it's removing lock/unlock code so possible decrement to sending request count. and reduce complexit in code.


## Changed
- Remove spin lock. (It is send too many request to redis)
- Apply lua script instead of lock operation. (It guarantees to atomic operation)
- Remove tests related to locks

## Check list
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
