### PR TITLE
DATAREDIS-1052 - Improve atomic operation in DefaultRedisCacheWriter.

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
@@ -15,62 +15,36 @@
  */
 package org.springframework.data.redis.cache;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Collections;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
+import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * {@link RedisCacheWriter} implementation capable of reading/writing binary data from/to Redis in {@literal standalone}
- * and {@literal cluster} environments. Works upon a given {@link RedisConnectionFactory} to obtain the actual
- * {@link RedisConnection}. <br />
- * {@link DefaultRedisCacheWriter} can be used in
- * {@link RedisCacheWriter#lockingRedisCacheWriter(RedisConnectionFactory) locking} or
- * {@link RedisCacheWriter#nonLockingRedisCacheWriter(RedisConnectionFactory) non-locking} mode. While
- * {@literal non-locking} aims for maximum performance it may result in overlapping, non atomic, command execution for
- * operations spanning multiple Redis interactions like {@code putIfAbsent}. The {@literal locking} counterpart prevents
- * command overlap by setting an explicit lock key and checking against presence of this key which leads to additional
- * requests and potential command wait times.
- *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Joongsoo Park
  * @since 2.0
  */
 class DefaultRedisCacheWriter implements RedisCacheWriter {
 
 	private final RedisConnectionFactory connectionFactory;
-	private final Duration sleepTime;
 
 	/**
 	 * @param connectionFactory must not be {@literal null}.
 	 */
 	DefaultRedisCacheWriter(RedisConnectionFactory connectionFactory) {
-		this(connectionFactory, Duration.ZERO);
-	}
-
-	/**
-	 * @param connectionFactory must not be {@literal null}.
-	 * @param sleepTime sleep time between lock request attempts. Must not be {@literal null}. Use {@link Duration#ZERO}
-	 *          to disable locking.
-	 */
-	DefaultRedisCacheWriter(RedisConnectionFactory connectionFactory, Duration sleepTime) {
 
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
-		Assert.notNull(sleepTime, "SleepTime must not be null!");
 
 		this.connectionFactory = connectionFactory;
-		this.sleepTime = sleepTime;
 	}
 
 	/*
@@ -84,7 +58,7 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		execute(name, connection -> {
+		execute(connection -> {
 
 			if (shouldExpireWithin(ttl)) {
 				connection.set(key, value, Expiration.from(ttl.toMillis(), TimeUnit.MILLISECONDS), SetOption.upsert());
@@ -106,7 +80,7 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(name, "Name must not be null!");
 		Assert.notNull(key, "Key must not be null!");
 
-		return execute(name, connection -> connection.get(key));
+		return execute(connection -> connection.get(key));
 	}
 
 	/*
@@ -120,28 +94,23 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		return execute(name, connection -> {
+		return execute(connection -> {
+			boolean shouldExpireWithin = shouldExpireWithin(ttl);
+			Long ttlMillis = shouldExpireWithin ? ttl.toMillis() : null;
 
-			if (isLockingCacheWriter()) {
-				doLock(name, connection);
-			}
-
-			try {
-				if (connection.setNX(key, value)) {
-
-					if (shouldExpireWithin(ttl)) {
-						connection.pExpire(key, ttl.toMillis());
-					}
-					return null;
-				}
-
-				return connection.get(key);
-			} finally {
-
-				if (isLockingCacheWriter()) {
-					doUnlock(name, connection);
-				}
-			}
+			return connection.eval((
+							"if (redis.call('setNX', KEYS[1], ARGV[1]) == 1) then " +
+								"if (ARGV[2] == 'true') then " +
+									"redis.call('pExpire', KEYS[1], ARGV[3]); " +
+								"end; " +
+								"return nil; " +
+							"else " +
+								"return redis.call('get', KEYS[1]); " +
+							"end;"
+					).getBytes(), ReturnType.VALUE, 1, key, value,
+					String.valueOf(shouldExpireWithin).getBytes(),
+					String.valueOf(ttlMillis).getBytes()
+			);
 		});
 	}
 
@@ -155,7 +124,7 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(name, "Name must not be null!");
 		Assert.notNull(key, "Key must not be null!");
 
-		execute(name, connection -> connection.del(key));
+		execute(connection -> connection.del(key));
 	}
 
 	/*
@@ -168,120 +137,30 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(name, "Name must not be null!");
 		Assert.notNull(pattern, "Pattern must not be null!");
 
-		execute(name, connection -> {
-
-			boolean wasLocked = false;
-
-			try {
-
-				if (isLockingCacheWriter()) {
-					doLock(name, connection);
-					wasLocked = true;
-				}
-
-				byte[][] keys = Optional.ofNullable(connection.keys(pattern)).orElse(Collections.emptySet())
-						.toArray(new byte[0][]);
-
-				if (keys.length > 0) {
-					connection.del(keys);
-				}
-			} finally {
-
-				if (wasLocked && isLockingCacheWriter()) {
-					doUnlock(name, connection);
-				}
-			}
+		execute(connection -> {
+			connection.eval((
+					"local k = unpack(redis.call('keys', ARGV[1])); " +
+					"if (k ~= nil) then " +
+						"return redis.call('del', k); " +
+					"end; " +
+					"return 0;"
+			).getBytes(), ReturnType.INTEGER, 0, pattern);
 
 			return "OK";
 		});
 	}
 
-	/**
-	 * Explicitly set a write lock on a cache.
-	 *
-	 * @param name the name of the cache to lock.
-	 */
-	void lock(String name) {
-		execute(name, connection -> doLock(name, connection));
-	}
-
-	/**
-	 * Explicitly remove a write lock from a cache.
-	 *
-	 * @param name the name of the cache to unlock.
-	 */
-	void unlock(String name) {
-		executeLockFree(connection -> doUnlock(name, connection));
-	}
-
-	private Boolean doLock(String name, RedisConnection connection) {
-		return connection.setNX(createCacheLockKey(name), new byte[0]);
-	}
-
-	private Long doUnlock(String name, RedisConnection connection) {
-		return connection.del(createCacheLockKey(name));
-	}
-
-	boolean doCheckLock(String name, RedisConnection connection) {
-		return connection.exists(createCacheLockKey(name));
-	}
-
-	/**
-	 * @return {@literal true} if {@link RedisCacheWriter} uses locks.
-	 */
-	private boolean isLockingCacheWriter() {
-		return !sleepTime.isZero() && !sleepTime.isNegative();
-	}
-
-	private <T> T execute(String name, Function<RedisConnection, T> callback) {
+	private <T> T execute(Function<RedisConnection, T> callback) {
 
 		RedisConnection connection = connectionFactory.getConnection();
 		try {
-
-			checkAndPotentiallyWaitUntilUnlocked(name, connection);
 			return callback.apply(connection);
 		} finally {
 			connection.close();
 		}
 	}
 
-	private void executeLockFree(Consumer<RedisConnection> callback) {
-
-		RedisConnection connection = connectionFactory.getConnection();
-
-		try {
-			callback.accept(connection);
-		} finally {
-			connection.close();
-		}
-	}
-
-	private void checkAndPotentiallyWaitUntilUnlocked(String name, RedisConnection connection) {
-
-		if (!isLockingCacheWriter()) {
-			return;
-		}
-
-		try {
-
-			while (doCheckLock(name, connection)) {
-				Thread.sleep(sleepTime.toMillis());
-			}
-		} catch (InterruptedException ex) {
-
-			// Re-interrupt current thread, to allow other participants to react.
-			Thread.currentThread().interrupt();
-
-			throw new PessimisticLockingFailureException(String.format("Interrupted while waiting to unlock cache %s", name),
-					ex);
-		}
-	}
-
 	private static boolean shouldExpireWithin(@Nullable Duration ttl) {
 		return ttl != null && !ttl.isZero() && !ttl.isNegative();
-	}
-
-	private static byte[] createCacheLockKey(String name) {
-		return (name + "~lock").getBytes(StandardCharsets.UTF_8);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
@@ -29,34 +29,22 @@ import org.springframework.util.Assert;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Joongsoo Park
  * @since 2.0
  */
 public interface RedisCacheWriter {
 
 	/**
-	 * Create new {@link RedisCacheWriter} without locking behavior.
+	 * Create new {@link RedisCacheWriter}
 	 *
 	 * @param connectionFactory must not be {@literal null}.
 	 * @return new instance of {@link DefaultRedisCacheWriter}.
 	 */
-	static RedisCacheWriter nonLockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
+	static RedisCacheWriter newDefaultRedisCacheWriter(RedisConnectionFactory connectionFactory) {
 
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
 
 		return new DefaultRedisCacheWriter(connectionFactory);
-	}
-
-	/**
-	 * Create new {@link RedisCacheWriter} with locking behavior.
-	 *
-	 * @param connectionFactory must not be {@literal null}.
-	 * @return new instance of {@link DefaultRedisCacheWriter}.
-	 */
-	static RedisCacheWriter lockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
-
-		Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
-
-		return new DefaultRedisCacheWriter(connectionFactory, Duration.ofMillis(50));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
@@ -22,9 +22,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.junit.AfterClass;
@@ -43,6 +41,7 @@ import org.springframework.data.redis.core.types.Expiration;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Joongsoo Park
  */
 @RunWith(Parameterized.class)
 public class DefaultRedisCacheWriterTests {
@@ -88,7 +87,7 @@ public class DefaultRedisCacheWriterTests {
 	@Test // DATAREDIS-481
 	public void putShouldAddEternalEntry() {
 
-		nonLockingRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
+		newDefaultRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
 
 		doWithConnection(connection -> {
 			assertThat(connection.get(binaryCacheKey)).isEqualTo(binaryCacheValue);
@@ -99,7 +98,7 @@ public class DefaultRedisCacheWriterTests {
 	@Test // DATAREDIS-481
 	public void putShouldAddExpiringEntry() {
 
-		nonLockingRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue,
+		newDefaultRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue,
 				Duration.ofSeconds(1));
 
 		doWithConnection(connection -> {
@@ -113,7 +112,7 @@ public class DefaultRedisCacheWriterTests {
 
 		doWithConnection(connection -> connection.set(binaryCacheKey, "foo".getBytes()));
 
-		nonLockingRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
+		newDefaultRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
 
 		doWithConnection(connection -> {
 			assertThat(connection.get(binaryCacheKey)).isEqualTo(binaryCacheValue);
@@ -127,7 +126,7 @@ public class DefaultRedisCacheWriterTests {
 		doWithConnection(connection -> connection.set(binaryCacheKey, "foo".getBytes(),
 				Expiration.from(1, TimeUnit.MINUTES), SetOption.upsert()));
 
-		nonLockingRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue,
+		newDefaultRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue,
 				Duration.ofSeconds(5));
 
 		doWithConnection(connection -> {
@@ -141,19 +140,19 @@ public class DefaultRedisCacheWriterTests {
 
 		doWithConnection(connection -> connection.set(binaryCacheKey, binaryCacheValue));
 
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).get(CACHE_NAME, binaryCacheKey))
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).get(CACHE_NAME, binaryCacheKey))
 				.isEqualTo(binaryCacheValue);
 	}
 
 	@Test // DATAREDIS-481
 	public void getShouldReturnNullWhenKeyDoesNotExist() {
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).get(CACHE_NAME, binaryCacheKey)).isNull();
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).get(CACHE_NAME, binaryCacheKey)).isNull();
 	}
 
 	@Test // DATAREDIS-481
 	public void putIfAbsentShouldAddEternalEntryWhenKeyDoesNotExist() {
 
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, binaryCacheValue,
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, binaryCacheValue,
 				Duration.ZERO)).isNull();
 
 		doWithConnection(connection -> {
@@ -166,7 +165,7 @@ public class DefaultRedisCacheWriterTests {
 
 		doWithConnection(connection -> connection.set(binaryCacheKey, binaryCacheValue));
 
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, "foo".getBytes(),
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, "foo".getBytes(),
 				Duration.ZERO)).isEqualTo(binaryCacheValue);
 
 		doWithConnection(connection -> {
@@ -177,7 +176,7 @@ public class DefaultRedisCacheWriterTests {
 	@Test // DATAREDIS-481
 	public void putIfAbsentShouldAddExpiringEntryWhenKeyDoesNotExist() {
 
-		assertThat(nonLockingRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, binaryCacheValue,
+		assertThat(newDefaultRedisCacheWriter(connectionFactory).putIfAbsent(CACHE_NAME, binaryCacheKey, binaryCacheValue,
 				Duration.ofSeconds(5))).isNull();
 
 		doWithConnection(connection -> {
@@ -190,7 +189,7 @@ public class DefaultRedisCacheWriterTests {
 
 		doWithConnection(connection -> connection.set(binaryCacheKey, binaryCacheValue));
 
-		nonLockingRedisCacheWriter(connectionFactory).remove(CACHE_NAME, binaryCacheKey);
+		newDefaultRedisCacheWriter(connectionFactory).remove(CACHE_NAME, binaryCacheKey);
 
 		doWithConnection(connection -> assertThat(connection.exists(binaryCacheKey)).isFalse());
 	}
@@ -203,118 +202,13 @@ public class DefaultRedisCacheWriterTests {
 			connection.set("foo".getBytes(), "bar".getBytes());
 		});
 
-		nonLockingRedisCacheWriter(connectionFactory).clean(CACHE_NAME,
+		newDefaultRedisCacheWriter(connectionFactory).clean(CACHE_NAME,
 				(CACHE_NAME + "::*").getBytes(Charset.forName("UTF-8")));
 
 		doWithConnection(connection -> {
 			assertThat(connection.exists(binaryCacheKey)).isFalse();
 			assertThat(connection.exists("foo".getBytes())).isTrue();
 		});
-	}
-
-	@Test // DATAREDIS-481
-	public void nonLockingCacheWriterShouldIgnoreExistingLock() {
-
-		((DefaultRedisCacheWriter) lockingRedisCacheWriter(connectionFactory)).lock(CACHE_NAME);
-
-		nonLockingRedisCacheWriter(connectionFactory).put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
-
-		doWithConnection(connection -> {
-			assertThat(connection.exists(binaryCacheKey)).isTrue();
-		});
-	}
-
-	@Test // DATAREDIS-481
-	public void lockingCacheWriterShouldIgnoreExistingLockOnDifferenceCache() {
-
-		((DefaultRedisCacheWriter) lockingRedisCacheWriter(connectionFactory)).lock(CACHE_NAME);
-
-		lockingRedisCacheWriter(connectionFactory).put(CACHE_NAME + "-no-the-other-cache", binaryCacheKey, binaryCacheValue,
-				Duration.ZERO);
-
-		doWithConnection(connection -> {
-			assertThat(connection.exists(binaryCacheKey)).isTrue();
-		});
-	}
-
-	@Test // DATAREDIS-481
-	public void lockingCacheWriterShouldWaitForLockRelease() throws InterruptedException {
-
-		DefaultRedisCacheWriter cw = (DefaultRedisCacheWriter) lockingRedisCacheWriter(connectionFactory);
-		cw.lock(CACHE_NAME);
-
-		CountDownLatch beforeWrite = new CountDownLatch(1);
-		CountDownLatch afterWrite = new CountDownLatch(1);
-
-		Thread th = new Thread(() -> {
-
-			RedisCacheWriter writer = lockingRedisCacheWriter(connectionFactory);
-			beforeWrite.countDown();
-			writer.put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
-			afterWrite.countDown();
-		});
-		th.start();
-
-		try {
-
-			beforeWrite.await();
-
-			Thread.sleep(200);
-
-			doWithConnection(connection -> {
-				assertThat(connection.exists(binaryCacheKey)).isFalse();
-			});
-
-			cw.unlock(CACHE_NAME);
-
-			afterWrite.await();
-			doWithConnection(connection -> {
-				assertThat(connection.exists(binaryCacheKey)).isTrue();
-			});
-		} finally {
-			th.interrupt();
-		}
-	}
-
-	@Test // DATAREDIS-481
-	public void lockingCacheWriterShouldExitWhenInterruptedWaitForLockRelease() throws InterruptedException {
-
-		DefaultRedisCacheWriter cw = (DefaultRedisCacheWriter) lockingRedisCacheWriter(connectionFactory);
-		cw.lock(CACHE_NAME);
-
-		CountDownLatch beforeWrite = new CountDownLatch(1);
-		CountDownLatch afterWrite = new CountDownLatch(1);
-		AtomicReference<Exception> exceptionRef = new AtomicReference<>();
-
-		Thread th = new Thread(() -> {
-
-			DefaultRedisCacheWriter writer = new DefaultRedisCacheWriter(connectionFactory, Duration.ofMillis(50)) {
-
-				@Override
-				boolean doCheckLock(String name, RedisConnection connection) {
-					beforeWrite.countDown();
-					return super.doCheckLock(name, connection);
-				}
-			};
-
-			try {
-				writer.put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
-			} catch (Exception e) {
-				exceptionRef.set(e);
-			} finally {
-				afterWrite.countDown();
-			}
-		});
-
-		th.start();
-		beforeWrite.await();
-
-		th.interrupt();
-
-		afterWrite.await();
-
-		assertThat(exceptionRef.get()).hasMessageContaining("Interrupted while waiting to unlock")
-				.hasCauseInstanceOf(InterruptedException.class);
 	}
 
 	private void doWithConnection(Consumer<RedisConnection> callback) {


### PR DESCRIPTION
issue : https://jira.spring.io/browse/DATAREDIS-1052

Hi. I'm joongsoo.

`lockingCacheWriter` using spin wait for lock. It is send very many request to redis.
And existing wait & acquire code is not atomic. It is check exists lock and do acquire lock, but not check is acquired lock.

In this case, the atomicity provided by Redis is effective.
If using lua script. it is guarantees to atomic. and it's removing lock/unlock code so possible decrement to sending request count. and reduce complexit in code.


## Changed
- Remove spin lock. (It is send too many request to redis)
- Apply lua script instead of lock operation. (It guarantees to atomic operation)
- Remove tests related to locks
- Remove `lockingRedisCacheWriter` in `RedisCacheWriter`, because lock is not needed anymore.
- Rename `nonLockingRedisCacheWriter`, because the name `lock` is meaningless because the lock is gone.

## Check list
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
