### PR TITLE
DATAREDIS-1145, DATAREDIS-1046 - Add ACL support and Sentinel authentication for Jedis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<beanutils>1.9.2</beanutils>
 		<xstream>1.4.12</xstream>
 		<pool>2.7.0</pool>
-		<lettuce>5.3.3.RELEASE</lettuce>
+		<lettuce>6.0.0.RC1</lettuce>
 		<jedis>3.3.0</jedis>
 		<multithreadedtc>1.01</multithreadedtc>
 		<netty>4.1.51.Final</netty>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.4.0-DATAREDIS-1197-SNAPSHOT</version>
+	<version>2.4.0-DATAREDIS-1046-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATAREDIS-1197-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -7,9 +7,9 @@ This section briefly covers items that are new and noteworthy in the latest rele
 == New in Spring Data Redis 2.4
 
 * `RedisCache` now exposes `CacheStatistics`.
+* ACL authentication support for Redis Standalone, Redis Cluster and Master/Replica.
 
 [[new-in-2.3.0]]
-
 == New in Spring Data Redis 2.3
 
 * Template API Method Refinements for `Duration` and `Instant`.

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -8,6 +8,7 @@ This section briefly covers items that are new and noteworthy in the latest rele
 
 * `RedisCache` now exposes `CacheStatistics`.
 * ACL authentication support for Redis Standalone, Redis Cluster and Master/Replica.
+* Password support for Redis Sentinel using Jedis.
 
 [[new-in-2.3.0]]
 == New in Spring Data Redis 2.3

--- a/src/main/asciidoc/reference/redis.adoc
+++ b/src/main/asciidoc/reference/redis.adoc
@@ -324,11 +324,6 @@ public RedisConnectionFactory lettuceConnectionFactory() {
 
 Sometimes, direct interaction with one of the Sentinels is required. Using `RedisConnectionFactory.getSentinelConnection()` or `RedisConnection.getSentinelCommands()` gives you access to the first active Sentinel configured.
 
-[NOTE]
-====
-Sentinel authentication is only available using https://lettuce.io/[Lettuce].
-====
-
 [[redis:template]]
 == Working with Objects through RedisTemplate
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisClusterConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.core.env.MapPropertySource;
@@ -49,6 +50,7 @@ public class RedisClusterConfiguration implements RedisConfiguration, ClusterCon
 
 	private Set<RedisNode> clusterNodes;
 	private @Nullable Integer maxRedirects;
+	private Optional<String> username = Optional.empty();
 	private RedisPassword password = RedisPassword.none();
 
 	/**
@@ -180,6 +182,24 @@ public class RedisClusterConfiguration implements RedisConfiguration, ClusterCon
 		for (String hostAndPort : hostAndPorts) {
 			addClusterNode(readHostAndPortFromString(hostAndPort));
 		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#setUsername(String)
+	 */
+	@Override
+	public void setUsername(String username) {
+		this.username = Optional.of(username);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#getUsername()
+	 */
+	@Override
+	public Optional<String> getUsername() {
+		return this.username;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSentinelConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.core.env.MapPropertySource;
@@ -50,6 +51,7 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 	private Set<RedisNode> sentinels;
 	private int database;
 
+	private Optional<String> dataNodeUsername = Optional.empty();
 	private RedisPassword dataNodePassword = RedisPassword.none();
 	private RedisPassword sentinelPassword = RedisPassword.none();
 
@@ -227,6 +229,24 @@ public class RedisSentinelConfiguration implements RedisConfiguration, SentinelC
 		Assert.isTrue(index >= 0, () -> String.format("Invalid DB index '%s' (a positive index required)", index));
 
 		this.database = index;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#setUsername(String)
+	 */
+	@Override
+	public void setUsername(String username) {
+		this.dataNodeUsername = Optional.of(username);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#getUsername()
+	 */
+	@Override
+	public Optional<String> getUsername() {
+		return this.dataNodeUsername;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/RedisSocketConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSocketConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.connection;
 
+import java.util.Optional;
+
 import org.springframework.data.redis.connection.RedisConfiguration.DomainSocketConfiguration;
 import org.springframework.util.Assert;
 
@@ -32,6 +34,7 @@ public class RedisSocketConfiguration implements RedisConfiguration, DomainSocke
 
 	private String socket = DEFAULT_SOCKET;
 	private int database;
+	private Optional<String> username = Optional.empty();
 	private RedisPassword password = RedisPassword.none();
 
 	/**
@@ -90,6 +93,24 @@ public class RedisSocketConfiguration implements RedisConfiguration, DomainSocke
 		Assert.isTrue(index >= 0, () -> String.format("Invalid DB index '%s' (a positive index required)", index));
 
 		this.database = index;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#setUsername(String)
+	 */
+	@Override
+	public void setUsername(String username) {
+		this.username = Optional.of(username);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#getUsername()
+	 */
+	@Override
+	public Optional<String> getUsername() {
+		return this.username;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStandaloneConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.connection;
 
+import java.util.Optional;
+
 import org.springframework.data.redis.connection.RedisConfiguration.WithDatabaseIndex;
 import org.springframework.data.redis.connection.RedisConfiguration.WithHostAndPort;
 import org.springframework.data.redis.connection.RedisConfiguration.WithPassword;
@@ -37,6 +39,7 @@ public class RedisStandaloneConfiguration
 	private String hostName = DEFAULT_HOST;
 	private int port = DEFAULT_PORT;
 	private int database;
+	private Optional<String> username = Optional.empty();
 	private RedisPassword password = RedisPassword.none();
 
 	/**
@@ -123,6 +126,24 @@ public class RedisStandaloneConfiguration
 		Assert.isTrue(index >= 0, () -> String.format("Invalid DB index '%s' (a positive index required)", index));
 
 		this.database = index;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#setUsername(String)
+	 */
+	@Override
+	public void setUsername(String username) {
+		this.username = Optional.of(username);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#getUsername()
+	 */
+	@Override
+	public Optional<String> getUsername() {
+		return this.username;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/RedisStaticMasterReplicaConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStaticMasterReplicaConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.redis.connection.RedisConfiguration.StaticMasterReplicaConfiguration;
 import org.springframework.util.Assert;
@@ -40,6 +41,7 @@ public class RedisStaticMasterReplicaConfiguration implements RedisConfiguration
 
 	private List<RedisStandaloneConfiguration> nodes = new ArrayList<>();
 	private int database;
+	private Optional<String> username = Optional.empty();
 	private RedisPassword password = RedisPassword.none();
 
 	/**
@@ -128,6 +130,24 @@ public class RedisStaticMasterReplicaConfiguration implements RedisConfiguration
 
 		this.database = index;
 		this.nodes.forEach(it -> it.setDatabase(database));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#setUsername(String)
+	 */
+	@Override
+	public void setUsername(String username) {
+		this.username = Optional.of(username);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisConfiguration.WithAuthentication#getUsername()
+	 */
+	@Override
+	public Optional<String> getUsername() {
+		return this.username;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveScriptingCommands.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.springframework.data.redis.connection.ReactiveScriptingCommands;
 import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.util.ByteUtils;
 import org.springframework.util.Assert;
 
 /**
@@ -80,7 +81,7 @@ class LettuceReactiveScriptingCommands implements ReactiveScriptingCommands {
 
 		Assert.notNull(script, "Script must not be null!");
 
-		return connection.execute(cmd -> cmd.scriptLoad(script)).next();
+		return connection.execute(cmd -> cmd.scriptLoad(ByteUtils.getBytes(script))).next();
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
@@ -24,6 +24,7 @@ import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.springframework.dao.DataAccessException;
@@ -267,14 +268,16 @@ class LettuceStreamCommands implements RedisStreamCommands {
 			io.lettuce.core.Consumer<byte[]> lettuceConsumer = toConsumer(consumer);
 
 			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().xgroupDelconsumer(key, lettuceConsumer)));
+				pipeline(connection.newLettuceResult(getAsyncConnection().xgroupDelconsumer(key, lettuceConsumer),
+						Objects::nonNull));
 				return null;
 			}
 			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().xgroupDelconsumer(key, lettuceConsumer)));
+				transaction(connection.newLettuceResult(getAsyncConnection().xgroupDelconsumer(key, lettuceConsumer),
+						Objects::nonNull));
 				return null;
 			}
-			return getConnection().xgroupDelconsumer(key, lettuceConsumer);
+			return Objects.nonNull(getConnection().xgroupDelconsumer(key, lettuceConsumer));
 		} catch (Exception ex) {
 			throw convertLettuceAccessException(ex);
 		}

--- a/src/test/java/org/springframework/data/redis/RedisTestProfileValueSource.java
+++ b/src/test/java/org/springframework/data/redis/RedisTestProfileValueSource.java
@@ -41,6 +41,7 @@ public class RedisTestProfileValueSource implements ProfileValueSource {
 	private static final String REDIS_30 = "3.0";
 	private static final String REDIS_32 = "3.2";
 	private static final String REDIS_50 = "5.0";
+	private static final String REDIS_60 = "6.0";
 	private static final String REDIS_VERSION_KEY = "redisVersion";
 
 	private static RedisTestProfileValueSource INSTANCE;
@@ -95,6 +96,10 @@ public class RedisTestProfileValueSource implements ProfileValueSource {
 
 		if (!REDIS_VERSION_KEY.equals(key)) {
 			return System.getProperty(key);
+		}
+
+		if (redisVersion.compareTo(RedisVersionUtils.parseVersion(REDIS_60)) >= 0) {
+			return REDIS_60;
 		}
 
 		if (redisVersion.compareTo(RedisVersionUtils.parseVersion(REDIS_50)) >= 0) {

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisAclIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisAclIntegrationTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.jedis;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assume.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.data.redis.RedisTestProfileValueSource;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+
+/**
+ * Integration tests for Redis 6 ACL.
+ *
+ * @author Mark Paluch
+ */
+public class JedisAclIntegrationTests {
+
+	@Before
+	public void before() {
+		assumeTrue(RedisTestProfileValueSource.atLeast("redisVersion", "6.0"));
+	}
+
+	@Test
+	public void shouldConnectWithDefaultAuthentication() {
+
+		RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration("localhost", 6382);
+		standaloneConfiguration.setPassword("foobared");
+
+		JedisConnectionFactory connectionFactory = new JedisConnectionFactory(standaloneConfiguration);
+		connectionFactory.afterPropertiesSet();
+
+		RedisConnection connection = connectionFactory.getConnection();
+
+		assertThat(connection.ping()).isEqualTo("PONG");
+		connection.close();
+
+		connectionFactory.destroy();
+	}
+
+	@Test // DATAREDIS-1046
+	public void shouldConnectStandaloneWithAclAuthentication() {
+
+		RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration("localhost", 6382);
+		standaloneConfiguration.setUsername("spring");
+		standaloneConfiguration.setPassword("data");
+
+		JedisConnectionFactory connectionFactory = new JedisConnectionFactory(standaloneConfiguration);
+		connectionFactory.afterPropertiesSet();
+
+		RedisConnection connection = connectionFactory.getConnection();
+
+		assertThat(connection.ping()).isEqualTo("PONG");
+		connection.close();
+
+		connectionFactory.destroy();
+	}
+
+	@Test // DATAREDIS-1046
+	public void shouldConnectStandaloneWithAclAuthenticationAndPooling() {
+
+		RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration("localhost", 6382);
+		standaloneConfiguration.setUsername("spring");
+		standaloneConfiguration.setPassword("data");
+
+		JedisConnectionFactory connectionFactory = new JedisConnectionFactory(standaloneConfiguration);
+		connectionFactory.setUsePool(true);
+		connectionFactory.afterPropertiesSet();
+
+		RedisConnection connection = connectionFactory.getConnection();
+
+		assertThat(connection.ping()).isEqualTo("PONG");
+		connection.close();
+
+		connectionFactory.destroy();
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClientTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/AuthenticatingRedisClientTests.java
@@ -22,24 +22,22 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
- * Integration test of {@link AuthenticatingRedisClient}. Enable requirepass and comment out the @Ignore to run.
+ * Integration test of {@link AuthenticatingRedisClient}.
  *
  * @author Jennifer Hickey
  * @author Thomas Darimont
  * @author Christoph Strobl
  */
-@Ignore("Redis must have requirepass set to run this test")
 public class AuthenticatingRedisClientTests {
 
 	private RedisClient client;
 
 	@Before
 	public void setUp() {
-		client = new AuthenticatingRedisClient("localhost", "foo");
+		client = new AuthenticatingRedisClient("localhost", 6382, "foobared");
 	}
 
 	@After
@@ -63,7 +61,7 @@ public class AuthenticatingRedisClientTests {
 			client.shutdown();
 		}
 
-		RedisClient badClient = new AuthenticatingRedisClient("localhost", "notthepassword");
+		RedisClient badClient = new AuthenticatingRedisClient("localhost", 6382, "notthepassword");
 		badClient.connect();
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/DefaultLettucePoolTests.java
@@ -171,16 +171,6 @@ public class DefaultLettucePoolTests {
 		pool.getResource();
 	}
 
-	@Test(expected = PoolException.class)
-	public void testCreateWithPasswordNoPassword() {
-
-		pool = new DefaultLettucePool(SettingsUtils.getHost(), SettingsUtils.getPort());
-		pool.setClientResources(LettuceTestClientResources.getSharedClientResources());
-		pool.setPassword("notthepassword");
-		pool.afterPropertiesSet();
-		pool.getResource();
-	}
-
 	@Ignore("Redis must have requirepass set to run this test")
 	@Test
 	public void testCreatePassword() {

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceAclIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceAclIntegrationTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assume.*;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.springframework.data.redis.RedisTestProfileValueSource;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
+
+/**
+ * Integration tests for Redis 6 ACL.
+ *
+ * @author Mark Paluch
+ */
+public class LettuceAclIntegrationTests {
+
+	@Before
+	public void before() {
+		assumeTrue(RedisTestProfileValueSource.atLeast("redisVersion", "6.0"));
+	}
+
+	@Test // DATAREDIS-1046
+	public void shouldConnectWithDefaultAuthentication() {
+
+		RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration("localhost", 6382);
+		standaloneConfiguration.setPassword("foobared");
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(standaloneConfiguration);
+		connectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		connectionFactory.afterPropertiesSet();
+
+		RedisConnection connection = connectionFactory.getConnection();
+
+		assertThat(connection.ping()).isEqualTo("PONG");
+		connection.close();
+
+		connectionFactory.destroy();
+	}
+
+	@Test // DATAREDIS-1046
+	public void shouldConnectStandaloneWithAclAuthentication() {
+
+		RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration("localhost", 6382);
+		standaloneConfiguration.setUsername("spring");
+		standaloneConfiguration.setPassword("data");
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(standaloneConfiguration);
+		connectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		connectionFactory.afterPropertiesSet();
+
+		RedisConnection connection = connectionFactory.getConnection();
+
+		assertThat(connection.ping()).isEqualTo("PONG");
+		connection.close();
+
+		connectionFactory.destroy();
+	}
+
+	@Test // DATAREDIS-1046
+	@Ignore("https://github.com/lettuce-io/lettuce-core/issues/1406")
+	public void shouldConnectMasterReplicaWithAclAuthentication() {
+
+		RedisStaticMasterReplicaConfiguration masterReplicaConfiguration = new RedisStaticMasterReplicaConfiguration(
+				"localhost", 6382);
+		masterReplicaConfiguration.setUsername("spring");
+		masterReplicaConfiguration.setPassword("data");
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(masterReplicaConfiguration);
+		connectionFactory.setClientResources(LettuceTestClientResources.getSharedClientResources());
+		connectionFactory.afterPropertiesSet();
+
+		RedisConnection connection = connectionFactory.getConnection();
+
+		assertThat(connection.ping()).isEqualTo("PONG");
+		connection.close();
+
+		connectionFactory.destroy();
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -22,12 +22,14 @@ import io.lettuce.core.EpollProvider;
 import io.lettuce.core.KqueueProvider;
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisException;
+import io.lettuce.core.RedisFuture;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.reactive.BaseRedisReactiveCommands;
 import reactor.test.StepVerifier;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -230,11 +232,12 @@ public class LettuceConnectionFactoryTests {
 		assertThat(conn2.isClosed()).isTrue();
 		// Give some time for native connection to asynchronously close
 		Thread.sleep(100);
+		RedisFuture<String> future = ((RedisAsyncCommands<byte[], byte[]>) conn2.getNativeConnection()).ping();
 		try {
-			((RedisAsyncCommands<byte[], byte[]>) conn2.getNativeConnection()).ping();
+			future.get();
 			fail("The native connection should be closed");
-		} catch (RedisException e) {
-			// expected
+		} catch (ExecutionException e) {
+			// expected, Lettuce async failures are signalled on the Future
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
@@ -17,7 +17,6 @@ package org.springframework.data.redis.connection.lettuce;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assume.*;
-import static org.springframework.data.redis.SpinBarrier.*;
 
 import io.lettuce.core.api.async.RedisAsyncCommands;
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommandsTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommandsTests.java
@@ -50,9 +50,7 @@ public class LettuceReactiveStreamCommandsTests extends LettuceReactiveCommandsT
 
 	@Before
 	public void before() {
-
-		// TODO: Upgrade to 5.0
-		assumeTrue(RedisTestProfileValueSource.atLeast("redisVersion", "4.9"));
+		assumeTrue(RedisTestProfileValueSource.atLeast("redisVersion", "5.0"));
 	}
 
 	@Test // DATAREDIS-864

--- a/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClientProvider.java
+++ b/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClientProvider.java
@@ -15,10 +15,13 @@
  */
 package org.springframework.data.redis.test.util;
 
+import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.protocol.ProtocolVersion;
 
 import org.junit.rules.ExternalResource;
+
 import org.springframework.data.redis.SettingsUtils;
 import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
 
@@ -44,6 +47,8 @@ public class LettuceRedisClientProvider extends ExternalResource {
 
 		client = RedisClient.create(LettuceTestClientResources.getSharedClientResources(),
 				RedisURI.builder().withHost(host).withPort(port).build());
+		client.setOptions(
+				ClientOptions.builder().protocolVersion(ProtocolVersion.RESP2).pingBeforeActivateConnection(false).build());
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClusterClientProvider.java
+++ b/src/test/java/org/springframework/data/redis/test/util/LettuceRedisClusterClientProvider.java
@@ -15,12 +15,15 @@
  */
 package org.springframework.data.redis.test.util;
 
-import org.junit.rules.ExternalResource;
-import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
-
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.protocol.ProtocolVersion;
+
+import org.junit.rules.ExternalResource;
+
+import org.springframework.data.redis.connection.lettuce.LettuceTestClientResources;
 
 /**
  * @author Christoph Strobl
@@ -44,6 +47,8 @@ public class LettuceRedisClusterClientProvider extends ExternalResource {
 
 		client = RedisClusterClient.create(LettuceTestClientResources.getSharedClientResources(),
 				RedisURI.builder().withHost(host).withPort(port).build());
+		client.setOptions(ClusterClientOptions.builder().protocolVersion(ProtocolVersion.RESP2)
+				.pingBeforeActivateConnection(false).build());
 	}
 
 	@Override


### PR DESCRIPTION
Upgrade to Redis 6 for tests. Introduce support for username in configurations that support authentication.

Depends on #554.