### PR TITLE
DATAREDIS-1060 - Redis password should not automatically be applied to Sentinel.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1060-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/reference/redis.adoc
+++ b/src/main/asciidoc/reference/redis.adoc
@@ -174,13 +174,14 @@ public RedisConnectionFactory lettuceConnectionFactory() {
 .Configuration Properties
 * `spring.redis.sentinel.master`: name of the master node.
 * `spring.redis.sentinel.nodes`: Comma delimited list of host:port pairs.
+* `spring.redis.sentinel.password`: The password to apply when authenticating with Redis Sentinel
 ====
 
 Sometimes, direct interaction with one of the Sentinels is required. Using `RedisConnectionFactory.getSentinelConnection()` or `RedisConnection.getSentinelCommands()` gives you access to the first active Sentinel configured.
 
 [NOTE]
 ====
-Configuration options like password, timeouts, SSL... also get applied to Redis Sentinel when using https://lettuce.io/[Lettuce].
+Sentinel authentication is only available using https://lettuce.io/[Lettuce].
 ====
 
 [[redis:template]]

--- a/src/main/java/org/springframework/data/redis/connection/RedisConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisConfiguration.java
@@ -337,6 +337,79 @@ public interface RedisConfiguration {
 		 * @return {@link Set} of sentinels. Never {@literal null}.
 		 */
 		Set<RedisNode> getSentinels();
+
+		/**
+		 * Get the {@link RedisPassword} used when authenticating with a Redis Server.
+		 * 
+		 * @return never {@literal null}.
+		 */
+		default RedisPassword getDataNodePassword() {
+			return getPassword();
+		}
+
+		/**
+		 * Create and set a {@link RedisPassword} to be used when authenticating with Sentinel from the given {@link String}
+		 *
+		 * @param password can be {@literal null}.
+		 * @throws IllegalStateException if the {@link #useDataNodeAuthenticationForSentinel(boolean) Data Node Password}
+		 *           should be used for authenticating with Redis Sentinel.
+		 * @since 2.2.2
+		 */
+		default void setSentinelPassword(@Nullable String password) {
+			setSentinelPassword(RedisPassword.of(password));
+		}
+
+		/**
+		 * Create and set a {@link RedisPassword} to be used when authenticating with Sentinel from the given
+		 * {@link Character} sequence.
+		 *
+		 * @param password can be {@literal null}.
+		 * @throws IllegalStateException if the {@link #useDataNodeAuthenticationForSentinel(boolean) Data Node Password}
+		 *           should be used for authenticating with Redis Sentinel.
+		 * @since 2.2.2
+		 */
+		default void setSentinelPassword(@Nullable char[] password) {
+			setSentinelPassword(RedisPassword.of(password));
+		}
+
+		/**
+		 * Set a {@link RedisPassword} to be used when authenticating with Sentinel.
+		 *
+		 * @param password must not be {@literal null} use {@link RedisPassword#none()} instead.
+		 * @throws IllegalStateException if the {@link #useDataNodeAuthenticationForSentinel(boolean) Data Node Password}
+		 *           should be used for authenticating with Redis Sentinel.
+		 * @since 2.2.2
+		 */
+		void setSentinelPassword(RedisPassword password);
+
+		/**
+		 * Get the {@link RedisPassword} to use when connecting to a Redis Sentinel. <br />
+		 * This can be the password explicitly set via {@link #setSentinelPassword(RedisPassword)}, or the
+		 * {@link #getDataNodePassword() Data Node password} if it should be also used for
+		 * {@link #getUseDataNodeAuthenticationForSentinel() sentinel}, or {@link RedisPassword#none()} if no password has
+		 * been set.
+		 *
+		 * @return the {@link RedisPassword} for authenticating with Sentinel.
+		 * @since 2.2.2
+		 */
+		RedisPassword getSentinelPassword();
+
+		/**
+		 * Use the {@link #getDataNodePassword() RedisPassword} also for authentication with Redis Sentinel.
+		 * 
+		 * @param useDataNodeAuthenticationForSentinel
+		 * @throws IllegalStateException if a {@link #getSentinelPassword() Sentinel Password} is already set.
+		 * @since 2.2.2
+		 */
+		void useDataNodeAuthenticationForSentinel(boolean useDataNodeAuthenticationForSentinel);
+
+		/**
+		 * Use the {@link #getDataNodePassword() RedisPassword} also for authentication with Redis Sentinel.
+		 *
+		 * @return
+		 * @since 2.2.2
+		 */
+		boolean getUseDataNodeAuthenticationForSentinel();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/RedisConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisConfiguration.java
@@ -339,20 +339,20 @@ public interface RedisConfiguration {
 		Set<RedisNode> getSentinels();
 
 		/**
-		 * Get the {@link RedisPassword} used when authenticating with a Redis Server.
-		 * 
+		 * Get the {@link RedisPassword} used when authenticating with a Redis Server..
+		 *
 		 * @return never {@literal null}.
+		 * @since 2.2.2
 		 */
 		default RedisPassword getDataNodePassword() {
 			return getPassword();
 		}
 
 		/**
-		 * Create and set a {@link RedisPassword} to be used when authenticating with Sentinel from the given {@link String}
+		 * Create and set a {@link RedisPassword} to be used when authenticating with Redis Sentinel from the given
+		 * {@link String}.
 		 *
 		 * @param password can be {@literal null}.
-		 * @throws IllegalStateException if the {@link #useDataNodeAuthenticationForSentinel(boolean) Data Node Password}
-		 *           should be used for authenticating with Redis Sentinel.
 		 * @since 2.2.2
 		 */
 		default void setSentinelPassword(@Nullable String password) {
@@ -360,12 +360,10 @@ public interface RedisConfiguration {
 		}
 
 		/**
-		 * Create and set a {@link RedisPassword} to be used when authenticating with Sentinel from the given
+		 * Create and set a {@link RedisPassword} to be used when authenticating with Redis Sentinel from the given
 		 * {@link Character} sequence.
 		 *
 		 * @param password can be {@literal null}.
-		 * @throws IllegalStateException if the {@link #useDataNodeAuthenticationForSentinel(boolean) Data Node Password}
-		 *           should be used for authenticating with Redis Sentinel.
 		 * @since 2.2.2
 		 */
 		default void setSentinelPassword(@Nullable char[] password) {
@@ -373,43 +371,22 @@ public interface RedisConfiguration {
 		}
 
 		/**
-		 * Set a {@link RedisPassword} to be used when authenticating with Sentinel.
+		 * Set a {@link RedisPassword} to be used when authenticating with Redis Sentinel.
 		 *
 		 * @param password must not be {@literal null} use {@link RedisPassword#none()} instead.
-		 * @throws IllegalStateException if the {@link #useDataNodeAuthenticationForSentinel(boolean) Data Node Password}
-		 *           should be used for authenticating with Redis Sentinel.
 		 * @since 2.2.2
 		 */
 		void setSentinelPassword(RedisPassword password);
 
 		/**
-		 * Get the {@link RedisPassword} to use when connecting to a Redis Sentinel. <br />
-		 * This can be the password explicitly set via {@link #setSentinelPassword(RedisPassword)}, or the
-		 * {@link #getDataNodePassword() Data Node password} if it should be also used for
-		 * {@link #getUseDataNodeAuthenticationForSentinel() sentinel}, or {@link RedisPassword#none()} if no password has
+		 * Returns the {@link RedisPassword} to use when connecting to a Redis Sentinel. <br />
+		 * Can be set via {@link #setSentinelPassword(RedisPassword)} or {@link RedisPassword#none()} if no password has
 		 * been set.
 		 *
-		 * @return the {@link RedisPassword} for authenticating with Sentinel.
+		 * @return the {@link RedisPassword} for authenticating with Redis Sentinel.
 		 * @since 2.2.2
 		 */
 		RedisPassword getSentinelPassword();
-
-		/**
-		 * Use the {@link #getDataNodePassword() RedisPassword} also for authentication with Redis Sentinel.
-		 * 
-		 * @param useDataNodeAuthenticationForSentinel
-		 * @throws IllegalStateException if a {@link #getSentinelPassword() Sentinel Password} is already set.
-		 * @since 2.2.2
-		 */
-		void useDataNodeAuthenticationForSentinel(boolean useDataNodeAuthenticationForSentinel);
-
-		/**
-		 * Use the {@link #getDataNodePassword() RedisPassword} also for authentication with Redis Sentinel.
-		 *
-		 * @return
-		 * @since 2.2.2
-		 */
-		boolean getUseDataNodeAuthenticationForSentinel();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -52,7 +52,6 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 
 	private RedisPassword dataNodePassword = RedisPassword.none();
 	private RedisPassword sentinelPassword = RedisPassword.none();
-	private boolean useDataNodePasswordForSentinel = false;
 
 	/**
 	 * Creates new {@link RedisSentinelConfiguration}.
@@ -253,47 +252,21 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithPassword#setSentinelPassword(org.springframework.data.redis.connection.RedisPassword)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.SentinelConfiguration#setSentinelPassword(org.springframework.data.redis.connection.RedisPassword)
 	 */
 	public void setSentinelPassword(RedisPassword sentinelPassword) {
 
-		Assert.state(!useDataNodePasswordForSentinel,
-				"Configuration uses Redis Data Node password for authenticating with Sentinel. Please set 'RedisSentinelConfiguration.useDataNodeAuthenticationForSentinel(false)' before using this option.");
 		Assert.notNull(sentinelPassword, "SentinelPassword must not be null!");
 		this.sentinelPassword = sentinelPassword;
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithPassword#setSentinelPassword()
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.SentinelConfiguration#setSentinelPassword()
 	 */
 	@Override
 	public RedisPassword getSentinelPassword() {
-		return getUseDataNodeAuthenticationForSentinel() ? this.dataNodePassword : sentinelPassword;
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithPassword#useDataNodeAuthenticationForSentinel(boolean)
-	 */
-	@Override
-	public void useDataNodeAuthenticationForSentinel(boolean useDataNodeAuthenticationForSentinel) {
-
-		if (useDataNodeAuthenticationForSentinel) {
-			Assert.state(!this.sentinelPassword.isPresent(),
-					"Configuration already defines a password for authenticating with Sentinel. Please use 'RedisSentinelConfiguration.setSentinelPassword(RedisPassword.none())' remove the password.");
-		}
-
-		this.useDataNodePasswordForSentinel = useDataNodeAuthenticationForSentinel;
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithPassword#getUseDataNodeAuthenticationForSentinel()
-	 */
-	@Override
-	public boolean getUseDataNodeAuthenticationForSentinel() {
-		return this.useDataNodePasswordForSentinel;
+		return sentinelPassword;
 	}
 
 	private RedisNode readHostAndPortFromString(String hostAndPort) {

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.redis.connection;
 
-import static org.springframework.util.Assert.*;
-import static org.springframework.util.Assert.hasText;
 import static org.springframework.util.StringUtils.*;
 
 import java.util.Collections;
@@ -46,11 +44,15 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 
 	private static final String REDIS_SENTINEL_MASTER_CONFIG_PROPERTY = "spring.redis.sentinel.master";
 	private static final String REDIS_SENTINEL_NODES_CONFIG_PROPERTY = "spring.redis.sentinel.nodes";
+	private static final String REDIS_SENTINEL_PASSWORD_CONFIG_PROPERTY = "spring.redis.sentinel.password";
 
 	private @Nullable NamedNode master;
 	private Set<RedisNode> sentinels;
 	private int database;
-	private RedisPassword password = RedisPassword.none();
+
+	private RedisPassword dataNodePassword = RedisPassword.none();
+	private RedisPassword sentinelPassword = RedisPassword.none();
+	private boolean useDataNodePasswordForSentinel = false;
 
 	/**
 	 * Creates new {@link RedisSentinelConfiguration}.
@@ -89,7 +91,7 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 	 */
 	public RedisSentinelConfiguration(PropertySource<?> propertySource) {
 
-		notNull(propertySource, "PropertySource must not be null!");
+		Assert.notNull(propertySource, "PropertySource must not be null!");
 
 		this.sentinels = new LinkedHashSet<>();
 
@@ -101,6 +103,10 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 			appendSentinels(
 					commaDelimitedListToSet(propertySource.getProperty(REDIS_SENTINEL_NODES_CONFIG_PROPERTY).toString()));
 		}
+
+		if (propertySource.containsProperty(REDIS_SENTINEL_PASSWORD_CONFIG_PROPERTY)) {
+			this.setSentinelPassword(propertySource.getProperty(REDIS_SENTINEL_PASSWORD_CONFIG_PROPERTY).toString());
+		}
 	}
 
 	/**
@@ -110,7 +116,7 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 	 */
 	public void setSentinels(Iterable<RedisNode> sentinels) {
 
-		notNull(sentinels, "Cannot set sentinels to 'null'.");
+		Assert.notNull(sentinels, "Cannot set sentinels to 'null'.");
 
 		this.sentinels.clear();
 
@@ -134,7 +140,7 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 	 */
 	public void addSentinel(RedisNode sentinel) {
 
-		notNull(sentinel, "Sentinel must not be 'null'.");
+		Assert.notNull(sentinel, "Sentinel must not be 'null'.");
 		this.sentinels.add(sentinel);
 	}
 
@@ -144,7 +150,7 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 	 */
 	public void setMaster(NamedNode master) {
 
-		notNull(master, "Sentinel master node must not be 'null'.");
+		Assert.notNull(master, "Sentinel master node must not be 'null'.");
 		this.master = master;
 	}
 
@@ -230,7 +236,7 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 	 */
 	@Override
 	public RedisPassword getPassword() {
-		return password;
+		return dataNodePassword;
 	}
 
 	/*
@@ -242,15 +248,60 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 
 		Assert.notNull(password, "RedisPassword must not be null!");
 
-		this.password = password;
+		this.dataNodePassword = password;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithPassword#setSentinelPassword(org.springframework.data.redis.connection.RedisPassword)
+	 */
+	public void setSentinelPassword(RedisPassword sentinelPassword) {
+
+		Assert.state(!useDataNodePasswordForSentinel,
+				"Configuration uses Redis Data Node password for authenticating with Sentinel. Please set 'RedisSentinelConfiguration.useDataNodeAuthenticationForSentinel(false)' before using this option.");
+		Assert.notNull(sentinelPassword, "SentinelPassword must not be null!");
+		this.sentinelPassword = sentinelPassword;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithPassword#setSentinelPassword()
+	 */
+	@Override
+	public RedisPassword getSentinelPassword() {
+		return getUseDataNodeAuthenticationForSentinel() ? this.dataNodePassword : sentinelPassword;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithPassword#useDataNodeAuthenticationForSentinel(boolean)
+	 */
+	@Override
+	public void useDataNodeAuthenticationForSentinel(boolean useDataNodeAuthenticationForSentinel) {
+
+		if (useDataNodeAuthenticationForSentinel) {
+			Assert.state(!this.sentinelPassword.isPresent(),
+					"Configuration already defines a password for authenticating with Sentinel. Please use 'RedisSentinelConfiguration.setSentinelPassword(RedisPassword.none())' remove the password.");
+		}
+
+		this.useDataNodePasswordForSentinel = useDataNodeAuthenticationForSentinel;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithPassword#getUseDataNodeAuthenticationForSentinel()
+	 */
+	@Override
+	public boolean getUseDataNodeAuthenticationForSentinel() {
+		return this.useDataNodePasswordForSentinel;
 	}
 
 	private RedisNode readHostAndPortFromString(String hostAndPort) {
 
 		String[] args = split(hostAndPort, ":");
 
-		notNull(args, "HostAndPort need to be seperated by  ':'.");
-		isTrue(args.length == 2, "Host and Port String needs to specified as host:port");
+		Assert.notNull(args, "HostAndPort need to be seperated by  ':'.");
+		Assert.isTrue(args.length == 2, "Host and Port String needs to specified as host:port");
 		return new RedisNode(args[0], Integer.valueOf(args[1]).intValue());
 	}
 
@@ -261,8 +312,8 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 	 */
 	private static Map<String, Object> asMap(String master, Set<String> sentinelHostAndPorts) {
 
-		hasText(master, "Master address must not be null or empty!");
-		notNull(sentinelHostAndPorts, "SentinelHostAndPorts must not be null!");
+		Assert.hasText(master, "Master address must not be null or empty!");
+		Assert.notNull(sentinelHostAndPorts, "SentinelHostAndPorts must not be null!");
 
 		Map<String, Object> map = new HashMap<>();
 		map.put(REDIS_SENTINEL_MASTER_CONFIG_PROPERTY, master);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -1080,7 +1080,6 @@ public class LettuceConnectionFactory
 
 		applyToAll(redisUri, it -> {
 
-			getRedisPassword().toOptional().ifPresent(it::setPassword);
 			clientConfiguration.getClientName().ifPresent(it::setClientName);
 
 			it.setSsl(clientConfiguration.isUseSsl());

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -640,22 +640,24 @@ abstract public class LettuceConverters extends Converters {
 		Assert.notNull(sentinelConfiguration, "RedisSentinelConfiguration is required");
 
 		Set<RedisNode> sentinels = sentinelConfiguration.getSentinels();
+		RedisPassword sentinelPassword = sentinelConfiguration.getSentinelPassword();
 		RedisURI.Builder builder = RedisURI.builder();
 		for (RedisNode sentinel : sentinels) {
 
-			RedisURI.Builder uri = RedisURI.Builder.sentinel(sentinel.getHost(), sentinel.getPort(),
-					sentinelConfiguration.getMaster().getName());
+			RedisURI.Builder sentinelBuilder = RedisURI.Builder.redis(sentinel.getHost(), sentinel.getPort());
 
-			if (sentinelConfiguration.getSentinelPassword().isPresent()) {
-				uri.withPassword(sentinelConfiguration.getSentinelPassword().get());
+			if (sentinelPassword.isPresent()) {
+				sentinelBuilder.withPassword(sentinelPassword.get());
 			}
-			builder.withSentinel(uri.build());
+			builder.withSentinel(sentinelBuilder.build());
 		}
 
 		RedisPassword password = sentinelConfiguration.getPassword();
 		if (password.isPresent()) {
 			builder.withPassword(password.get());
 		}
+
+		builder.withSentinelMasterId(sentinelConfiguration.getMaster().getName());
 
 		return builder.build();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/RedisSentinelConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisSentinelConfigurationUnitTests.java
@@ -121,41 +121,6 @@ public class RedisSentinelConfigurationUnitTests {
 	}
 
 	@Test // DATAREDIS-1060
-	public void throwsExceptionOnSentinelPasswordAlreadySetWhenTryingToReuseDataNodePassword() {
-
-		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration("myMaster",
-				Collections.singleton(HOST_AND_PORT_1));
-		configuration.setSentinelPassword(RedisPassword.of("so-secret-you'll-never-guess-123"));
-
-		assertThatExceptionOfType(IllegalStateException.class)
-				.isThrownBy(() -> configuration.useDataNodeAuthenticationForSentinel(true));
-	}
-
-	@Test // DATAREDIS-1060
-	public void throwsExceptionOnSettingSentinelPasswordWhenAlreadyReusingDataNodePassword() {
-
-		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration("myMaster",
-				Collections.singleton(HOST_AND_PORT_1));
-		configuration.setPassword(RedisPassword.of("qwerty"));
-		configuration.useDataNodeAuthenticationForSentinel(true);
-
-		assertThatExceptionOfType(IllegalStateException.class)
-				.isThrownBy(() -> configuration.setSentinelPassword(RedisPassword.of("who-needs-security-anyway")));
-	}
-
-	@Test // DATAREDIS-1060
-	public void settingSentinelPasswordReturnsDataNodePasswordIfUseDataNodeAuthIsTrue() {
-
-		RedisPassword password = RedisPassword.of("monkey-dragon->yeah-getting-better-combining-trivial-ones");
-		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration("myMaster",
-				Collections.singleton(HOST_AND_PORT_1));
-		configuration.setPassword(password);
-		configuration.useDataNodeAuthenticationForSentinel(true);
-
-		assertThat(configuration.getSentinelPassword()).isEqualTo(password);
-	}
-
-	@Test // DATAREDIS-1060
 	public void dataNodePasswordDoesNotAffectSentinelPassword() {
 
 		RedisPassword password = RedisPassword.of("88888888-8x8-getting-creative-now");
@@ -177,7 +142,6 @@ public class RedisSentinelConfigurationUnitTests {
 		RedisSentinelConfiguration config = new RedisSentinelConfiguration(propertySource);
 
 		assertThat(config.getSentinelPassword()).isEqualTo(RedisPassword.of("computer-says-no"));
-		assertThat(config.getSentinels().size()).isEqualTo(1);
-		assertThat(config.getSentinels()).contains(new RedisNode("127.0.0.1", 123));
+		assertThat(config.getSentinels()).hasSize(1).contains(new RedisNode("127.0.0.1", 123));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/RedisSentinelConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisSentinelConfigurationUnitTests.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import org.junit.Test;
-
 import org.springframework.core.env.PropertySource;
 import org.springframework.mock.env.MockPropertySource;
 import org.springframework.util.StringUtils;
@@ -51,8 +50,7 @@ public class RedisSentinelConfigurationUnitTests {
 	public void shouldCreateRedisSentinelConfigurationCorrectlyGivenMasterAndMultipleHostAndPortStrings() {
 
 		RedisSentinelConfiguration config = new RedisSentinelConfiguration("mymaster",
-				new HashSet<>(Arrays.asList(
-				HOST_AND_PORT_1, HOST_AND_PORT_2, HOST_AND_PORT_3)));
+				new HashSet<>(Arrays.asList(HOST_AND_PORT_1, HOST_AND_PORT_2, HOST_AND_PORT_3)));
 
 		assertThat(config.getSentinels().size()).isEqualTo(3);
 		assertThat(config.getSentinels()).contains(new RedisNode("127.0.0.1", 123), new RedisNode("localhost", 456),
@@ -120,5 +118,66 @@ public class RedisSentinelConfigurationUnitTests {
 		assertThat(config.getSentinels().size()).isEqualTo(3);
 		assertThat(config.getSentinels()).contains(new RedisNode("127.0.0.1", 123), new RedisNode("localhost", 456),
 				new RedisNode("localhost", 789));
+	}
+
+	@Test // DATAREDIS-1060
+	public void throwsExceptionOnSentinelPasswordAlreadySetWhenTryingToReuseDataNodePassword() {
+
+		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration("myMaster",
+				Collections.singleton(HOST_AND_PORT_1));
+		configuration.setSentinelPassword(RedisPassword.of("so-secret-you'll-never-guess-123"));
+
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> configuration.useDataNodeAuthenticationForSentinel(true));
+	}
+
+	@Test // DATAREDIS-1060
+	public void throwsExceptionOnSettingSentinelPasswordWhenAlreadyReusingDataNodePassword() {
+
+		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration("myMaster",
+				Collections.singleton(HOST_AND_PORT_1));
+		configuration.setPassword(RedisPassword.of("qwerty"));
+		configuration.useDataNodeAuthenticationForSentinel(true);
+
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> configuration.setSentinelPassword(RedisPassword.of("who-needs-security-anyway")));
+	}
+
+	@Test // DATAREDIS-1060
+	public void settingSentinelPasswordReturnsDataNodePasswordIfUseDataNodeAuthIsTrue() {
+
+		RedisPassword password = RedisPassword.of("monkey-dragon->yeah-getting-better-combining-trivial-ones");
+		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration("myMaster",
+				Collections.singleton(HOST_AND_PORT_1));
+		configuration.setPassword(password);
+		configuration.useDataNodeAuthenticationForSentinel(true);
+
+		assertThat(configuration.getSentinelPassword()).isEqualTo(password);
+	}
+
+	@Test // DATAREDIS-1060
+	public void dataNodePasswordDoesNotAffectSentinelPassword() {
+
+		RedisPassword password = RedisPassword.of("88888888-8x8-getting-creative-now");
+		RedisSentinelConfiguration configuration = new RedisSentinelConfiguration("myMaster",
+				Collections.singleton(HOST_AND_PORT_1));
+		configuration.setPassword(password);
+
+		assertThat(configuration.getSentinelPassword()).isEqualTo(RedisPassword.none());
+	}
+
+	@Test // DATAREDIS-1060
+	public void readSentinelPasswordFromConfigProperty() {
+
+		MockPropertySource propertySource = new MockPropertySource();
+		propertySource.setProperty("spring.redis.sentinel.master", "myMaster");
+		propertySource.setProperty("spring.redis.sentinel.nodes", HOST_AND_PORT_1);
+		propertySource.setProperty("spring.redis.sentinel.password", "computer-says-no");
+
+		RedisSentinelConfiguration config = new RedisSentinelConfiguration(propertySource);
+
+		assertThat(config.getSentinelPassword()).isEqualTo(RedisPassword.of("computer-says-no"));
+		assertThat(config.getSentinels().size()).isEqualTo(1);
+		assertThat(config.getSentinels()).contains(new RedisNode("127.0.0.1", 123));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -225,30 +225,6 @@ public class LettuceConnectionFactoryUnitTests {
 	}
 
 	@Test // DATAREDIS-1060
-	public void redisPasswordShouldBeSetOnSentinelClientIfItShouldBeReused() {
-
-		RedisSentinelConfiguration config = new RedisSentinelConfiguration("mymaster", Collections.singleton("host:1234"));
-		config.useDataNodeAuthenticationForSentinel(true);
-
-		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(config);
-		connectionFactory.setClientResources(getSharedClientResources());
-		connectionFactory.setPassword("o_O");
-		connectionFactory.afterPropertiesSet();
-		ConnectionFactoryTracker.add(connectionFactory);
-
-		AbstractRedisClient client = (AbstractRedisClient) getField(connectionFactory, "client");
-		assertThat(client).isInstanceOf(RedisClient.class);
-
-		RedisURI redisUri = (RedisURI) getField(client, "redisURI");
-
-		assertThat(redisUri.getPassword()).isEqualTo(connectionFactory.getPassword().toCharArray());
-
-		for (RedisURI sentinel : redisUri.getSentinels()) {
-			assertThat(sentinel.getPassword()).isEqualTo("o_O".toCharArray());
-		}
-	}
-
-	@Test // DATAREDIS-1060
 	public void sentinelPasswordShouldNotLeakIntoDataNodeClient() {
 
 		RedisSentinelConfiguration config = new RedisSentinelConfiguration("mymaster", Collections.singleton("host:1234"));


### PR DESCRIPTION
Instead we now offer a dedicated property for authenticating with Sentinel.

However providing authentication for Sentinel only works using Lettuce until xetorthio/jedis#1943 is resolved.