### PR TITLE
Support cache manager extensions

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
@@ -47,10 +47,10 @@ import org.springframework.util.Assert;
  */
 public class RedisCacheManager extends AbstractTransactionSupportingCacheManager {
 
-	private final RedisCacheWriter cacheWriter;
-	private final RedisCacheConfiguration defaultCacheConfig;
-	private final Map<String, RedisCacheConfiguration> initialCacheConfiguration;
-	private final boolean allowInFlightCacheCreation;
+	protected final RedisCacheWriter cacheWriter;
+	protected final RedisCacheConfiguration defaultCacheConfig;
+	protected final Map<String, RedisCacheConfiguration> initialCacheConfiguration;
+	protected final boolean allowInFlightCacheCreation;
 
 	/**
 	 * Creates new {@link RedisCacheManager} using given {@link RedisCacheWriter} and default
@@ -278,13 +278,13 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 	 */
 	public static class RedisCacheManagerBuilder {
 
-		private final RedisCacheWriter cacheWriter;
-		private RedisCacheConfiguration defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig();
-		private final Map<String, RedisCacheConfiguration> initialCaches = new LinkedHashMap<>();
-		private boolean enableTransactions;
-		boolean allowInFlightCacheCreation = true;
+	    protected final RedisCacheWriter cacheWriter;
+	    protected RedisCacheConfiguration defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig();
+	    protected final Map<String, RedisCacheConfiguration> initialCaches = new LinkedHashMap<>();
+	    protected boolean enableTransactions;
+	    protected allowInFlightCacheCreation = true;
 
-		private RedisCacheManagerBuilder(RedisCacheWriter cacheWriter) {
+	    protected RedisCacheManagerBuilder(RedisCacheWriter cacheWriter) {
 			this.cacheWriter = cacheWriter;
 		}
 

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
@@ -278,11 +278,12 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 	 */
 	public static class RedisCacheManagerBuilder {
 
-	    protected final RedisCacheWriter cacheWriter;
-	    protected RedisCacheConfiguration defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig();
-	    protected final Map<String, RedisCacheConfiguration> initialCaches = new LinkedHashMap<>();
-	    protected boolean enableTransactions;
-	    protected allowInFlightCacheCreation = true;
+		protected final RedisCacheWriter cacheWriter;
+		protected RedisCacheConfiguration defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig();
+		protected final Map<String, RedisCacheConfiguration> initialCaches = new LinkedHashMap<>();
+		protected boolean enableTransactions;
+
+		protected allowInFlightCacheCreation = true;
 
 	    protected RedisCacheManagerBuilder(RedisCacheWriter cacheWriter) {
 			this.cacheWriter = cacheWriter;


### PR DESCRIPTION
I am trying to implement a wrapper/subclass around the Redis Cache functionality to support a circuit breaker to be able to bypass the cache when the circuit is open. I have code ready and tested, but cannot use my custom cache manager in other code unless some fields are protected instead of private.

https://github.com/gee4vee/circuit-breaker-redis-cache

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
