### PR TITLE
DATAREDIS-1210 - fix StreamReadOptions toString method

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/stream/StreamReadOptions.java
+++ b/src/main/java/org/springframework/data/redis/connection/stream/StreamReadOptions.java
@@ -124,8 +124,7 @@ public class StreamReadOptions {
 
 	@Override
 	public String toString() {
-		return "StreamReadOptions{" + "block=" + block + ", count=" + count + ", noack=" + noack + ", autoAcknowledge="
-				+ autoAcknowledge() + ", blocking=" + isBlocking() + '}';
+		return "StreamReadOptions{" + "block=" + block + ", count=" + count + ", noack=" + noack  + ", blocking=" + isBlocking() + '}';
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/connection/stream/StreamReadOptionsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/stream/StreamReadOptionsUnitTests.java
@@ -35,4 +35,10 @@ public class StreamReadOptionsUnitTests {
 		assertThat(StreamReadOptions.empty().block(Duration.ofSeconds(1)).isBlocking()).isTrue();
 		assertThat(StreamReadOptions.empty().block(Duration.ZERO).isBlocking()).isTrue();
 	}
+
+	@Test // DATAREDIS-1210
+	public void testToString() {
+
+		assertThat(StreamReadOptions.empty().toString()).isEqualTo("StreamReadOptions{block=null, count=null, noack=false, blocking=false}");
+	}
 }


### PR DESCRIPTION
original StreamReadOptions toString method build String with another StreamReadOptions  (formed by autoAcknowledge() ) inside, which cause StringBuilder append be called infinitely, and cause StackOverflowError.
fix it by change toString return string to

"StreamReadOptions{" + "block=" + block + ", count=" + count + ", noack=" + noack  + ", blocking=" + isBlocking() + '}'
