### PR TITLE
[DATAREDIS-1062] :  Disable select  dbIndex in case dbIndex is 0

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -975,9 +975,12 @@ public class LettuceConnection extends AbstractRedisConnection {
 		if (asyncDedicatedConn == null) {
 
 			asyncDedicatedConn = doGetAsyncDedicatedConnection();
-
-			if (asyncDedicatedConn instanceof StatefulRedisConnection) {
+			
+			if (asyncDedicatedConn instanceof StatefulRedisConnection && dbIndex > 0) {
 				((StatefulRedisConnection<byte[], byte[]>) asyncDedicatedConn).sync().select(dbIndex);
+			}
+			else if (asyncDedicatedConn instanceof StatefulRedisConnection) {
+				((StatefulRedisConnection<byte[], byte[]>) asyncDedicatedConn).sync();
 			}
 		}
 


### PR DESCRIPTION
https://jira.spring.io/browse/DATAREDIS-1062

When shareNativeConnection was set to false and enabled connection pooling before executing each redis command, select dbIndex command was executed. this is un-necessary call. since my application was configured to use single database and i don't want to select a database every time.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
