### PR TITLE
DATAREDIS-1173 - Correctly unsubscribe from patterns/channels through LettuceSubscription

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.3.2.BUILD-SNAPSHOT</version>
+	<version>2.3.2.DATAREDIS-1173-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisSubscription.java
@@ -36,6 +36,11 @@ class JedisSubscription extends AbstractSubscription {
 		this.jedisPubSub = jedisPubSub;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doClose()
+	 */
+	@Override
 	protected void doClose() {
 		if (!getChannels().isEmpty()) {
 			jedisPubSub.unsubscribe();
@@ -45,10 +50,20 @@ class JedisSubscription extends AbstractSubscription {
 		}
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doPsubscribe(byte[][])
+	 */
+	@Override
 	protected void doPsubscribe(byte[]... patterns) {
 		jedisPubSub.psubscribe(patterns);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doPUnsubscribe(boolean, byte[][])
+	 */
+	@Override
 	protected void doPUnsubscribe(boolean all, byte[]... patterns) {
 		if (all) {
 			jedisPubSub.punsubscribe();
@@ -57,10 +72,20 @@ class JedisSubscription extends AbstractSubscription {
 		}
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doSubscribe(byte[][])
+	 */
+	@Override
 	protected void doSubscribe(byte[]... channels) {
 		jedisPubSub.subscribe(channels);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doUnsubscribe(boolean, byte[][])
+	 */
+	@Override
 	protected void doUnsubscribe(boolean all, byte[]... channels) {
 		if (all) {
 			jedisPubSub.unsubscribe();

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
@@ -67,11 +67,11 @@ public class LettuceSubscription extends AbstractSubscription {
 	protected void doClose() {
 
 		if (!getChannels().isEmpty()) {
-			doUnsubscribe(true, new byte[0]);
+			doUnsubscribe(true);
 		}
 
 		if (!getPatterns().isEmpty()) {
-			doPUnsubscribe(true, new byte[0]);
+			doPUnsubscribe(true);
 		}
 
 		connection.removeListener(this.listener);
@@ -92,8 +92,11 @@ public class LettuceSubscription extends AbstractSubscription {
 	 */
 	protected void doPUnsubscribe(boolean all, byte[]... patterns) {
 
-		// ignore `all` flag as Lettuce unsubscribes from all patterns if none provided.
-		pubsub.punsubscribe(patterns);
+		if (all) {
+			pubsub.punsubscribe();
+		} else {
+			pubsub.punsubscribe(patterns);
+		}
 	}
 
 	/*
@@ -110,8 +113,11 @@ public class LettuceSubscription extends AbstractSubscription {
 	 */
 	protected void doUnsubscribe(boolean all, byte[]... channels) {
 
-		// ignore `all` flag as Lettuce unsubscribes from all channels if none provided.
-		pubsub.unsubscribe(channels);
+		if (all) {
+			pubsub.unsubscribe();
+		} else {
+			pubsub.unsubscribe(channels);
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSubscription.java
@@ -64,6 +64,7 @@ public class LettuceSubscription extends AbstractSubscription {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doClose()
 	 */
+	@Override
 	protected void doClose() {
 
 		if (!getChannels().isEmpty()) {
@@ -82,6 +83,7 @@ public class LettuceSubscription extends AbstractSubscription {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doPsubscribe(byte[][])
 	 */
+	@Override
 	protected void doPsubscribe(byte[]... patterns) {
 		pubsub.psubscribe(patterns);
 	}
@@ -90,6 +92,7 @@ public class LettuceSubscription extends AbstractSubscription {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doPUnsubscribe(boolean, byte[][])
 	 */
+	@Override
 	protected void doPUnsubscribe(boolean all, byte[]... patterns) {
 
 		if (all) {
@@ -103,6 +106,7 @@ public class LettuceSubscription extends AbstractSubscription {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doSubscribe(byte[][])
 	 */
+	@Override
 	protected void doSubscribe(byte[]... channels) {
 		pubsub.subscribe(channels);
 	}
@@ -111,6 +115,7 @@ public class LettuceSubscription extends AbstractSubscription {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.util.AbstractSubscription#doUnsubscribe(boolean, byte[][])
 	 */
+	@Override
 	protected void doUnsubscribe(boolean all, byte[]... channels) {
 
 		if (all) {
@@ -119,5 +124,4 @@ public class LettuceSubscription extends AbstractSubscription {
 			pubsub.unsubscribe(channels);
 		}
 	}
-
 }

--- a/src/main/java/org/springframework/data/redis/connection/util/AbstractSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/util/AbstractSubscription.java
@@ -111,22 +111,42 @@ public abstract class AbstractSubscription implements Subscription {
 	 */
 	protected abstract void doClose();
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#getListener()
+	 */
+	@Override
 	public MessageListener getListener() {
 		return listener;
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#getChannels()
+	 */
+	@Override
 	public Collection<byte[]> getChannels() {
 		synchronized (channels) {
 			return clone(channels);
 		}
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#getPatterns()
+	 */
+	@Override
 	public Collection<byte[]> getPatterns() {
 		synchronized (patterns) {
 			return clone(patterns);
 		}
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#pSubscribe(byte[][])
+	 */
+	@Override
 	public void pSubscribe(byte[]... patterns) {
 		checkPulse();
 
@@ -139,10 +159,20 @@ public abstract class AbstractSubscription implements Subscription {
 		doPsubscribe(patterns);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#pUnsubscribe()
+	 */
+	@Override
 	public void pUnsubscribe() {
 		pUnsubscribe((byte[][]) null);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#subscribe(byte[][])
+	 */
+	@Override
 	public void subscribe(byte[]... channels) {
 		checkPulse();
 
@@ -155,10 +185,20 @@ public abstract class AbstractSubscription implements Subscription {
 		doSubscribe(channels);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#unsubscribe()
+	 */
+	@Override
 	public void unsubscribe() {
 		unsubscribe((byte[][]) null);
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#pUnsubscribe(byte[][])
+	 */
+	@Override
 	public void pUnsubscribe(@Nullable byte[]... patts) {
 		if (!isAlive()) {
 			return;
@@ -186,6 +226,11 @@ public abstract class AbstractSubscription implements Subscription {
 		closeIfUnsubscribed();
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#unsubscribe(byte[][])
+	 */
+	@Override
 	public void unsubscribe(@Nullable byte[]... chans) {
 		if (!isAlive()) {
 			return;
@@ -213,6 +258,11 @@ public abstract class AbstractSubscription implements Subscription {
 		closeIfUnsubscribed();
 	}
 
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.Subscription#isAlive()
+	 */
+	@Override
 	public boolean isAlive() {
 		return alive.get();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSubscriptionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSubscriptionTests.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.connection.RedisInvalidSubscriptionException;
@@ -41,9 +40,7 @@ public class LettuceSubscriptionTests {
 
 	private LettuceSubscription subscription;
 
-	StatefulRedisPubSubConnection<byte[], byte[]> pubsub;
-
-	private MessageListener listener;
+	private StatefulRedisPubSubConnection<byte[], byte[]> pubsub;
 
 	private RedisPubSubCommands<byte[], byte[]> asyncCommands;
 
@@ -53,126 +50,159 @@ public class LettuceSubscriptionTests {
 	@Before
 	public void setUp() {
 
-		pubsub = Mockito.mock(StatefulRedisPubSubConnection.class);
-		listener = Mockito.mock(MessageListener.class);
-		asyncCommands = Mockito.mock(RedisPubSubCommands.class);
-		connectionProvider = Mockito.mock(LettuceConnectionProvider.class);
+		pubsub = mock(StatefulRedisPubSubConnection.class);
+		asyncCommands = mock(RedisPubSubCommands.class);
+		connectionProvider = mock(LettuceConnectionProvider.class);
 
-		Mockito.when(pubsub.sync()).thenReturn(asyncCommands);
-		subscription = new LettuceSubscription(listener, pubsub, connectionProvider);
+		when(pubsub.sync()).thenReturn(asyncCommands);
+		subscription = new LettuceSubscription(mock(MessageListener.class), pubsub, connectionProvider);
 	}
 
 	@Test
 	public void testUnsubscribeAllAndClose() {
+
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.unsubscribe();
+
 		verify(asyncCommands).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
+
 		assertThat(subscription.isAlive()).isFalse();
-		assertThat(subscription.getChannels().isEmpty()).isTrue();
-		assertThat(subscription.getPatterns().isEmpty()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
+		assertThat(subscription.getPatterns()).isEmpty();
 	}
 
 	@Test
 	public void testUnsubscribeAllChannelsWithPatterns() {
+
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.unsubscribe();
+
 		verify(asyncCommands).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
+
 		assertThat(subscription.isAlive()).isTrue();
-		assertThat(subscription.getChannels().isEmpty()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
+
 		Collection<byte[]> patterns = subscription.getPatterns();
-		assertThat(patterns.size()).isEqualTo(1);
+		assertThat(patterns).hasSize(1);
 		assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
 	}
 
 	@Test
 	public void testUnsubscribeChannelAndClose() {
+
 		byte[][] channel = new byte[][] { "a".getBytes() };
+
 		subscription.subscribe(channel);
 		subscription.unsubscribe(channel);
+
 		verify(asyncCommands).unsubscribe(channel);
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
+
 		assertThat(subscription.isAlive()).isFalse();
-		assertThat(subscription.getChannels().isEmpty()).isTrue();
-		assertThat(subscription.getPatterns().isEmpty()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
+		assertThat(subscription.getPatterns()).isEmpty();
 	}
 
 	@Test
 	public void testUnsubscribeChannelSomeLeft() {
+
 		byte[][] channels = new byte[][] { "a".getBytes(), "b".getBytes() };
+
 		subscription.subscribe(channels);
 		subscription.unsubscribe(new byte[][] { "a".getBytes() });
+
 		verify(asyncCommands).unsubscribe(new byte[][] { "a".getBytes() });
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
+
 		assertThat(subscription.isAlive()).isTrue();
+
 		Collection<byte[]> subChannels = subscription.getChannels();
-		assertThat(subChannels.size()).isEqualTo(1);
+		assertThat(subChannels).hasSize(1);
 		assertThat(subChannels.iterator().next()).isEqualTo("b".getBytes());
-		assertThat(subscription.getPatterns().isEmpty()).isTrue();
+		assertThat(subscription.getPatterns()).isEmpty();
 	}
 
 	@Test
 	public void testUnsubscribeChannelWithPatterns() {
+
 		byte[][] channel = new byte[][] { "a".getBytes() };
+
 		subscription.subscribe(channel);
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.unsubscribe(channel);
+
 		verify(asyncCommands).unsubscribe(channel);
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
+
 		assertThat(subscription.isAlive()).isTrue();
-		assertThat(subscription.getChannels().isEmpty()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
+
 		Collection<byte[]> patterns = subscription.getPatterns();
-		assertThat(patterns.size()).isEqualTo(1);
+		assertThat(patterns).hasSize(1);
 		assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
 	}
 
 	@Test
 	public void testUnsubscribeChannelWithPatternsSomeLeft() {
+
 		byte[][] channel = new byte[][] { "a".getBytes() };
-		subscription.subscribe(new byte[][] { "a".getBytes(), "b".getBytes() });
+
+		subscription.subscribe("a".getBytes(), "b".getBytes());
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.unsubscribe(channel);
+
 		verify(asyncCommands).unsubscribe(channel);
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
+
 		Collection<byte[]> channels = subscription.getChannels();
-		assertThat(channels.size()).isEqualTo(1);
+		assertThat(channels).hasSize(1);
 		assertThat(channels.iterator().next()).isEqualTo("b".getBytes());
+
 		Collection<byte[]> patterns = subscription.getPatterns();
-		assertThat(patterns.size()).isEqualTo(1);
+		assertThat(patterns).hasSize(1);
 		assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
 	}
 
 	@Test
 	public void testUnsubscribeAllNoChannels() {
+
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.unsubscribe();
+
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
+
 		assertThat(subscription.isAlive()).isTrue();
-		assertThat(subscription.getChannels().isEmpty()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
+
 		Collection<byte[]> patterns = subscription.getPatterns();
-		assertThat(patterns.size()).isEqualTo(1);
+		assertThat(patterns).hasSize(1);
 		assertThat(patterns.iterator().next()).isEqualTo("s*".getBytes());
 	}
 
 	@Test
 	public void testUnsubscribeNotAlive() {
+
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.unsubscribe();
+
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
+
 		assertThat(subscription.isAlive()).isFalse();
+
 		subscription.unsubscribe();
 		verify(asyncCommands).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
@@ -180,122 +210,157 @@ public class LettuceSubscriptionTests {
 
 	@Test(expected = RedisInvalidSubscriptionException.class)
 	public void testSubscribeNotAlive() {
+
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.unsubscribe();
+
 		assertThat(subscription.isAlive()).isFalse();
 		subscription.subscribe(new byte[][] { "s".getBytes() });
 	}
 
 	@Test
 	public void testPUnsubscribeAllAndClose() {
+
 		subscription.pSubscribe(new byte[][] { "a*".getBytes() });
 		subscription.pUnsubscribe();
+
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands).punsubscribe();
-		assertThat(subscription.isAlive()).isFalse();
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
-		assertThat(subscription.getChannels().isEmpty()).isTrue();
-		assertThat(subscription.getPatterns().isEmpty()).isTrue();
+
+		assertThat(subscription.isAlive()).isFalse();
+		assertThat(subscription.getChannels()).isEmpty();
+		assertThat(subscription.getPatterns()).isEmpty();
 	}
 
 	@Test
 	public void testPUnsubscribeAllPatternsWithChannels() {
+
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.pUnsubscribe();
+
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands).punsubscribe();
+
 		assertThat(subscription.isAlive()).isTrue();
-		assertThat(subscription.getPatterns().isEmpty()).isTrue();
+		assertThat(subscription.getPatterns()).isEmpty();
+
 		Collection<byte[]> channels = subscription.getChannels();
-		assertThat(channels.size()).isEqualTo(1);
+		assertThat(channels).hasSize(1);
 		assertThat(channels.iterator().next()).isEqualTo("a".getBytes());
 	}
 
 	@Test
 	public void testPUnsubscribeAndClose() {
+
 		byte[][] pattern = new byte[][] { "a*".getBytes() };
+
 		subscription.pSubscribe(pattern);
 		subscription.pUnsubscribe(pattern);
+
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
 		verify(asyncCommands).punsubscribe(pattern);
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
+
 		assertThat(subscription.isAlive()).isFalse();
-		assertThat(subscription.getChannels().isEmpty()).isTrue();
-		assertThat(subscription.getPatterns().isEmpty()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
+		assertThat(subscription.getPatterns()).isEmpty();
 	}
 
 	@Test
 	public void testPUnsubscribePatternSomeLeft() {
+
 		byte[][] patterns = new byte[][] { "a*".getBytes(), "b*".getBytes() };
 		subscription.pSubscribe(patterns);
 		subscription.pUnsubscribe(new byte[][] { "a*".getBytes() });
+
 		verify(asyncCommands).punsubscribe(new byte[][] { "a*".getBytes() });
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
+
 		assertThat(subscription.isAlive()).isTrue();
+
 		Collection<byte[]> subPatterns = subscription.getPatterns();
-		assertThat(subPatterns.size()).isEqualTo(1);
+		assertThat(subPatterns).hasSize(1);
 		assertThat(subPatterns.iterator().next()).isEqualTo("b*".getBytes());
-		assertThat(subscription.getChannels().isEmpty()).isTrue();
+		assertThat(subscription.getChannels()).isEmpty();
 	}
 
 	@Test
 	public void testPUnsubscribePatternWithChannels() {
+
 		byte[][] pattern = new byte[][] { "s*".getBytes() };
+
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.pSubscribe(pattern);
 		subscription.pUnsubscribe(pattern);
+
 		verify(asyncCommands).punsubscribe(pattern);
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
+
 		assertThat(subscription.isAlive()).isTrue();
-		assertThat(subscription.getPatterns().isEmpty()).isTrue();
+		assertThat(subscription.getPatterns()).isEmpty();
+
 		Collection<byte[]> channels = subscription.getChannels();
-		assertThat(channels.size()).isEqualTo(1);
+		assertThat(channels).hasSize(1);
 		assertThat(channels.iterator().next()).isEqualTo("a".getBytes());
 	}
 
 	@Test
 	public void testUnsubscribePatternWithChannelsSomeLeft() {
+
 		byte[][] pattern = new byte[][] { "a*".getBytes() };
-		subscription.pSubscribe(new byte[][] { "a*".getBytes(), "b*".getBytes() });
+
+		subscription.pSubscribe("a*".getBytes(), "b*".getBytes());
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.pUnsubscribe(pattern);
+
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
 		verify(asyncCommands).punsubscribe(pattern);
+
 		assertThat(subscription.isAlive()).isTrue();
+
 		Collection<byte[]> channels = subscription.getChannels();
-		assertThat(channels.size()).isEqualTo(1);
+		assertThat(channels).hasSize(1);
 		assertThat(channels.iterator().next()).isEqualTo("a".getBytes());
+
 		Collection<byte[]> patterns = subscription.getPatterns();
-		assertThat(patterns.size()).isEqualTo(1);
+		assertThat(patterns).hasSize(1);
 		assertThat(patterns.iterator().next()).isEqualTo("b*".getBytes());
 	}
 
 	@Test
 	public void testPUnsubscribeAllNoPatterns() {
+
 		subscription.subscribe(new byte[][] { "s".getBytes() });
 		subscription.pUnsubscribe();
+
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
-		assertThat(subscription.getPatterns().isEmpty()).isTrue();
+		assertThat(subscription.getPatterns()).isEmpty();
+
 		Collection<byte[]> channels = subscription.getChannels();
-		assertThat(channels.size()).isEqualTo(1);
+		assertThat(channels).hasSize(1);
 		assertThat(channels.iterator().next()).isEqualTo("s".getBytes());
 	}
 
 	@Test
 	public void testPUnsubscribeNotAlive() {
+
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.unsubscribe();
+
 		assertThat(subscription.isAlive()).isFalse();
+
 		subscription.pUnsubscribe();
+
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
 		verify(asyncCommands).unsubscribe();
@@ -304,31 +369,40 @@ public class LettuceSubscriptionTests {
 
 	@Test(expected = RedisInvalidSubscriptionException.class)
 	public void testPSubscribeNotAlive() {
+
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.unsubscribe();
+
 		assertThat(subscription.isAlive()).isFalse();
+
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 	}
 
 	@Test
 	public void testDoCloseNotSubscribed() {
+
 		subscription.doClose();
+
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
 	}
 
 	@Test
 	public void testDoCloseSubscribedChannels() {
+
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.doClose();
+
 		verify(asyncCommands).unsubscribe();
 		verify(asyncCommands, never()).punsubscribe();
 	}
 
 	@Test
 	public void testDoCloseSubscribedPatterns() {
+
 		subscription.pSubscribe(new byte[][] { "a*".getBytes() });
 		subscription.doClose();
+
 		verify(asyncCommands, never()).unsubscribe();
 		verify(asyncCommands).punsubscribe();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSubscriptionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSubscriptionTests.java
@@ -66,9 +66,8 @@ public class LettuceSubscriptionTests {
 	public void testUnsubscribeAllAndClose() {
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.unsubscribe();
-		verify(asyncCommands, times(1)).unsubscribe(new byte[][] { "a".getBytes() });
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
 		assertThat(subscription.isAlive()).isFalse();
@@ -81,9 +80,8 @@ public class LettuceSubscriptionTests {
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.unsubscribe();
-		verify(asyncCommands, times(1)).unsubscribe(new byte[][] { "a".getBytes() });
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
 		assertThat(subscription.getChannels().isEmpty()).isTrue();
 		Collection<byte[]> patterns = subscription.getPatterns();
@@ -96,9 +94,9 @@ public class LettuceSubscriptionTests {
 		byte[][] channel = new byte[][] { "a".getBytes() };
 		subscription.subscribe(channel);
 		subscription.unsubscribe(channel);
-		verify(asyncCommands, times(1)).unsubscribe(channel);
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).unsubscribe(channel);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
 		assertThat(subscription.isAlive()).isFalse();
@@ -111,9 +109,9 @@ public class LettuceSubscriptionTests {
 		byte[][] channels = new byte[][] { "a".getBytes(), "b".getBytes() };
 		subscription.subscribe(channels);
 		subscription.unsubscribe(new byte[][] { "a".getBytes() });
-		verify(asyncCommands, times(1)).unsubscribe(new byte[][] { "a".getBytes() });
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).unsubscribe(new byte[][] { "a".getBytes() });
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
 		Collection<byte[]> subChannels = subscription.getChannels();
 		assertThat(subChannels.size()).isEqualTo(1);
@@ -127,9 +125,9 @@ public class LettuceSubscriptionTests {
 		subscription.subscribe(channel);
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.unsubscribe(channel);
-		verify(asyncCommands, times(1)).unsubscribe(channel);
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).unsubscribe(channel);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
 		assertThat(subscription.getChannels().isEmpty()).isTrue();
 		Collection<byte[]> patterns = subscription.getPatterns();
@@ -143,9 +141,9 @@ public class LettuceSubscriptionTests {
 		subscription.subscribe(new byte[][] { "a".getBytes(), "b".getBytes() });
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.unsubscribe(channel);
-		verify(asyncCommands, times(1)).unsubscribe(channel);
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).unsubscribe(channel);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
 		Collection<byte[]> channels = subscription.getChannels();
 		assertThat(channels.size()).isEqualTo(1);
@@ -159,8 +157,8 @@ public class LettuceSubscriptionTests {
 	public void testUnsubscribeAllNoChannels() {
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.unsubscribe();
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
 		assertThat(subscription.getChannels().isEmpty()).isTrue();
 		Collection<byte[]> patterns = subscription.getPatterns();
@@ -172,13 +170,12 @@ public class LettuceSubscriptionTests {
 	public void testUnsubscribeNotAlive() {
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.unsubscribe();
-		verify(connectionProvider, times(1)).release(pubsub);
-		verify(pubsub, times(1)).removeListener(any(LettuceMessageListener.class));
+		verify(connectionProvider).release(pubsub);
+		verify(pubsub).removeListener(any(LettuceMessageListener.class));
 		assertThat(subscription.isAlive()).isFalse();
 		subscription.unsubscribe();
-		verify(asyncCommands, times(1)).unsubscribe(new byte[][] { "a".getBytes() });
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 	}
 
 	@Test(expected = RedisInvalidSubscriptionException.class)
@@ -193,9 +190,8 @@ public class LettuceSubscriptionTests {
 	public void testPUnsubscribeAllAndClose() {
 		subscription.pSubscribe(new byte[][] { "a*".getBytes() });
 		subscription.pUnsubscribe();
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
-		verify(asyncCommands, times(1)).punsubscribe(new byte[][] { "a*".getBytes() });
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands).punsubscribe();
 		assertThat(subscription.isAlive()).isFalse();
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
@@ -208,9 +204,8 @@ public class LettuceSubscriptionTests {
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.pSubscribe(new byte[][] { "s*".getBytes() });
 		subscription.pUnsubscribe();
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
-		verify(asyncCommands, times(1)).punsubscribe(new byte[][] { "s*".getBytes() });
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
 		assertThat(subscription.getPatterns().isEmpty()).isTrue();
 		Collection<byte[]> channels = subscription.getChannels();
@@ -223,9 +218,9 @@ public class LettuceSubscriptionTests {
 		byte[][] pattern = new byte[][] { "a*".getBytes() };
 		subscription.pSubscribe(pattern);
 		subscription.pUnsubscribe(pattern);
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
-		verify(asyncCommands, times(1)).punsubscribe(pattern);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
+		verify(asyncCommands).punsubscribe(pattern);
 		verify(connectionProvider).release(pubsub);
 		verify(pubsub).removeListener(any(LettuceMessageListener.class));
 		assertThat(subscription.isAlive()).isFalse();
@@ -238,9 +233,9 @@ public class LettuceSubscriptionTests {
 		byte[][] patterns = new byte[][] { "a*".getBytes(), "b*".getBytes() };
 		subscription.pSubscribe(patterns);
 		subscription.pUnsubscribe(new byte[][] { "a*".getBytes() });
-		verify(asyncCommands, times(1)).punsubscribe(new byte[][] { "a*".getBytes() });
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).punsubscribe(new byte[][] { "a*".getBytes() });
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
 		Collection<byte[]> subPatterns = subscription.getPatterns();
 		assertThat(subPatterns.size()).isEqualTo(1);
@@ -254,9 +249,9 @@ public class LettuceSubscriptionTests {
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.pSubscribe(pattern);
 		subscription.pUnsubscribe(pattern);
-		verify(asyncCommands, times(1)).punsubscribe(pattern);
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).punsubscribe(pattern);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
 		assertThat(subscription.getPatterns().isEmpty()).isTrue();
 		Collection<byte[]> channels = subscription.getChannels();
@@ -270,9 +265,9 @@ public class LettuceSubscriptionTests {
 		subscription.pSubscribe(new byte[][] { "a*".getBytes(), "b*".getBytes() });
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.pUnsubscribe(pattern);
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
-		verify(asyncCommands, times(1)).punsubscribe(pattern);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
+		verify(asyncCommands).punsubscribe(pattern);
 		assertThat(subscription.isAlive()).isTrue();
 		Collection<byte[]> channels = subscription.getChannels();
 		assertThat(channels.size()).isEqualTo(1);
@@ -286,8 +281,8 @@ public class LettuceSubscriptionTests {
 	public void testPUnsubscribeAllNoPatterns() {
 		subscription.subscribe(new byte[][] { "s".getBytes() });
 		subscription.pUnsubscribe();
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 		assertThat(subscription.isAlive()).isTrue();
 		assertThat(subscription.getPatterns().isEmpty()).isTrue();
 		Collection<byte[]> channels = subscription.getChannels();
@@ -301,11 +296,10 @@ public class LettuceSubscriptionTests {
 		subscription.unsubscribe();
 		assertThat(subscription.isAlive()).isFalse();
 		subscription.pUnsubscribe();
-		verify(connectionProvider, times(1)).release(pubsub);
-		verify(pubsub, times(1)).removeListener(any(LettuceMessageListener.class));
-		verify(asyncCommands, times(1)).unsubscribe(new byte[][] { "a".getBytes() });
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(connectionProvider).release(pubsub);
+		verify(pubsub).removeListener(any(LettuceMessageListener.class));
+		verify(asyncCommands).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 	}
 
 	@Test(expected = RedisInvalidSubscriptionException.class)
@@ -319,23 +313,23 @@ public class LettuceSubscriptionTests {
 	@Test
 	public void testDoCloseNotSubscribed() {
 		subscription.doClose();
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 	}
 
 	@Test
 	public void testDoCloseSubscribedChannels() {
 		subscription.subscribe(new byte[][] { "a".getBytes() });
 		subscription.doClose();
-		verify(asyncCommands, times(1)).unsubscribe(new byte[0]);
-		verify(asyncCommands, never()).punsubscribe(new byte[0]);
+		verify(asyncCommands).unsubscribe();
+		verify(asyncCommands, never()).punsubscribe();
 	}
 
 	@Test
 	public void testDoCloseSubscribedPatterns() {
 		subscription.pSubscribe(new byte[][] { "a*".getBytes() });
 		subscription.doClose();
-		verify(asyncCommands, never()).unsubscribe(new byte[0]);
-		verify(asyncCommands, times(1)).punsubscribe(new byte[0]);
+		verify(asyncCommands, never()).unsubscribe();
+		verify(asyncCommands).punsubscribe();
 	}
 }


### PR DESCRIPTION
`doPUnsubscribe(…)` and `doUnsubscribe(…)` now consider the all flag to unsubscribe from all subscribed patterns/channels. Previously, both methods didn't consider all and were invoked with an empty byte array which unsubscribed from an empty pattern/channel name and left subscriptions active.

---

Related ticket: DATAREDIS-1173
Should be forward/backported to all maintained versions.