### PR TITLE
DATAREDIS-1041 - Introduce RedisCache configuration option prefixCacheNameWith.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1041-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/cache/CacheKeyPrefix.java
+++ b/src/main/java/org/springframework/data/redis/cache/CacheKeyPrefix.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.cache;
 
+import org.springframework.util.Assert;
+
 /**
  * {@link CacheKeyPrefix} provides a hook for creating custom prefixes prepended to the actual {@literal key} stored in
  * Redis.
@@ -25,6 +27,13 @@ package org.springframework.data.redis.cache;
  */
 @FunctionalInterface
 public interface CacheKeyPrefix {
+
+	/**
+	 * Default separator.
+	 * 
+	 * @since 2.3
+	 */
+	String SEPARATOR = "::";
 
 	/**
 	 * Compute the prefix for the actual {@literal key} stored in Redis.
@@ -41,6 +50,21 @@ public interface CacheKeyPrefix {
 	 * @return the default {@link CacheKeyPrefix} scheme.
 	 */
 	static CacheKeyPrefix simple() {
-		return name -> name + "::";
+		return name -> name + SEPARATOR;
+	}
+
+	/**
+	 * Creates a {@link CacheKeyPrefix} scheme that prefixes cache keys with the given {@code prefix} prepended to the
+	 * {@code cacheName} followed by double colons. A cache named {@code myCache} with prefix {@code redis-} will result
+	 * in {@code redis-myCache::}.
+	 *
+	 * @param prefix must not be {@literal null}.
+	 * @return the default {@link CacheKeyPrefix} scheme.
+	 * @since 2.3
+	 */
+	static CacheKeyPrefix prefixed(String prefix) {
+
+		Assert.notNull(prefix, "Prefix must not be null!");
+		return name -> prefix + name + SEPARATOR;
 	}
 }

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheConfiguration.java
@@ -144,16 +144,35 @@ public class RedisCacheConfiguration {
 	}
 
 	/**
-	 * Use the given prefix instead of the default one.
+	 * Use the given prefix instead of the default one. <br />
+	 * This option overrides the default cache name and is not recommended. {@link #prefixCacheNameWith(String)} or
+	 * {@link #computePrefixWith(CacheKeyPrefix)}. <br />
+	 * The generated cache key will be: {@code prefix + cache entry key}.
 	 *
 	 * @param prefix must not be {@literal null}.
 	 * @return new {@link RedisCacheConfiguration}.
+	 * @deprecated since 2.3. Use {@link #prefixCacheNameWith(String)} or {@link #computePrefixWith(CacheKeyPrefix)} instead.
 	 */
+	@Deprecated
 	public RedisCacheConfiguration prefixKeysWith(String prefix) {
 
 		Assert.notNull(prefix, "Prefix must not be null!");
 
 		return computePrefixWith((cacheName) -> prefix);
+	}
+
+	/**
+	 * Prefix the {@link RedisCache#getName() cache name} with the given value. <br />
+	 * The generated cache key will be: {@code prefix + cache name + "::" + cache entry key}.
+	 *
+	 * @param prefix the prefix to prepend to the cache name.
+	 * @return this.
+	 * @see #computePrefixWith(CacheKeyPrefix)
+	 * @see CacheKeyPrefix#prefixed(String)
+	 * @since 2.3
+	 */
+	public RedisCacheConfiguration prefixCacheNameWith(String prefix) {
+		return computePrefixWith(CacheKeyPrefix.prefixed(prefix));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheTests.java
@@ -287,6 +287,22 @@ public class RedisCacheTests {
 		});
 	}
 
+	@Test // DATAREDIS-1041
+	public void prefixCacheNameCreatesCacheKeyCorrectly() {
+
+		RedisCache cacheWithCustomPrefix = new RedisCache("cache", new DefaultRedisCacheWriter(connectionFactory),
+				RedisCacheConfiguration.defaultCacheConfig().serializeValuesWith(SerializationPair.fromSerializer(serializer))
+						.prefixCacheNameWith("redis::"));
+
+		cacheWithCustomPrefix.put("key-1", sample);
+
+		doWithConnection(connection -> {
+
+			assertThat(connection.stringCommands().get("redis::cache::key-1".getBytes(StandardCharsets.UTF_8)))
+					.isEqualTo(binarySample);
+		});
+	}
+
 	@Test // DATAREDIS-715
 	public void fetchKeyWithComputedPrefixReturnsExpectedResult() {
 


### PR DESCRIPTION
`prefixCacheNameWith` allows to prefix the cache name, still sicking to the default `CacheKeyPrefix.simple()` format.