### PR TITLE
DATAREDIS-1053 - Subscribe to cleanup publishers when cancelling a listenTo() stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1053-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
@@ -235,7 +235,7 @@ public class ReactiveRedisTemplate<K, V> implements ReactiveRedisOperations<K, V
 		return container
 				.receive(Arrays.asList(topics), getSerializationContext().getStringSerializationPair(),
 						getSerializationContext().getValueSerializationPair()) //
-				.doFinally((signalType) -> container.destroyLater().subscribeOn(Schedulers.elastic()));
+				.doFinally((signalType) -> container.destroyLater().subscribe());
 	}
 
 	// -------------------------------------------------------------------------

--- a/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateUnitTests.java
@@ -25,7 +25,6 @@ import reactor.test.StepVerifier;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
-
 import org.springframework.data.redis.connection.ReactivePubSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisConnection;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
@@ -59,7 +58,7 @@ public class ReactiveRedisTemplateUnitTests {
 		verifyNoMoreInteractions(connectionMock);
 	}
 
-	@Test // DATAREDIS-999
+	@Test // DATAREDIS-1053
 	public void listenToShouldSubscribeToChannel() {
 
 		AtomicBoolean closed = new AtomicBoolean();


### PR DESCRIPTION
Cleanup publishers are now subscribed to instead of setting the `subscribeOn` `Scheduler` to ensure connections get closed after canceling the stream.

---

Related ticket: [DATAREDIS-1053](https://jira.spring.io/browse/DATAREDIS-1053).
Should be backported to 2.1.x and 2.2.x.