### PR TITLE
DATAREDIS-1234 - Consistently return List<Long> from LPOS command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATAREDIS-1234-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceListCommands.java
@@ -83,7 +83,8 @@ class LettuceListCommands implements RedisListCommands {
 				if (count != null) {
 					pipeline(connection.newLettuceResult(getAsyncConnection().lpos(key, element, count, args)));
 				} else {
-					pipeline(connection.newLettuceResult(getAsyncConnection().lpos(key, element, args)));
+					pipeline(
+							connection.newLettuceResult(getAsyncConnection().lpos(key, element, args), Collections::singletonList));
 				}
 				return null;
 			}
@@ -91,7 +92,8 @@ class LettuceListCommands implements RedisListCommands {
 				if (count != null) {
 					transaction(connection.newLettuceResult(getAsyncConnection().lpos(key, element, count, args)));
 				} else {
-					transaction(connection.newLettuceResult(getAsyncConnection().lpos(key, element, args)));
+					transaction(
+							connection.newLettuceResult(getAsyncConnection().lpos(key, element, args), Collections::singletonList));
 				}
 				return null;
 			}

--- a/src/test/java/org/springframework/data/redis/RedisTestProfileValueSource.java
+++ b/src/test/java/org/springframework/data/redis/RedisTestProfileValueSource.java
@@ -42,6 +42,7 @@ public class RedisTestProfileValueSource implements ProfileValueSource {
 	private static final String REDIS_32 = "3.2";
 	private static final String REDIS_50 = "5.0";
 	private static final String REDIS_60 = "6.0";
+	private static final String REDIS_606 = "6.0.6";
 	private static final String REDIS_VERSION_KEY = "redisVersion";
 
 	private static RedisTestProfileValueSource INSTANCE;
@@ -96,6 +97,10 @@ public class RedisTestProfileValueSource implements ProfileValueSource {
 
 		if (!REDIS_VERSION_KEY.equals(key)) {
 			return System.getProperty(key);
+		}
+
+		if (redisVersion.compareTo(RedisVersionUtils.parseVersion(REDIS_606)) >= 0) {
+			return REDIS_606;
 		}
 
 		if (redisVersion.compareTo(RedisVersionUtils.parseVersion(REDIS_60)) >= 0) {

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -1501,9 +1501,9 @@ public abstract class AbstractConnectionIntegrationTests {
 	public void lPos() {
 
 		actual.add(connection.rPush("mylist", "a", "b", "c", "1", "2", "3", "c", "c"));
-		actual.add(connection.lPos("mylist", "c"));
+		actual.add(connection.lPos("mylist", "c", null, null));
 
-		assertThat((Long) getResults().get(1)).isEqualTo(2);
+		assertThat((List<Long>) getResults().get(1)).containsOnly(2L);
 	}
 
 	@Test // DATAREDIS-1196


### PR DESCRIPTION
We now convert pipeline/transaction results to `List<Long>` to ensure a consistent return type.

---

Related ticket: [DATAREDIS-1234](https://jira.spring.io/browse/DATAREDIS-1234).