### PR TITLE
DATAREDIS-1245 - Consider List subtypes used with RedisScript as MULTI return type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-DATAREDIS-1245-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/ReturnType.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReturnType.java
@@ -25,6 +25,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Jennifer Hickey
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public enum ReturnType {
 
@@ -62,15 +63,19 @@ public enum ReturnType {
 		if (javaType == null) {
 			return ReturnType.STATUS;
 		}
-		if (javaType.isAssignableFrom(List.class)) {
+
+		if (List.class.isAssignableFrom(javaType)) {
 			return ReturnType.MULTI;
 		}
+
 		if (javaType.isAssignableFrom(Boolean.class)) {
 			return ReturnType.BOOLEAN;
 		}
+
 		if (javaType.isAssignableFrom(Long.class)) {
 			return ReturnType.INTEGER;
 		}
+
 		return ReturnType.VALUE;
 	}
 }

--- a/src/main/java/org/springframework/data/redis/core/script/RedisScript.java
+++ b/src/main/java/org/springframework/data/redis/core/script/RedisScript.java
@@ -27,7 +27,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @param <T> The script result type. Should be one of Long, Boolean, List, or deserialized value type. Can be
- *          {@litearl null} if the script returns a throw-away status (i.e "OK")
+ *          {@literal null} if the script returns a throw-away status (i.e "OK")
  */
 public interface RedisScript<T> {
 
@@ -57,7 +57,7 @@ public interface RedisScript<T> {
 	}
 
 	/**
-	 * Creates new {@link RedisScript} from {@link String}.
+	 * Creates new {@link RedisScript} from {@code script} as {@link String}.
 	 *
 	 * @param script must not be {@literal null}.
 	 * @return new instance of {@link RedisScript}.
@@ -68,19 +68,19 @@ public interface RedisScript<T> {
 	}
 
 	/**
-	 * Creates new {@link RedisScript} from {@link String}.
+	 * Creates new {@link RedisScript} from {@code script} as {@link String}.
 	 *
 	 * @param script must not be {@literal null}.
 	 * @param resultType must not be {@literal null}.
 	 * @return new instance of {@link RedisScript}.
 	 * @since 2.0
 	 */
-	static <T> RedisScript of(String script, Class<T> resultType) {
+	static <T> RedisScript<T> of(String script, Class<T> resultType) {
 
 		Assert.notNull(script, "Script must not be null!");
 		Assert.notNull(resultType, "ResultType must not be null!");
 
-		return new DefaultRedisScript(script, resultType);
+		return new DefaultRedisScript<>(script, resultType);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/connection/ReturnTypeUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ReturnTypeUnitTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for {@link ReturnType}.
+ *
+ * @author Mark Paluch
+ */
+class ReturnTypeUnitTests {
+
+	@ParameterizedTest // DATAREDIS-1245
+	@ValueSource(classes = { List.class, ArrayList.class, LinkedList.class })
+	void shouldConsiderListsAsMultiType(Class<?> listClass) {
+
+		assertThat(ReturnType.fromJavaType(listClass)).isEqualTo(ReturnType.MULTI);
+	}
+
+}


### PR DESCRIPTION
We now consider `List` and subtypes of `List` to be returned as `MULTI` return type. Previously, `List` subtypes were considered to represent the value type.