### PR TITLE
DATAREDIS-1084 - Add support for XPENDING & XCLAIM. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1084-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -37,6 +37,8 @@ import org.springframework.data.redis.connection.convert.SetConverter;
 import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
@@ -3696,6 +3698,44 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#xPending(java.lang.String, java.lang.String)
+	 */
+	@Override
+	public PendingMessagesSummary xPending(String key, String groupName) {
+		return convertAndReturn(delegate.xPending(serialize(key), groupName), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#xPending(java.lang.String, java.lang.String, java.lang.String, org.springframework.data.domain.Range, java.lang.Long)
+	 */
+	@Override
+	public PendingMessages xPending(String key, String groupName, String consumer,
+			org.springframework.data.domain.Range<String> range, Long count) {
+		return convertAndReturn(delegate.xPending(serialize(key), groupName, consumer, range, count), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#xPending(java.lang.String, java.lang.String, org.springframework.data.domain.Range, java.lang.Long)
+	 */
+	@Override
+	public PendingMessages xPending(String key, String groupName, org.springframework.data.domain.Range<String> range,
+			Long count) {
+		return convertAndReturn(delegate.xPending(serialize(key), groupName, range, count), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#xPending(java.lang.String, org.springframework.data.redis.connection.RedisStreamCommands.XPendingOptions)
+	 */
+	@Override
+	public PendingMessages xPending(String key, String groupName, XPendingOptions options) {
+		return convertAndReturn(delegate.xPending(serialize(key), groupName, options), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.StringRedisConnection#xRange(java.lang.String, org.springframework.data.domain.Range, org.springframework.data.redis.connection.RedisZSetCommands.Limit)
 	 */
 	@Override
@@ -3719,7 +3759,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	 */
 	@Override
 	public List<StringRecord> xReadGroupAsString(Consumer consumer, StreamReadOptions readOptions,
-												 StreamOffset<String>... streams) {
+			StreamOffset<String>... streams) {
 
 		return convertAndReturn(delegate.xReadGroup(consumer, readOptions, serialize(streams)),
 				listByteMapRecordToStringMapRecordConverter);
@@ -3810,6 +3850,24 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands#xPending(byte[], java.lang.String)
+	 */
+	@Override
+	public PendingMessagesSummary xPending(byte[] key, String groupName) {
+		return delegate.xPending(key, groupName);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands#xPending(byte[], java.lang.String)
+	 */
+	@Override
+	public PendingMessages xPending(byte[] key, String groupName, XPendingOptions options) {
+		return delegate.xPending(key, groupName, options);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisStreamCommands#xRange(byte[], org.springframework.data.domain.Range, org.springframework.data.redis.connection.RedisZSetCommands.Limit)
 	 */
 	@Override
@@ -3832,7 +3890,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	 */
 	@Override
 	public List<ByteRecord> xReadGroup(Consumer consumer, StreamReadOptions readOptions,
-									   StreamOffset<byte[]>... streams) {
+			StreamOffset<byte[]>... streams) {
 		return delegate.xReadGroup(consumer, readOptions, streams);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -3653,6 +3653,24 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#xClaimJustId(java.lang.String, java.lang.String, java.lang.String, org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions)
+	 */
+	@Override
+	public List<RecordId> xClaimJustId(String key, String group, String consumer, XClaimOptions options) {
+		return convertAndReturn(delegate.xClaimJustId(serialize(key), group, consumer, options), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#xClaim(java.lang.String, java.lang.String, java.lang.String, org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions)
+	 */
+	@Override
+	public List<StringRecord> xClaim(String key, String group, String consumer, XClaimOptions options) {
+		return convertAndReturn(delegate.xClaim(serialize(key), group, consumer, options), listByteMapRecordToStringMapRecordConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.StringRedisConnection#xDel(java.lang.String, java.lang.String[])
 	 */
 	@Override
@@ -3801,6 +3819,24 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	@Override
 	public RecordId xAdd(MapRecord<byte[], byte[], byte[]> record) {
 		return delegate.xAdd(record);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands#xClaimJustId(byte[], java.lang.String, java.lag.String, org.springframework.data.redis.connection.RedisStreamCommands.XCLaimOptions)
+	 */
+	@Override
+	public List<RecordId> xClaimJustId(byte[] key, String group, String newOwner, XClaimOptions options) {
+		return delegate.xClaimJustId(key, group, newOwner, options);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands#xClaim(byte[], java.lang.String, java.lag.String, org.springframework.data.redis.connection.RedisStreamCommands.XCLaimOptions)
+	 */
+	@Override
+	public List<ByteRecord> xClaim(byte[] key, String group, String newOwner, XClaimOptions options) {
+		return delegate.xClaim(key, group, newOwner, options);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -31,6 +31,8 @@ import org.springframework.data.geo.Point;
 import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
@@ -489,6 +491,20 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
 	@Override
 	@Deprecated
+	default PendingMessagesSummary xPending(byte[] key, String groupName) {
+		return streamCommands().xPending(key, groupName);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
+	@Override
+	@Deprecated
+	default PendingMessages xPending(byte[] key, String groupName, XPendingOptions options) {
+		return streamCommands().xPending(key, groupName, options);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
+	@Override
+	@Deprecated
 	default List<ByteRecord> xRange(byte[] key, org.springframework.data.domain.Range<String> range) {
 		return streamCommands().xRange(key, range);
 	}
@@ -525,7 +541,7 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	@Override
 	@Deprecated
 	default List<ByteRecord> xReadGroup(Consumer consumer, StreamReadOptions readOptions,
-										StreamOffset<byte[]>... streams) {
+			StreamOffset<byte[]>... streams) {
 		return streamCommands().xReadGroup(consumer, readOptions, streams);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -456,6 +456,20 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
 	@Override
 	@Deprecated
+	default List<RecordId> xClaimJustId(byte[] key, String group, String newOwner, XClaimOptions options) {
+		return streamCommands().xClaimJustId(key, group, newOwner, options);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
+	@Override
+	@Deprecated
+	default List<ByteRecord> xClaim(byte[] key, String group, String newOwner, XClaimOptions options) {
+		return streamCommands().xClaim(key, group, newOwner, options);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
+	@Override
+	@Deprecated
 	default Long xDel(byte[] key, RecordId... recordIds) {
 		return streamCommands().xDel(key, recordIds);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -23,12 +23,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
@@ -2070,6 +2074,68 @@ public interface StringRedisConnection extends RedisConnection {
 	 */
 	@Nullable
 	Long xLen(String key);
+
+	/**
+	 * Obtain the {@link PendingMessagesSummary} for a given {@literal consumer group}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @return a summary of pending messages within the given {@literal consumer group} or {@literal null} when used in
+	 *         pipeline / transaction.
+	 *         @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	@Nullable
+	PendingMessagesSummary xPending(String key, String groupName);
+
+	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link org.springframework.data.domain.Range} within a
+	 * {@literal consumer group}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @param consumerName the name of the {@literal consumer}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @return pending messages for the given {@literal consumer group} or {@literal null} when used in pipeline /
+	 *         transaction.
+	 *         @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	@Nullable
+	PendingMessages xPending(String key, String groupName, String consumerName, org.springframework.data.domain.Range<String> range, Long count);
+
+	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link org.springframework.data.domain.Range} within a
+	 * {@literal consumer group}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @return pending messages for the given {@literal consumer group} or {@literal null} when used in pipeline /
+	 *         transaction.
+	 *         @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	@Nullable
+	PendingMessages xPending(String key, String groupName, org.springframework.data.domain.Range<String> range, Long count);
+
+
+	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} applying given {@link XPendingOptions
+	 * options}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @param options the options containing {@literal range}, {@literal consumer} and {@literal count}. Must not be
+	 *          {@literal null}.
+	 * @return pending messages matching given criteria or {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	@Nullable
+	PendingMessages xPending(String key, String groupName, XPendingOptions options);
 
 	/**
 	 * Read records from a stream within a specific {@link Range}.

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.springframework.data.domain.Range;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResults;
@@ -2014,6 +2013,50 @@ public interface StringRedisConnection extends RedisConnection {
 	RecordId xAdd(StringRecord record);
 
 	/**
+	 * Change the ownership of a pending message to the given new {@literal consumer} without increasing the delivered
+	 * count.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param options must not be {@literal null}.
+	 * @return list of {@link RecordId ids} that changed user.
+	 * @see <a href="https://redis.io/commands/xclaim">Redis Documentation: XCLAIM</a>
+	 * @since 2.3
+	 */
+	List<RecordId> xClaimJustId(String key, String group, String newOwner, XClaimOptions options);
+
+	/**
+	 * Change the ownership of a pending message to the given new {@literal consumer}.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param minIdleTime must not be {@literal null}.
+	 * @param recordIds must not be {@literal null}.
+	 * @return list of {@link StringRecord} that changed user.
+	 * @see <a href="https://redis.io/commands/xclaim">Redis Documentation: XCLAIM</a>
+	 * @since 2.3
+	 */
+	default List<StringRecord> xClaim(String key, String group, String newOwner, Duration minIdleTime,
+			RecordId... recordIds) {
+		return xClaim(key, group, newOwner, XClaimOptions.minIdle(minIdleTime).ids(recordIds));
+	}
+
+	/**
+	 * Change the ownership of a pending message to the given new {@literal consumer}.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param options must not be {@literal null}.
+	 * @return list of {@link StringRecord} that changed user.
+	 * @see <a href="https://redis.io/commands/xclaim">Redis Documentation: XCLAIM</a>
+	 * @since 2.3
+	 */
+	List<StringRecord> xClaim(String key, String group, String newOwner, XClaimOptions options);
+
+	/**
 	 * Removes the specified entries from the stream. Returns the number of items deleted, that may be different from the
 	 * number of IDs passed in case certain IDs do not exist.
 	 *
@@ -2082,15 +2125,15 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
 	 * @return a summary of pending messages within the given {@literal consumer group} or {@literal null} when used in
 	 *         pipeline / transaction.
-	 *         @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
 	 * @since 2.3
 	 */
 	@Nullable
 	PendingMessagesSummary xPending(String key, String groupName);
 
 	/**
-	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link org.springframework.data.domain.Range} within a
-	 * {@literal consumer group}.
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given
+	 * {@link org.springframework.data.domain.Range} within a {@literal consumer group}.
 	 *
 	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
 	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
@@ -2099,15 +2142,16 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param count limit the number of results. Must not be {@literal null}.
 	 * @return pending messages for the given {@literal consumer group} or {@literal null} when used in pipeline /
 	 *         transaction.
-	 *         @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
 	 * @since 2.3
 	 */
 	@Nullable
-	PendingMessages xPending(String key, String groupName, String consumerName, org.springframework.data.domain.Range<String> range, Long count);
+	PendingMessages xPending(String key, String groupName, String consumerName,
+			org.springframework.data.domain.Range<String> range, Long count);
 
 	/**
-	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link org.springframework.data.domain.Range} within a
-	 * {@literal consumer group}.
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given
+	 * {@link org.springframework.data.domain.Range} within a {@literal consumer group}.
 	 *
 	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
 	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
@@ -2115,12 +2159,12 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param count limit the number of results. Must not be {@literal null}.
 	 * @return pending messages for the given {@literal consumer group} or {@literal null} when used in pipeline /
 	 *         transaction.
-	 *         @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
 	 * @since 2.3
 	 */
 	@Nullable
-	PendingMessages xPending(String key, String groupName, org.springframework.data.domain.Range<String> range, Long count);
-
+	PendingMessages xPending(String key, String groupName, org.springframework.data.domain.Range<String> range,
+			Long count);
 
 	/**
 	 * Obtain detailed information about pending {@link PendingMessage messages} applying given {@link XPendingOptions

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -18,11 +18,16 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.*;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode.NodeFlag;
+import io.lettuce.core.models.stream.PendingMessage;
+import io.lettuce.core.models.stream.PendingMessages;
+import io.lettuce.core.models.stream.PendingParser;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import org.springframework.core.convert.converter.Converter;
@@ -64,6 +69,9 @@ import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.connection.convert.ListConverter;
 import org.springframework.data.redis.connection.convert.LongToBooleanConverter;
 import org.springframework.data.redis.connection.convert.StringToRedisClientInfoConverter;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
+import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
@@ -71,6 +79,7 @@ import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.NumberUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -108,6 +117,8 @@ abstract public class LettuceConverters extends Converters {
 	private static final Converter<KeyValue<Object, Object>, Object> KEY_VALUE_UNWRAPPER;
 	private static final ListConverter<KeyValue<Object, Object>, Object> KEY_VALUE_LIST_UNWRAPPER;
 	private static final Converter<TransactionResult, List<Object>> TRANSACTION_RESULT_UNWRAPPER;
+	private static final BiFunction<List<Object>, String, org.springframework.data.redis.connection.stream.PendingMessages> PENDING_MESSAGES_CONVERTER;
+	private static final BiFunction<List<Object>, String, PendingMessagesSummary> PENDING_MESSAGES_SUMMARY_CONVERTER;
 
 	public static final byte[] PLUS_BYTES;
 	public static final byte[] MINUS_BYTES;
@@ -308,6 +319,70 @@ abstract public class LettuceConverters extends Converters {
 		KEY_VALUE_LIST_UNWRAPPER = new ListConverter<>(KEY_VALUE_UNWRAPPER);
 
 		TRANSACTION_RESULT_UNWRAPPER = transactionResult -> transactionResult.stream().collect(Collectors.toList());
+
+		PENDING_MESSAGES_CONVERTER = (source, groupName) -> {
+
+			List<Object> target = source.stream().map(LettuceConverters::preConvertNativeValues).collect(Collectors.toList());
+			List<PendingMessage> pendingMessages = PendingParser.parseRange(target);
+
+			List<org.springframework.data.redis.connection.stream.PendingMessage> messages = pendingMessages.stream()
+					.map(it -> {
+
+						RecordId id = RecordId.of(it.getId());
+						Consumer consumer = Consumer.from(groupName, it.getConsumer());
+
+						return new org.springframework.data.redis.connection.stream.PendingMessage(id, consumer,
+								Duration.ofMillis(it.getMsSinceLastDelivery()), it.getRedeliveryCount());
+
+					}).collect(Collectors.toList());
+
+			return new org.springframework.data.redis.connection.stream.PendingMessages(groupName, messages);
+
+		};
+
+		PENDING_MESSAGES_SUMMARY_CONVERTER = (source, groupName) -> {
+
+			List<Object> target = source.stream().map(LettuceConverters::preConvertNativeValues).collect(Collectors.toList());
+
+			PendingMessages pendingMessages = PendingParser.parse(target);
+			org.springframework.data.domain.Range<String> range = org.springframework.data.domain.Range.open(
+					pendingMessages.getMessageIds().getLower().getValue(), pendingMessages.getMessageIds().getUpper().getValue());
+
+			return new PendingMessagesSummary(groupName, pendingMessages.getCount(), range,
+					pendingMessages.getConsumerMessageCount());
+		};
+	}
+
+	/**
+	 * We need to convert values into the correct target type since lettuce will give us {@link ByteBuffer} or arrays but
+	 * the parser requires us to have them as {@link String} or numeric values. Oh and {@literal null} values aren't real
+	 * good citizens as well, so we make them empty strings instead - see it works - somehow ;P
+	 * 
+	 * @param value dont't get me started om this.
+	 * @return preconverted values that Lettuce parsers are able to understand \ö/.
+	 */
+	private static Object preConvertNativeValues(Object value) {
+
+		if (value instanceof ByteBuffer || value instanceof byte[]) {
+
+			byte[] targetArray = value instanceof ByteBuffer ? ByteUtils.getBytes((ByteBuffer) value) : (byte[]) value;
+			String tmp = toString(targetArray);
+
+			try {
+				return NumberUtils.parseNumber(tmp, Long.class);
+			} catch (NumberFormatException e) {
+				return tmp;
+			}
+		}
+		if (value instanceof List) {
+			List<Object> targetList = new ArrayList<>();
+			for (Object it : (List) value) {
+				targetList.add(preConvertNativeValues(it));
+			}
+			return targetList;
+		}
+
+		return value != null ? value : "";
 	}
 
 	public static List<Tuple> toTuple(List<byte[]> list) {
@@ -1040,6 +1115,32 @@ abstract public class LettuceConverters extends Converters {
 	 */
 	static long getUpperBoundIndex(org.springframework.data.domain.Range<Long> range) {
 		return getUpperBound(range).orElse(INDEXED_RANGE_END);
+	}
+
+	/**
+	 * Convert the raw lettuce xpending result to {@link PendingMessages}.
+	 *
+	 * @param groupName the group name
+	 * @param range the range of messages requested
+	 * @param source the raw lettuce response.
+	 * @return
+	 * @since 2.3
+	 */
+	static org.springframework.data.redis.connection.stream.PendingMessages toPendingMessages(String groupName,
+			org.springframework.data.domain.Range<?> range, List<Object> source) {
+		return PENDING_MESSAGES_CONVERTER.apply(source, groupName).withinRange(range);
+	}
+
+	/**
+	 * Convert the raw lettuce xpending result to {@link PendingMessagesSummary}.
+	 * 
+	 * @param groupName
+	 * @param source the raw lettuce response.
+	 * @return
+	 * @since 2.3
+	 */
+	static PendingMessagesSummary toPendingMessagesInfo(String groupName, List<Object> source) {
+		return PENDING_MESSAGES_SUMMARY_CONVERTER.apply(source, groupName);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StreamConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StreamConverters.java
@@ -16,15 +16,19 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.StreamMessage;
+import io.lettuce.core.XClaimArgs;
 import io.lettuce.core.XReadArgs;
 
 import java.util.List;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
+import org.springframework.data.redis.connection.convert.ListConverter;
 import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.connection.stream.StreamRecords;
-import org.springframework.data.redis.connection.convert.ListConverter;
+import org.springframework.lang.Nullable;
 
 /**
  * Converters for Redis Stream-specific types.
@@ -39,6 +43,9 @@ import org.springframework.data.redis.connection.convert.ListConverter;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 class StreamConverters {
 
+	private static final Converter<List<StreamMessage<byte[], byte[]>>, List<RecordId>> MESSAGEs_TO_IDs = new ListConverter<>(
+			messageToIdConverter());
+
 	/**
 	 * Convert {@link StreamReadOptions} to Lettuce's {@link XReadArgs}.
 	 *
@@ -49,12 +56,31 @@ class StreamConverters {
 		return StreamReadOptionsToXReadArgsConverter.INSTANCE.convert(readOptions);
 	}
 
-	public static Converter<StreamMessage<byte[], byte[]>, ByteRecord> byteRecordConverter() {
+	/**
+	 * Convert {@link XClaimOptions} to Lettuce's {@link XClaimArgs}.
+	 *
+	 * @param options must not be {@literal null}.
+	 * @return the converted {@link XClaimArgs}.
+	 * @since 2.3
+	 */
+	static XClaimArgs toXClaimArgs(XClaimOptions options) {
+		return XClaimOptionsToXClaimArgsConverter.INSTANCE.convert(options);
+	}
+
+	static Converter<StreamMessage<byte[], byte[]>, ByteRecord> byteRecordConverter() {
 		return (it) -> StreamRecords.newRecord().in(it.getStream()).withId(it.getId()).ofBytes(it.getBody());
 	}
 
-	public static Converter<List<StreamMessage<byte[], byte[]>>, List<ByteRecord>> byteRecordListConverter() {
+	static Converter<List<StreamMessage<byte[], byte[]>>, List<ByteRecord>> byteRecordListConverter() {
 		return new ListConverter<>(byteRecordConverter());
+	}
+
+	static Converter<StreamMessage<byte[], byte[]>, RecordId> messageToIdConverter() {
+		return (it) -> RecordId.of(it.getId());
+	}
+
+	static Converter<List<StreamMessage<byte[], byte[]>>, List<RecordId>> messagesToIds() {
+		return MESSAGEs_TO_IDs;
 	}
 
 	/**
@@ -85,6 +111,37 @@ class StreamConverters {
 				args.count(source.getCount());
 			}
 			return args;
+		}
+	}
+
+	/**
+	 * {@link Converter} to convert {@link XClaimOptions} to Lettuce's {@link XClaimArgs}.
+	 * 
+	 * @since 2.3
+	 */
+	enum XClaimOptionsToXClaimArgsConverter implements Converter<XClaimOptions, XClaimArgs> {
+		INSTANCE;
+
+		@Nullable
+		@Override
+		public XClaimArgs convert(XClaimOptions source) {
+
+			XClaimArgs args = XClaimArgs.Builder.minIdleTime(source.getMinIdleTime());
+			args.minIdleTime(source.getMinIdleTime());
+			args.force(source.isForce());
+
+			if (source.getIdleTime() != null) {
+				args.idle(source.getIdleTime());
+			}
+			if (source.getRetryCount() != null) {
+				args.retryCount(source.getRetryCount());
+			}
+			if (source.getUnixTime() != null) {
+				args.time(source.getUnixTime());
+			}
+
+			return args;
+
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/stream/PendingMessage.java
+++ b/src/main/java/org/springframework/data/redis/connection/stream/PendingMessage.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.stream;
+
+import java.time.Duration;
+
+/**
+ * Value object representing a single pending message containing its {@literal ID}, the {@literal consumer} that fetched
+ * the message and has still to acknowledge it, the time elapsed since the messages last delivery and the the total
+ * number of times delivered.
+ * 
+ * @author Christoph Strobl
+ * @since 2.3
+ */
+public class PendingMessage {
+
+	private final RecordId id;
+	private final Consumer consumer;
+	private final Duration elapsedTimeSinceLastDelivery;
+	private final Long totalDeliveryCount;
+
+	public PendingMessage(RecordId id, Consumer consumer, Duration elapsedTimeSinceLastDelivery,
+			Long totalDeliveryCount) {
+
+		this.id = id;
+		this.consumer = consumer;
+		this.elapsedTimeSinceLastDelivery = elapsedTimeSinceLastDelivery;
+		this.totalDeliveryCount = totalDeliveryCount;
+	}
+
+	/**
+	 * @return the message id.
+	 */
+	public RecordId getId() {
+		return id;
+	}
+
+	/**
+	 * @return the message id as {@link String}.
+	 */
+	public String getStringId() {
+		return id.getValue();
+	}
+
+	/**
+	 * The {@link Consumer} to acknowledge the message.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public Consumer getConsumer() {
+		return consumer;
+	}
+
+	/**
+	 * The {@literal consumer name} to acknowledge the message.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public String getConsumerName() {
+		return consumer.getName();
+	}
+
+	/**
+	 * Get the {@literal consumer group}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public String getGroupName() {
+		return consumer.getGroup();
+	}
+
+	/**
+	 * Get the time elapsed since the messages last delivery to the {@link #getConsumer() consumer}.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public Duration getElapsedTimeSinceLastDelivery() {
+		return elapsedTimeSinceLastDelivery;
+	}
+
+	/**
+	 * Get the milliseconds elapsed since the messages last delivery to the {@link #getConsumer() consumer}.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public Long getElapsedTimeSinceLastDeliveryMS() {
+		return elapsedTimeSinceLastDelivery.toMillis();
+	}
+
+	/**
+	 * Get the total number of times the messages has been delivered to the {@link #getConsumer() consumer}.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public Long getTotalDeliveryCount() {
+		return totalDeliveryCount;
+	}
+
+	@Override
+	public String toString() {
+		return "PendingMessage{" + "id=" + id + ", consumer=" + consumer + ", elapsedTimeSinceLastDeliveryMS="
+				+ elapsedTimeSinceLastDelivery.toMillis() + ", totalDeliveryCount=" + totalDeliveryCount + '}';
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/stream/PendingMessages.java
+++ b/src/main/java/org/springframework/data/redis/connection/stream/PendingMessages.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.stream;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.data.domain.Range;
+import org.springframework.data.util.Streamable;
+
+/**
+ * Value object holding detailed information about pending messages in {@literal consumer group} for a given
+ * {@link org.springframework.data.redis.connection.SortParameters.Range} and offset.
+ * 
+ * @author Christoph Strobl
+ * @since 2.3
+ */
+public class PendingMessages implements Streamable<PendingMessage> {
+
+	private final String groupName;
+	private final Range<?> range;
+	private final List<PendingMessage> pendingMessages;
+
+	public PendingMessages(String groupName, List<PendingMessage> pendingMessages) {
+		this(groupName, Range.unbounded(), pendingMessages);
+	}
+
+	public PendingMessages(String groupName, Range<?> range, List<PendingMessage> pendingMessages) {
+
+		this.groupName = groupName;
+		this.range = range;
+		this.pendingMessages = pendingMessages;
+	}
+
+	/**
+	 * Adds the range to the current {@link PendingMessages}.
+	 * 
+	 * @param range must not be {@literal null}.
+	 * @return new instance of {@link PendingMessages}.
+	 */
+	public PendingMessages withinRange(Range<?> range) {
+		return new PendingMessages(groupName, range, pendingMessages);
+	}
+
+	/**
+	 * The {@literal consumer group} name.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public String getGroupName() {
+		return groupName;
+	}
+
+	/**
+	 * The {@link Range} pending messages have been loaded.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public Range<?> getRange() {
+		return range;
+	}
+
+	/**
+	 * @return {@literal true} if no messages pending within range.
+	 */
+	public boolean isEmpty() {
+		return pendingMessages.isEmpty();
+	}
+
+	/**
+	 * @return the number of pending messages in range.
+	 */
+	public int size() {
+		return pendingMessages.size();
+	}
+
+	/**
+	 * Get the {@link PendingMessage} at the given position.
+	 * 
+	 * @param index
+	 * @return the {@link PendingMessage} a the given index.
+	 * @throws IndexOutOfBoundsException if the index is out of range.
+	 */
+	public PendingMessage get(int index) {
+		return pendingMessages.get(index);
+	}
+
+	/*
+	 * (non-Javadoc) 
+	 * @see java.lang.Iterable#iterator()
+	 */
+	@Override
+	public Iterator<PendingMessage> iterator() {
+		return pendingMessages.iterator();
+	}
+
+	@Override
+	public String toString() {
+		return "PendingMessages{" + "groupName='" + groupName + '\'' + ", range=" + range + ", pendingMessages="
+				+ pendingMessages + '}';
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/stream/PendingMessagesSummary.java
+++ b/src/main/java/org/springframework/data/redis/connection/stream/PendingMessagesSummary.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.stream;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.data.domain.Range;
+
+/**
+ * Value Object summarizing pending messages in a {@literal consumer group}. It contains the total number and ID range
+ * of pending messages for this consumer group, as well as a collection of total pending messages per consumer.
+ * 
+ * @since 2.3
+ * @author Christoph Strobl
+ */
+public class PendingMessagesSummary {
+
+	private final String groupName;
+	private final Long totalPendingMessages;
+	private final Range<String> idRange;
+	private final Map<String, Long> pendingMessagesPerConsumer;
+
+	public PendingMessagesSummary(String groupName, Long totalPendingMessages, Range<String> idRange,
+			Map<String, Long> pendingMessagesPerConsumer) {
+
+		this.groupName = groupName;
+		this.totalPendingMessages = totalPendingMessages;
+		this.idRange = idRange;
+		this.pendingMessagesPerConsumer = pendingMessagesPerConsumer;
+	}
+
+	/**
+	 * Get the range between the smallest and greatest ID among the pending messages.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public Range<String> getIdRange() {
+		return idRange;
+	}
+
+	/**
+	 * Get the smallest ID among the pending messages.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public RecordId minRecordId() {
+		return RecordId.of(minMessageId());
+	}
+
+	/**
+	 * Get the greatest ID among the pending messages.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public RecordId maxRecordId() {
+		return RecordId.of(maxMessageId());
+	}
+
+	/**
+	 * Get the smallest ID as {@link String} among the pending messages.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public String minMessageId() {
+		return idRange.getLowerBound().getValue().get();
+	}
+
+	/**
+	 * Get the greatest ID as {@link String} among the pending messages.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public String maxMessageId() {
+		return idRange.getUpperBound().getValue().get();
+	}
+
+	/**
+	 * Get the number of total pending messages within the {@literal consumer group}.
+	 *
+	 * @return
+	 */
+	public Long getTotalPendingMessages() {
+		return totalPendingMessages;
+	}
+
+	/**
+	 * @return the {@literal consumer group} name.
+	 */
+	public String getGroupName() {
+		return groupName;
+	}
+
+	/**
+	 * Obtain a map of every {@literal consumer} in the {@literal consumer group} with at least one pending message, and
+	 * the number of pending messages.
+	 * 
+	 * @return never {@literal null}.
+	 */
+	public Map<String, Long> getPendingMessagesPerConsumer() {
+		return Collections.unmodifiableMap(pendingMessagesPerConsumer);
+	}
+
+	@Override
+	public String toString() {
+
+		return "PendingMessagesSummary{" + "groupName='" + groupName + '\'' + ", totalPendingMessages='"
+				+ getTotalPendingMessages() + '\'' + ", minMessageId='" + minMessageId() + '\'' + ", maxMessageId='"
+				+ maxMessageId() + '\'' + ", pendingMessagesPerConsumer=" + pendingMessagesPerConsumer + '}';
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.core;
 
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -182,6 +184,40 @@ class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperat
 
 		return createMono(connection -> connection.xGroupDestroy(rawKey(key), group));
 	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.StreamOperations#pending(java.lang.Object, java.lang.String, org.springframework.data.domain.Range, java.lang.Long)
+	 */
+	@Override
+	public Mono<PendingMessages> pending(K key, String group, Range<?> range, Long count) {
+
+		ByteBuffer rawKey = rawKey(key);
+		return createMono(connection -> connection.xPending(rawKey, group, range, count));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.StreamOperations#pending(java.lang.Object, org.springframework.data.redis.connection.stream.Consumer, org.springframework.data.domain.Range, java.lang.Long)
+	 */
+	@Override
+	public Mono<PendingMessages> pending(K key, Consumer consumer, Range<?> range, Long count) {
+
+		ByteBuffer rawKey = rawKey(key);
+		return createMono(connection -> connection.xPending(rawKey, consumer, range, count));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.StreamOperations#pending(java.lang.Object, java.lang.String)
+	 */
+	@Override
+	public Mono<PendingMessagesSummary> pending(K key, String group) {
+
+		ByteBuffer rawKey = rawKey(key);
+		return createMono(connection -> connection.xPending(rawKey, group));
+	}
+
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -29,6 +29,8 @@ import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.Record;
 import org.springframework.data.redis.connection.stream.RecordId;
@@ -181,6 +183,39 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.StreamOperations#pending(java.lang.Object, java.lang.String, org.springframework.data.domain.Range, java.lang.Long)
+	 */
+	@Override
+	public PendingMessages pending(K key, String group, Range<?> range, Long count) {
+
+		byte[] rawKey = rawKey(key);
+		return execute(connection -> connection.xPending(rawKey, group, range, count), true);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.StreamOperations#pending(java.lang.Object, org.springframework.data.redis.connection.stream.Consumer, org.springframework.data.domain.Range, java.lang.Long)
+	 */
+	@Override
+	public PendingMessages pending(K key, Consumer consumer, Range<?> range, Long count) {
+
+		byte[] rawKey = rawKey(key);
+		return execute(connection -> connection.xPending(rawKey, consumer, range, count), true);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.StreamOperations#pending(java.lang.Object, java.lang.String)
+	 */
+	@Override
+	public PendingMessagesSummary pending(K key, String group) {
+
+		byte[] rawKey = rawKey(key);
+		return execute(connection -> connection.xPending(rawKey, group), true);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.StreamOperations#size(java.lang.Object)
 	 */
 	@Override
@@ -279,7 +314,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 		return hashValueSerializer() != null;
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private byte[] serialize(Object value, RedisSerializer serializer) {
 
 		Object _value = value;
@@ -303,7 +338,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 		public final List<MapRecord<K, HK, HV>> doInRedis(RedisConnection connection) {
 
 			List<ByteRecord> raw = inRedis(connection);
-			if(raw == null) {
+			if (raw == null) {
 				return Collections.emptyList();
 			}
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
@@ -24,16 +24,9 @@ import java.util.Map;
 import org.reactivestreams.Publisher;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
-import org.springframework.data.redis.connection.stream.Consumer;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ObjectRecord;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.Record;
-import org.springframework.data.redis.connection.stream.RecordId;
-import org.springframework.data.redis.connection.stream.StreamOffset;
-import org.springframework.data.redis.connection.stream.StreamReadOptions;
-import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.hash.HashMapper;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -200,6 +193,61 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @return the {@link Mono} {@literal OK} if successful. {@literal null} when used in pipeline / transaction.
 	 */
 	Mono<String> destroyGroup(K key, String group);
+
+	/**
+	 * Obtain the {@link PendingMessagesSummary} for a given {@literal consumer group}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param group the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @return a summary of pending messages within the given {@literal consumer group} or {@literal null} when used in
+	 *         pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	@Nullable
+	Mono<PendingMessagesSummary> pending(K key, String group);
+
+	/**
+	 * Obtained detailed information about all pending messages for a given {@link Consumer}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param consumer the consumer to fetch {@link PendingMessages} for. Must not be {@literal null}.
+	 * @return pending messages for the given {@link Consumer} or {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	default Mono<PendingMessages> pending(K key, Consumer consumer) {
+		return pending(key, consumer, Range.unbounded(), -1L);
+	}
+
+	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} within a
+	 * {@literal consumer group}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param group the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @return pending messages for the given {@literal consumer group} or {@literal null} when used in pipeline /
+	 *         transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	Mono<PendingMessages> pending(K key, String group, Range<?> range, Long count);
+
+	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} and
+	 * {@link Consumer} within a {@literal consumer group}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param consumer the name of the {@link Consumer}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @return pending messages for the given {@link Consumer} or {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	Mono<PendingMessages> pending(K key, Consumer consumer, Range<?> range, Long count);
 
 	/**
 	 * Get the length of a stream.

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -23,15 +23,7 @@ import java.util.Map;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
-import org.springframework.data.redis.connection.stream.Consumer;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ObjectRecord;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.Record;
-import org.springframework.data.redis.connection.stream.RecordId;
-import org.springframework.data.redis.connection.stream.StreamOffset;
-import org.springframework.data.redis.connection.stream.StreamReadOptions;
-import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.hash.HashMapper;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -200,6 +192,61 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 */
 	@Nullable
 	Boolean destroyGroup(K key, String group);
+
+	/**
+	 * Obtain the {@link PendingMessagesSummary} for a given {@literal consumer group}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param group the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @return a summary of pending messages within the given {@literal consumer group} or {@literal null} when used in
+	 *         pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	@Nullable
+	PendingMessagesSummary pending(K key, String group);
+
+	/**
+	 * Obtained detailed information about all pending messages for a given {@link Consumer}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param consumer the consumer to fetch {@link PendingMessages} for. Must not be {@literal null}.
+	 * @return pending messages for the given {@link Consumer} or {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	default PendingMessages pending(K key, Consumer consumer) {
+		return pending(key, consumer, Range.unbounded(), -1L);
+	}
+
+	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} within a
+	 * {@literal consumer group}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param group the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @return pending messages for the given {@literal consumer group} or {@literal null} when used in pipeline /
+	 *         transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	PendingMessages pending(K key, String group, Range<?> range, Long count);
+
+	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} and
+	 * {@link Consumer} within a {@literal consumer group}.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param consumer the name of the {@link Consumer}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @return pending messages for the given {@link Consumer} or {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 2.3
+	 */
+	PendingMessages pending(K key, Consumer consumer, Range<?> range, Long count);
 
 	/**
 	 * Get the length of a stream.

--- a/src/test/java/org/springframework/data/redis/RedisTestProfileValueSource.java
+++ b/src/test/java/org/springframework/data/redis/RedisTestProfileValueSource.java
@@ -129,4 +129,18 @@ public class RedisTestProfileValueSource implements ProfileValueSource {
 		}
 		return INSTANCE.get(key) != null ? INSTANCE.get(key).equals(value) : value == null;
 	}
+
+	public static boolean atLeast(String key, String value) {
+
+		if (INSTANCE == null) {
+			INSTANCE = new RedisTestProfileValueSource();
+		}
+
+		String current = INSTANCE.get(key);
+		if(current == null) {
+			return value == null;
+		}
+
+		return org.springframework.data.util.Version.parse(current).isGreaterThanOrEqualTo(org.springframework.data.util.Version.parse(value));
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
@@ -126,6 +126,12 @@ abstract public class AbstractConnectionPipelineIntegrationTests extends Abstrac
 		super.scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection();
 	}
 
+	@Test
+	@Ignore
+	public void xClaim() throws InterruptedException {
+		super.xClaim();
+	}
+
 	protected void initConnection() {
 		connection.openPipeline();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionTransactionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionTransactionIntegrationTests.java
@@ -114,6 +114,12 @@ abstract public class AbstractConnectionTransactionIntegrationTests extends Abst
 		super.scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection();
 	}
 
+	@Test
+	@Ignore
+	public void xClaim() throws InterruptedException {
+		super.xClaim();
+	}
+
 	protected void initConnection() {
 		connection.multi();
 	}

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveStreamOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveStreamOperationsTests.java
@@ -40,6 +40,7 @@ import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
@@ -321,5 +322,54 @@ public class DefaultReactiveStreamOperationsTests<K, HK, HV> {
 				.as(StepVerifier::create) //
 				.expectNext(2L) //
 				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-1084
+	public void pendingShouldReadMessageSummary() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = valueFactory.instance();
+
+		streamOperations.add(key, Collections.singletonMap(hashKey, value)).then().as(StepVerifier::create)
+				.verifyComplete();
+
+		streamOperations.createGroup(key, ReadOffset.from("0-0"), "my-group").then().as(StepVerifier::create)
+				.verifyComplete();
+
+		streamOperations.read(Consumer.from("my-group", "my-consumer"), StreamOffset.create(key, ReadOffset.lastConsumed()))
+				.then().as(StepVerifier::create).verifyComplete();
+
+		streamOperations.pending(key, "my-group").as(StepVerifier::create).assertNext(pending -> {
+
+			assertThat(pending.getTotalPendingMessages()).isOne();
+			assertThat(pending.getGroupName()).isEqualTo("my-group");
+		}).verifyComplete();
+	}
+
+	@Test // DATAREDIS-1084
+	public void pendingShouldReadMessageDetails() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = valueFactory.instance();
+
+		streamOperations.add(key, Collections.singletonMap(hashKey, value)).then().as(StepVerifier::create)
+				.verifyComplete();
+
+		streamOperations.createGroup(key, ReadOffset.from("0-0"), "my-group").then().as(StepVerifier::create)
+				.verifyComplete();
+
+		streamOperations.read(Consumer.from("my-group", "my-consumer"), StreamOffset.create(key, ReadOffset.lastConsumed()))
+				.then().as(StepVerifier::create).verifyComplete();
+
+		streamOperations.pending(key, "my-group", Range.unbounded(), 10L).as(StepVerifier::create).assertNext(pending -> {
+
+			assertThat(pending).hasSize(1);
+			assertThat(pending.get(0).getGroupName()).isEqualTo("my-group");
+			assertThat(pending.get(0).getConsumerName()).isEqualTo("my-consumer");
+			assertThat(pending.get(0).getTotalDeliveryCount()).isOne();
+		}).verifyComplete();
+
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/DefaultStreamOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultStreamOperationsTests.java
@@ -36,6 +36,8 @@ import org.springframework.data.redis.ObjectFactory;
 import org.springframework.data.redis.Person;
 import org.springframework.data.redis.RedisTestProfileValueSource;
 import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.ObjectRecord;
@@ -72,7 +74,7 @@ public class DefaultStreamOperationsTests<K, HK, HV> {
 		// See https://github.com/xetorthio/jedis/issues/1820
 		assumeTrue(redisTemplate.getConnectionFactory() instanceof LettuceConnectionFactory);
 
-		assumeTrue(RedisTestProfileValueSource.matches("redisVersion", "5.0"));
+		assumeTrue(RedisTestProfileValueSource.atLeast("redisVersion", "5.0"));
 
 		this.redisTemplate = redisTemplate;
 		this.keyFactory = keyFactory;
@@ -321,5 +323,45 @@ public class DefaultStreamOperationsTests<K, HK, HV> {
 
 		streamOps.add(key, Collections.singletonMap(hashKey, value));
 		assertThat(streamOps.size(key)).isEqualTo(2);
+	}
+
+	@Test // DATAREDIS-1084
+	public void pendingShouldReadMessageSummary() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = hashValueFactory.instance();
+
+		RecordId messageId = streamOps.add(key, Collections.singletonMap(hashKey, value));
+		streamOps.createGroup(key, ReadOffset.from("0-0"), "my-group");
+
+		streamOps.read(Consumer.from("my-group", "my-consumer"),
+				StreamOffset.create(key, ReadOffset.lastConsumed()));
+
+		PendingMessagesSummary pending = streamOps.pending(key, "my-group");
+
+		assertThat(pending.getTotalPendingMessages()).isOne();
+		assertThat(pending.getGroupName()).isEqualTo("my-group");
+	}
+
+	@Test // DATAREDIS-1084
+	public void pendingShouldReadMessageDetails() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = hashValueFactory.instance();
+
+		RecordId messageId = streamOps.add(key, Collections.singletonMap(hashKey, value));
+		streamOps.createGroup(key, ReadOffset.from("0-0"), "my-group");
+
+		streamOps.read(Consumer.from("my-group", "my-consumer"),
+				StreamOffset.create(key, ReadOffset.lastConsumed()));
+
+		PendingMessages pending = streamOps.pending(key, "my-group", Range.unbounded(), 10L);
+
+		assertThat(pending).hasSize(1);
+		assertThat(pending.get(0).getGroupName()).isEqualTo("my-group");
+		assertThat(pending.get(0).getConsumerName()).isEqualTo("my-consumer");
+		assertThat(pending.get(0).getTotalDeliveryCount()).isOne();
 	}
 }


### PR DESCRIPTION
There are a couple of issues that need to be discussed before we continue with this PR.

* The `JUSTID` flag is currently not suppoprted by drivers.
* `Mono<PendingMessages> xPending(ByteBuffer key, Consumer consumer)` vs. `Flux<PendingMessage> xPending(ByteBuffer key, Consumer consumer)`.
* Coupling between `RedisStreamCommands` and `ReactiveStreamCommands` via `RedisStreamCommands.XClaimOptions`.