### PR TITLE
DATAREDIS-1161 - Avoid returning null in ReactiveHashCommands.hGet(…)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATAREDIS-1161-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -282,7 +283,7 @@ public interface ReactiveHashCommands {
 	 * @see <a href="https://redis.io/commands/hget">Redis Documentation: HGET</a>
 	 */
 	default Mono<ByteBuffer> hGet(ByteBuffer key, ByteBuffer field) {
-		return hMGet(key, Collections.singletonList(field)).map(val -> val.isEmpty() ? null : val.iterator().next());
+		return hMGet(key, Collections.singletonList(field)).flatMapIterable(Function.identity()).next();
 	}
 
 	/**


### PR DESCRIPTION
We now use `flatMapIterable(…).next()` to return the first value from the hash. Previously, if the returned list was empty, we could return a null value in the mapping function which might have caused an exception.

---

Related ticket: DATAREDIS-1161.