### PR TITLE
DATAREDIS-1190 - Cluster rename now correctly overwrites existing keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,4 +157,5 @@ test:
 	sleep 1
 	./mvnw clean test -U -DrunLongTests=true -P$(SPRING_PROFILE) || (echo "maven failed $$?"; exit 1)
 	$(MAKE) stop
+	$(MAKE) clean
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATAREDIS-1190-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
@@ -270,7 +270,7 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 
 		if (value != null && value.length > 0) {
 
-			restore(targetKey, 0, value);
+			restore(targetKey, 0, value, true);
 			del(sourceKey);
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyCommands.java
@@ -118,7 +118,7 @@ class LettuceClusterKeyCommands extends LettuceKeyCommands {
 
 		if (value != null && value.length > 0) {
 
-			restore(targetKey, 0, value);
+			restore(targetKey, 0, value, true);
 			del(sourceKey);
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
@@ -413,6 +413,9 @@ public interface ClusterConnectionTests {
 	// DATAREDIS-315
 	void rename();
 
+	// DATAREDIS-1190
+	void renameShouldOverwriteTargetKey();
+
 	// DATAREDIS-315
 	void renameNXWhenOnSameSlot();
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -1421,6 +1421,18 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES);
 	}
 
+	@Test // DATAREDIS-1190
+	public void renameShouldOverwriteTargetKey() {
+
+		nativeConnection.set(KEY_1_BYTES, VALUE_1_BYTES);
+		nativeConnection.set(KEY_2_BYTES, VALUE_2_BYTES);
+
+		clusterConnection.rename(KEY_1_BYTES, KEY_2_BYTES);
+
+		assertThat(nativeConnection.exists(KEY_1_BYTES)).isFalse();
+		assertThat(nativeConnection.get(KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES);
+	}
+
 	@Test // DATAREDIS-315
 	public void renameNXWhenOnSameSlot() {
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -1437,6 +1437,18 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(nativeConnection.get(KEY_2)).isEqualTo(VALUE_1);
 	}
 
+	@Test // DATAREDIS-1190
+	public void renameShouldOverwriteTargetKey() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+		nativeConnection.set(KEY_2, VALUE_2);
+
+		clusterConnection.rename(KEY_1_BYTES, KEY_2_BYTES);
+
+		assertThat(nativeConnection.exists(KEY_1)).isEqualTo(0L);
+		assertThat(nativeConnection.get(KEY_2)).isEqualTo(VALUE_1);
+	}
+
 	@Test // DATAREDIS-315
 	public void renameNXWhenOnSameSlot() {
 


### PR DESCRIPTION
`rename(…)` behavior in cluster-mode is now aligned with standalone Redis behavior that overwrites the target key if it already exists and the renamed key uses a different slot. Previously, the underlying `restore` command was called without the replace option which caused `BUSYKEY` failures.

---

Related ticket: DATAREDIS-1190.