### PR TITLE
DATAREDIS-1049 - Fix retrieval of empty keyspaceNotificationsConfigParameter used to keep server defaults.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1049-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/repository/configuration/EnableRedisRepositories.java
+++ b/src/main/java/org/springframework/data/redis/repository/configuration/EnableRedisRepositories.java
@@ -168,7 +168,7 @@ public @interface EnableRedisRepositories {
 
 	/**
 	 * Configure the {@literal notify-keyspace-events} property if not already set. <br />
-	 * Use an empty {@link String} to keep <b>not</b> alter existing server configuration.
+	 * Use an empty {@link String} to keep (<b>not</b> alter) existing server configuration.
 	 *
 	 * @return {@literal Ex} by default.
 	 * @since 1.8

--- a/src/main/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtension.java
@@ -144,7 +144,7 @@ public class RedisRepositoryConfigurationExtension extends KeyValueRepositoryCon
 				.addPropertyValue("enableKeyspaceEvents",
 						configuration.getRequiredAttribute("enableKeyspaceEvents", EnableKeyspaceEvents.class)) //
 				.addPropertyValue("keyspaceNotificationsConfigParameter",
-						configuration.getRequiredAttribute("keyspaceNotificationsConfigParameter", String.class)) //
+						configuration.getAttribute("keyspaceNotificationsConfigParameter", String.class).orElse("")) //
 				.getBeanDefinition();
 	}
 

--- a/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtensionUnitTests.java
@@ -114,6 +114,15 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 		assertThat(getKeyspaceNotificationsConfigParameter(beanDefintionRegistry)).isEqualTo((Object) "KEA");
 	}
 
+	@Test // DATAREDIS-1049
+	public void explicitlyEmptyKeyspaceNotificationsConfigParameterShouldBeCapturedCorrectly() {
+
+		metadata = new StandardAnnotationMetadata(ConfigWithEmptyConfigParameter.class, true);
+		BeanDefinitionRegistry beanDefintionRegistry = getBeanDefinitionRegistry();
+
+		assertThat(getKeyspaceNotificationsConfigParameter(beanDefintionRegistry)).isEqualTo("");
+	}
+
 	private static void assertDoesNotHaveRepo(Class<?> repositoryInterface,
 			Collection<RepositoryConfiguration<RepositoryConfigurationSource>> configs) {
 
@@ -176,6 +185,12 @@ public class RedisRepositoryConfigurationExtensionUnitTests {
 	@EnableRedisRepositories(considerNestedRepositories = true, enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP,
 			keyspaceNotificationsConfigParameter = "KEA")
 	static class ConfigWithKeyspaceEventsEnabledAndCustomEventConfig {
+
+	}
+
+	@EnableRedisRepositories(considerNestedRepositories = true, enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP,
+			keyspaceNotificationsConfigParameter = "")
+	static class ConfigWithEmptyConfigParameter {
 
 	}
 


### PR DESCRIPTION
Empty Strings changed to be considered `null` throwing an exception on `getRequiredAttribute` so we now set the value explicitly for this attribute when considered empty.