### PR TITLE
DATAREDIS-1173 - Close connection unsubscribes from all channels incorrectly.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
@@ -27,6 +27,9 @@ import org.springframework.data.redis.connection.util.AbstractSubscription;
  * @author Costin Leau
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Sarah Abbey
+ * @author Murtuza Boxwala
+ * @author Jens Deppe
  */
 public class LettuceSubscription extends AbstractSubscription {
 
@@ -67,11 +70,11 @@ public class LettuceSubscription extends AbstractSubscription {
 	protected void doClose() {
 
 		if (!getChannels().isEmpty()) {
-			doUnsubscribe(true, new byte[0]);
+			doUnsubscribe(true);
 		}
 
 		if (!getPatterns().isEmpty()) {
-			doPUnsubscribe(true, new byte[0]);
+			doPUnsubscribe(true);
 		}
 
 		connection.removeListener(this.listener);


### PR DESCRIPTION
The LettuceSubscription doClose method calls doUnsubscribe with an empty byte array, which results in a call to Redis of:

`UNSUBSCRIBE ""`
This command will unsubscribe from a channel with the name ""  However, we believe the intended behavior is to unsubscribe from all channels, which can be done by not sending any argument to doUnsubscribe, resulting in a call to Redis of:

`UNSUBSCRIBE`
We wrote a failing and passing test showing the problem.  We could not find a way to expose the issue by calling doClose on the subscription (because doClose also releases the connection), so we had to call unsubscribe directly.  We are not sure where this belongs in your testing pyramid.

Co-authored-by: Sarah Abbey <sabbey@pivotal.io>
Co-authored-by: Murtuza Boxwala <mboxwala@pivotal.io>
Co-authored-by: Jens Deppe <jdeppe@vmware.com>
