### PR TITLE
DATAREDIS-1175 - Allow direct mapping of Collection like structures via MappingRedisConverter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATAREDIS-1175</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -176,6 +176,11 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 	 */
 	@Override
 	public <R> R read(Class<R> type, RedisData source) {
+
+		TypeInformation<?> readType = typeMapper.readType(source.getBucket().getPath(), ClassTypeInformation.from(type));
+		if(readType.isCollectionLike()) {
+			return (R) readCollectionOrArray("", ArrayList.class, Object.class, source.getBucket());
+		}
 		return readInternal("", type, source);
 	}
 
@@ -395,7 +400,11 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 
 		sink.setKeyspace(entity.getKeySpace());
 
-		writeInternal(entity.getKeySpace(), "", source, entity.getTypeInformation(), sink);
+		if(entity.getTypeInformation().isCollectionLike()) {
+			writeCollection(entity.getKeySpace(), "", (List) source, entity.getTypeInformation().getComponentType(), sink);
+		} else {
+			writeInternal(entity.getKeySpace(), "", source, entity.getTypeInformation(), sink);
+		}
 
 		Object identifier = entity.getIdentifierAccessor(source).getIdentifier();
 
@@ -713,7 +722,7 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 				break;
 			}
 
-			String currentPath = path + ".[" + i + "]";
+			String currentPath = path + (path.equals("") ? "" : ".") + "[" + i + "]";
 
 			if (!ClassUtils.isAssignable(typeHint.getType(), value.getClass())) {
 				throw new MappingException(

--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -1882,6 +1883,38 @@ public class MappingRedisConverterUnitTests {
 
 		assertThat(target.getAccount()).isEqualTo("123456");
 		assertThat(target.getAccountName()).isEqualTo("Golam Mazid Sajib");
+	}
+
+	@Test // DATAREDIS-1175
+	public void writePlainList() {
+
+		List<Object> source =  Arrays.asList("Hello", "stream", "message", 100L);
+		RedisTestData target = write(source);
+
+		System.out.println(target.getBucket().toString());
+
+		assertThat(target).containsEntry("[0]", "Hello") //
+				.containsEntry("[1]", "stream") //
+				.containsEntry("[2]", "message") //
+				.containsEntry("[3]", "100");
+	}
+
+	@Test // DATAREDIS-1175
+	public void readPlainList() {
+
+		Map<String, String> source = new LinkedHashMap<>();
+		source.put("[0]._class", "java.lang.String");
+		source.put("[0]", "Hello");
+		source.put("[1]._class", "java.lang.String");
+		source.put("[1]", "stream");
+		source.put("[2]._class", "java.lang.String");
+		source.put("[2]", "message");
+		source.put("[3]._class", "java.lang.Long");
+		source.put("[3]", "100");
+
+		List target = read(List.class, source);
+
+		assertThat(target).containsExactly("Hello", "stream", "message", 100L);
 	}
 
 	private RedisTestData write(Object source) {

--- a/src/test/java/org/springframework/data/redis/test/util/RedisTestData.java
+++ b/src/test/java/org/springframework/data/redis/test/util/RedisTestData.java
@@ -140,13 +140,20 @@ public class RedisTestData implements AssertProvider<RedisTestData.RedisBucketAs
 			return actual.get(path);
 		}
 
-		private static Map<String, String> toStringMap(Map<String, byte[]> source) {
+	}
 
-			Map<String, String> converted = new LinkedHashMap<>();
 
-			source.forEach((k, v) -> converted.put(k, new String(v, StandardCharsets.UTF_8)));
+	private static Map<String, String> toStringMap(Map<String, byte[]> source) {
 
-			return converted;
-		}
+		Map<String, String> converted = new LinkedHashMap<>();
+
+		source.forEach((k, v) -> converted.put(k, new String(v, StandardCharsets.UTF_8)));
+
+		return converted;
+	}
+
+	@Override
+	public String toString() {
+		return toStringMap(getBucket().asMap()).toString();
 	}
 }


### PR DESCRIPTION
It is now possible to hand a plain `List` to the converter that is then converted into a hash structure using index numbers as keys.