### PR TITLE
DATAREDIS-1096 - Move off deprecated Lettuce API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1096-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePool.java
@@ -21,6 +21,7 @@ import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.resource.ClientResources;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.pool2.BasePooledObjectFactory;
@@ -139,7 +140,7 @@ public class DefaultLettucePool implements LettucePool, InitializingBean {
 	}
 
 	private RedisURI createSimpleHostRedisURI() {
-		return RedisURI.Builder.redis(hostName, port).withTimeout(timeout, TimeUnit.MILLISECONDS).build();
+		return RedisURI.Builder.redis(hostName, port).withTimeout(Duration.ofMillis(timeout)).build();
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -18,9 +18,9 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.*;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode.NodeFlag;
-import io.lettuce.core.protocol.LettuceCharsets;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -452,7 +452,7 @@ abstract public class LettuceConverters extends Converters {
 			return args;
 		}
 		if (params.getByPattern() != null) {
-			args.by(new String(params.getByPattern(), LettuceCharsets.ASCII));
+			args.by(new String(params.getByPattern(), StandardCharsets.US_ASCII));
 		}
 		if (params.getLimit() != null) {
 			args.limit(params.getLimit().getStart(), params.getLimit().getCount());
@@ -460,7 +460,7 @@ abstract public class LettuceConverters extends Converters {
 		if (params.getGetPattern() != null) {
 			byte[][] pattern = params.getGetPattern();
 			for (byte[] bs : pattern) {
-				args.get(new String(bs, LettuceCharsets.ASCII));
+				args.get(new String(bs, StandardCharsets.US_ASCII));
 			}
 		}
 		if (params.getOrder() != null) {
@@ -602,8 +602,8 @@ abstract public class LettuceConverters extends Converters {
 						|| ObjectUtils.nullSafeEquals(value, "-")) {
 					return Range.Boundary.unbounded();
 				}
-				return inclusive ? Range.Boundary.including(value.toString().getBytes(LettuceCharsets.UTF8))
-						: Range.Boundary.excluding(value.toString().getBytes(LettuceCharsets.UTF8));
+				return inclusive ? Range.Boundary.including(value.toString().getBytes(StandardCharsets.UTF_8))
+						: Range.Boundary.excluding(value.toString().getBytes(StandardCharsets.UTF_8));
 			}
 
 			return inclusive ? Range.Boundary.including((byte[]) value) : Range.Boundary.excluding((byte[]) value);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
@@ -120,7 +120,7 @@ class LettuceReactiveStreamCommands implements ReactiveStreamCommands {
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public Flux<CommandResponse<GroupCommand, String>> xGroup(Publisher<GroupCommand> commands) {
 
 		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StandaloneConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StandaloneConnectionProvider.java
@@ -22,6 +22,8 @@ import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.masterreplica.MasterReplica;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 import io.lettuce.core.masterslave.MasterSlave;
 import io.lettuce.core.masterslave.StatefulRedisMasterSlaveConnection;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
@@ -156,8 +158,7 @@ class StandaloneConnectionProvider implements LettuceConnectionProvider, TargetA
 
 	private StatefulRedisConnection masterReplicaConnection(RedisURI redisUri, ReadFrom readFrom) {
 
-		// See https://github.com/lettuce-io/lettuce-core/issues/845 for MasterSlave -> MasterReplica change.
-		StatefulRedisMasterSlaveConnection<?, ?> connection = MasterSlave.connect(client, codec, redisUri);
+		StatefulRedisMasterReplicaConnection<?, ?> connection = MasterReplica.connect(client, codec, redisUri);
 		connection.setReadFrom(readFrom);
 
 		return connection;
@@ -166,7 +167,8 @@ class StandaloneConnectionProvider implements LettuceConnectionProvider, TargetA
 	private CompletionStage<StatefulRedisConnection<?, ?>> masterReplicaConnectionAsync(RedisURI redisUri,
 			ReadFrom readFrom) {
 
-		CompletableFuture<? extends StatefulRedisMasterSlaveConnection<?, ?>> connection = MasterSlave.connectAsync(client,
+		CompletableFuture<? extends StatefulRedisMasterReplicaConnection<?, ?>> connection = MasterReplica
+				.connectAsync(client,
 				codec, redisUri);
 
 		return connection.thenApply(conn -> {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StaticMasterReplicaConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StaticMasterReplicaConnectionProvider.java
@@ -20,8 +20,8 @@ import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.codec.RedisCodec;
-import io.lettuce.core.masterslave.MasterSlave;
-import io.lettuce.core.masterslave.StatefulRedisMasterSlaveConnection;
+import io.lettuce.core.masterreplica.MasterReplica;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -72,8 +72,7 @@ class StaticMasterReplicaConnectionProvider implements LettuceConnectionProvider
 
 		if (StatefulConnection.class.isAssignableFrom(connectionType)) {
 
-			// See https://github.com/lettuce-io/lettuce-core/issues/845 for MasterSlave -> MasterReplica change.
-			StatefulRedisMasterSlaveConnection<?, ?> connection = MasterSlave.connect(client, codec, nodes);
+			StatefulRedisMasterReplicaConnection<?, ?> connection = MasterReplica.connect(client, codec, nodes);
 			readFrom.ifPresent(connection::setReadFrom);
 
 			return connectionType.cast(connection);
@@ -91,8 +90,7 @@ class StaticMasterReplicaConnectionProvider implements LettuceConnectionProvider
 
 		if (StatefulConnection.class.isAssignableFrom(connectionType)) {
 
-			// See https://github.com/lettuce-io/lettuce-core/issues/845 for MasterSlave -> MasterReplica change.
-			CompletableFuture<? extends StatefulRedisMasterSlaveConnection<?, ?>> connection = MasterSlave
+			CompletableFuture<? extends StatefulRedisMasterReplicaConnection<?, ?>> connection = MasterReplica
 					.connectAsync(client, codec, nodes);
 
 			connection.thenApply(it -> {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StreamConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StreamConverters.java
@@ -64,7 +64,7 @@ class StreamConverters {
 
 		INSTANCE;
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.core.convert.converter.Converter#convert(java.lang.Object)
 		 */

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -111,7 +111,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 	public void setUp() {
 
 		client = RedisClusterClient.create(LettuceTestClientResources.getSharedClientResources(),
-				Builder.redis(CLUSTER_HOST, MASTER_NODE_1_PORT).withTimeout(500, TimeUnit.MILLISECONDS).build());
+				Builder.redis(CLUSTER_HOST, MASTER_NODE_1_PORT).withTimeout(Duration.ofMillis(500)).build());
 		nativeConnection = client.connect().sync();
 		binaryConnection = client.connect(ByteArrayCodec.INSTANCE).sync();
 		clusterConnection = new LettuceClusterConnection(client);


### PR DESCRIPTION
We don't require a backport for this one.