### PR TITLE
DATAREDIS-1158 - Rename unit tests class

### DIFF
--- a/src/test/java/org/springframework/data/redis/connection/RedisStaticMasterReplicaConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisStaticMasterReplicaConfigurationUnitTests.java
@@ -23,8 +23,9 @@ import org.junit.Test;
  * Unit tests for {@link RedisStaticMasterReplicaConfiguration}.
  *
  * @author Mark Paluch
+ * @author Tamer Soliman
  */
-public class RedisElastiCacheConfigurationUnitTests {
+public class RedisStaticMasterReplicaConfigurationUnitTests {
 
 	@Test // DATAREDIS-762
 	public void shouldCreateSingleHostConfiguration() {


### PR DESCRIPTION
Rename `RedisElastiCacheConfigurationUnitTests` to `RedisStaticMasterReplicaConfigurationUnitTests` to reflect subject class name; i.e. `RedisStaticMasterReplicaConfiguration`.

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
