### PR TITLE
DATAREDIS-1118 - Allow configuration of RedisCacheWriter on existing RedisCacheManagerBuilder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1118-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
@@ -193,6 +193,16 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 	/**
 	 * Entry point for builder style {@link RedisCacheManager} configuration.
 	 *
+	 * @return new {@link RedisCacheManagerBuilder}.
+	 * @since 2.3
+	 */
+	public static RedisCacheManagerBuilder builder() {
+		return new RedisCacheManagerBuilder();
+	}
+
+	/**
+	 * Entry point for builder style {@link RedisCacheManager} configuration.
+	 *
 	 * @param connectionFactory must not be {@literal null}.
 	 * @return new {@link RedisCacheManagerBuilder}.
 	 */
@@ -272,17 +282,19 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 	 * Configurator for creating {@link RedisCacheManager}.
 	 *
 	 * @author Christoph Strobl
-	 * @author Mark Strobl
+	 * @author Mark Paluch
 	 * @author Kezhu Wang
 	 * @since 2.0
 	 */
 	public static class RedisCacheManagerBuilder {
 
-		private final RedisCacheWriter cacheWriter;
+		private @Nullable RedisCacheWriter cacheWriter;
 		private RedisCacheConfiguration defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig();
 		private final Map<String, RedisCacheConfiguration> initialCaches = new LinkedHashMap<>();
 		private boolean enableTransactions;
 		boolean allowInFlightCacheCreation = true;
+
+		private RedisCacheManagerBuilder() {}
 
 		private RedisCacheManagerBuilder(RedisCacheWriter cacheWriter) {
 			this.cacheWriter = cacheWriter;
@@ -298,7 +310,7 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 
 			Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
 
-			return builder(new DefaultRedisCacheWriter(connectionFactory));
+			return new RedisCacheManagerBuilder(new DefaultRedisCacheWriter(connectionFactory));
 		}
 
 		/**
@@ -325,6 +337,22 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 			Assert.notNull(defaultCacheConfiguration, "DefaultCacheConfiguration must not be null!");
 
 			this.defaultCacheConfiguration = defaultCacheConfiguration;
+
+			return this;
+		}
+
+		/**
+		 * Configure a {@link RedisCacheWriter}.
+		 *
+		 * @param cacheWriter must not be {@literal null}.
+		 * @return this {@link RedisCacheManagerBuilder}.
+		 * @since 2.3
+		 */
+		public RedisCacheManagerBuilder cacheWriter(RedisCacheWriter cacheWriter) {
+
+			Assert.notNull(cacheWriter, "CacheWriter must not be null!");
+
+			this.cacheWriter = cacheWriter;
 
 			return this;
 		}
@@ -434,6 +462,8 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 		 * @return new instance of {@link RedisCacheManager}.
 		 */
 		public RedisCacheManager build() {
+
+			Assert.notNull(cacheWriter, "CacheWriter must not be null!");
 
 			RedisCacheManager cm = new RedisCacheManager(cacheWriter, defaultCacheConfiguration, initialCaches,
 					allowInFlightCacheCreation);

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.cache;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.util.Collections;
 
@@ -23,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.cache.Cache;
 import org.springframework.cache.transaction.TransactionAwareCacheDecorator;
 import org.springframework.data.redis.cache.RedisCacheManager.RedisCacheManagerBuilder;
@@ -149,5 +151,20 @@ public class RedisCacheManagerUnitTests {
 				.initialCacheNames(Collections.singleton("configured")).disableCreateOnMissingCache();
 
 		assertThat(cmb.getCacheConfigurationFor("unknown")).isNotPresent();
+	}
+
+	@Test // DATAREDIS-1118
+	public void shouldConfigureRedisCacheWriter() {
+
+		RedisCacheWriter writerMock = mock(RedisCacheWriter.class);
+
+		RedisCacheManager cm = RedisCacheManager.builder(cacheWriter).cacheWriter(writerMock).build();
+
+		assertThat(cm).extracting("cacheWriter").isEqualTo(writerMock);
+	}
+
+	@Test // DATAREDIS-1118
+	public void builderShouldRequireCacheWriter() {
+		assertThatIllegalArgumentException().isThrownBy(() -> RedisCacheManager.builder().build());
 	}
 }


### PR DESCRIPTION
We now allow configuration of the `RedisCacheWriter` on existing `RedisCacheManagerBuilder` objects.

---

Related ticket: [DATAREDIS-1118](https://jira.spring.io/browse/DATAREDIS-1118).