### PR TITLE
DATAREDIS-1230 - Revise error handling in StreamReceiver and StreamMessageListenerContainer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-DATAREDIS-1230-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
@@ -416,7 +416,8 @@ class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperat
 		return (HV) serializationContext.getHashValueSerializationPair().read(buffer);
 	}
 
-	private MapRecord<K, HK, HV> deserializeRecord(ByteBufferRecord record) {
+	@Override
+	public MapRecord<K, HK, HV> deserializeRecord(ByteBufferRecord record) {
 		return record.map(it -> it.mapEntries(this::deserializeRecordFields).withStreamKey(readKey(record.getStream())));
 	}
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -347,6 +347,11 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 		return objectMapper.getHashMapper(targetType);
 	}
 
+	@Override
+	public MapRecord<K, HK, HV> deserializeRecord(ByteRecord record) {
+		return record.deserialize(keySerializer(), hashKeySerializer(), hashValueSerializer());
+	}
+
 	protected byte[] serializeHashValueIfRequires(HV value) {
 		return hashValueSerializerPresent() ? serialize(value, hashValueSerializer())
 				: objectMapper.getConversionService().convert(value, byte[].class);
@@ -386,7 +391,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 
 			List<MapRecord<K, HK, HV>> result = new ArrayList<>();
 			for (ByteRecord record : raw) {
-				result.add(record.deserialize(keySerializer(), hashKeySerializer(), hashValueSerializer()));
+				result.add(deserializeRecord(record));
 			}
 
 			return result;

--- a/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
@@ -22,23 +22,13 @@ import java.util.Arrays;
 import java.util.Map;
 
 import org.reactivestreams.Publisher;
+
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
-import org.springframework.data.redis.connection.stream.Consumer;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ObjectRecord;
-import org.springframework.data.redis.connection.stream.PendingMessage;
-import org.springframework.data.redis.connection.stream.PendingMessages;
-import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.Record;
-import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.connection.stream.StreamInfo.XInfoConsumer;
 import org.springframework.data.redis.connection.stream.StreamInfo.XInfoGroup;
 import org.springframework.data.redis.connection.stream.StreamInfo.XInfoStream;
-import org.springframework.data.redis.connection.stream.StreamOffset;
-import org.springframework.data.redis.connection.stream.StreamReadOptions;
-import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.hash.HashMapper;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -354,7 +344,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 
 		Assert.notNull(targetType, "Target type must not be null");
 
-		return range(key, range, limit).map(it -> StreamObjectMapper.toObjectRecord(this, it, targetType));
+		return range(key, range, limit).map(it -> map(it, targetType));
 	}
 
 	/**
@@ -435,7 +425,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 
 		Assert.notNull(targetType, "Target type must not be null");
 
-		return read(readOptions, streams).map(it -> StreamObjectMapper.toObjectRecord(this, it, targetType));
+		return read(readOptions, streams).map(it -> map(it, targetType));
 	}
 
 	/**
@@ -489,7 +479,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 
 		Assert.notNull(targetType, "Target type must not be null");
 
-		return read(consumer, readOptions, streams).map(it -> StreamObjectMapper.toObjectRecord(this, it, targetType));
+		return read(consumer, readOptions, streams).map(it -> map(it, targetType));
 	}
 
 	/**
@@ -543,7 +533,7 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 
 		Assert.notNull(targetType, "Target type must not be null");
 
-		return reverseRange(key, range, limit).map(it -> StreamObjectMapper.toObjectRecord(this, it, targetType));
+		return reverseRange(key, range, limit).map(it -> map(it, targetType));
 	}
 
 	/**
@@ -577,4 +567,29 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 */
 	@Override
 	<V> HashMapper<V, HK, HV> getHashMapper(Class<V> targetType);
+
+	/**
+	 * Map records from {@link MapRecord} to {@link ObjectRecord}.
+	 *
+	 * @param record the stream records to map.
+	 * @param targetType the target type of the payload.
+	 * @return the mapped {@link ObjectRecord}.
+	 * @since 2.x
+	 */
+	default <V> ObjectRecord<K, V> map(MapRecord<K, HK, HV> record, Class<V> targetType) {
+
+		Assert.notNull(record, "Records must not be null");
+		Assert.notNull(targetType, "Target type must not be null");
+
+		return StreamObjectMapper.toObjectRecord(record, this, targetType);
+	}
+
+	/**
+	 * Deserialize a {@link ByteBufferRecord} using the configured serialization context into a {@link MapRecord}.
+	 *
+	 * @param record the stream record to map.
+	 * @return deserialized {@link MapRecord}.
+	 * @since 2.x
+	 */
+	MapRecord<K, HK, HV> deserializeRecord(ByteBufferRecord record);
 }

--- a/src/main/java/org/springframework/data/redis/core/StreamObjectMapper.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamObjectMapper.java
@@ -128,13 +128,13 @@ class StreamObjectMapper {
 	/**
 	 * Convert the given {@link Record} into an {@link ObjectRecord}.
 	 *
-	 * @param provider provider for {@link HashMapper} to apply mapping for {@link ObjectRecord}.
 	 * @param source the source value.
+	 * @param provider provider for {@link HashMapper} to apply mapping for {@link ObjectRecord}.
 	 * @param targetType the desired target type.
 	 * @return the converted {@link ObjectRecord}.
 	 */
-	static <K, V, HK, HV> ObjectRecord<K, V> toObjectRecord(HashMapperProvider<HK, HV> provider,
-			MapRecord<K, HK, HV> source, Class<V> targetType) {
+	static <K, V, HK, HV> ObjectRecord<K, V> toObjectRecord(MapRecord<K, HK, HV> source,
+			HashMapperProvider<HK, HV> provider, Class<V> targetType) {
 		return source.toObjectRecord(provider.getHashMapper(targetType));
 	}
 
@@ -149,7 +149,7 @@ class StreamObjectMapper {
 	 *         {@literal null}.
 	 */
 	@Nullable
-	static <K, V, HK, HV> List<ObjectRecord<K, V>> map(@Nullable List<MapRecord<K, HK, HV>> records,
+	static <K, V, HK, HV> List<ObjectRecord<K, V>> toObjectRecords(@Nullable List<MapRecord<K, HK, HV>> records,
 			HashMapperProvider<HK, HV> hashMapperProvider, Class<V> targetType) {
 
 		if (records == null) {
@@ -161,7 +161,7 @@ class StreamObjectMapper {
 		}
 
 		if (records.size() == 1) {
-			return Collections.singletonList(toObjectRecord(hashMapperProvider, records.get(0), targetType));
+			return Collections.singletonList(toObjectRecord(records.get(0), hashMapperProvider, targetType));
 		}
 
 		List<ObjectRecord<K, V>> transformed = new ArrayList<>(records.size());

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -23,21 +23,10 @@ import java.util.Map;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
-import org.springframework.data.redis.connection.stream.Consumer;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ObjectRecord;
-import org.springframework.data.redis.connection.stream.PendingMessage;
-import org.springframework.data.redis.connection.stream.PendingMessages;
-import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.Record;
-import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.connection.stream.StreamInfo.XInfoConsumers;
 import org.springframework.data.redis.connection.stream.StreamInfo.XInfoGroups;
 import org.springframework.data.redis.connection.stream.StreamInfo.XInfoStream;
-import org.springframework.data.redis.connection.stream.StreamOffset;
-import org.springframework.data.redis.connection.stream.StreamReadOptions;
-import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.hash.HashMapper;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -356,7 +345,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 
 		Assert.notNull(targetType, "Target type must not be null");
 
-		return StreamObjectMapper.map(range(key, range, limit), this, targetType);
+		return map(range(key, range, limit), targetType);
 	}
 
 	/**
@@ -409,7 +398,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 
 		Assert.notNull(targetType, "Target type must not be null");
 
-		return StreamObjectMapper.map(read(readOptions, streams), this, targetType);
+		return map(read(readOptions, streams), targetType);
 	}
 
 	/**
@@ -467,7 +456,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 
 		Assert.notNull(targetType, "Target type must not be null");
 
-		return StreamObjectMapper.map(read(consumer, readOptions, streams), this, targetType);
+		return map(read(consumer, readOptions, streams), targetType);
 	}
 
 	/**
@@ -523,7 +512,7 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 
 		Assert.notNull(targetType, "Target type must not be null");
 
-		return StreamObjectMapper.map(reverseRange(key, range, limit), this, targetType);
+		return map(reverseRange(key, range, limit), targetType);
 	}
 
 	/**
@@ -560,4 +549,45 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	@Override
 	<V> HashMapper<V, HK, HV> getHashMapper(Class<V> targetType);
 
+	/**
+	 * Map record from {@link MapRecord} to {@link ObjectRecord}.
+	 *
+	 * @param record the stream record to map.
+	 * @param targetType the target type of the payload.
+	 * @return the mapped {@link ObjectRecord}.
+	 * @since 2.x
+	 */
+	default <V> ObjectRecord<K, V> map(MapRecord<K, HK, HV> record, Class<V> targetType) {
+
+		Assert.notNull(record, "Record must not be null");
+		Assert.notNull(targetType, "Target type must not be null");
+
+		return StreamObjectMapper.toObjectRecord(record, this, targetType);
+	}
+
+	/**
+	 * Map records from {@link MapRecord} to {@link ObjectRecord}s.
+	 *
+	 * @param records the stream records to map.
+	 * @param targetType the target type of the payload.
+	 * @return the mapped {@link ObjectRecord object records}.
+	 * @since 2.x
+	 */
+	@Nullable
+	default <V> List<ObjectRecord<K, V>> map(@Nullable List<MapRecord<K, HK, HV>> records, Class<V> targetType) {
+
+		Assert.notNull(records, "Records must not be null");
+		Assert.notNull(targetType, "Target type must not be null");
+
+		return StreamObjectMapper.toObjectRecords(records, this, targetType);
+	}
+
+	/**
+	 * Deserialize a {@link ByteRecord} using the configured serializers into a {@link MapRecord}.
+	 *
+	 * @param record the stream record to map.
+	 * @return deserialized {@link MapRecord}.
+	 * @since 2.x
+	 */
+	MapRecord<K, HK, HV> deserializeRecord(ByteRecord record);
 }

--- a/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
@@ -417,7 +417,7 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 		}
 
 		/**
-		 * Configure a {@link ErrorHandler} to be notified on {@link Throwable errors}.
+		 * Configure a {@link ErrorHandler} to be notified on {@link Throwable read, deserialization, and listener errors}.
 		 *
 		 * @param errorHandler must not be null.
 		 * @return {@code this} {@link ConsumerStreamReadRequestBuilder}.
@@ -429,8 +429,9 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 		}
 
 		/**
-		 * Configure a cancellation {@link Predicate} to be notified on {@link Throwable errors}. The outcome of the
-		 * {@link Predicate} decides whether to cancel the subscription by returning {@literal true}.
+		 * Configure a cancellation {@link Predicate} to be notified on {@link Throwable read, deserialization, and listener
+		 * errors}. The outcome of the {@link Predicate} decides whether to cancel the subscription by returning
+		 * {@literal true}.
 		 *
 		 * @param cancelSubscriptionOnError must not be null.
 		 * @return {@code this} {@link ConsumerStreamReadRequestBuilder}.
@@ -568,6 +569,19 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 			return hashMapper;
 		}
 
+		public HashMapper<Object, Object, Object> getRequiredHashMapper() {
+
+			if (!hasHashMapper()) {
+				throw new IllegalStateException("No HashMapper configured");
+			}
+
+			return hashMapper;
+		}
+
+		public boolean hasHashMapper() {
+			return hashMapper != null;
+		}
+
 		public Class<Object> getTargetType() {
 
 			if (this.targetType != null) {
@@ -590,6 +604,7 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 		public Executor getExecutor() {
 			return executor;
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
Reading and deserialization in StreamReceiver and StreamMessageListener is now decoupled from each other to allow fine-grained control over errors and resumption.

Previously, we used the Template API to read and deserialize stream records. Now the actual read happens before the deserialization so that errors during deserialization of individual messages can be handled properly. This split also allows advancing in the stream read. Previously, the failed deserialization prevented of getting hold of the non-serialized Stream record which caused the stream receiver to remain at the offset that fetched the offending record which effectively lead to an infinite loop.

We also support a resume function in StreamReceiver to control whether stream reads should be resumed or terminated.

---

Related ticket: DATAREDIS-1230.