### PR TITLE
Fix comment on ZSetOperations.reverseRangeByScore()

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -225,7 +225,7 @@ public interface ZSetOperations<K, V> {
 	 * @param min
 	 * @param max
 	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="https://redis.io/commands/zrevrange">Redis Documentation: ZREVRANGE</a>
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
 	 */
 	@Nullable
 	Set<V> reverseRangeByScore(K key, double min, double max);


### PR DESCRIPTION
DATAREDIS-1070 - Fix incorrect comments.

ZSetOperations.reverseRangeByScore corresponds to redis command zrevrangebyscore instead of zrevrange.