### PR TITLE
DATAREDIS-1222 - DefaultStringRedisConnection#zRangeByLex(String, Range, Limit) ignores the limit parameter

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -3625,7 +3625,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	 */
 	@Override
 	public Set<String> zRangeByLex(String key, Range range) {
-		return zRangeByLex(key, range, null);
+		return zRangeByLex(key, range, Limit.unlimited());
 	}
 
 	/*
@@ -3634,7 +3634,7 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	 */
 	@Override
 	public Set<String> zRangeByLex(String key, Range range, Limit limit) {
-		return convertAndReturn(delegate.zRangeByLex(serialize(key), range), byteSetToStringSet);
+		return convertAndReturn(delegate.zRangeByLex(serialize(key), range, limit), byteSetToStringSet);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
@@ -863,7 +863,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		try {
 			if (isPipelined()) {
-				if (limit != null) {
+				if (limit != null && !limit.isUnlimited()) {
 					pipeline(connection.newJedisResult(
 							connection.getRequiredPipeline().zrangeByLex(key, min, max, limit.getOffset(), limit.getCount())));
 				} else {
@@ -873,7 +873,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 			}
 
 			if (isQueueing()) {
-				if (limit != null) {
+				if (limit != null && !limit.isUnlimited()) {
 					transaction(connection.newJedisResult(
 							connection.getRequiredTransaction().zrangeByLex(key, min, max, limit.getOffset(), limit.getCount())));
 				} else {

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -62,6 +62,7 @@ import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptio
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.connection.RedisZSetCommands.Aggregate;
+import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
 import org.springframework.data.redis.connection.RedisZSetCommands.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Tuple;
 import org.springframework.data.redis.connection.SortParameters.Order;
@@ -2389,6 +2390,10 @@ public abstract class AbstractConnectionIntegrationTests {
 		actual.add(connection.zRangeByLex("myzset", Range.range().gte("aaa").lt("g")));
 		actual.add(connection.zRangeByLex("myzset", Range.range().gte("e")));
 
+		actual.add(connection.zRangeByLex("myzset", Range.range().lte("c"), Limit.unlimited()));
+		actual.add(connection.zRangeByLex("myzset", Range.range().lte("c"), Limit.limit().count(1)));
+		actual.add(connection.zRangeByLex("myzset", Range.range().lte("c"), Limit.limit().count(1).offset(1)));
+
 		List<Object> results = getResults();
 
 		Set<String> values = (Set<String>) results.get(7);
@@ -2407,6 +2412,18 @@ public abstract class AbstractConnectionIntegrationTests {
 		values = (Set<String>) results.get(10);
 		assertThat(values).contains("e", "f", "g");
 		assertThat(values).doesNotContain("a", "b", "c", "d");
+
+		values = (Set<String>) results.get(11);
+		assertThat(values).contains("a", "b", "c");
+		assertThat(values).doesNotContain("d", "e", "f", "g");
+
+		values = (Set<String>) results.get(12);
+		assertThat(values).contains("a");
+		assertThat(values).doesNotContain("b", "c", "d", "e", "f", "g");
+
+		values = (Set<String>) results.get(13);
+		assertThat(values).contains("b");
+		assertThat(values).doesNotContain("a", "c", "d", "e", "f", "g");
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATAREDIS-316, DATAREDIS-692


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
