### PR TITLE
DATAREDIS-1042 - Add support for MKSTREAM parameter when creating a Consumer Group

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -3693,6 +3693,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.StringRedisConnection#xGroupCreate(java.lang.String, org.springframework.data.redis.connection.RedisStreamCommands.ReadOffset, java.lang.String, boolean)
+	 */
+	@Override
+	public String xGroupCreate(String key, ReadOffset readOffset, String group, boolean mkStream) {
+		return convertAndReturn(delegate.xGroupCreate(serialize(key), group, readOffset, mkStream), identityConverter);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.StringRedisConnection#xGroupDelConsumer(java.lang.String, org.springframework.data.redis.connection.RedisStreamCommands.Consumer)
 	 */
 	@Override
@@ -3886,6 +3895,15 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	@Override
 	public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset) {
 		return delegate.xGroupCreate(key, groupName, readOffset);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands#xGroupCreate(byte[], org.springframework.data.redis.connection.RedisStreamCommands.ReadOffset, java.lang.String, boolean)
+	 */
+	@Override
+	public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset, boolean mkStream) {
+		return delegate.xGroupCreate(key, groupName, readOffset, mkStream);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -67,6 +67,7 @@ import org.springframework.util.ObjectUtils;
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Ninad Divadkar
+ * @author Tugdual Grall
  */
 public class DefaultStringRedisConnection implements StringRedisConnection, DecoratedRedisConnection {
 

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -54,6 +54,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Tugdual Grall
  * @since 2.0
  */
 public interface DefaultedRedisConnection extends RedisConnection {

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -487,6 +487,13 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
 	@Override
 	@Deprecated
+	default String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset, boolean mkStream) {
+		return streamCommands().xGroupCreate(key, groupName, readOffset, mkStream);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
+	@Override
+	@Deprecated
 	default Boolean xGroupDelConsumer(byte[] key, Consumer consumer) {
 		return streamCommands().xGroupDelConsumer(key, consumer);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Tugdual Grall
  * @since 2.2
  */
 public interface ReactiveStreamCommands {

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
@@ -1134,15 +1134,22 @@ public interface ReactiveStreamCommands {
 		private final @Nullable String groupName;
 		private final @Nullable String consumerName;
 		private final @Nullable ReadOffset offset;
+		private final boolean mkStream;
 
 		public GroupCommand(@Nullable ByteBuffer key, GroupCommandAction action, @Nullable String groupName,
-				@Nullable String consumerName, @Nullable ReadOffset offset) {
+				@Nullable String consumerName, @Nullable ReadOffset offset, boolean mkStream) {
 
 			super(key);
 			this.action = action;
 			this.groupName = groupName;
 			this.consumerName = consumerName;
 			this.offset = offset;
+			this.mkStream = mkStream;
+		}
+
+		public GroupCommand(@Nullable ByteBuffer key, GroupCommandAction action, @Nullable String groupName,
+				@Nullable String consumerName, @Nullable ReadOffset offset) {
+			this(key, action, groupName, consumerName, offset, false);
 		}
 
 		public static GroupCommand createGroup(String group) {
@@ -1161,6 +1168,10 @@ public interface ReactiveStreamCommands {
 			return new GroupCommand(null, GroupCommandAction.DELETE_CONSUMER, consumer.getGroup(), consumer.getName(), null);
 		}
 
+		public GroupCommand makeStream(boolean mkStream) {
+			return new GroupCommand(getKey(), action, groupName, consumerName, offset,mkStream);
+		}
+
 		public GroupCommand at(ReadOffset offset) {
 			return new GroupCommand(getKey(), action, groupName, consumerName, offset);
 		}
@@ -1171,6 +1182,10 @@ public interface ReactiveStreamCommands {
 
 		public GroupCommand fromGroup(String groupName) {
 			return new GroupCommand(getKey(), action, groupName, consumerName, offset);
+		}
+
+		public boolean getMkStream() {
+			return this.mkStream;
 		}
 
 		@Nullable
@@ -1208,6 +1223,20 @@ public interface ReactiveStreamCommands {
 	default Mono<String> xGroupCreate(ByteBuffer key, String groupName, ReadOffset readOffset) {
 
 		return xGroup(Mono.just(GroupCommand.createGroup(groupName).forStream(key).at(readOffset))).next()
+				.map(CommandResponse::getOutput);
+	}
+
+	/**
+	 * Create a consumer group.
+	 *
+	 * @param key key the {@literal key} the stream is stored at.
+	 * @param groupName name of the consumer group to create.
+	 * @param readOffset the offset to start at.
+	 * @param mkStream if true the group will create the stream if needed (MKSTREAM)
+	 * @return the {@link Mono} emitting {@literal ok} if successful.
+	 */
+	default Mono<String> xGroupCreate(ByteBuffer key, String groupName, ReadOffset readOffset, boolean mkStream) {
+		return xGroup(Mono.just(GroupCommand.createGroup(groupName).forStream(key).at(readOffset).makeStream(mkStream))).next()
 				.map(CommandResponse::getOutput);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
@@ -459,6 +459,18 @@ public interface RedisStreamCommands {
 	String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset);
 
 	/**
+	 * Create a consumer group.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param groupName name of the consumer group to create.
+	 * @param readOffset the offset to start at.
+	 * @param mkStream if true the group will create the stream if not already present (MKSTREAM)
+	 * @return {@literal ok} if successful. {@literal null} when used in pipeline / transaction.
+	 */
+	@Nullable
+	String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset, boolean mkStream);
+
+	/**
 	 * Delete a consumer from a consumer group.
 	 *
 	 * @param key the {@literal key} the stream is stored at.

--- a/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
@@ -39,6 +39,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Tugdual Grall
  * @see <a href="https://redis.io/topics/streams-intro">Redis Documentation - Streams</a>
  * @since 2.2
  */

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -60,6 +60,7 @@ import org.springframework.lang.Nullable;
  * @author David Liu
  * @author Mark Paluch
  * @author Ninad Divadkar
+ * @author Tugdual Grall
  * @see RedisCallback
  * @see RedisSerializer
  * @see StringRedisTemplate

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -2110,6 +2110,19 @@ public interface StringRedisConnection extends RedisConnection {
 	String xGroupCreate(String key, ReadOffset readOffset, String group);
 
 	/**
+	 * Create a consumer group.
+	 *
+	 * @param key
+	 * @param readOffset
+	 * @param group name of the consumer group.
+	 * @param mkStream if true the group will create the stream if needed (MKSTREAM)
+	 * @since
+	 * @return {@literal true} if successful. {@literal null} when used in pipeline / transaction.
+	 */
+	@Nullable
+	String xGroupCreate(String key, ReadOffset readOffset, String group, boolean mkStream);
+
+	/**
 	 * Delete a consumer from a consumer group.
 	 *
 	 * @param key the stream key.

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
@@ -52,6 +52,7 @@ import org.springframework.util.Assert;
  * {@link ReactiveStreamCommands} implementation for {@literal Lettuce}.
  *
  * @author Mark Paluch
+ * @author Tugdual Grall
  * @since 2.2
  */
 class LettuceReactiveStreamCommands implements ReactiveStreamCommands {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.XAddArgs;
 import io.lettuce.core.XClaimArgs;
+import io.lettuce.core.XGroupCreateArgs;
 import io.lettuce.core.XReadArgs;
 import io.lettuce.core.XReadArgs.StreamOffset;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
@@ -188,8 +189,12 @@ class LettuceReactiveStreamCommands implements ReactiveStreamCommands {
 
 				StreamOffset offset = StreamOffset.from(command.getKey(), command.getReadOffset().getOffset());
 
-				return cmd.xgroupCreate(offset, ByteUtils.getByteBuffer(command.getGroupName()))
-						.map(it -> new CommandResponse<>(command, it));
+				return cmd.xgroupCreate(offset,
+							ByteUtils.getByteBuffer(command.getGroupName()),
+							XGroupCreateArgs.Builder.mkstream( command.getMkStream()))
+						.map(it ->
+								new CommandResponse<>(command, it)
+						);
 			}
 
 			if (command.getAction().equals(GroupCommandAction.DELETE_CONSUMER)) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.XAddArgs;
 import io.lettuce.core.XClaimArgs;
+import io.lettuce.core.XGroupCreateArgs;
 import io.lettuce.core.XReadArgs;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
@@ -216,6 +217,15 @@ class LettuceStreamCommands implements RedisStreamCommands {
 	 */
 	@Override
 	public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset) {
+		return xGroupCreate(key, groupName, readOffset, false);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands#xGroupCreate(byte[], org.springframework.data.redis.connection.RedisStreamCommands.ReadOffset, java.lang.String, boolean)
+	 */
+	@Override
+	public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset, boolean mkSteam) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.hasText(groupName, "Group name must not be null or empty!");
@@ -226,15 +236,17 @@ class LettuceStreamCommands implements RedisStreamCommands {
 
 			if (isPipelined()) {
 				pipeline(connection
-						.newLettuceResult(getAsyncConnection().xgroupCreate(streamOffset, LettuceConverters.toBytes(groupName))));
+						.newLettuceResult(getAsyncConnection().xgroupCreate(streamOffset, LettuceConverters.toBytes(groupName),
+								XGroupCreateArgs.Builder.mkstream(mkSteam))));
 				return null;
 			}
 			if (isQueueing()) {
 				transaction(connection
-						.newLettuceResult(getAsyncConnection().xgroupCreate(streamOffset, LettuceConverters.toBytes(groupName))));
+						.newLettuceResult(getAsyncConnection().xgroupCreate(streamOffset, LettuceConverters.toBytes(groupName),
+								XGroupCreateArgs.Builder.mkstream(mkSteam))));
 				return null;
 			}
-			return getConnection().xgroupCreate(streamOffset, LettuceConverters.toBytes(groupName));
+			return getConnection().xgroupCreate(streamOffset, LettuceConverters.toBytes(groupName), XGroupCreateArgs.Builder.mkstream(mkSteam));
 		} catch (Exception ex) {
 			throw convertLettuceAccessException(ex);
 		}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Mark Paluch
+ * @author Tugdual Grall
  * @since 2.2
  */
 @RequiredArgsConstructor

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
@@ -55,6 +55,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Tugdual Grall
  * @since 2.2
  */
 class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperations<K, HK, HV> {

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
@@ -162,12 +162,17 @@ class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperat
 
 	@Override
 	public Mono<String> createGroup(K key, ReadOffset readOffset, String group) {
+		return createMono(connection -> connection.xGroupCreate(rawKey(key), group, readOffset, false));
+	}
+
+	@Override
+	public Mono<String> createGroup(K key, ReadOffset readOffset, String group, boolean mkStream) {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(readOffset, "ReadOffset must not be null!");
 		Assert.notNull(group, "Group must not be null!");
 
-		return createMono(connection -> connection.xGroupCreate(rawKey(key), group, readOffset));
+		return createMono(connection -> connection.xGroupCreate(rawKey(key), group, readOffset, mkStream));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -164,6 +164,20 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.StreamOperations#createGroup(java.lang.Object, org.springframework.data.redis.connection.RedisStreamCommands.ReadOffset, java.lang.String, boolean)
+	 */
+	@Override
+	public String createGroup(K key, ReadOffset readOffset, String group, boolean mkStream) {
+		byte[] rawKey = rawKey(key);
+		if (!mkStream) {
+			return createGroup(key, readOffset, group);
+		} else {
+			return execute(connection -> connection.xGroupCreate(rawKey, group, readOffset, true), true);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.StreamOperations#deleteConsumer(java.lang.Object, org.springframework.data.redis.connection.RedisStreamCommands.Consumer)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -50,6 +50,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @autor Tugdual Grall
  * @since 2.2
  */
 class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> implements StreamOperations<K, HK, HV> {

--- a/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Tugdual Grall
  * @since 2.2
  */
 public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> {

--- a/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
@@ -170,6 +170,19 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	}
 
 	/**
+	 * Create a consumer group at the {@link ReadOffset#latest() latest offset}.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group name of the consumer group.
+	 * @param mkStream if true the group will create the stream if not already present (MKSTREAM)
+	 * @return the {@link Mono} emitting {@literal OK} if successful.. {@literal null} when used in pipeline /
+	 *         transaction.
+	 */
+	default Mono<String> createGroup(K key, String group, boolean mkStream) {
+		return createGroup(key, ReadOffset.latest(), group, mkStream);
+	}
+
+	/**
 	 * Create a consumer group.
 	 *
 	 * @param key the {@literal key} the stream is stored at.
@@ -179,6 +192,16 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 */
 	Mono<String> createGroup(K key, ReadOffset readOffset, String group);
 
+	/**
+	 * Create a consumer group.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param readOffset the {@link ReadOffset} to apply.
+	 * @param group name of the consumer group.
+	 * @param mkStream if true the group will create the stream if needed (MKSTREAM)
+	 * @return the {@link Mono} emitting {@literal OK} if successful.
+	 */
+	Mono<String> createGroup(K key, ReadOffset readOffset, String group, boolean mkStream);
 	/**
 	 * Delete a consumer from a consumer group.
 	 *

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Tugdual Grall
  * @since 2.2
  */
 public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> {

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -177,6 +177,18 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	String createGroup(K key, ReadOffset readOffset, String group);
 
 	/**
+	 * Create a consumer group.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param readOffset the {@link ReadOffset} to apply.
+	 * @param group name of the consumer group.
+	 * @param mkStream if true the group will create the stream if needed (MKSTREAM)
+	 * @return {@literal OK} if successful. {@literal null} when used in pipeline / transaction.
+	 */
+	@Nullable
+	String createGroup(K key, ReadOffset readOffset, String group, boolean mkStream);
+
+	/**
 	 * Delete a consumer from a consumer group.
 	 *
 	 * @param key the stream key.

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
@@ -119,8 +119,26 @@ suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.cr
  * @author Mark Paluch
  * @since 2.2
  */
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.createGroupAndAwait(key: K, group: String, mkStream: Boolean): String =
+		createGroup(key, group, mkStream).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.createGroup].
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
 suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.createGroupAndAwait(key: K, readOffset: ReadOffset, group: String): String =
 		createGroup(key, readOffset, group).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.createGroup].
+ *
+ * @author Tugdual Grall
+ * @since
+ */
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.createGroupAndAwait(key: K, readOffset: ReadOffset, group: String, mkStream: Boolean): String =
+		createGroup(key, readOffset, group, mkStream).awaitSingle()
 
 /**
  * Coroutines variant of [ReactiveStreamOperations.deleteConsumer].

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -98,6 +98,7 @@ import org.springframework.test.annotation.ProfileValueSourceConfiguration;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Tugdual Grall
  */
 @ProfileValueSourceConfiguration(RedisTestProfileValueSource.class)
 public abstract class AbstractConnectionIntegrationTests {

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommandsTests.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assume.*;
 
 import io.lettuce.core.XReadArgs;
+import org.springframework.data.redis.RedisSystemException;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
@@ -183,6 +184,19 @@ public class LettuceReactiveStreamCommandsTests extends LettuceReactiveCommandsT
 		nativeCommands.xadd(KEY_1, Collections.singletonMap(KEY_2, VALUE_2));
 
 		connection.streamCommands().xGroupCreate(KEY_1_BBUFFER, "group-1", ReadOffset.latest()) //
+				.as(StepVerifier::create) //
+				.expectNext("OK") //
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-864
+	public void xGroupCreateShouldCreateGroupBeforeStream() {
+		connection.streamCommands().xGroupCreate(KEY_1_BBUFFER, "group-1", ReadOffset.latest(), false)
+				.as(StepVerifier::create) //
+				.expectError(RedisSystemException.class) //
+				.verify();
+
+		connection.streamCommands().xGroupCreate(KEY_1_BBUFFER, "group-1", ReadOffset.latest(), true) //
 				.as(StepVerifier::create) //
 				.expectNext("OK") //
 				.verifyComplete();

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommandsTests.java
@@ -43,6 +43,7 @@ import org.springframework.data.redis.connection.stream.StreamOffset;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Tugdual Grall
  */
 public class LettuceReactiveStreamCommandsTests extends LettuceReactiveCommandsTestsBase {
 

--- a/src/test/java/org/springframework/data/redis/stream/StreamReceiverIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/StreamReceiverIntegrationTests.java
@@ -256,6 +256,31 @@ public class StreamReceiverIntegrationTests {
 				.verify(Duration.ofSeconds(5));
 	}
 
+	@Test // DATAREDIS-864
+	public void shouldCreateGroupWithOrWithoutExistingStream() {
+		StreamReceiver<String, MapRecord<String, String, String>> receiver = StreamReceiver.create(connectionFactory);
+
+		Flux<MapRecord<String, String, String>> messages = receiver.receive(Consumer.from("my-group", "my-consumer-id"),
+				StreamOffset.create("my-stream", ReadOffset.lastConsumed()));
+
+		// required to initialize stream
+		redisTemplate.opsForStream().createGroup("my-stream", ReadOffset.from("0-0"), "my-group", true);
+		redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value"));
+		redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key2", "value2"));
+
+		messages.as(StepVerifier::create) //
+				.consumeNextWith(it -> {
+					assertThat(it.getStream()).isEqualTo("my-stream");
+					assertThat(it.getValue()).containsValue("value");
+				}).consumeNextWith(it -> {
+
+			assertThat(it.getStream()).isEqualTo("my-stream");
+			assertThat(it.getValue()).containsValue("value2");
+		}) //
+				.thenCancel() //
+				.verify(Duration.ofSeconds(5));
+	}
+
 	@Data
 	@AllArgsConstructor
 	static class LoginEvent {

--- a/src/test/java/org/springframework/data/redis/stream/StreamReceiverIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/StreamReceiverIntegrationTests.java
@@ -55,6 +55,7 @@ import org.springframework.data.redis.stream.StreamReceiver.StreamReceiverOption
  * Integration tests for {@link StreamReceiver}.
  *
  * @author Mark Paluch
+ * @author Tugdual Grall
  */
 public class StreamReceiverIntegrationTests {
 

--- a/src/test/java/org/springframework/data/redis/test/util/RedisClientRule.java
+++ b/src/test/java/org/springframework/data/redis/test/util/RedisClientRule.java
@@ -27,6 +27,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
  *
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Tugdual Grall
  */
 public abstract class RedisClientRule implements TestRule {
 

--- a/src/test/java/org/springframework/data/redis/test/util/RedisClientRule.java
+++ b/src/test/java/org/springframework/data/redis/test/util/RedisClientRule.java
@@ -50,7 +50,7 @@ public abstract class RedisClientRule implements TestRule {
 							return;
 						}
 					}
-					throw new AssumptionViolatedException("not a vaild redis connection for driver: " + redisConnectionFactory);
+					throw new AssumptionViolatedException("not a valid redis connection for driver: " + redisConnectionFactory);
 				}
 
 				base.evaluate();

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensionsUnitTests.kt
@@ -35,6 +35,7 @@ import reactor.core.publisher.Mono
  *
  * @author Mark Paluch
  * @author Sebastien Deleuze
+ * @author Tugdual Grall
  */
 class ReactiveStreamOperationsExtensionsUnitTests {
 


### PR DESCRIPTION

It is my first contribution to Spring Data/Spring Data Redis, so I am not used yet to this project.

I have not done anything serious with Kotlin, I will need some help from the community to add more tests.

---
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

