### PR TITLE
DATAREDIS-1095 - Use Flux.usingWhen(…) in DefaultReactiveScriptExecutor.execute(…)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1095-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
@@ -17,7 +17,6 @@ package org.springframework.data.redis.core;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.lang.reflect.Proxy;
 import java.nio.ByteBuffer;
@@ -205,7 +204,7 @@ public class ReactiveRedisTemplate<K, V> implements ReactiveRedisOperations<K, V
 
 			return postProcessResult(result, conn, false);
 
-		}, ReactiveRedisConnection::closeLater, ReactiveRedisConnection::closeLater);
+		}, ReactiveRedisConnection::closeLater);
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutorUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.core.script;
 import static org.mockito.Mockito.*;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.nio.ByteBuffer;
@@ -37,6 +38,8 @@ import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 
 /**
+ * Unit tests for {@link DefaultReactiveScriptExecutor}.
+ *
  * @author Mark Paluch
  * @author Christoph Strobl
  */
@@ -56,6 +59,7 @@ public class DefaultReactiveScriptExecutorUnitTests {
 
 		when(connectionFactoryMock.getReactiveConnection()).thenReturn(connectionMock);
 		when(connectionMock.scriptingCommands()).thenReturn(scriptingCommandsMock);
+		when(connectionMock.closeLater()).thenReturn(Mono.empty());
 
 		executor = new DefaultReactiveScriptExecutor<>(connectionFactoryMock, RedisSerializationContext.string());
 	}
@@ -108,7 +112,8 @@ public class DefaultReactiveScriptExecutorUnitTests {
 
 		StepVerifier.create(execute).expectNext("FOO").verifyComplete();
 
-		verify(connectionMock).close();
+		verify(connectionMock).closeLater();
+		verify(connectionMock, never()).close();
 	}
 
 	@Test // DATAREDIS-683
@@ -119,7 +124,8 @@ public class DefaultReactiveScriptExecutorUnitTests {
 
 		StepVerifier.create(executor.execute(SCRIPT)).expectError().verify();
 
-		verify(connectionMock).close();
+		verify(connectionMock).closeLater();
+		verify(connectionMock, never()).close();
 	}
 
 	@Test // DATAREDIS-683

--- a/src/test/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/script/DefaultReactiveScriptExecutorUnitTests.java
@@ -70,7 +70,7 @@ public class DefaultReactiveScriptExecutorUnitTests {
 		when(scriptingCommandsMock.evalSha(anyString(), any(ReturnType.class), anyInt()))
 				.thenReturn(Flux.just(ByteBuffer.wrap("FOO".getBytes())));
 
-		StepVerifier.create(executor.execute(SCRIPT)).expectNext("FOO").verifyComplete();
+		executor.execute(SCRIPT).as(StepVerifier::create).expectNext("FOO").verifyComplete();
 
 		verify(scriptingCommandsMock).evalSha(anyString(), any(ReturnType.class), anyInt());
 		verify(scriptingCommandsMock, never()).eval(any(), any(ReturnType.class), anyInt());
@@ -85,7 +85,7 @@ public class DefaultReactiveScriptExecutorUnitTests {
 		when(scriptingCommandsMock.eval(any(), any(ReturnType.class), anyInt()))
 				.thenReturn(Flux.just(ByteBuffer.wrap("FOO".getBytes())));
 
-		StepVerifier.create(executor.execute(SCRIPT)).expectNext("FOO").verifyComplete();
+		executor.execute(SCRIPT).as(StepVerifier::create).expectNext("FOO").verifyComplete();
 
 		verify(scriptingCommandsMock).evalSha(anyString(), any(ReturnType.class), anyInt());
 		verify(scriptingCommandsMock).eval(any(), any(ReturnType.class), anyInt());
@@ -97,7 +97,7 @@ public class DefaultReactiveScriptExecutorUnitTests {
 		when(scriptingCommandsMock.evalSha(anyString(), any(ReturnType.class), anyInt())).thenReturn(Flux
 				.error(new UnsupportedOperationException("NOSCRIPT No matching script. Please use EVAL.", new Exception())));
 
-		StepVerifier.create(executor.execute(SCRIPT)).expectError(UnsupportedOperationException.class).verify();
+		executor.execute(SCRIPT).as(StepVerifier::create).verifyError(UnsupportedOperationException.class);
 	}
 
 	@Test // DATAREDIS-683
@@ -110,7 +110,7 @@ public class DefaultReactiveScriptExecutorUnitTests {
 
 		verify(connectionMock, never()).close();
 
-		StepVerifier.create(execute).expectNext("FOO").verifyComplete();
+		execute.as(StepVerifier::create).expectNext("FOO").verifyComplete();
 
 		verify(connectionMock).closeLater();
 		verify(connectionMock, never()).close();
@@ -122,7 +122,7 @@ public class DefaultReactiveScriptExecutorUnitTests {
 		when(scriptingCommandsMock.evalSha(anyString(), any(ReturnType.class), anyInt()))
 				.thenReturn(Flux.error(new RuntimeException()));
 
-		StepVerifier.create(executor.execute(SCRIPT)).expectError().verify();
+		executor.execute(SCRIPT).as(StepVerifier::create).verifyError();
 
 		verify(connectionMock).closeLater();
 		verify(connectionMock, never()).close();
@@ -136,6 +136,7 @@ public class DefaultReactiveScriptExecutorUnitTests {
 		when(scriptingCommandsMock.evalSha(anyString(), any(ReturnType.class), anyInt()))
 				.thenReturn(Flux.just(returnValue));
 
-		StepVerifier.create(executor.execute(RedisScript.of("return KEYS[0]"))).expectNext(returnValue).verifyComplete();
+		executor.execute(RedisScript.of("return KEYS[0]")).as(StepVerifier::create).expectNext(returnValue)
+				.verifyComplete();
 	}
 }


### PR DESCRIPTION
We now consistently use `Flux.usingWhen(…)` to obtain and release Redis connections without blocking the calling thread.

---

Related ticket: [DATAREDIS-1095](https://jira.spring.io/browse/DATAREDIS-1095).