### PR TITLE
DATAREDIS-1138, DATAREDIS-1139 - Fix detection whether XREAD is blocking and polishing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.0.BUILD-SNAPSHOT</version>
+	<version>2.3.0.DATAREDIS-1138-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
@@ -91,6 +91,7 @@ public interface RedisStreamCommands {
 	 * @param record the {@link MapRecord record} to append.
 	 * @return the {@link RecordId id} after save. {@literal null} when used in pipeline / transaction.
 	 */
+	@Nullable
 	default RecordId xAdd(MapRecord<byte[], byte[], byte[]> record) {
 		return xAdd(record, XAddOptions.none());
 	}
@@ -106,6 +107,7 @@ public interface RedisStreamCommands {
 	 * @return the {@link RecordId id} after save. {@literal null} when used in pipeline / transaction.
 	 * @since 2.3
 	 */
+	@Nullable
 	RecordId xAdd(MapRecord<byte[], byte[], byte[]> record, XAddOptions options);
 
 	/**
@@ -188,6 +190,7 @@ public interface RedisStreamCommands {
 	 * @see <a href="https://redis.io/commands/xclaim">Redis Documentation: XCLAIM</a>
 	 * @since 2.3
 	 */
+	@Nullable
 	List<RecordId> xClaimJustId(byte[] key, String group, String newOwner, XClaimOptions options);
 
 	/**
@@ -202,6 +205,7 @@ public interface RedisStreamCommands {
 	 * @see <a href="https://redis.io/commands/xclaim">Redis Documentation: XCLAIM</a>
 	 * @since 2.3
 	 */
+	@Nullable
 	default List<ByteRecord> xClaim(byte[] key, String group, String newOwner, Duration minIdleTime,
 			RecordId... recordIds) {
 		return xClaim(key, group, newOwner, XClaimOptions.minIdle(minIdleTime).ids(recordIds));
@@ -218,6 +222,7 @@ public interface RedisStreamCommands {
 	 * @see <a href="https://redis.io/commands/xclaim">Redis Documentation: XCLAIM</a>
 	 * @since 2.3
 	 */
+	@Nullable
 	List<ByteRecord> xClaim(byte[] key, String group, String newOwner, XClaimOptions options);
 
 	/**
@@ -445,6 +450,7 @@ public interface RedisStreamCommands {
 	 * @return number of removed entries. {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/xdel">Redis Documentation: XDEL</a>
 	 */
+	@Nullable
 	Long xDel(byte[] key, RecordId... recordIds);
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
@@ -322,7 +322,7 @@ class LettuceReactiveStreamCommands implements ReactiveStreamCommands {
 
 			StreamReadOptions readOptions = command.getReadOptions();
 
-			if (readOptions.getBlock() != null && readOptions.getBlock() > 0) {
+			if (readOptions.isBlocking()) {
 				return new CommandResponse<>(command, connection.executeDedicated(cmd -> doRead(command, readOptions, cmd)));
 			}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
@@ -516,7 +516,7 @@ class LettuceStreamCommands implements RedisStreamCommands {
 		XReadArgs.StreamOffset<byte[]>[] streamOffsets = toStreamOffsets(streams);
 		XReadArgs args = StreamConverters.toReadArgs(readOptions);
 
-		if (isBlocking(readOptions)) {
+		if (readOptions.isBlocking()) {
 
 			try {
 				if (isPipelined()) {
@@ -568,7 +568,7 @@ class LettuceStreamCommands implements RedisStreamCommands {
 		XReadArgs args = StreamConverters.toReadArgs(readOptions);
 		io.lettuce.core.Consumer<byte[]> lettuceConsumer = toConsumer(consumer);
 
-		if (isBlocking(readOptions)) {
+		if (readOptions.isBlocking()) {
 
 			try {
 				if (isPipelined()) {
@@ -699,9 +699,6 @@ class LettuceStreamCommands implements RedisStreamCommands {
 		return connection.convertLettuceAccessException(ex);
 	}
 
-	private static boolean isBlocking(StreamReadOptions readOptions) {
-		return readOptions.getBlock() != null && readOptions.getBlock() > 0;
-	}
 
 	@SuppressWarnings("unchecked")
 	private static XReadArgs.StreamOffset<byte[]>[] toStreamOffsets(StreamOffset<byte[]>[] streams) {

--- a/src/main/java/org/springframework/data/redis/connection/stream/StreamReadOptions.java
+++ b/src/main/java/org/springframework/data/redis/connection/stream/StreamReadOptions.java
@@ -105,4 +105,12 @@ public class StreamReadOptions {
 
 		return new StreamReadOptions(block, count, noack);
 	}
+
+	/**
+	 * @return {@literal true} if the arguments indicate a blocking read.
+	 * @since 2.3
+	 */
+	public boolean isBlocking() {
+		return getBlock() != null && getBlock() >= 0;
+	}
 }

--- a/src/main/java/org/springframework/data/redis/core/RedisCommand.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisCommand.java
@@ -140,7 +140,10 @@ public enum RedisCommand {
 	QUIT("rw", 0, 0), //
 	// -- R
 	RANDOMKEY("r", 0, 0), //
+
+	@Deprecated
 	RANAME("w", 2, 2), //
+	RENAME("w", 2, 2), //
 	RENAMENX("w", 2, 2), //
 	RESTORE("w", 3, 3), //
 	RPOP("rw", 1, 1), //
@@ -200,7 +203,7 @@ public enum RedisCommand {
 	ZRANK("r", 2, 2), //
 	ZREM("rw", 2), //
 	ZREMRANGEBYRANK("rw", 3, 3), //
-	ZREMRANGEBYSCORE("rm", 3, 3), //
+	ZREMRANGEBYSCORE("rw", 3, 3), //
 	ZREVRANGE("r", 3), //
 	ZREVRANGEBYSCORE("r", 3), //
 	ZREVRANK("r", 2, 2), //

--- a/src/test/java/org/springframework/data/redis/connection/stream/StreamReadOptionsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/stream/StreamReadOptionsUnitTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.stream;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link StreamReadOptions}.
+ * 
+ * @author Mark Paluch
+ */
+public class StreamReadOptionsUnitTests {
+
+	@Test // DATAREDIS-1138
+	public void shouldConsiderBlocking() {
+
+		assertThat(StreamReadOptions.empty().isBlocking()).isFalse();
+		assertThat(StreamReadOptions.empty().block(Duration.ofSeconds(1)).isBlocking()).isTrue();
+		assertThat(StreamReadOptions.empty().block(Duration.ZERO).isBlocking()).isTrue();
+	}
+}


### PR DESCRIPTION
DATAREDIS-1138 - Fix detection whether XREAD is blocking.

We now correctly check if a BLOCK option is configured using a timeout of zero or higher. Previously we only checked if the configured value is greater than zero and didn't consider that a timeout of zero blocks indefinitely.

DATAREDIS-1139 - Fix command constants.
Deprecate constants with typos. Fix mode of ZREMRANGEBYSCORE.

---

Should be backported to 2.2.x.
