### PR TITLE
DATAREDIS1142 - getReactiveConnection fallback to getReactiveClusterC…

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -90,6 +90,7 @@ import org.springframework.util.ClassUtils;
  * @author Balázs Németh
  * @author Ruben Cervilla
  * @author Luis De Bello
+ * @author Andrea Como
  */
 public class LettuceConnectionFactory
 		implements InitializingBean, DisposableBean, RedisConnectionFactory, ReactiveRedisConnectionFactory {
@@ -431,6 +432,10 @@ public class LettuceConnectionFactory
 	 */
 	@Override
 	public LettuceReactiveRedisConnection getReactiveConnection() {
+
+		if (isClusterAware()) {
+			return getReactiveClusterConnection();
+		}
 
 		return getShareNativeConnection()
 				? new LettuceReactiveRedisConnection(getSharedReactiveConnection(), reactiveConnectionProvider)


### PR DESCRIPTION
This patch fixes [Jira DATAREDIS-1142](https://jira.spring.io/browse/DATAREDIS-1142), when `ReactiveRedisTemplate` is connected to a Redis Cluster