### PR TITLE
DATAREDIS-1045 - Apply password to all Sentinel endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1045-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -1080,7 +1080,7 @@ public class LettuceConnectionFactory
 
 		applyToAll(redisUri, it -> {
 
-			getRedisPassword().toOptional().ifPresent(redisUri::setPassword);
+			getRedisPassword().toOptional().ifPresent(it::setPassword);
 			clientConfiguration.getClientName().ifPresent(it::setClientName);
 
 			it.setSsl(clientConfiguration.isUseSsl());

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -179,7 +179,7 @@ public class LettuceConnectionFactoryUnitTests {
 		}
 	}
 
-	@Test // DATAREDIS-524
+	@Test // DATAREDIS-524, DATAREDIS-1045
 	public void passwordShouldBeSetCorrectlyOnSentinelClient() {
 
 		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(
@@ -195,6 +195,11 @@ public class LettuceConnectionFactoryUnitTests {
 		RedisURI redisUri = (RedisURI) getField(client, "redisURI");
 
 		assertThat(redisUri.getPassword()).isEqualTo(connectionFactory.getPassword().toCharArray());
+
+		for (RedisURI sentinel : redisUri.getSentinels()) {
+			assertThat(sentinel.getPassword())
+					.isEqualTo(connectionFactory.getPassword().toCharArray());
+		}
 	}
 
 	@Test // DATAREDIS-462


### PR DESCRIPTION
We now apply the password to all Sentinel endpoints described through RedisURI.

We also apply all remaining settings to all Sentinel endpoints to ensure configuration propagation.

---

Related ticket: [DATAREDIS-1045](https://jira.spring.io/browse/DATAREDIS-1045).