### PR TITLE
DATAREDIS-1207 - Fix LettuceStreamCommands.xRevRange Range conversion.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
 /**
  * @author Mark Paluch
  * @author Tugdual Grall
+ * @author Dejan Jankov
  * @since 2.2
  */
 class LettuceStreamCommands implements RedisStreamCommands {
@@ -632,7 +633,7 @@ class LettuceStreamCommands implements RedisStreamCommands {
 		Assert.notNull(range, "Range must not be null!");
 		Assert.notNull(limit, "Limit must not be null!");
 
-		io.lettuce.core.Range<String> lettuceRange = RangeConverter.toRange(range);
+		io.lettuce.core.Range<String> lettuceRange = RangeConverter.toRange(range, Function.identity());
 		io.lettuce.core.Limit lettuceLimit = LettuceConverters.toLimit(limit);
 		try {
 			if (isPipelined()) {


### PR DESCRIPTION
LettuceStreamCommands.xRevRange converts Ranges with a StringCodec that produces Boundary<ByteBuffer>, while Lettuce expects the range's Boundary to include strings. The conversion worked well only in cases where the Range was unbounded (- or +), and failed with ClassCastException on the consuming site for other cases.
