### PR TITLE
DATAREDIS-1157 Allow define prefix key using StringRedisSerializer as…

### DIFF
--- a/src/main/java/org/springframework/data/redis/serializer/StringRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/StringRedisSerializer.java
@@ -17,7 +17,6 @@ package org.springframework.data.redis.serializer;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -32,10 +31,13 @@ import org.springframework.util.Assert;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Luram Archanjo
  */
 public class StringRedisSerializer implements RedisSerializer<String> {
 
 	private final Charset charset;
+
+	private final String prefix;
 
 	/**
 	 * {@link StringRedisSerializer} to use 7 bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the Unicode
@@ -70,14 +72,28 @@ public class StringRedisSerializer implements RedisSerializer<String> {
 	}
 
 	/**
-	 * Creates a new {@link StringRedisSerializer} using the given {@link Charset} to encode and decode strings.
+	 * Creates a new {@link StringRedisSerializer} using the given {@link Charset} to encode and decode strings
 	 *
 	 * @param charset must not be {@literal null}.
 	 */
 	public StringRedisSerializer(Charset charset) {
-
 		Assert.notNull(charset, "Charset must not be null!");
 		this.charset = charset;
+		this.prefix = "";
+	}
+
+	/**
+	 * Creates a new {@link StringRedisSerializer} using the given {@link Charset} to encode and decode strings and
+	 * {@link #prefix} to complement it e.g: Keys application-name:some-key.
+	 *
+	 * @param charset must not be {@literal null}.
+	 */
+	public StringRedisSerializer(Charset charset, String prefix) {
+		Assert.notNull(charset, "Charset must not be null!");
+		this.charset = charset;
+
+		Assert.notNull(prefix, "Prefix must not be null!");
+		this.prefix = prefix;
 	}
 
 	/*
@@ -95,11 +111,18 @@ public class StringRedisSerializer implements RedisSerializer<String> {
 	 */
 	@Override
 	public byte[] serialize(@Nullable String string) {
-		return (string == null ? null : string.getBytes(charset));
+		if (string == null) {
+			return null;
+		} else if (prefix.isEmpty() || string.startsWith(prefix)) {
+			return string.getBytes(charset);
+		} else {
+			return prefix.concat(string).getBytes(charset);
+		}
 	}
 
 	@Override
 	public Class<?> getTargetType() {
 		return String.class;
 	}
+
 }

--- a/src/test/java/org/springframework/data/redis/serializer/StringRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/StringRedisSerializerUnitTests.java
@@ -19,45 +19,42 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
 
+import java.util.UUID;
 import org.junit.Test;
 
 /**
  * Unit tests for {@link StringRedisSerializer}.
  *
  * @author Mark Paluch
+ * @author Luram Archanjo
  */
 public class StringRedisSerializerUnitTests {
 
 	@Test
 	public void shouldSerializeToAscii() {
-
 		assertThat(StringRedisSerializer.US_ASCII.serialize("foo-bar")).isEqualTo("foo-bar".getBytes());
 		assertThat(StringRedisSerializer.US_ASCII.serialize("üßØ")).isEqualTo("???".getBytes());
 	}
 
 	@Test
 	public void shouldDeserializeFromAscii() {
-
 		assertThat(StringRedisSerializer.US_ASCII.deserialize("foo-bar".getBytes())).isEqualTo("foo-bar");
 	}
 
 	@Test
 	public void shouldSerializeToIso88591() {
-
 		assertThat(StringRedisSerializer.ISO_8859_1.serialize("üßØ"))
 				.isEqualTo("üßØ".getBytes(StandardCharsets.ISO_8859_1));
 	}
 
 	@Test
 	public void shouldDeserializeFromIso88591() {
-
 		assertThat(StringRedisSerializer.ISO_8859_1.deserialize("üßØ".getBytes(StandardCharsets.ISO_8859_1)))
 				.isEqualTo("üßØ");
 	}
 
 	@Test
 	public void shouldSerializeToUtf8() {
-
 		assertThat(StringRedisSerializer.UTF_8.serialize("foo-bar")).isEqualTo("foo-bar".getBytes());
 		assertThat(StringRedisSerializer.UTF_8.serialize("üßØ")).isEqualTo("üßØ".getBytes(StandardCharsets.UTF_8));
 	}
@@ -66,4 +63,45 @@ public class StringRedisSerializerUnitTests {
 	public void shouldDeserializeFromUtf8() {
 		assertThat(StringRedisSerializer.UTF_8.deserialize("üßØ".getBytes(StandardCharsets.UTF_8))).isEqualTo("üßØ");
 	}
+
+	@Test
+	public void shouldSerializeToAsciiWithPrefix() {
+		final String randomPrefix = UUID.randomUUID().toString();
+		final StringRedisSerializer stringRedisSerializer = new StringRedisSerializer(StandardCharsets.US_ASCII, randomPrefix);
+
+		// Values without prefix
+		assertThat(stringRedisSerializer.serialize("foo-bar")).isEqualTo(randomPrefix.concat("foo-bar").getBytes());
+		assertThat(stringRedisSerializer.serialize("üßØ")).isEqualTo(randomPrefix.concat("???").getBytes());
+
+		// Values with prefix
+		assertThat(stringRedisSerializer.serialize(randomPrefix.concat("foo-bar"))).isEqualTo(randomPrefix.concat("foo-bar").getBytes());
+		assertThat(stringRedisSerializer.serialize(randomPrefix.concat("üßØ"))).isEqualTo(randomPrefix.concat("???").getBytes());
+	}
+
+	@Test
+	public void shouldSerializeToUtf8WithPrefix() {
+		final String randomPrefix = UUID.randomUUID().toString();
+		final StringRedisSerializer stringRedisSerializer = new StringRedisSerializer(StandardCharsets.UTF_8, randomPrefix);
+
+		// Values without prefix
+		assertThat(stringRedisSerializer.serialize("foo-bar")).isEqualTo(randomPrefix.concat("foo-bar").getBytes());
+		assertThat(stringRedisSerializer.serialize("üßØ")).isEqualTo(randomPrefix.concat("üßØ").getBytes(StandardCharsets.UTF_8));
+
+		// Values with prefix
+		assertThat(stringRedisSerializer.serialize(randomPrefix.concat("foo-bar"))).isEqualTo(randomPrefix.concat("foo-bar").getBytes());
+		assertThat(stringRedisSerializer.serialize(randomPrefix.concat("üßØ"))).isEqualTo(randomPrefix.concat("üßØ").getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	public void shouldSerializeToIso88591WithPrefix() {
+		final String randomPrefix = UUID.randomUUID().toString();
+		final StringRedisSerializer stringRedisSerializer = new StringRedisSerializer(StandardCharsets.ISO_8859_1, randomPrefix);
+
+		// Values without prefix
+		assertThat(stringRedisSerializer.serialize("üßØ")).isEqualTo(randomPrefix.concat("üßØ").getBytes(StandardCharsets.ISO_8859_1));
+
+		// Values with prefix
+		assertThat(stringRedisSerializer.serialize(randomPrefix.concat("üßØ"))).isEqualTo(randomPrefix.concat("üßØ").getBytes(StandardCharsets.ISO_8859_1));
+	}
+
 }


### PR DESCRIPTION
I am using Spring Data Redis with RedisTemplate to save some cache, but I want to set a prefix key.

 
```
RedisTemplate<String, T> redisTemplate = new RedisTemplate<>();
redisTemplate.setKeySerializer(new StringRedisSerializer()); // Set a prefix key
```