### PR TITLE
DATAREDIS-611 - Add overloads accepting Duration and Instant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-611-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/BoundKeyOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundKeyOperations.java
@@ -15,11 +15,14 @@
  */
 package org.springframework.data.redis.core;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * Operations over a Redis key. Useful for executing common key-'bound' operations to all implementations.
@@ -60,6 +63,22 @@ public interface BoundKeyOperations<K> {
 	/**
 	 * Sets the key time-to-live/expiration.
 	 *
+	 * @param timeout must not be {@literal null}.
+	 * @return true if expiration was set, false otherwise. {@literal null} when used in pipeline / transaction.
+	 * @since 2.3
+	 */
+	@Nullable
+	default Boolean expire(Duration timeout) {
+
+		Assert.notNull(timeout, "Timeout must not be null");
+		Assert.isTrue(!timeout.isNegative(), "Timeout must not be negative");
+
+		return expire(timeout.toMillis(), TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Sets the key time-to-live/expiration.
+	 *
 	 * @param timeout expiration value
 	 * @param unit expiration unit
 	 * @return true if expiration was set, false otherwise. {@literal null} when used in pipeline / transaction.
@@ -75,6 +94,21 @@ public interface BoundKeyOperations<K> {
 	 */
 	@Nullable
 	Boolean expireAt(Date date);
+
+	/**
+	 * Sets the key time-to-live/expiration.
+	 *
+	 * @param time expiration time.
+	 * @return true if expiration was set, false otherwise. {@literal null} when used in pipeline / transaction.
+	 * @since 2.3
+	 */
+	@Nullable
+	default Boolean expireAt(Instant expireAt) {
+
+		Assert.notNull(expireAt, "Timestamp must not be null");
+
+		return expireAt(Date.from(expireAt));
+	}
 
 	/**
 	 * Removes the expiration (if any) of the key.

--- a/src/main/java/org/springframework/data/redis/core/BoundListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundListOperations.java
@@ -15,10 +15,12 @@
  */
 package org.springframework.data.redis.core;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * List operations bound to a certain key.
@@ -189,6 +191,24 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	V leftPop(long timeout, TimeUnit unit);
 
 	/**
+	 * Removes and returns first element from lists stored at the bound key . <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param timeout must not be {@literal null}.
+	 * @return {@literal null} when timeout reached or used in pipeline / transaction.
+	 * @since 2.3
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 */
+	@Nullable
+	default V leftPop(Duration timeout) {
+
+		Assert.notNull(timeout, "Timeout must not be null");
+		Assert.isTrue(!timeout.isNegative(), "Timeout must not be negative");
+
+		return leftPop(TimeoutUtils.toSeconds(timeout), TimeUnit.SECONDS);
+	}
+
+	/**
 	 * Removes and returns last element in list stored at the bound key.
 	 *
 	 * @return {@literal null} when used in pipeline / transaction.
@@ -208,6 +228,24 @@ public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 	 */
 	@Nullable
 	V rightPop(long timeout, TimeUnit unit);
+
+	/**
+	 * Removes and returns last element from lists stored at the bound key. <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param timeout must not be {@literal null}.
+	 * @return {@literal null} when timeout reached or used in pipeline / transaction.
+	 * @since 2.3
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 */
+	@Nullable
+	default V rightPop(Duration timeout) {
+
+		Assert.notNull(timeout, "Timeout must not be null");
+		Assert.isTrue(!timeout.isNegative(), "Timeout must not be negative");
+
+		return rightPop(TimeoutUtils.toSeconds(timeout), TimeUnit.SECONDS);
+	}
 
 	RedisOperations<K, V> getOperations();
 }

--- a/src/main/java/org/springframework/data/redis/core/ListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ListOperations.java
@@ -15,11 +15,13 @@
  */
 package org.springframework.data.redis.core;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * Redis list specific operations.
@@ -235,6 +237,25 @@ public interface ListOperations<K, V> {
 	V leftPop(K key, long timeout, TimeUnit unit);
 
 	/**
+	 * Removes and returns first element from lists stored at {@code key} . <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param timeout must not be {@literal null}.
+	 * @return can be {@literal null}.
+	 * @since 2.3
+	 * @see <a href="https://redis.io/commands/blpop">Redis Documentation: BLPOP</a>
+	 */
+	@Nullable
+	default V leftPop(K key, Duration timeout) {
+
+		Assert.notNull(timeout, "Timeout must not be null");
+		Assert.isTrue(!timeout.isNegative(), "Timeout must not be negative");
+
+		return leftPop(key, TimeoutUtils.toSeconds(timeout), TimeUnit.SECONDS);
+	}
+
+	/**
 	 * Removes and returns last element in list stored at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
@@ -256,6 +277,25 @@ public interface ListOperations<K, V> {
 	 */
 	@Nullable
 	V rightPop(K key, long timeout, TimeUnit unit);
+
+	/**
+	 * Removes and returns last element from lists stored at {@code key}. <br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param timeout must not be {@literal null}.
+	 * @return can be {@literal null}.
+	 * @since 2.3
+	 * @see <a href="https://redis.io/commands/brpop">Redis Documentation: BRPOP</a>
+	 */
+	@Nullable
+	default V rightPop(K key, Duration timeout) {
+
+		Assert.notNull(timeout, "Timeout must not be null");
+		Assert.isTrue(!timeout.isNegative(), "Timeout must not be negative");
+
+		return rightPop(key, TimeoutUtils.toSeconds(timeout), TimeUnit.SECONDS);
+	}
 
 	/**
 	 * Remove the last element from list at {@code sourceKey}, append it to {@code destinationKey} and return its value.
@@ -281,6 +321,26 @@ public interface ListOperations<K, V> {
 	 */
 	@Nullable
 	V rightPopAndLeftPush(K sourceKey, K destinationKey, long timeout, TimeUnit unit);
+
+	/**
+	 * Remove the last element from list at {@code srcKey}, append it to {@code dstKey} and return its value.<br>
+	 * <b>Blocks connection</b> until element available or {@code timeout} reached.
+	 *
+	 * @param sourceKey must not be {@literal null}.
+	 * @param destinationKey must not be {@literal null}.
+	 * @param timeout must not be {@literal null}.
+	 * @return can be {@literal null}.
+	 * @since 2.3
+	 * @see <a href="https://redis.io/commands/brpoplpush">Redis Documentation: BRPOPLPUSH</a>
+	 */
+	@Nullable
+	default V rightPopAndLeftPush(K sourceKey, K destinationKey, Duration timeout) {
+
+		Assert.notNull(timeout, "Timeout must not be null");
+		Assert.isTrue(!timeout.isNegative(), "Timeout must not be negative");
+
+		return rightPopAndLeftPush(sourceKey, destinationKey, TimeoutUtils.toSeconds(timeout), TimeUnit.SECONDS);
+	}
 
 	RedisOperations<K, V> getOperations();
 }

--- a/src/main/java/org/springframework/data/redis/core/TimeoutUtils.java
+++ b/src/main/java/org/springframework/data/redis/core/TimeoutUtils.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
  * @author Mark Paluch
  * @author Christoph Strobl
  */
-abstract public class TimeoutUtils {
+public abstract class TimeoutUtils {
 
 	/**
 	 * Check if a given Duration can be represented in {@code sec} or requires {@code msec} representation.
@@ -36,6 +36,20 @@ abstract public class TimeoutUtils {
 	 */
 	public static boolean hasMillis(Duration duration) {
 		return duration.toMillis() % 1000 != 0;
+	}
+
+	/**
+	 * Converts the given timeout to seconds.
+	 * <p>
+	 * Since a 0 timeout blocks some Redis ops indefinitely, this method will return 1 if the original value is greater
+	 * than 0 but is truncated to 0 on conversion.
+	 *
+	 * @param duration The duration to convert
+	 * @return The converted timeout
+	 * @since 2.3
+	 */
+	public static long toSeconds(Duration duration) {
+		return roundUpIfNecessary(duration.toMillis(), duration.getSeconds());
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/DefaultListOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultListOperationsTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.core;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assume.*;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,6 +35,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.ObjectFactory;
 import org.springframework.data.redis.RedisTestProfileValueSource;
+import org.springframework.data.redis.StringObjectFactory;
 
 /**
  * Integration test of {@link DefaultListOperations}
@@ -130,9 +132,40 @@ public class DefaultListOperationsTests<K, V> {
 	}
 
 	@Test
+	public void testLeftPopDuration() {
+		// 1 ms timeout gets upgraded to 1 sec timeout at the moment
+		assumeTrue(RedisTestProfileValueSource.matches("runLongTests", "true"));
+		assumeTrue(valueFactory instanceof StringObjectFactory);
+
+		K key = keyFactory.instance();
+		V v1 = valueFactory.instance();
+		V v2 = valueFactory.instance();
+
+		assertThat(listOps.leftPop(key, Duration.ofSeconds(1))).isNull();
+		listOps.rightPushAll(key, v1, v2);
+		assertThat(listOps.leftPop(key, Duration.ofSeconds(1))).isEqualTo(v1);
+	}
+
+	@Test
+	public void testRightPopDuration() {
+		// 1 ms timeout gets upgraded to 1 sec timeout at the moment
+		assumeTrue(RedisTestProfileValueSource.matches("runLongTests", "true"));
+		assumeTrue(valueFactory instanceof StringObjectFactory);
+
+		K key = keyFactory.instance();
+		V v1 = valueFactory.instance();
+		V v2 = valueFactory.instance();
+
+		assertThat(listOps.rightPop(key, Duration.ofSeconds(1))).isNull();
+		listOps.rightPushAll(key, v1, v2);
+		assertThat(listOps.rightPop(key, Duration.ofSeconds(1))).isEqualTo(v2);
+	}
+
+	@Test
 	public void testRightPopAndLeftPushTimeout() {
 		// 1 ms timeout gets upgraded to 1 sec timeout at the moment
 		assumeTrue(RedisTestProfileValueSource.matches("runLongTests", "true"));
+		assumeTrue(valueFactory instanceof StringObjectFactory);
 
 		K key = keyFactory.instance();
 		K key2 = keyFactory.instance();
@@ -141,6 +174,21 @@ public class DefaultListOperationsTests<K, V> {
 		assertThat(listOps.rightPopAndLeftPush(key, key2, 1, TimeUnit.MILLISECONDS)).isNull();
 		listOps.leftPush(key, v1);
 		assertThat(listOps.rightPopAndLeftPush(key, key2, 1, TimeUnit.MILLISECONDS)).isEqualTo(v1);
+	}
+
+	@Test // DATAREDIS-611
+	public void testRightPopAndLeftPushDuration() {
+		// 1 ms timeout gets upgraded to 1 sec timeout at the moment
+		assumeTrue(RedisTestProfileValueSource.matches("runLongTests", "true"));
+		assumeTrue(valueFactory instanceof StringObjectFactory);
+
+		K key = keyFactory.instance();
+		K key2 = keyFactory.instance();
+		V v1 = valueFactory.instance();
+
+		assertThat(listOps.rightPopAndLeftPush(key, key2, Duration.ofMillis(1))).isNull();
+		listOps.leftPush(key, v1);
+		assertThat(listOps.rightPopAndLeftPush(key, key2, Duration.ofMillis(1))).isEqualTo(v1);
 	}
 
 	@Test


### PR DESCRIPTION
We revised our imperative Template API by accepting `Duration` and `Instant` types in addition to methods accepting timeout/`TimeUnit` respective `Date`.

---

Related ticket: [DATAREDIS-611](https://jira.spring.io/browse/DATAREDIS-611).