### PR TITLE
DATAREDIS-1253 - Fixed a bug that the key is temporarily deleted.

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -99,6 +99,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Takahiro Shigemoto
  * @since 1.7
  */
 public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
@@ -231,7 +232,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 			byte[] key = toBytes(rdo.getId());
 			byte[] objectKey = createKey(rdo.getKeyspace(), rdo.getId());
 
-			boolean isNew = connection.del(objectKey) == 0;
+			boolean isNew = !connection.exists(objectKey);
 
 			connection.hMSet(objectKey, rdo.getBucket().rawMap());
 

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterUnitTests.java
@@ -54,6 +54,7 @@ import org.springframework.data.redis.listener.KeyExpirationEventMessageListener
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Takahiro Shigemoto
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -107,7 +108,7 @@ class RedisKeyValueAdapterUnitTests {
 
 		when(redisConnectionMock.sMembers(Mockito.any(byte[].class)))
 				.thenReturn(new LinkedHashSet<>(Arrays.asList("persons:firstname:rand".getBytes())));
-		when(redisConnectionMock.del((byte[][]) any())).thenReturn(1L);
+		when(redisConnectionMock.exists((byte[]) any())).thenReturn(true);
 
 		adapter.put("1", rd, "persons");
 
@@ -122,7 +123,7 @@ class RedisKeyValueAdapterUnitTests {
 
 		when(redisConnectionMock.sMembers(Mockito.any(byte[].class)))
 				.thenReturn(new LinkedHashSet<>(Arrays.asList("persons:firstname:rand".getBytes())));
-		when(redisConnectionMock.del((byte[][]) any())).thenReturn(0L);
+		when(redisConnectionMock.exists((byte[]) any())).thenReturn(false);
 
 		adapter.put("1", rd, "persons");
 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

The put method of the RedisKeyValueAdapter class temporarily removes the key (del & hMSet), so the existing hash could sometimes disappear.
To avoid this issue, I changed the hash existence check from connection.del to connection.exists.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAREDIS).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
