### PR TITLE
DATAREDIS-1150 - Add ReactiveRedisClusterCommands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATAREDIS-1150-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveClusterCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveClusterCommands.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.data.redis.connection.RedisClusterNode.SlotRange;
+
+/**
+ * Interface for the {@literal cluster} commands supported by Redis executed using reactive infrastructure.. A
+ * {@link RedisClusterNode} can be obtained from {@link #clusterGetNodes()} or it can be constructed using either
+ * {@link RedisClusterNode#getHost() host} and {@link RedisClusterNode#getPort()} or the {@link RedisClusterNode#getId()
+ * node Id}.
+ *
+ * @author Mark Paluch
+ * @since 2.3.1
+ */
+public interface ReactiveClusterCommands {
+
+	/**
+	 * Retrieve cluster node information such as {@literal id}, {@literal host}, {@literal port} and {@literal slots}.
+	 *
+	 * @return never {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-nodes">Redis Documentation: CLUSTER NODES</a>
+	 */
+	Flux<RedisClusterNode> clusterGetNodes();
+
+	/**
+	 * Retrieve information about connected slaves for given master node.
+	 *
+	 * @param master must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-slaves">Redis Documentation: CLUSTER SLAVES</a>
+	 */
+	Flux<RedisClusterNode> clusterGetSlaves(RedisClusterNode master);
+
+	/**
+	 * Retrieve information about masters and their connected slaves.
+	 *
+	 * @return never {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-slaves">Redis Documentation: CLUSTER SLAVES</a>
+	 */
+	Mono<Map<RedisClusterNode, Collection<RedisClusterNode>>> clusterGetMasterSlaveMap();
+
+	/**
+	 * Find the slot for a given {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 * @see <a href="https://redis.io/commands/cluster-keyslot">Redis Documentation: CLUSTER KEYSLOT</a>
+	 */
+	Mono<Integer> clusterGetSlotForKey(ByteBuffer key);
+
+	/**
+	 * Find the {@link RedisClusterNode} serving given {@literal slot}.
+	 *
+	 * @param slot
+	 * @return
+	 */
+	Mono<RedisClusterNode> clusterGetNodeForSlot(int slot);
+
+	/**
+	 * Find the {@link RedisClusterNode} serving given {@literal key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return
+	 */
+	Mono<RedisClusterNode> clusterGetNodeForKey(ByteBuffer key);
+
+	/**
+	 * Get cluster information.
+	 *
+	 * @return
+	 * @see <a href="https://redis.io/commands/cluster-info">Redis Documentation: CLUSTER INFO</a>
+	 */
+	Mono<ClusterInfo> clusterGetClusterInfo();
+
+	/**
+	 * Assign slots to given {@link RedisClusterNode}.
+	 *
+	 * @param node must not be {@literal null}.
+	 * @param slots
+	 * @see <a href="https://redis.io/commands/cluster-addslots">Redis Documentation: CLUSTER ADDSLOTS</a>
+	 */
+	Mono<Void> clusterAddSlots(RedisClusterNode node, int... slots);
+
+	/**
+	 * Assign {@link SlotRange#getSlotsArray()} to given {@link RedisClusterNode}.
+	 *
+	 * @param node must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-addslots">Redis Documentation: CLUSTER ADDSLOTS</a>
+	 */
+	Mono<Void> clusterAddSlots(RedisClusterNode node, SlotRange range);
+
+	/**
+	 * Count the number of keys assigned to one {@literal slot}.
+	 *
+	 * @param slot
+	 * @return
+	 * @see <a href="https://redis.io/commands/cluster-countkeysinslot">Redis Documentation: CLUSTER COUNTKEYSINSLOT</a>
+	 */
+	Mono<Long> clusterCountKeysInSlot(int slot);
+
+	/**
+	 * Remove slots from {@link RedisClusterNode}.
+	 *
+	 * @param node must not be {@literal null}.
+	 * @param slots
+	 * @see <a href="https://redis.io/commands/cluster-delslots">Redis Documentation: CLUSTER DELSLOTS</a>
+	 */
+	Mono<Void> clusterDeleteSlots(RedisClusterNode node, int... slots);
+
+	/**
+	 * Removes {@link SlotRange#getSlotsArray()} from given {@link RedisClusterNode}.
+	 *
+	 * @param node must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-delslots">Redis Documentation: CLUSTER DELSLOTS</a>
+	 */
+	Mono<Void> clusterDeleteSlotsInRange(RedisClusterNode node, SlotRange range);
+
+	/**
+	 * Remove given {@literal node} from cluster.
+	 *
+	 * @param node must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-forget">Redis Documentation: CLUSTER FORGET</a>
+	 */
+	Mono<Void> clusterForget(RedisClusterNode node);
+
+	/**
+	 * Add given {@literal node} to cluster.
+	 *
+	 * @param node must contain {@link RedisClusterNode#getHost() host} and {@link RedisClusterNode#getPort()} and must
+	 *          not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-meet">Redis Documentation: CLUSTER MEET</a>
+	 */
+	Mono<Void> clusterMeet(RedisClusterNode node);
+
+	/**
+	 * @param node must not be {@literal null}.
+	 * @param slot
+	 * @param mode must not be{@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-setslot">Redis Documentation: CLUSTER SETSLOT</a>
+	 */
+	Mono<Void> clusterSetSlot(RedisClusterNode node, int slot, AddSlots mode);
+
+	/**
+	 * Get {@literal keys} served by slot.
+	 *
+	 * @param slot
+	 * @param count must not be {@literal null}.
+	 * @return
+	 * @see <a href="https://redis.io/commands/cluster-getkeysinslot">Redis Documentation: CLUSTER GETKEYSINSLOT</a>
+	 */
+	Flux<ByteBuffer> clusterGetKeysInSlot(int slot, int count);
+
+	/**
+	 * Assign a {@literal slave} to given {@literal master}.
+	 *
+	 * @param master must not be {@literal null}.
+	 * @param replica must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/cluster-replicate">Redis Documentation: CLUSTER REPLICATE</a>
+	 */
+	Mono<Void> clusterReplicate(RedisClusterNode master, RedisClusterNode replica);
+
+	enum AddSlots {
+		MIGRATING, IMPORTING, STABLE, NODE
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveRedisClusterConnection.java
@@ -22,7 +22,7 @@ import reactor.core.publisher.Mono;
  * @author Mark Paluch
  * @since 2.0
  */
-public interface ReactiveRedisClusterConnection extends ReactiveRedisConnection {
+public interface ReactiveRedisClusterConnection extends ReactiveRedisConnection, ReactiveClusterCommands {
 
 	@Override
 	ReactiveClusterKeyCommands keyCommands();

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -286,6 +286,44 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnection#ping()
+	 */
+	@Override
+	public String ping() {
+		Collection<String> ping = clusterCommandExecutor
+				.executeCommandOnAllNodes((LettuceClusterCommandCallback<String>) BaseRedisCommands::ping).resultsAsList();
+
+		for (String result : ping) {
+			if (!ObjectUtils.nullSafeEquals("PONG", result)) {
+				return "";
+			}
+		}
+
+		return "PONG";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisClusterConnection#ping(org.springframework.data.redis.connection.RedisClusterNode)
+	 */
+	@Override
+	public String ping(RedisClusterNode node) {
+
+		return clusterCommandExecutor
+				.executeCommandOnSingleNode((LettuceClusterCommandCallback<String>) BaseRedisCommands::ping, node).getValue();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisClusterCommands#getClusterNodes()
+	 */
+	@Override
+	public List<RedisClusterNode> clusterGetNodes() {
+		return new ArrayList<>(topologyProvider.getTopology().getNodes());
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisClusterCommands#getClusterSlaves(org.springframework.data.redis.connection.RedisClusterNode)
 	 */
 	@Override
@@ -299,6 +337,27 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 				.executeCommandOnSingleNode((LettuceClusterCommandCallback<Set<RedisClusterNode>>) client -> LettuceConverters
 						.toSetOfRedisClusterNodes(client.clusterSlaves(nodeToUse.getId())), master)
 				.getValue();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisClusterCommands#clusterGetMasterSlaveMap()
+	 */
+	@Override
+	public Map<RedisClusterNode, Collection<RedisClusterNode>> clusterGetMasterSlaveMap() {
+
+		List<NodeResult<Collection<RedisClusterNode>>> nodeResults = clusterCommandExecutor.executeCommandAsyncOnNodes(
+				(LettuceClusterCommandCallback<Collection<RedisClusterNode>>) client -> Converters
+						.toSetOfRedisClusterNodes(client.clusterSlaves(client.clusterMyId())),
+				topologyProvider.getTopology().getActiveMasterNodes()).getResults();
+
+		Map<RedisClusterNode, Collection<RedisClusterNode>> result = new LinkedHashMap<>();
+
+		for (NodeResult<Collection<RedisClusterNode>> nodeResult : nodeResults) {
+			result.put(nodeResult.getNode(), nodeResult.getValue());
+		}
+
+		return result;
 	}
 
 	/*
@@ -367,6 +426,20 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 		Assert.notNull(range, "Range must not be null.");
 
 		clusterAddSlots(node, range.getSlotsArray());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisClusterCommands#countKeys(int)
+	 */
+	@Override
+	public Long clusterCountKeysInSlot(int slot) {
+
+		try {
+			return getConnection().clusterCountKeysInSlot(slot);
+		} catch (Exception ex) {
+			throw exceptionConverter.translate(ex);
+		}
 	}
 
 	/*
@@ -466,20 +539,6 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisClusterCommands#countKeys(int)
-	 */
-	@Override
-	public Long clusterCountKeysInSlot(int slot) {
-
-		try {
-			return getConnection().clusterCountKeysInSlot(slot);
-		} catch (Exception ex) {
-			throw exceptionConverter.translate(ex);
-		}
-	}
-
-	/*
-	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisClusterCommands#clusterReplicate(org.springframework.data.redis.connection.RedisClusterNode, org.springframework.data.redis.connection.RedisClusterNode)
 	 */
 	@Override
@@ -488,35 +547,6 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 		RedisClusterNode masterNode = topologyProvider.getTopology().lookup(master);
 		clusterCommandExecutor.executeCommandOnSingleNode(
 				(LettuceClusterCommandCallback<String>) client -> client.clusterReplicate(masterNode.getId()), replica);
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnection#ping()
-	 */
-	@Override
-	public String ping() {
-		Collection<String> ping = clusterCommandExecutor
-				.executeCommandOnAllNodes((LettuceClusterCommandCallback<String>) BaseRedisCommands::ping).resultsAsList();
-
-		for (String result : ping) {
-			if (!ObjectUtils.nullSafeEquals("PONG", result)) {
-				return "";
-			}
-		}
-
-		return "PONG";
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisClusterConnection#ping(org.springframework.data.redis.connection.RedisClusterNode)
-	 */
-	@Override
-	public String ping(RedisClusterNode node) {
-
-		return clusterCommandExecutor
-				.executeCommandOnSingleNode((LettuceClusterCommandCallback<String>) BaseRedisCommands::ping, node).getValue();
 	}
 
 	/*
@@ -561,15 +591,6 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisClusterCommands#getClusterNodes()
-	 */
-	@Override
-	public List<RedisClusterNode> clusterGetNodes() {
-		return new ArrayList<>(topologyProvider.getTopology().getNodes());
-	}
-
-	/*
-	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnection#watch(byte[][])
 	 */
 	@Override
@@ -595,26 +616,6 @@ public class LettuceClusterConnection extends LettuceConnection implements Defau
 		throw new InvalidDataAccessApiUsageException("MULTI is currently not supported in cluster mode.");
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.redis.connection.RedisClusterCommands#clusterGetMasterSlaveMap()
-	 */
-	@Override
-	public Map<RedisClusterNode, Collection<RedisClusterNode>> clusterGetMasterSlaveMap() {
-
-		List<NodeResult<Collection<RedisClusterNode>>> nodeResults = clusterCommandExecutor.executeCommandAsyncOnNodes(
-				(LettuceClusterCommandCallback<Collection<RedisClusterNode>>) client -> Converters
-						.toSetOfRedisClusterNodes(client.clusterSlaves(client.clusterMyId())),
-				topologyProvider.getTopology().getActiveMasterNodes()).getResults();
-
-		Map<RedisClusterNode, Collection<RedisClusterNode>> result = new LinkedHashMap<>();
-
-		for (NodeResult<Collection<RedisClusterNode>> nodeResult : nodeResults) {
-			result.put(nodeResult.getNode(), nodeResult.getValue());
-		}
-
-		return result;
-	}
 
 	public ClusterCommandExecutor getClusterCommandExecutor() {
 		return clusterCommandExecutor;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisClusterConnection.java
@@ -20,17 +20,29 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.reactive.BaseRedisReactiveCommands;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.SlotHash;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.connection.ClusterInfo;
 import org.springframework.data.redis.connection.ClusterTopologyProvider;
 import org.springframework.data.redis.connection.ReactiveRedisClusterConnection;
 import org.springframework.data.redis.connection.RedisClusterNode;
 import org.springframework.data.redis.connection.RedisNode;
+import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -190,6 +202,15 @@ class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisConnecti
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterConnection#ping()
+	 */
+	@Override
+	public Mono<String> ping() {
+		return clusterGetNodes().flatMap(node -> execute(node, BaseRedisReactiveCommands::ping)).last();
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterConnection#ping(org.springframework.data.redis.connection.RedisClusterNode)
 	 */
 	@Override
@@ -197,7 +218,242 @@ class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisConnecti
 		return execute(node, BaseRedisReactiveCommands::ping).next();
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterGetNodes()
+	 */
+	@Override
+	public Flux<RedisClusterNode> clusterGetNodes() {
+		return Flux.fromIterable(doGetActiveNodes());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterGetSlaves(org.springframework.data.redis.connection.RedisClusterNode)
+	 */
+	@Override
+	public Flux<RedisClusterNode> clusterGetSlaves(RedisClusterNode master) {
+
+		Assert.notNull(master, "Master must not be null!");
+
+		RedisClusterNode nodeToUse = lookup(master);
+
+		return execute(nodeToUse, cmd -> cmd.clusterSlaves(nodeToUse.getId()) //
+				.flatMapIterable(LettuceConverters::toSetOfRedisClusterNodes));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterGetMasterSlaveMap()
+	 */
+	@Override
+	public Mono<Map<RedisClusterNode, Collection<RedisClusterNode>>> clusterGetMasterSlaveMap() {
+
+		return Flux.fromIterable(topologyProvider.getTopology().getActiveMasterNodes()) //
+				.flatMap(node -> {
+					return Mono.just(node).zipWith(execute(node, cmd -> cmd.clusterSlaves(node.getId())) //
+							.collectList() //
+							.map(Converters::toSetOfRedisClusterNodes));
+				}).collect(Collectors.toMap(Tuple2::getT1, Tuple2::getT2));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterGetSlotForKey(java.nio.ByteBuffer)
+	 */
+	@Override
+	public Mono<Integer> clusterGetSlotForKey(ByteBuffer key) {
+		return Mono.fromSupplier(() -> SlotHash.getSlot(key));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterGetNodeForSlot(int)
+	 */
+	@Override
+	public Mono<RedisClusterNode> clusterGetNodeForSlot(int slot) {
+
+		Set<RedisClusterNode> nodes = topologyProvider.getTopology().getSlotServingNodes(slot);
+		return nodes.isEmpty() ? Mono.empty() : Flux.fromIterable(nodes).next();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterGetNodeForKey(java.nio.ByteBuffer)
+	 */
+	@Override
+	public Mono<RedisClusterNode> clusterGetNodeForKey(ByteBuffer key) {
+
+		Assert.notNull(key, "Key must not be null.");
+
+		return clusterGetSlotForKey(key).flatMap(this::clusterGetNodeForSlot);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterGetClusterInfo()
+	 */
+	@Override
+	public Mono<ClusterInfo> clusterGetClusterInfo() {
+		return executeCommandOnArbitraryNode(RedisClusterReactiveCommands::clusterInfo) //
+				.map(LettuceConverters::toProperties) //
+				.map(ClusterInfo::new) //
+				.single();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterAddSlots(org.springframework.data.redis.connection.RedisClusterNode, int[])
+	 */
+	@Override
+	public Mono<Void> clusterAddSlots(RedisClusterNode node, int... slots) {
+		return execute(node, cmd -> cmd.clusterAddSlots(slots)).then();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterAddSlots(org.springframework.data.redis.connection.RedisClusterNode, org.springframework.data.redis.connection.RedisClusterNode.SlotRange)
+	 */
+	@Override
+	public Mono<Void> clusterAddSlots(RedisClusterNode node, RedisClusterNode.SlotRange range) {
+
+		Assert.notNull(range, "Range must not be null.");
+
+		return execute(node, cmd -> cmd.clusterAddSlots(range.getSlotsArray())).then();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterCountKeysInSlot(int)
+	 */
+	@Override
+	public Mono<Long> clusterCountKeysInSlot(int slot) {
+		return execute(cmd -> cmd.clusterCountKeysInSlot(slot)).next();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterDeleteSlots(org.springframework.data.redis.connection.RedisClusterNode, int[])
+	 */
+	@Override
+	public Mono<Void> clusterDeleteSlots(RedisClusterNode node, int... slots) {
+		return execute(node, cmd -> cmd.clusterDelSlots(slots)).then();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterDeleteSlotsInRange(org.springframework.data.redis.connection.RedisClusterNode, org.springframework.data.redis.connection.RedisClusterNode.SlotRange)
+	 */
+	@Override
+	public Mono<Void> clusterDeleteSlotsInRange(RedisClusterNode node, RedisClusterNode.SlotRange range) {
+
+		Assert.notNull(range, "Range must not be null.");
+
+		return execute(node, cmd -> cmd.clusterDelSlots(range.getSlotsArray())).then();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterForget(org.springframework.data.redis.connection.RedisClusterNode)
+	 */
+	@Override
+	public Mono<Void> clusterForget(RedisClusterNode node) {
+
+		List<RedisClusterNode> nodes = new ArrayList<>(doGetActiveNodes());
+		RedisClusterNode nodeToRemove = lookup(node);
+		nodes.remove(nodeToRemove);
+
+		return Flux.fromIterable(nodes).flatMap(actualNode -> execute(node, cmd -> cmd.clusterForget(nodeToRemove.getId())))
+				.then();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterMeet(org.springframework.data.redis.connection.RedisClusterNode)
+	 */
+	@Override
+	public Mono<Void> clusterMeet(RedisClusterNode node) {
+
+		Assert.notNull(node, "Cluster node must not be null for CLUSTER MEET command!");
+		Assert.hasText(node.getHost(), "Node to meet cluster must have a host!");
+		Assert.isTrue(node.getPort() != null && node.getPort() > 0, "Node to meet cluster must have a port greater 0!");
+
+		return clusterGetNodes()
+				.flatMap(actualNode -> execute(node, cmd -> cmd.clusterMeet(node.getHost(), node.getPort()))).then();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterSetSlot(org.springframework.data.redis.connection.RedisClusterNode, int, org.springframework.data.redis.connection.ReactiveRedisClusterCommands.AddSlots)
+	 */
+	@Override
+	public Mono<Void> clusterSetSlot(RedisClusterNode node, int slot, AddSlots mode) {
+
+		Assert.notNull(node, "Node must not be null.");
+		Assert.notNull(mode, "AddSlots mode must not be null.");
+
+		RedisClusterNode nodeToUse = lookup(node);
+		String nodeId = nodeToUse.getId();
+
+		return execute(node, cmd -> {
+
+			switch (mode) {
+				case MIGRATING:
+					return cmd.clusterSetSlotMigrating(slot, nodeId);
+				case IMPORTING:
+					return cmd.clusterSetSlotImporting(slot, nodeId);
+				case NODE:
+					return cmd.clusterSetSlotNode(slot, nodeId);
+				case STABLE:
+					return cmd.clusterSetSlotStable(slot);
+				default:
+					throw new InvalidDataAccessApiUsageException("Invalid import mode for cluster slot: " + slot);
+			}
+
+		}).then();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterGetKeysInSlot(int, int)
+	 */
+	@Override
+	public Flux<ByteBuffer> clusterGetKeysInSlot(int slot, int count) {
+		return execute(cmd -> cmd.clusterGetKeysInSlot(slot, count));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.ReactiveRedisClusterCommands#clusterReplicate(org.springframework.data.redis.connection.RedisClusterNode, org.springframework.data.redis.connection.RedisClusterNode)
+	 */
+	@Override
+	public Mono<Void> clusterReplicate(RedisClusterNode master, RedisClusterNode replica) {
+
+		RedisClusterNode masterToUse = lookup(master);
+
+		return execute(replica, cmd -> cmd.clusterReplicate(masterToUse.getId())).then();
+	}
+
 	/**
+	 * Run {@link LettuceReactiveCallback} on a random node.
+	 *
+	 * @param callback must not be {@literal null}.
+	 * @throws IllegalArgumentException when {@code node} or {@code callback} is {@literal null}.
+	 * @return {@link Flux} emitting execution results.
+	 */
+	public <T> Flux<T> executeCommandOnArbitraryNode(LettuceReactiveCallback<T> callback) {
+
+		Assert.notNull(callback, "ReactiveCallback must not be null!");
+
+		List<RedisClusterNode> nodes = new ArrayList<>(doGetActiveNodes());
+		int random = new Random().nextInt(nodes.size());
+
+		return execute(nodes.get(random), callback);
+	}
+
+	/**
+	 * Run {@link LettuceReactiveCallback} on given {@link RedisClusterNode}.
+	 *
 	 * @param node must not be {@literal null}.
 	 * @param callback must not be {@literal null}.
 	 * @throws IllegalArgumentException when {@code node} or {@code callback} is {@literal null}.
@@ -205,12 +461,8 @@ class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisConnecti
 	 */
 	public <T> Flux<T> execute(RedisNode node, LettuceReactiveCallback<T> callback) {
 
-		try {
-			Assert.notNull(node, "RedisClusterNode must not be null!");
-			Assert.notNull(callback, "ReactiveCallback must not be null!");
-		} catch (IllegalArgumentException e) {
-			return Flux.error(e);
-		}
+		Assert.notNull(node, "RedisClusterNode must not be null!");
+		Assert.notNull(callback, "ReactiveCallback must not be null!");
 
 		return getCommands(node).flatMapMany(callback::doWithCommands).onErrorMap(translateException());
 	}
@@ -243,5 +495,20 @@ class LettuceReactiveRedisClusterConnection extends LettuceReactiveRedisConnecti
 
 		return getConnection().flatMap(it -> Mono.fromCompletionStage(it.getConnectionAsync(node.getHost(), node.getPort()))
 				.map(StatefulRedisConnection::reactive));
+	}
+
+	/**
+	 * Lookup a {@link RedisClusterNode} by using either ids {@link RedisClusterNode#getId() node id} or host and port to
+	 * obtain the full node details from the underlying {@link ClusterTopologyProvider}.
+	 *
+	 * @param nodeToLookup the node to lookup.
+	 * @return the {@link RedisClusterNode} from the topology lookup.
+	 */
+	private RedisClusterNode lookup(RedisClusterNode nodeToLookup) {
+		return topologyProvider.getTopology().lookup(nodeToLookup);
+	}
+
+	private Set<RedisClusterNode> doGetActiveNodes() {
+		return topologyProvider.getTopology().getActiveNodes();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterCommandsTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.assertj.core.api.Assertions.*;
+
+import reactor.test.StepVerifier;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import org.springframework.data.redis.connection.ReactiveClusterCommands;
+import org.springframework.data.redis.connection.RedisClusterNode;
+
+/**
+ * Integration tests for {@link LettuceReactiveRedisClusterConnection} via {@link ReactiveClusterCommands}.
+ * <p>
+ * Some assertions check against node 1 and node 4 (ports 7379/7382) as sometimes a failover happens and node 4 becomes
+ * the master node.
+ *
+ * @author Mark Paluch
+ */
+public class LettuceReactiveClusterCommandsTests extends LettuceReactiveClusterCommandsTestsBase {
+
+	@Test // DATAREDIS-1150
+	public void clusterGetNodesShouldReturnNodes() {
+
+		connection.clusterGetNodes().collectList() //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual).hasSizeGreaterThan(3);
+				}).verifyComplete();
+	}
+
+	@Test // DATAREDIS-1150
+	public void clusterGetSlavesShouldReturnNodes() {
+
+		connection.clusterGetNodes().filter(RedisClusterNode::isMaster)
+				.filter(node -> (node.getPort() == 7379 || node.getPort() == 7382))
+				.flatMap(it -> connection.clusterGetSlaves(it)) //
+				.collectList() //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual).hasSize(1);
+				}).verifyComplete();
+	}
+
+	@Test // DATAREDIS-1150
+	public void clusterGetMasterSlaveMapShouldReportTopology() {
+
+		connection.clusterGetMasterSlaveMap() //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual).hasSize(3);
+				}).verifyComplete();
+	}
+
+	@Test // DATAREDIS-1150
+	public void clusterGetSlotForKeyShouldResolveSlot() {
+
+		connection.clusterGetSlotForKey(ByteBuffer.wrap("hello".getBytes())) //
+				.as(StepVerifier::create) //
+				.expectNext(866) //
+				.verifyComplete();
+	}
+
+	@Test // DATAREDIS-1150
+	public void clusterGetNodeForSlotShouldReportNode() {
+
+		connection.clusterGetNodeForSlot(866) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual.getPort()).isIn(7379, 7382);
+				}).verifyComplete();
+	}
+
+	@Test // DATAREDIS-1150
+	public void clusterGetNodeForKeyShouldReportNode() {
+
+		connection.clusterGetNodeForKey(ByteBuffer.wrap("hello".getBytes())) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual.getPort()).isIn(7379, 7382);
+				}).verifyComplete();
+	}
+
+	@Test // DATAREDIS-1150
+	public void clusterGetClusterInfoShouldReportState() {
+
+		connection.clusterGetClusterInfo() //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual.getSlotsAssigned()).isEqualTo(16384);
+				}).verifyComplete();
+	}
+}


### PR DESCRIPTION
We now provide Redis Cluster commands (`CLUSTER INFO`, `CLUSTER NODES`, …) exposed through a reactive API.

---

Should be backported to 2.3.x as well.

Related ticket: DATAREDIS-1150