### PR TITLE
DATAREDIS-1128 - Improve test stability.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
 	<properties>
 		<springdata.keyvalue>2.3.0.BUILD-SNAPSHOT</springdata.keyvalue>
+		<awaitility>4.0.2</awaitility>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.8</xstream>
@@ -221,6 +222,13 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<version>${awaitility}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1128-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/test/java/org/springframework/data/redis/SpinBarrier.java
+++ b/src/test/java/org/springframework/data/redis/SpinBarrier.java
@@ -15,10 +15,17 @@
  */
 package org.springframework.data.redis;
 
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+
 /**
  * @author Jennifer Hickey
+ * @author Mark Paluch
+ * @deprecated Use {@link Awaitility}.
  */
-abstract public class SpinBarrier {
+@Deprecated
+public abstract class SpinBarrier {
 
 	/**
 	 * Periodically tests for a condition until it is met or a timeout occurs
@@ -28,16 +35,12 @@ abstract public class SpinBarrier {
 	 * @return true if condition passes, false if condition does not pass within timeout
 	 */
 	public static boolean waitFor(TestCondition condition, long timeout) {
-		boolean passes = false;
-		for (long currentTime = System.currentTimeMillis(); System.currentTimeMillis() - currentTime < timeout;) {
-			if (condition.passes()) {
-				passes = true;
-				break;
-			}
-			try {
-				Thread.sleep(100);
-			} catch (InterruptedException e) {}
+
+		try {
+			Awaitility.await().atMost(timeout, TimeUnit.MILLISECONDS).until(condition::passes);
+			return true;
+		} catch (Exception e) {
+			return false;
 		}
-		return passes;
 	}
 }

--- a/src/test/java/org/springframework/data/redis/config/NamespaceTest.java
+++ b/src/test/java/org/springframework/data/redis/config/NamespaceTest.java
@@ -17,8 +17,6 @@ package org.springframework.data.redis.config;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,12 +24,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.test.util.RelaxedJUnit4ClassRunner;
-import org.springframework.test.annotation.IfProfileValue;
 import org.springframework.test.annotation.ProfileValueSourceConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Costin Leau
+ * @author Mark Paluch
  */
 @RunWith(RelaxedJUnit4ClassRunner.class)
 @ContextConfiguration("namespace.xml")
@@ -45,24 +43,13 @@ public class NamespaceTest {
 	@Autowired private StubErrorHandler handler;
 
 	@Test
-	@IfProfileValue(name = "runLongTests", value = "true")
 	public void testSanityTest() throws Exception {
 		assertThat(container.isRunning()).isTrue();
-		Thread.sleep(TimeUnit.SECONDS.toMillis(8));
 	}
 
 	@Test
-	@IfProfileValue(name = "runLongTests", value = "true")
 	public void testWithMessages() throws Exception {
 		template.convertAndSend("x1", "[X]test");
 		template.convertAndSend("z1", "[Z]test");
-		Thread.sleep(TimeUnit.SECONDS.toMillis(8));
-	}
-
-	public void testErrorHandler() throws Exception {
-		int index = handler.throwables.size();
-		template.convertAndSend("exception", "test1");
-		handler.throwables.pollLast(3, TimeUnit.SECONDS);
-		assertThat(handler.throwables.size()).isEqualTo(index + 1);
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.data.Offset;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.AssumptionViolatedException;
@@ -396,7 +397,8 @@ public abstract class AbstractConnectionIntegrationTests {
 		Thread.sleep(200);
 		connection.scriptKill();
 		getResults();
-		assertThat(waitFor(() -> scriptDead.get(), 3000l)).isTrue();
+
+		Awaitility.await().untilTrue(scriptDead);
 	}
 
 	@Test
@@ -833,7 +835,7 @@ public abstract class AbstractConnectionIntegrationTests {
 
 		connection.watch("testitnow".getBytes());
 		// Give some time for watch to be asynch executed in extending tests
-		Thread.sleep(500);
+		Thread.sleep(200);
 		DefaultStringRedisConnection conn2 = new DefaultStringRedisConnection(connectionFactory.getConnection());
 		conn2.set("testitnow", "something");
 		conn2.close();
@@ -852,11 +854,10 @@ public abstract class AbstractConnectionIntegrationTests {
 
 		connection.watch("testitnow".getBytes());
 		connection.unwatch();
-
 		connection.multi();
 
 		// Give some time for unwatch to be asynch executed
-		Thread.sleep(100);
+		Thread.sleep(200);
 		DefaultStringRedisConnection conn2 = new DefaultStringRedisConnection(connectionFactory.getConnection());
 		conn2.set("testitnow", "something");
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -2365,7 +2365,7 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		nativeConnection.set(KEY_1, VALUE_1);
 		nativeConnection.get(KEY_1);
 
-		assertThat(clusterConnection.keyCommands().idletime(KEY_1_BYTES)).isEqualTo(Duration.ofSeconds(0));
+		assertThat(clusterConnection.keyCommands().idletime(KEY_1_BYTES)).isLessThanOrEqualTo(Duration.ofSeconds(2));
 	}
 
 	@Test // DATAREDIS-716

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -315,25 +315,6 @@ public class LettuceConnectionFactoryTests {
 		pool.destroy();
 	}
 
-	@Ignore("Uncomment this test to manually check connection reuse in a pool scenario")
-	@Test
-	public void testLotsOfConnections() throws InterruptedException {
-		// Running a netstat here should show only the 8 conns from the pool (plus 2 from setUp and 1 from factory2
-		// afterPropertiesSet for shared conn)
-		DefaultLettucePool pool = new DefaultLettucePool(SettingsUtils.getHost(), SettingsUtils.getPort());
-		pool.afterPropertiesSet();
-		final LettuceConnectionFactory factory2 = new LettuceConnectionFactory(pool);
-		factory2.afterPropertiesSet();
-
-		ConnectionFactoryTracker.add(factory2);
-
-		for (int i = 1; i < 1000; i++) {
-			Thread th = new Thread(() -> factory2.getConnection().bRPop(50000, "foo".getBytes()));
-			th.start();
-		}
-		Thread.sleep(234234234);
-	}
-
 	@Ignore("Redis must have requirepass set to run this test")
 	@Test
 	public void testConnectWithPassword() {

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -275,7 +276,8 @@ public class LettuceConnectionIntegrationTests extends AbstractConnectionIntegra
 		th.start();
 		Thread.sleep(1000);
 		connection.scriptKill();
-		assertThat(waitFor(scriptDead::get, 3000l)).isTrue();
+
+		Awaitility.await().untilTrue(scriptDead);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionPipelineIntegrationTests.java
@@ -22,6 +22,7 @@ import static org.springframework.data.redis.SpinBarrier.*;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -79,7 +80,8 @@ public class LettuceConnectionPipelineIntegrationTests extends AbstractConnectio
 		Thread.sleep(1000);
 		connection.scriptKill();
 		getResults();
-		assertThat(waitFor(scriptDead::get, 3000l)).isTrue();
+
+		Awaitility.await().untilTrue(scriptDead);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommandsTests.java
@@ -20,6 +20,7 @@ import static org.junit.Assume.*;
 import static org.springframework.data.redis.SpinBarrier.*;
 
 import io.lettuce.core.ScriptOutputType;
+import org.awaitility.Awaitility;
 import reactor.test.StepVerifier;
 
 import java.nio.ByteBuffer;
@@ -174,7 +175,7 @@ public class LettuceReactiveScriptingCommandsTests extends LettuceReactiveComman
 
 		connection.scriptingCommands().scriptKill().as(StepVerifier::create).expectNext("OK").verifyComplete();
 
-		assertThat(waitFor(scriptDead::get, 3000L)).isTrue();
+		Awaitility.await().untilTrue(scriptDead);
 	}
 
 	private static ByteBuffer wrap(String content) {

--- a/src/test/java/org/springframework/data/redis/core/DefaultHyperLogLogOperationsTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultHyperLogLogOperationsTests.java
@@ -35,6 +35,7 @@ import org.springframework.test.annotation.IfProfileValue;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(Parameterized.class)
 @IfProfileValue(name = "redisVersion", value = "2.8.9+")
@@ -132,10 +133,11 @@ public class DefaultHyperLogLogOperationsTests<K, V> {
 
 		K key2 = keyFactory.instance();
 		V v4 = valueFactory.instance();
+		V v5 = valueFactory.instance();
 
 		hyperLogLogOps.add(key, v1, v2, v3);
-		hyperLogLogOps.add(key2, v4);
-		assertThat(hyperLogLogOps.size(key, key2)).isEqualTo(4L);
+		hyperLogLogOps.add(key2, v4, v5);
+		assertThat(hyperLogLogOps.size(key, key2)).isGreaterThan(3L);
 	}
 
 	@Test // DATAREDIS-308
@@ -149,16 +151,14 @@ public class DefaultHyperLogLogOperationsTests<K, V> {
 
 		K sourceKey_2 = keyFactory.instance();
 		V v4 = valueFactory.instance();
+		V v5 = valueFactory.instance();
 
 		K desinationKey = keyFactory.instance();
 
 		hyperLogLogOps.add(sourceKey_1, v1, v2, v3);
-		hyperLogLogOps.add(sourceKey_2, v4);
-
-		Thread.sleep(10); // give redis a little time to catch up
+		hyperLogLogOps.add(sourceKey_2, v4, v5);
 		hyperLogLogOps.union(desinationKey, sourceKey_1, sourceKey_2);
-		Thread.sleep(10); // give redis a little time to catch up
 
-		assertThat(hyperLogLogOps.size(desinationKey)).isEqualTo(4L);
+		assertThat(hyperLogLogOps.size(desinationKey)).isGreaterThan(3L);
 	}
 }

--- a/src/test/java/org/springframework/data/redis/listener/KeyExpirationEventMessageListenerTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/KeyExpirationEventMessageListenerTests.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +39,7 @@ import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @RunWith(MockitoJUnitRunner.class)
 public class KeyExpirationEventMessageListenerTests {
@@ -62,17 +65,14 @@ public class KeyExpirationEventMessageListenerTests {
 		listener = new KeyExpirationEventMessageListener(container);
 		listener.setApplicationEventPublisher(publisherMock);
 		listener.init();
+
+		try (RedisConnection connection = connectionFactory.getConnection()) {
+			connection.flushAll();
+		}
 	}
 
 	@After
 	public void tearDown() throws Exception {
-
-		RedisConnection connection = connectionFactory.getConnection();
-		try {
-			connection.flushAll();
-		} finally {
-			connection.close();
-		}
 
 		listener.destroy();
 		container.destroy();
@@ -82,25 +82,23 @@ public class KeyExpirationEventMessageListenerTests {
 	}
 
 	@Test // DATAREDIS-425
-	public void listenerShouldPublishEventCorrectly() throws InterruptedException {
+	public void listenerShouldPublishEventCorrectly() {
 
 		byte[] key = ("to-expire:" + UUID.randomUUID().toString()).getBytes();
+		AtomicBoolean called = new AtomicBoolean();
+		doAnswer(invocation -> {
+			called.set(true);
+			return null;
+		}).when(publisherMock).publishEvent(any(ApplicationEvent.class));
 
-		RedisConnection connection = connectionFactory.getConnection();
-		try {
-			connection.setEx(key, 2, "foo".getBytes());
+		try (RedisConnection connection = connectionFactory.getConnection()) {
 
-			int iteration = 0;
-			while (connection.get(key) != null || iteration >= 3) {
-
-				Thread.sleep(2000);
-				iteration++;
-			}
-		} finally {
-			connection.close();
+			connection.pSetEx(key, 1, key);
+			Awaitility.await().until(() -> !connection.exists(key));
 		}
 
-		Thread.sleep(2000);
+		Awaitility.await().untilTrue(called);
+
 		ArgumentCaptor<ApplicationEvent> captor = ArgumentCaptor.forClass(ApplicationEvent.class);
 
 		verify(publisherMock, times(1)).publishEvent(captor.capture());
@@ -112,18 +110,13 @@ public class KeyExpirationEventMessageListenerTests {
 
 		byte[] key = ("to-delete:" + UUID.randomUUID().toString()).getBytes();
 
-		RedisConnection connection = connectionFactory.getConnection();
-		try {
+		try (RedisConnection connection = connectionFactory.getConnection()) {
 
 			connection.setEx(key, 10, "foo".getBytes());
-			Thread.sleep(2000);
 			connection.del(key);
-			Thread.sleep(2000);
-		} finally {
-			connection.close();
 		}
 
-		Thread.sleep(2000);
-		verifyZeroInteractions(publisherMock);
+		Thread.sleep(500);
+		verifyNoInteractions(publisherMock);
 	}
 }

--- a/src/test/java/org/springframework/data/redis/listener/PubSubAwaitUtil.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubAwaitUtil.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.listener;
+
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.output.ArrayOutput;
+import io.lettuce.core.output.IntegerOutput;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.awaitility.Awaitility;
+
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnection;
+
+/**
+ * Utility providing await support.
+ * 
+ * @author Mark Paluch
+ */
+class PubSubAwaitUtil {
+
+	/**
+	 * Run the {@link Runnable} and wait until the number of Pub/Sub patterns has increased in comparison to before
+	 * running the callback.
+	 * 
+	 * @param connectionFactory
+	 * @param runnable
+	 */
+	public static void runAndAwaitPatternSubscription(RedisConnectionFactory connectionFactory, Runnable runnable) {
+
+		try (RedisConnection connection = connectionFactory.getConnection()) {
+
+			Number before = numPat(connection);
+
+			runnable.run();
+
+			runAndAwait(runnable, () -> {
+
+				Number after = numPat(connection);
+
+				return after.longValue() > before.longValue();
+			});
+		}
+	}
+
+	/**
+	 * Run the {@link Runnable} and wait until the number of channel subscribers has increased in comparison to before
+	 * running the callback.
+	 * 
+	 * @param connectionFactory
+	 * @param channel
+	 * @param runnable
+	 */
+	public static void runAndAwaitChannelSubscription(RedisConnectionFactory connectionFactory, String channel,
+			Runnable runnable) {
+
+		try (RedisConnection connection = connectionFactory.getConnection()) {
+
+			Number before = numSub(connection, channel);
+
+			runnable.run();
+
+			runAndAwait(runnable, () -> {
+
+				Number after = numSub(connection, channel);
+
+				return after.longValue() > before.longValue();
+			});
+		}
+	}
+
+	private static long numPat(RedisConnection connection) {
+
+		if (connection instanceof LettuceConnection) {
+			return ((Number) ((LettuceConnection) connection).execute("PUBSUB", new IntegerOutput<>(ByteArrayCodec.INSTANCE),
+					"NUMPAT".getBytes())).longValue();
+		}
+
+		return ((Number) connection.execute("PUBSUB", "NUMPAT".getBytes())).longValue();
+	}
+
+	private static long numSub(RedisConnection connection, String channel) {
+
+		List<?> pubsub;
+		if (connection instanceof LettuceConnection) {
+			pubsub = (List<?>) ((LettuceConnection) connection).execute("PUBSUB", new ArrayOutput<>(ByteArrayCodec.INSTANCE),
+					"NUMSUB".getBytes(), channel.getBytes());
+		} else {
+			pubsub = (List<?>) connection.execute("PUBSUB", "NUMSUB".getBytes(), channel.getBytes());
+		}
+
+		return ((Number) pubsub.get(1)).longValue();
+	}
+
+	private static void runAndAwait(Runnable runnable, Callable<Boolean> predicate) {
+
+		runnable.run();
+		Awaitility.await().until(predicate);
+	}
+}

--- a/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerIntegrationTests.java
@@ -27,6 +27,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+
 import org.springframework.data.redis.ConnectionFactoryTracker;
 import org.springframework.data.redis.connection.ReactiveSubscription;
 import org.springframework.data.redis.connection.ReactiveSubscription.ChannelMessage;
@@ -198,16 +200,7 @@ public class ReactiveRedisMessageListenerContainerIntegrationTests {
 	private static Runnable awaitSubscription(Supplier<Collection<ReactiveSubscription>> activeSubscriptions) {
 
 		return () -> {
-
-			try {
-
-				while (activeSubscriptions.get().isEmpty()) {
-					Thread.sleep(10);
-				}
-
-			} catch (InterruptedException e) {
-				return;
-			}
+			Awaitility.await().until(() -> !activeSubscriptions.get().isEmpty());
 		};
 	}
 }

--- a/src/test/java/org/springframework/data/redis/stream/StreamReceiverIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/StreamReceiverIntegrationTests.java
@@ -183,24 +183,18 @@ public class StreamReceiverIntegrationTests {
 
 		messages.as(publisher -> StepVerifier.create(publisher, 0)) //
 				.thenRequest(1) //
+				.thenAwait(Duration.ofMillis(500)) //
 				.then(() -> {
-					try {
-						Thread.sleep(500);
-						reactiveRedisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value1"))
-								.subscribe();
-					} catch (InterruptedException e) {}
+					reactiveRedisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value1")).subscribe();
 				}) //
 				.expectNextCount(1) //
 				.then(() -> {
 					reactiveRedisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value2")).subscribe();
 				}) //
 				.thenRequest(1) //
+				.thenAwait(Duration.ofMillis(500)) //
 				.then(() -> {
-					try {
-						Thread.sleep(500);
-						reactiveRedisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value3"))
-								.subscribe();
-					} catch (InterruptedException e) {}
+					reactiveRedisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value3")).subscribe();
 				}).consumeNextWith(it -> {
 
 					assertThat(it.getStream()).isEqualTo("my-stream");

--- a/src/test/java/org/springframework/data/redis/test/util/RedisClusterRule.java
+++ b/src/test/java/org/springframework/data/redis/test/util/RedisClusterRule.java
@@ -30,6 +30,7 @@ import org.springframework.data.redis.connection.jedis.JedisConverters;
  * Simple {@link TestRule} implementation that check Redis is running in cluster mode.
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.7
  */
 public class RedisClusterRule extends ExternalResource {
@@ -65,6 +66,13 @@ public class RedisClusterRule extends ExternalResource {
 
 	public RedisClusterConfiguration getConfiguration() {
 		return this.clusterConfig;
+	}
+
+	/**
+	 * @return {@literal true} if Redis Cluster is available.
+	 */
+	public boolean isAvailable() {
+		return "cluster".equals(mode);
 	}
 
 	private void init() {


### PR DESCRIPTION
Replace condition-based polling/waiting with Awaitility. Improve assertions for timing-based checks. Increase number of HyperLogLog samples to reduce probability of clashing elements.

Remove long-waiting sleeps that did not lead to an assertion.

---

Related ticket: DATAREDIS-1128.