### PR TITLE
DATAREDIS-1212 Avoid allocation when accessing DefaultMessage channel and body

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -826,7 +826,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 
 		private boolean isKeyExpirationMessage(Message message) {
 
-			if (message == null || message.getChannel() == null || message.getBody() == null) {
+			if (message == null) {
 				return false;
 			}
 


### PR DESCRIPTION
This PR avoids allocating new byte arrays when accessing `DefaultMessage.getChannel` and `DefaultMessage.getBody`.

`DefaultMessage.channelStartsWith` and `DefaultMessage.bodyStartsWith` are added so Spring Session can process messages without allocations:

https://github.com/spring-projects/spring-session/blob/0f3ea33b50678a764a50f7851b86fa45a99d2c85/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java#L503

See https://jira.spring.io/browse/DATAREDIS-1212