### PR TITLE
Introduce LettuceInvoker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-DATAREDIS-1224-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisListCommands.java
@@ -75,6 +75,7 @@ public interface RedisListCommands {
 	 * @see <a href="https://redis.io/commands/lpos">Redis Documentation: LPOS</a>
 	 * @since 2.4
 	 */
+	@Nullable
 	List<Long> lPos(byte[] key, byte[] element, @Nullable Integer rank, @Nullable Integer count);
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/convert/LongToBooleanConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/LongToBooleanConverter.java
@@ -25,6 +25,8 @@ import org.springframework.core.convert.converter.Converter;
  */
 public class LongToBooleanConverter implements Converter<Long, Boolean> {
 
+	public static final LongToBooleanConverter INSTANCE = new LongToBooleanConverter();
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.core.convert.converter.Converter#convert(Object)

--- a/src/main/java/org/springframework/data/redis/connection/convert/StringToRedisClientInfoConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/StringToRedisClientInfoConverter.java
@@ -35,6 +35,8 @@ import org.springframework.data.redis.core.types.RedisClientInfo.RedisClientInfo
  */
 public class StringToRedisClientInfoConverter implements Converter<String[], List<RedisClientInfo>> {
 
+	public static final StringToRedisClientInfoConverter INSTANCE = new StringToRedisClientInfoConverter();
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.core.convert.converter.Converter#convert(Object)

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterHyperLogLogCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterHyperLogLogCommands.java
@@ -38,14 +38,9 @@ class LettuceClusterHyperLogLogCommands extends LettuceHyperLogLogCommands {
 	public Long pfCount(byte[]... keys) {
 
 		if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
-
-			try {
-				return super.pfCount(keys);
-			} catch (Exception ex) {
-				throw convertLettuceAccessException(ex);
-			}
-
+			return super.pfCount(keys);
 		}
+
 		throw new InvalidDataAccessApiUsageException("All keys must map to same slot for pfcount in cluster mode.");
 	}
 
@@ -59,14 +54,10 @@ class LettuceClusterHyperLogLogCommands extends LettuceHyperLogLogCommands {
 		byte[][] allKeys = ByteUtils.mergeArrays(destinationKey, sourceKeys);
 
 		if (ClusterSlotHashUtil.isSameSlotForAllKeys(allKeys)) {
-			try {
-				super.pfMerge(destinationKey, sourceKeys);
-				return;
-			} catch (Exception ex) {
-				throw convertLettuceAccessException(ex);
-			}
-
+			super.pfMerge(destinationKey, sourceKeys);
+			return;
 		}
+
 		throw new InvalidDataAccessApiUsageException("All keys must map to same slot for pfmerge in cluster mode.");
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -104,7 +104,7 @@ abstract public class LettuceConverters extends Converters {
 	private static final Converter<Partitions, List<RedisClusterNode>> PARTITIONS_TO_CLUSTER_NODES;
 	private static Converter<io.lettuce.core.cluster.models.partitions.RedisClusterNode, RedisClusterNode> CLUSTER_NODE_TO_CLUSTER_NODE_CONVERTER;
 	private static final Converter<List<byte[]>, Long> BYTES_LIST_TO_TIME_CONVERTER;
-	private static final Converter<GeoCoordinates, Point> GEO_COORDINATE_TO_POINT_CONVERTER;
+	public static final Converter<GeoCoordinates, Point> GEO_COORDINATE_TO_POINT_CONVERTER;
 	private static final ListConverter<GeoCoordinates, Point> GEO_COORDINATE_LIST_TO_POINT_LIST_CONVERTER;
 	private static final Converter<KeyValue<Object, Object>, Object> KEY_VALUE_UNWRAPPER;
 	private static final ListConverter<KeyValue<Object, Object>, Object> KEY_VALUE_LIST_UNWRAPPER;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceGeoCommands.java
@@ -36,6 +36,7 @@ import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.NullableResult;
 import org.springframework.data.redis.connection.RedisGeoCommands;
 import org.springframework.data.redis.connection.convert.ListConverter;
 import org.springframework.lang.Nullable;
@@ -165,23 +166,12 @@ class LettuceGeoCommands implements RedisGeoCommands {
 		GeoArgs.Unit geoUnit = LettuceConverters.toGeoArgsUnit(metric);
 		Converter<Double, Distance> distanceConverter = LettuceConverters.distanceConverterForMetric(metric);
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().geodist(key, member1, member2, geoUnit),
-						distanceConverter));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().geodist(key, member1, member2, geoUnit),
-						distanceConverter));
-				return null;
-			}
+//		return connection.execute(
+//				sync -> sync.geodist(key, member1, member2, geoUnit),
+//				async -> async.geodist(key, member1, member2, geoUnit),
+//				distanceConverter);
 
-			Double distance = getConnection().geodist(key, member1, member2, geoUnit);
-			return distance != null ? distanceConverter.convert(distance) : null;
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke(connection.getAsyncConnection().geodist(key, member1, member2, geoUnit), distanceConverter);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceGeoCommands.java
@@ -165,7 +165,7 @@ class LettuceGeoCommands implements RedisGeoCommands {
 		Assert.noNullElements(members, "Members must not contain null!");
 
 		return connection.invoke().fromMany(RedisGeoAsyncCommands::geopos, key, members)
-				.toList(LettuceConverters.GEO_COORDINATE_TO_POINT_CONVERTER);
+				.toList(LettuceConverters::geoCoordinatesToPoint);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
@@ -159,7 +159,7 @@ class LettuceHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return connection.invoke().from(RedisHashAsyncCommands::hkeys, key).get(LettuceConverters.bytesListToBytesSet());
+		return connection.invoke().fromMany(RedisHashAsyncCommands::hkeys, key).toSet();
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
@@ -17,15 +17,13 @@ package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.MapScanCursor;
 import io.lettuce.core.ScanArgs;
-import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
-import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+import io.lettuce.core.api.async.RedisHashAsyncCommands;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.RedisHashCommands;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.KeyBoundCursor;
@@ -58,19 +56,7 @@ class LettuceHashCommands implements RedisHashCommands {
 		Assert.notNull(field, "Field must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hset(key, field, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hset(key, field, value)));
-				return null;
-			}
-			return getConnection().hset(key, field, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hset, key, field, value);
 	}
 
 	/*
@@ -84,19 +70,7 @@ class LettuceHashCommands implements RedisHashCommands {
 		Assert.notNull(field, "Field must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hsetnx(key, field, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hsetnx(key, field, value)));
-				return null;
-			}
-			return getConnection().hsetnx(key, field, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hsetnx, key, field, value);
 	}
 
 	/*
@@ -109,19 +83,7 @@ class LettuceHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(fields, "Fields must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hdel(key, fields)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hdel(key, fields)));
-				return null;
-			}
-			return getConnection().hdel(key, fields);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hdel, key, fields);
 	}
 
 	/*
@@ -134,19 +96,7 @@ class LettuceHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Fields must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hexists(key, field)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hexists(key, field)));
-				return null;
-			}
-			return getConnection().hexists(key, field);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hexists, key, field);
 	}
 
 	/*
@@ -159,19 +109,7 @@ class LettuceHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Field must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hget(key, field)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hget(key, field)));
-				return null;
-			}
-			return getConnection().hget(key, field);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hget, key, field);
 	}
 
 	/*
@@ -183,19 +121,7 @@ class LettuceHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hgetall(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hgetall(key)));
-				return null;
-			}
-			return getConnection().hgetall(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hgetall, key);
 	}
 
 	/*
@@ -208,19 +134,7 @@ class LettuceHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Field must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hincrby(key, field, delta)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hincrby(key, field, delta)));
-				return null;
-			}
-			return getConnection().hincrby(key, field, delta);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hincrby, key, field, delta);
 	}
 
 	/*
@@ -233,19 +147,7 @@ class LettuceHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Field must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hincrbyfloat(key, field, delta)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hincrbyfloat(key, field, delta)));
-				return null;
-			}
-			return getConnection().hincrbyfloat(key, field, delta);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hincrbyfloat, key, field, delta);
 	}
 
 	/*
@@ -257,20 +159,7 @@ class LettuceHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hkeys(key), LettuceConverters.bytesListToBytesSet()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(
-						connection.newLettuceResult(getAsyncConnection().hkeys(key), LettuceConverters.bytesListToBytesSet()));
-				return null;
-			}
-			return LettuceConverters.toBytesSet(getConnection().hkeys(key));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().from(RedisHashAsyncCommands::hkeys, key).get(LettuceConverters.bytesListToBytesSet());
 	}
 
 	/*
@@ -282,19 +171,7 @@ class LettuceHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hlen(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hlen(key)));
-				return null;
-			}
-			return getConnection().hlen(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hlen, key);
 	}
 
 	/*
@@ -307,21 +184,8 @@ class LettuceHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(fields, "Fields must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hmget(key, fields),
-						LettuceConverters.keyValueListUnwrapper()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hmget(key, fields),
-						LettuceConverters.keyValueListUnwrapper()));
-				return null;
-			}
-			return LettuceConverters.<byte[], byte[]> keyValueListUnwrapper().convert(getConnection().hmget(key, fields));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().fromMany(RedisHashAsyncCommands::hmget, key, fields)
+				.toList(source -> source.getValueOrElse(null));
 	}
 
 	/*
@@ -334,19 +198,7 @@ class LettuceHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(hashes, "Hashes must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceStatusResult(getAsyncConnection().hmset(key, hashes)));
-				return;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceStatusResult(getAsyncConnection().hmset(key, hashes)));
-				return;
-			}
-			getConnection().hmset(key, hashes);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		connection.invokeStatus().just(RedisHashAsyncCommands::hmset, key, hashes);
 	}
 
 	/*
@@ -358,22 +210,11 @@ class LettuceHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hvals(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hvals(key)));
-				return null;
-			}
-			return getConnection().hvals(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisHashAsyncCommands::hvals, key);
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisHashCommands#hScan(byte[], org.springframework.data.redis.core.ScanOptions)
 	 */
 	@Override
@@ -397,14 +238,15 @@ class LettuceHashCommands implements RedisHashCommands {
 			@Override
 			protected ScanIteration<Entry<byte[], byte[]>> doScan(byte[] key, long cursorId, ScanOptions options) {
 
-				if (isQueueing() || isPipelined()) {
+				if (connection.isQueueing() || connection.isPipelined()) {
 					throw new UnsupportedOperationException("'HSCAN' cannot be called in pipeline / transaction mode.");
 				}
 
 				io.lettuce.core.ScanCursor scanCursor = connection.getScanCursor(cursorId);
 				ScanArgs scanArgs = LettuceConverters.toScanArgs(options);
 
-				MapScanCursor<byte[], byte[]> mapScanCursor = getConnection().hscan(key, scanCursor, scanArgs);
+				MapScanCursor<byte[], byte[]> mapScanCursor = connection.invoke().just(RedisHashAsyncCommands::hscan, key,
+						scanCursor, scanArgs);
 				String nextCursorId = mapScanCursor.getCursor();
 
 				Map<byte[], byte[]> values = mapScanCursor.getMap();
@@ -429,47 +271,8 @@ class LettuceHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Field must not be null!");
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().hstrlen(key, field)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().hstrlen(key, field)));
-				return null;
-			}
-			return getConnection().hstrlen(key, field);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
-	}
 
-	private boolean isPipelined() {
-		return connection.isPipelined();
-	}
-
-	private boolean isQueueing() {
-		return connection.isQueueing();
-	}
-
-	private void pipeline(LettuceResult result) {
-		connection.pipeline(result);
-	}
-
-	private void transaction(LettuceResult result) {
-		connection.transaction(result);
-	}
-
-	private RedisClusterAsyncCommands<byte[], byte[]> getAsyncConnection() {
-		return connection.getAsyncConnection();
-	}
-
-	public RedisClusterCommands<byte[], byte[]> getConnection() {
-		return connection.getConnection();
-	}
-
-	private DataAccessException convertLettuceAccessException(Exception ex) {
-		return connection.convertLettuceAccessException(ex);
+		return connection.invoke().just(RedisHashAsyncCommands::hstrlen, key, field);
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceInvoker.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceInvoker.java
@@ -1,0 +1,665 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Utility for functional invocation of {@link RedisClusterAsyncCommands Lettuce methods}. Typically used to express the
+ * method call as method reference and passing method arguments through one of the {@code just} or {@code from} methods.
+ * <p>
+ * {@code just} methods record the method call and evaluate the method result immediately. {@code from} methods allows
+ * composing a functional pipeline to transform the result using a {@link Converter}.
+ * <p>
+ * Usage example:
+ *
+ * <pre class="code">
+ * LettuceInvoker invoker = …;
+ *
+ * Long result = invoker.just(RedisGeoAsyncCommands::geoadd, key, point.getX(), point.getY(), member);
+ *
+ * List&lt;byte[]&gt; result = invoker.fromMany(RedisGeoAsyncCommands::geohash, key, members)
+ * 				.toList(it -> it.getValueOrElse(null));
+ * </pre>
+ * <p>
+ * The actual translation from {@link RedisFuture} is delegated to {@link Synchronizer} which can either await
+ * completion or record the future along {@link Converter} for further processing.
+ *
+ * @author Mark Paluch
+ * @since 2.5
+ */
+class LettuceInvoker {
+
+	private final RedisClusterAsyncCommands<byte[], byte[]> connection;
+	private final Synchronizer synchronizer;
+
+	LettuceInvoker(RedisClusterAsyncCommands<byte[], byte[]> connection, Synchronizer synchronizer) {
+		this.connection = connection;
+		this.synchronizer = synchronizer;
+	}
+
+	/**
+	 * Returns a {@link Converter} that always returns its input argument.
+	 *
+	 * @param <T> the type of the input and output objects to the function
+	 * @return a function that always returns its input argument
+	 */
+	static <T> Converter<T, T> identityConverter() {
+		return t -> t;
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction0} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	@Nullable
+	<R> R just(ConnectionFunction0<R> function) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return synchronizer.invoke(() -> function.apply(connection), identityConverter(), () -> null);
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction1} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	@Nullable
+	<R, T1> R just(ConnectionFunction1<T1, R> function, T1 t1) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return synchronizer.invoke(() -> function.apply(connection, t1));
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction2} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	@Nullable
+	<R, T1, T2> R just(ConnectionFunction2<T1, T2, R> function, T1 t1, T2 t2) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return synchronizer.invoke(() -> function.apply(connection, t1, t2));
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction3} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	@Nullable
+	<R, T1, T2, T3> R just(ConnectionFunction3<T1, T2, T3, R> function, T1 t1, T2 t2, T3 t3) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return synchronizer.invoke(() -> function.apply(connection, t1, t2, t3));
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction4} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	@Nullable
+	<R, T1, T2, T3, T4> R just(ConnectionFunction4<T1, T2, T3, T4, R> function, T1 t1, T2 t2, T3 t3, T4 t4) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return synchronizer.invoke(() -> function.apply(connection, t1, t2, t3, t4));
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction5} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	@Nullable
+	<R, T1, T2, T3, T4, T5> R just(ConnectionFunction5<T1, T2, T3, T4, T5, R> function, T1 t1, T2 t2, T3 t3, T4 t4,
+			T5 t5) {
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return synchronizer.invoke(() -> function.apply(connection, t1, t2, t3, t4, t5));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction0} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R> SingleInvocationSpec<R> from(ConnectionFunction0<R> function) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return new DefaultSingleInvocationSpec<>(() -> function.apply(connection), synchronizer);
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction1} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R, T1> SingleInvocationSpec<R> from(ConnectionFunction1<T1, R> function, T1 t1) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return from(it -> function.apply(it, t1));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction2} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R, T1, T2> SingleInvocationSpec<R> from(ConnectionFunction2<T1, T2, R> function, T1 t1, T2 t2) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return from(it -> function.apply(it, t1, t2));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction3} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R, T1, T2, T3> SingleInvocationSpec<R> from(ConnectionFunction3<T1, T2, T3, R> function, T1 t1, T2 t2, T3 t3) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return from(it -> function.apply(it, t1, t2, t3));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction4} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R, T1, T2, T3, T4> SingleInvocationSpec<R> from(ConnectionFunction4<T1, T2, T3, T4, R> function, T1 t1, T2 t2, T3 t3,
+			T4 t4) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return from(it -> function.apply(it, t1, t2, t3, t4));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction5} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R, T1, T2, T3, T4, T5> SingleInvocationSpec<R> from(ConnectionFunction5<T1, T2, T3, T4, T5, R> function, T1 t1,
+			T2 t2, T3 t3, T4 t4, T5 t5) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return from(it -> function.apply(it, t1, t2, t3, t4, t5));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction0} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R extends Collection<E>, E> ManyInvocationSpec<E> fromMany(ConnectionFunction0<R> function) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return new DefaultManyInvocationSpec<>(() -> function.apply(connection), synchronizer);
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction1} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R extends Collection<E>, E, T1> ManyInvocationSpec<E> fromMany(ConnectionFunction1<T1, R> function, T1 t1) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return fromMany(it -> function.apply(it, t1));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction2} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R extends Collection<E>, E, T1, T2> ManyInvocationSpec<E> fromMany(ConnectionFunction2<T1, T2, R> function, T1 t1,
+			T2 t2) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return fromMany(it -> function.apply(it, t1, t2));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction3} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R extends Collection<E>, E, T1, T2, T3> ManyInvocationSpec<E> fromMany(ConnectionFunction3<T1, T2, T3, R> function,
+			T1 t1, T2 t2, T3 t3) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return fromMany(it -> function.apply(it, t1, t2, t3));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction4} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R extends Collection<E>, E, T1, T2, T3, T4> ManyInvocationSpec<E> fromMany(
+			ConnectionFunction4<T1, T2, T3, T4, R> function, T1 t1, T2 t2, T3 t3, T4 t4) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return fromMany(it -> function.apply(it, t1, t2, t3, t4));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction5} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 */
+	<R extends Collection<E>, E, T1, T2, T3, T4, T5> ManyInvocationSpec<E> fromMany(
+			ConnectionFunction5<T1, T2, T3, T4, T5, R> function, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null");
+
+		return fromMany(it -> function.apply(it, t1, t2, t3, t4, t5));
+	}
+
+	/**
+	 * Represents an element in the invocation pipleline allowing consuming the result by applying a {@link Converter}.
+	 *
+	 * @param <S>
+	 */
+	public interface SingleInvocationSpec<S> {
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result after applying
+		 * {@link Converter}.
+		 *
+		 * @param converter must not be {@literal null}.
+		 * @param <T> target type.
+		 * @return the converted result, can be {@literal null}.
+		 */
+		@Nullable
+		<T> T get(Converter<S, T> converter);
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result after applying
+		 * {@link Converter}.
+		 *
+		 * @param converter must not be {@literal null}.
+		 * @param nullDefault must not be {@literal null}.
+		 * @param <T> target type.
+		 * @return the converted result, can be {@literal null}.
+		 */
+		@Nullable
+		<T> T getOrElse(Converter<S, T> converter, Supplier<T> nullDefault);
+	}
+
+	/**
+	 * Represents an element in the invocation pipleline for methods returning {@link Collection}-like results allowing
+	 * consuming the result by applying a {@link Converter}.
+	 *
+	 * @param <S>
+	 */
+	public interface ManyInvocationSpec<S> {
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result.
+		 *
+		 * @return the result as {@link List}.
+		 */
+		default List<S> toList() {
+			return toList(identityConverter());
+		}
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result after applying
+		 * {@link Converter}.
+		 *
+		 * @param converter must not be {@literal null}.
+		 * @param <T> target type.
+		 * @return the converted {@link List}.
+		 */
+		<T> List<T> toList(Converter<S, T> converter);
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result.
+		 *
+		 * @return the result as {@link Set}.
+		 */
+		default Set<S> toSet() {
+			return toSet(identityConverter());
+		}
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result after applying
+		 * {@link Converter}.
+		 *
+		 * @param converter must not be {@literal null}.
+		 * @param <T> target type.
+		 * @return the converted {@link Set}.
+		 */
+		<T> Set<T> toSet(Converter<S, T> converter);
+	}
+
+	/**
+	 * A function accepting {@link RedisClusterAsyncCommands} with 0 arguments.
+	 *
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	public interface ConnectionFunction0<R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link RedisFuture}.
+		 */
+		RedisFuture<R> apply(RedisClusterAsyncCommands<byte[], byte[]> connection);
+	}
+
+	/**
+	 * A function accepting {@link RedisClusterAsyncCommands} with 1 argument.
+	 *
+	 * @param <T1>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	public interface ConnectionFunction1<T1, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link RedisFuture}.
+		 */
+		RedisFuture<R> apply(RedisClusterAsyncCommands<byte[], byte[]> connection, T1 t1);
+	}
+
+	/**
+	 * A function accepting {@link RedisClusterAsyncCommands} with 2 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	public interface ConnectionFunction2<T1, T2, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link RedisFuture}.
+		 */
+		RedisFuture<R> apply(RedisClusterAsyncCommands<byte[], byte[]> connection, T1 t1, T2 t2);
+	}
+
+	/**
+	 * A function accepting {@link RedisClusterAsyncCommands} with 3 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	public interface ConnectionFunction3<T1, T2, T3, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link RedisFuture}.
+		 */
+		RedisFuture<R> apply(RedisClusterAsyncCommands<byte[], byte[]> connection, T1 t1, T2 t2, T3 t3);
+	}
+
+	/**
+	 * A function accepting {@link RedisClusterAsyncCommands} with 4 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	public interface ConnectionFunction4<T1, T2, T3, T4, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link RedisFuture}.
+		 */
+		RedisFuture<R> apply(RedisClusterAsyncCommands<byte[], byte[]> connection, T1 t1, T2 t2, T3 t3, T4 t4);
+	}
+
+	/**
+	 * A function accepting {@link RedisClusterAsyncCommands} with 5 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <T5>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	public interface ConnectionFunction5<T1, T2, T3, T4, T5, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link RedisFuture}.
+		 */
+		RedisFuture<R> apply(RedisClusterAsyncCommands<byte[], byte[]> connection, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
+	}
+
+	/**
+	 * A function accepting {@link RedisClusterAsyncCommands} with 6 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <T5>
+	 * @param <T6>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	public interface ConnectionFunction6<T1, T2, T3, T4, T5, T6, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link RedisFuture}.
+		 */
+		RedisFuture<R> apply(RedisClusterAsyncCommands<byte[], byte[]> connection, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5,
+				T6 t6);
+	}
+
+	/**
+	 * A function accepting {@link RedisClusterAsyncCommands} with 7 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <T5>
+	 * @param <T6>
+	 * @param <T7>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	public interface ConnectionFunction7<T1, T2, T3, T4, T5, T6, T7, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link RedisFuture}.
+		 */
+		RedisFuture<R> apply(RedisClusterAsyncCommands<byte[], byte[]> connection, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6,
+				T7 t7);
+	}
+
+	/**
+	 * A function accepting {@link RedisClusterAsyncCommands} with 8 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <T5>
+	 * @param <T6>
+	 * @param <T7>
+	 * @param <T8>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	public interface ConnectionFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link RedisFuture}.
+		 */
+		RedisFuture<R> apply(RedisClusterAsyncCommands<byte[], byte[]> connection, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6,
+				T7 t7, T8 t8);
+	}
+
+	static class DefaultSingleInvocationSpec<S> implements SingleInvocationSpec<S> {
+
+		private final Supplier<RedisFuture<S>> parent;
+		private final Synchronizer synchronizer;
+
+		public DefaultSingleInvocationSpec(Supplier<RedisFuture<S>> parent, Synchronizer synchronizer) {
+			this.parent = parent;
+			this.synchronizer = synchronizer;
+		}
+
+		@Override
+		public <T> T get(Converter<S, T> converter) {
+
+			Assert.notNull(converter, "Converter must not be null");
+
+			return synchronizer.invoke(parent, converter, () -> null);
+		}
+
+		@Nullable
+		@Override
+		public <T> T getOrElse(Converter<S, T> converter, Supplier<T> nullDefault) {
+
+			Assert.notNull(converter, "Converter must not be null");
+
+			return synchronizer.invoke(parent, converter, nullDefault);
+		}
+	}
+
+	static class DefaultManyInvocationSpec<S> implements ManyInvocationSpec<S> {
+
+		private final Supplier<RedisFuture<Collection<S>>> parent;
+		private final Synchronizer synchronizer;
+
+		public DefaultManyInvocationSpec(Supplier<RedisFuture<? extends Collection<S>>> parent, Synchronizer synchronizer) {
+			this.parent = (Supplier) parent;
+			this.synchronizer = synchronizer;
+		}
+
+		@Override
+		public <T> List<T> toList(Converter<S, T> converter) {
+
+			Assert.notNull(converter, "Converter must not be null");
+
+			return synchronizer.invoke(parent, source -> {
+
+				if (source.isEmpty()) {
+					return Collections.emptyList();
+				}
+
+				List<T> result = new ArrayList<>(source.size());
+
+				for (S s : source) {
+					result.add(converter.convert(s));
+				}
+
+				return result;
+			}, Collections::emptyList);
+		}
+
+		@Override
+		public <T> Set<T> toSet(Converter<S, T> converter) {
+
+			Assert.notNull(converter, "Converter must not be null");
+
+			return synchronizer.invoke(parent, source -> {
+
+				if (source.isEmpty()) {
+					return Collections.emptySet();
+				}
+
+				Set<T> result = new LinkedHashSet<>(source.size());
+
+				for (S s : source) {
+					result.add(converter.convert(s));
+				}
+
+				return result;
+			}, Collections::emptySet);
+		}
+	}
+
+	/**
+	 * Interface to define a synchronization function to evaluate {@link RedisFuture}.
+	 */
+	interface Synchronizer {
+
+		@Nullable
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		default <I, T> T invoke(Supplier<RedisFuture<I>> futureSupplier) {
+			return (T) doInvoke((Supplier) futureSupplier, identityConverter(), () -> null);
+		}
+
+		@Nullable
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		default <I, T> T invoke(Supplier<RedisFuture<I>> futureSupplier, Converter<I, T> converter,
+				Supplier<T> nullDefault) {
+			return (T) doInvoke((Supplier) futureSupplier, (Converter<Object, Object>) converter,
+					(Supplier<Object>) nullDefault);
+		}
+
+		@Nullable
+		Object doInvoke(Supplier<RedisFuture<Object>> futureSupplier, Converter<Object, Object> converter,
+				Supplier<Object> nullDefault);
+
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceKeyCommands.java
@@ -135,7 +135,7 @@ class LettuceKeyCommands implements RedisKeyCommands {
 
 		Assert.notNull(pattern, "Pattern must not be null!");
 
-		return connection.invoke().from(RedisKeyAsyncCommands::keys, pattern).get(LettuceConverters.bytesListToBytesSet());
+		return connection.invoke().fromMany(RedisKeyAsyncCommands::keys, pattern).toSet();
 	}
 
 	/**
@@ -406,7 +406,7 @@ class LettuceKeyCommands implements RedisKeyCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return connection.invokeStatus().from(RedisKeyAsyncCommands::objectEncoding, key).getOrElse(ValueEncoding::of,
+		return connection.invoke().from(RedisKeyAsyncCommands::objectEncoding, key).getOrElse(ValueEncoding::of,
 				() -> RedisValueEncoding.VACANT);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceListCommands.java
@@ -16,13 +16,11 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.LPosArgs;
-import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
-import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+import io.lettuce.core.api.async.RedisListAsyncCommands;
 
 import java.util.Collections;
 import java.util.List;
 
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.RedisListCommands;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -49,19 +47,7 @@ class LettuceListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().rpush(key, values)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().rpush(key, values)));
-				return null;
-			}
-			return getConnection().rpush(key, values);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::rpush, key, values);
 	}
 
 	/*
@@ -78,33 +64,12 @@ class LettuceListCommands implements RedisListCommands {
 		if (rank != null) {
 			args.rank(rank);
 		}
-		try {
-			if (isPipelined()) {
-				if (count != null) {
-					pipeline(connection.newLettuceResult(getAsyncConnection().lpos(key, element, count, args)));
-				} else {
-					pipeline(
-							connection.newLettuceResult(getAsyncConnection().lpos(key, element, args), Collections::singletonList));
-				}
-				return null;
-			}
-			if (isQueueing()) {
-				if (count != null) {
-					transaction(connection.newLettuceResult(getAsyncConnection().lpos(key, element, count, args)));
-				} else {
-					transaction(
-							connection.newLettuceResult(getAsyncConnection().lpos(key, element, args), Collections::singletonList));
-				}
-				return null;
-			}
-			if (count != null) {
-				return getConnection().lpos(key, element, count, args);
-			}
 
-			return Collections.singletonList(getConnection().lpos(key, element, args));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
+		if (count != null) {
+			return connection.invoke().just(RedisListAsyncCommands::lpos, key, element, count, args);
 		}
+
+		return connection.invoke().from(RedisListAsyncCommands::lpos, key, element, args).get(Collections::singletonList);
 	}
 
 	/*
@@ -118,19 +83,7 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.notNull(values, "Values must not be null!");
 		Assert.noNullElements(values, "Values must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().lpush(key, values)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().lpush(key, values)));
-				return null;
-			}
-			return getConnection().lpush(key, values);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::lpush, key, values);
 	}
 
 	/*
@@ -143,19 +96,7 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().rpushx(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().rpushx(key, value)));
-				return null;
-			}
-			return getConnection().rpushx(key, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::rpushx, key, value);
 	}
 
 	/*
@@ -168,19 +109,7 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().lpushx(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().lpushx(key, value)));
-				return null;
-			}
-			return getConnection().lpushx(key, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::lpushx, key, value);
 	}
 
 	/*
@@ -192,19 +121,7 @@ class LettuceListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().llen(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().llen(key)));
-				return null;
-			}
-			return getConnection().llen(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::llen, key);
 	}
 
 	/*
@@ -216,19 +133,7 @@ class LettuceListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().lrange(key, start, end)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().lrange(key, start, end)));
-				return null;
-			}
-			return getConnection().lrange(key, start, end);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::lrange, key, start, end);
 	}
 
 	/*
@@ -240,19 +145,7 @@ class LettuceListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceStatusResult(getAsyncConnection().ltrim(key, start, end)));
-				return;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceStatusResult(getAsyncConnection().ltrim(key, start, end)));
-				return;
-			}
-			getConnection().ltrim(key, start, end);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		connection.invokeStatus().just(RedisListAsyncCommands::ltrim, key, start, end);
 	}
 
 	/*
@@ -264,19 +157,7 @@ class LettuceListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().lindex(key, index)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().lindex(key, index)));
-				return null;
-			}
-			return getConnection().lindex(key, index);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::lindex, key, index);
 	}
 
 	/*
@@ -288,21 +169,8 @@ class LettuceListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection
-						.newLettuceResult(getAsyncConnection().linsert(key, LettuceConverters.toBoolean(where), pivot, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection
-						.newLettuceResult(getAsyncConnection().linsert(key, LettuceConverters.toBoolean(where), pivot, value)));
-				return null;
-			}
-			return getConnection().linsert(key, LettuceConverters.toBoolean(where), pivot, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::linsert, key, LettuceConverters.toBoolean(where), pivot,
+				value);
 	}
 
 	/*
@@ -315,19 +183,7 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceStatusResult(getAsyncConnection().lset(key, index, value)));
-				return;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceStatusResult(getAsyncConnection().lset(key, index, value)));
-				return;
-			}
-			getConnection().lset(key, index, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		connection.invokeStatus().just(RedisListAsyncCommands::lset, key, index, value);
 	}
 
 	/*
@@ -340,19 +196,7 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().lrem(key, count, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().lrem(key, count, value)));
-				return null;
-			}
-			return getConnection().lrem(key, count, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::lrem, key, count, value);
 	}
 
 	/*
@@ -364,19 +208,7 @@ class LettuceListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().lpop(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().lpop(key)));
-				return null;
-			}
-			return getConnection().lpop(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::lpop, key);
 	}
 
 	/*
@@ -388,19 +220,7 @@ class LettuceListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().rpop(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().rpop(key)));
-				return null;
-			}
-			return getConnection().rpop(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::rpop, key);
 	}
 
 	/*
@@ -413,21 +233,8 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.notNull(keys, "Key must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(connection.getAsyncDedicatedConnection().blpop(timeout, keys),
-						LettuceConverters.keyValueToBytesList()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(connection.getAsyncDedicatedConnection().blpop(timeout, keys),
-						LettuceConverters.keyValueToBytesList()));
-				return null;
-			}
-			return LettuceConverters.toBytesList(connection.getDedicatedConnection().blpop(timeout, keys));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke(connection.getAsyncDedicatedConnection())
+				.from(RedisListAsyncCommands::blpop, timeout, keys).get(LettuceConverters.keyValueToBytesList());
 	}
 
 	/*
@@ -440,21 +247,8 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.notNull(keys, "Key must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(connection.getAsyncDedicatedConnection().brpop(timeout, keys),
-						LettuceConverters.keyValueToBytesList()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(connection.getAsyncDedicatedConnection().brpop(timeout, keys),
-						LettuceConverters.keyValueToBytesList()));
-				return null;
-			}
-			return LettuceConverters.toBytesList(connection.getDedicatedConnection().brpop(timeout, keys));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke(connection.getAsyncDedicatedConnection())
+				.from(RedisListAsyncCommands::brpop, timeout, keys).get(LettuceConverters.keyValueToBytesList());
 	}
 
 	/*
@@ -467,19 +261,7 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.notNull(srcKey, "Source key must not be null!");
 		Assert.notNull(dstKey, "Destination key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().rpoplpush(srcKey, dstKey)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().rpoplpush(srcKey, dstKey)));
-				return null;
-			}
-			return getConnection().rpoplpush(srcKey, dstKey);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisListAsyncCommands::rpoplpush, srcKey, dstKey);
 	}
 
 	/*
@@ -492,49 +274,8 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.notNull(srcKey, "Source key must not be null!");
 		Assert.notNull(dstKey, "Destination key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(
-						connection.newLettuceResult(connection.getAsyncDedicatedConnection().brpoplpush(timeout, srcKey, dstKey)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(
-						connection.newLettuceResult(connection.getAsyncDedicatedConnection().brpoplpush(timeout, srcKey, dstKey)));
-				return null;
-			}
-			return connection.getDedicatedConnection().brpoplpush(timeout, srcKey, dstKey);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
-	}
-
-	private boolean isPipelined() {
-		return connection.isPipelined();
-	}
-
-	private boolean isQueueing() {
-		return connection.isQueueing();
-	}
-
-	private void pipeline(LettuceResult result) {
-		connection.pipeline(result);
-	}
-
-	private void transaction(LettuceResult result) {
-		connection.transaction(result);
-	}
-
-	private RedisClusterAsyncCommands<byte[], byte[]> getAsyncConnection() {
-		return connection.getAsyncConnection();
-	}
-
-	public RedisClusterCommands<byte[], byte[]> getConnection() {
-		return connection.getConnection();
-	}
-
-	private DataAccessException convertLettuceAccessException(Exception ex) {
-		return connection.convertLettuceAccessException(ex);
+		return connection.invoke(connection.getAsyncDedicatedConnection()).just(RedisListAsyncCommands::brpoplpush, timeout,
+				srcKey, dstKey);
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceListCommands.java
@@ -15,9 +15,11 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
+import io.lettuce.core.KeyValue;
 import io.lettuce.core.LPosArgs;
 import io.lettuce.core.api.async.RedisListAsyncCommands;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -234,7 +236,16 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
 		return connection.invoke(connection.getAsyncDedicatedConnection())
-				.from(RedisListAsyncCommands::blpop, timeout, keys).get(LettuceConverters.keyValueToBytesList());
+				.from(RedisListAsyncCommands::blpop, timeout, keys).get(LettuceListCommands::toBytesList);
+	}
+
+	private static List<byte[]> toBytesList(KeyValue<byte[], byte[]> source) {
+
+		List<byte[]> list = new ArrayList<>(2);
+		list.add(source.getKey());
+		list.add(source.getValue());
+
+		return list;
 	}
 
 	/*
@@ -248,7 +259,7 @@ class LettuceListCommands implements RedisListCommands {
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
 		return connection.invoke(connection.getAsyncDedicatedConnection())
-				.from(RedisListAsyncCommands::brpop, timeout, keys).get(LettuceConverters.keyValueToBytesList());
+				.from(RedisListAsyncCommands::brpop, timeout, keys).get(LettuceListCommands::toBytesList);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceServerCommands.java
@@ -68,7 +68,7 @@ class LettuceServerCommands implements RedisServerCommands {
 	 */
 	@Override
 	public Long lastSave() {
-		return connection.invoke().from(RedisServerAsyncCommands::lastsave).get(LettuceConverters.dateToLong());
+		return connection.invoke().from(RedisServerAsyncCommands::lastsave).get(LettuceConverters::toLong);
 	}
 
 	/*
@@ -241,7 +241,7 @@ class LettuceServerCommands implements RedisServerCommands {
 	 */
 	@Override
 	public String getClientName() {
-		return connection.invoke().from(RedisServerAsyncCommands::clientGetname).get(LettuceConverters.bytesToString());
+		return connection.invoke().from(RedisServerAsyncCommands::clientGetname).get(LettuceConverters::toString);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSetCommands.java
@@ -17,15 +17,13 @@ package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.ScanArgs;
 import io.lettuce.core.ValueScanCursor;
-import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+import io.lettuce.core.api.async.RedisSetAsyncCommands;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.RedisSetCommands;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.KeyBoundCursor;
@@ -57,19 +55,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(values, "Values must not be null!");
 		Assert.noNullElements(values, "Values must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().sadd(key, values)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().sadd(key, values)));
-				return null;
-			}
-			return getConnection().sadd(key, values);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::sadd, key, values);
 	}
 
 	/*
@@ -81,19 +67,7 @@ class LettuceSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().scard(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().scard(key)));
-				return null;
-			}
-			return getConnection().scard(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::scard, key);
 	}
 
 	/*
@@ -106,19 +80,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Keys must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().sdiff(keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().sdiff(keys)));
-				return null;
-			}
-			return getConnection().sdiff(keys);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::sdiff, keys);
 	}
 
 	/*
@@ -132,19 +94,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Source keys must not be null!");
 		Assert.noNullElements(keys, "Source keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().sdiffstore(destKey, keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().sdiffstore(destKey, keys)));
-				return null;
-			}
-			return getConnection().sdiffstore(destKey, keys);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::sdiffstore, destKey, keys);
 	}
 
 	/*
@@ -157,19 +107,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Keys must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().sinter(keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().sinter(keys)));
-				return null;
-			}
-			return getConnection().sinter(keys);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::sinter, keys);
 	}
 
 	/*
@@ -183,19 +121,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Source keys must not be null!");
 		Assert.noNullElements(keys, "Source keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().sinterstore(destKey, keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().sinterstore(destKey, keys)));
-				return null;
-			}
-			return getConnection().sinterstore(destKey, keys);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::sinterstore, destKey, keys);
 	}
 
 	/*
@@ -208,19 +134,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().sismember(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().sismember(key, value)));
-				return null;
-			}
-			return getConnection().sismember(key, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::sismember, key, value);
 	}
 
 	/*
@@ -232,19 +146,7 @@ class LettuceSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().smembers(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().smembers(key)));
-				return null;
-			}
-			return getConnection().smembers(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::smembers, key);
 	}
 
 	/*
@@ -258,19 +160,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(destKey, "Destination key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().smove(srcKey, destKey, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().smove(srcKey, destKey, value)));
-				return null;
-			}
-			return getConnection().smove(srcKey, destKey, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::smove, srcKey, destKey, value);
 	}
 
 	/*
@@ -282,19 +172,7 @@ class LettuceSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().spop(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().spop(key)));
-				return null;
-			}
-			return getConnection().spop(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::spop, key);
 	}
 
 	/*
@@ -306,20 +184,7 @@ class LettuceSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().spop(key, count), ArrayList::new));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().spop(key, count),
-						(Converter<Set<byte[]>, List<byte[]>>) ArrayList::new));
-				return null;
-			}
-			return new ArrayList<>(getConnection().spop(key, count));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().from(RedisSetAsyncCommands::spop, key, count).get(ArrayList::new);
 	}
 
 	/*
@@ -331,19 +196,7 @@ class LettuceSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().srandmember(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().srandmember(key)));
-				return null;
-			}
-			return getConnection().srandmember(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::srandmember, key);
 	}
 
 	/*
@@ -355,19 +208,7 @@ class LettuceSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().srandmember(key, count)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().srandmember(key, count)));
-				return null;
-			}
-			return LettuceConverters.toBytesList(getConnection().srandmember(key, count));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::srandmember, key, count);
 	}
 
 	/*
@@ -381,19 +222,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(values, "Values must not be null!");
 		Assert.noNullElements(values, "Values must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().srem(key, values)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().srem(key, values)));
-				return null;
-			}
-			return getConnection().srem(key, values);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::srem, key, values);
 	}
 
 	/*
@@ -406,19 +235,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Keys must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().sunion(keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().sunion(keys)));
-				return null;
-			}
-			return getConnection().sunion(keys);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::sunion, keys);
 	}
 
 	/*
@@ -432,19 +249,7 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Source keys must not be null!");
 		Assert.noNullElements(keys, "Source keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().sunionstore(destKey, keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().sunionstore(destKey, keys)));
-				return null;
-			}
-			return getConnection().sunionstore(destKey, keys);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisSetAsyncCommands::sunionstore, destKey, keys);
 	}
 
 	/*
@@ -472,14 +277,15 @@ class LettuceSetCommands implements RedisSetCommands {
 			@Override
 			protected ScanIteration<byte[]> doScan(byte[] key, long cursorId, ScanOptions options) {
 
-				if (isQueueing() || isPipelined()) {
+				if (connection.isQueueing() || connection.isPipelined()) {
 					throw new UnsupportedOperationException("'SSCAN' cannot be called in pipeline / transaction mode.");
 				}
 
 				io.lettuce.core.ScanCursor scanCursor = connection.getScanCursor(cursorId);
 				ScanArgs scanArgs = LettuceConverters.toScanArgs(options);
 
-				ValueScanCursor<byte[]> valueScanCursor = getConnection().sscan(key, scanCursor, scanArgs);
+				ValueScanCursor<byte[]> valueScanCursor = connection.invoke().just(RedisSetAsyncCommands::sscan, key,
+						scanCursor, scanArgs);
 				String nextCursorId = valueScanCursor.getCursor();
 
 				List<byte[]> values = connection.failsafeReadScanValues(valueScanCursor.getValues(), null);
@@ -493,32 +299,8 @@ class LettuceSetCommands implements RedisSetCommands {
 		}.open();
 	}
 
-	private boolean isPipelined() {
-		return connection.isPipelined();
-	}
-
-	private boolean isQueueing() {
-		return connection.isQueueing();
-	}
-
-	private void pipeline(LettuceResult result) {
-		connection.pipeline(result);
-	}
-
-	private void transaction(LettuceResult result) {
-		connection.transaction(result);
-	}
-
-	RedisClusterAsyncCommands<byte[], byte[]> getAsyncConnection() {
-		return connection.getAsyncConnection();
-	}
-
-	public RedisClusterCommands<byte[], byte[]> getConnection() {
+	public RedisClusterCommands<byte[], byte[]> getCommands() {
 		return connection.getConnection();
-	}
-
-	private DataAccessException convertLettuceAccessException(Exception ex) {
-		return connection.convertLettuceAccessException(ex);
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStringCommands.java
@@ -16,15 +16,11 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.BitFieldArgs;
-import io.lettuce.core.RedisFuture;
-import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
-import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+import io.lettuce.core.api.async.RedisStringAsyncCommands;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Future;
 
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.RedisStringCommands;
@@ -56,19 +52,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().get(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().get(key)));
-				return null;
-			}
-			return getConnection().get(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::get, key);
 	}
 
 	/*
@@ -81,19 +65,7 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().getset(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().getset(key, value)));
-				return null;
-			}
-			return getConnection().getset(key, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::getset, key, value);
 	}
 
 	/*
@@ -106,22 +78,8 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(keys, "Keys must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(
-						connection.newLettuceResult(getAsyncConnection().mget(keys), LettuceConverters.keyValueListUnwrapper()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(
-						connection.newLettuceResult(getAsyncConnection().mget(keys), LettuceConverters.keyValueListUnwrapper()));
-				return null;
-			}
-
-			return LettuceConverters.<byte[], byte[]> keyValueListUnwrapper().convert(getConnection().mget(keys));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().fromMany(RedisStringAsyncCommands::mget, keys)
+				.toList(source -> source.getValueOrElse(null));
 	}
 
 	/*
@@ -134,21 +92,8 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(
-						connection.newLettuceResult(getAsyncConnection().set(key, value), Converters.stringToBooleanConverter()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(
-						connection.newLettuceResult(getAsyncConnection().set(key, value), Converters.stringToBooleanConverter()));
-				return null;
-			}
-			return Converters.stringToBoolean(getConnection().set(key, value));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().from(RedisStringAsyncCommands::set, key, value)
+				.get(Converters.stringToBooleanConverter());
 	}
 
 	/*
@@ -163,24 +108,9 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(expiration, "Expiration must not be null!");
 		Assert.notNull(option, "Option must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(
-						getAsyncConnection().set(key, value, LettuceConverters.toSetArgs(expiration, option)),
-						Converters.stringToBooleanConverter(), () -> false));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(
-						getAsyncConnection().set(key, value, LettuceConverters.toSetArgs(expiration, option)),
-						Converters.stringToBooleanConverter(), () -> false));
-				return null;
-			}
-			return Converters
-					.stringToBoolean(getConnection().set(key, value, LettuceConverters.toSetArgs(expiration, option)));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke()
+				.from(RedisStringAsyncCommands::set, key, value, LettuceConverters.toSetArgs(expiration, option))
+				.getOrElse(LettuceConverters.stringToBooleanConverter(), () -> false);
 	}
 
 	/*
@@ -193,19 +123,7 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().setnx(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().setnx(key, value)));
-				return null;
-			}
-			return getConnection().setnx(key, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::setnx, key, value);
 	}
 
 	/*
@@ -218,21 +136,8 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().setex(key, seconds, value),
-						Converters.stringToBooleanConverter()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().setex(key, seconds, value),
-						Converters.stringToBooleanConverter()));
-				return null;
-			}
-			return Converters.stringToBoolean(getConnection().setex(key, seconds, value));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().from(RedisStringAsyncCommands::setex, key, seconds, value)
+				.get(Converters.stringToBooleanConverter());
 	}
 
 	/*
@@ -245,21 +150,8 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().psetex(key, milliseconds, value),
-						Converters.stringToBooleanConverter()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().psetex(key, milliseconds, value),
-						Converters.stringToBooleanConverter()));
-				return null;
-			}
-			return Converters.stringToBoolean(getConnection().psetex(key, milliseconds, value));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().from(RedisStringAsyncCommands::psetex, key, milliseconds, value)
+				.get(Converters.stringToBooleanConverter());
 	}
 
 	/*
@@ -271,20 +163,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(tuples, "Tuples must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().mset(tuples), Converters.stringToBooleanConverter()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(
-						connection.newLettuceResult(getAsyncConnection().mset(tuples), Converters.stringToBooleanConverter()));
-				return null;
-			}
-			return Converters.stringToBoolean(getConnection().mset(tuples));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().from(RedisStringAsyncCommands::mset, tuples).get(Converters.stringToBooleanConverter());
 	}
 
 	/*
@@ -296,19 +175,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(tuples, "Tuples must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().msetnx(tuples)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().msetnx(tuples)));
-				return null;
-			}
-			return getConnection().msetnx(tuples);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::msetnx, tuples);
 	}
 
 	/*
@@ -320,19 +187,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().incr(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().incr(key)));
-				return null;
-			}
-			return getConnection().incr(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::incr, key);
 	}
 
 	/*
@@ -344,19 +199,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().incrby(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().incrby(key, value)));
-				return null;
-			}
-			return getConnection().incrby(key, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::incrby, key, value);
 	}
 
 	/*
@@ -368,19 +211,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().incrbyfloat(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().incrbyfloat(key, value)));
-				return null;
-			}
-			return getConnection().incrbyfloat(key, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::incrbyfloat, key, value);
 	}
 
 	/*
@@ -392,19 +223,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().decr(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().decr(key)));
-				return null;
-			}
-			return getConnection().decr(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::decr, key);
 	}
 
 	/*
@@ -416,19 +235,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().decrby(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().decrby(key, value)));
-				return null;
-			}
-			return getConnection().decrby(key, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::decrby, key, value);
 	}
 
 	/*
@@ -441,19 +248,7 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().append(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().append(key, value)));
-				return null;
-			}
-			return getConnection().append(key, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::append, key, value);
 	}
 
 	/*
@@ -465,19 +260,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().getrange(key, start, end)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().getrange(key, start, end)));
-				return null;
-			}
-			return getConnection().getrange(key, start, end);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::getrange, key, start, end);
 	}
 
 	/*
@@ -490,19 +273,7 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceStatusResult(getAsyncConnection().setrange(key, offset, value)));
-				return;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceStatusResult(getAsyncConnection().setrange(key, offset, value)));
-				return;
-			}
-			getConnection().setrange(key, offset, value);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		connection.invokeStatus().just(RedisStringAsyncCommands::setrange, key, offset, value);
 	}
 
 	/*
@@ -514,21 +285,8 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(
-						connection.newLettuceResult(getAsyncConnection().getbit(key, offset), LettuceConverters.longToBoolean()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(
-						connection.newLettuceResult(getAsyncConnection().getbit(key, offset), LettuceConverters.longToBoolean()));
-				return null;
-			}
-			return LettuceConverters.toBoolean(getConnection().getbit(key, offset));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().from(RedisStringAsyncCommands::getbit, key, offset)
+				.get(LettuceConverters.longToBoolean());
 	}
 
 	/*
@@ -540,23 +298,8 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().setbit(key, offset, LettuceConverters.toInt(value)),
-						LettuceConverters.longToBooleanConverter()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(
-						connection.newLettuceResult(getAsyncConnection().setbit(key, offset, LettuceConverters.toInt(value)),
-								LettuceConverters.longToBooleanConverter()));
-				return null;
-			}
-			return LettuceConverters.longToBooleanConverter()
-					.convert(getConnection().setbit(key, offset, LettuceConverters.toInt(value)));
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().from(RedisStringAsyncCommands::setbit, key, offset, LettuceConverters.toInt(value))
+				.get(LettuceConverters.longToBoolean());
 	}
 
 	/*
@@ -568,19 +311,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().bitcount(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().bitcount(key)));
-				return null;
-			}
-			return getConnection().bitcount(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::bitcount, key);
 	}
 
 	/*
@@ -592,19 +323,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().bitcount(key, start, end)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().bitcount(key, start, end)));
-				return null;
-			}
-			return getConnection().bitcount(key, start, end);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::bitcount, key, start, end);
 	}
 
 	/*
@@ -619,19 +338,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		BitFieldArgs args = LettuceConverters.toBitFieldArgs(subCommands);
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().bitfield(key, args)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().bitfield(key, args)));
-				return null;
-			}
-			return getConnection().bitfield(key, args);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
+		return connection.invoke().just(RedisStringAsyncCommands::bitfield, key, args);
 	}
 
 	/*
@@ -647,57 +354,25 @@ class LettuceStringCommands implements RedisStringCommands {
 		if (op == BitOperation.NOT && keys.length > 1) {
 			throw new UnsupportedOperationException("Bitop NOT should only be performed against one key");
 		}
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(asyncBitOp(op, destination, keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(asyncBitOp(op, destination, keys)));
-				return null;
-			}
-			return syncBitOp(op, destination, keys);
-		} catch (UnsupportedOperationException ex) {
-			throw ex;
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
-	}
 
-	private Future<Long> asyncBitOp(BitOperation op, byte[] destination, byte[]... keys) {
-		switch (op) {
-			case AND:
-				return getAsyncConnection().bitopAnd(destination, keys);
-			case OR:
-				return getAsyncConnection().bitopOr(destination, keys);
-			case XOR:
-				return getAsyncConnection().bitopXor(destination, keys);
-			case NOT:
-				if (keys.length != 1) {
-					throw new UnsupportedOperationException("Bitop NOT should only be performed against one key");
-				}
-				return getAsyncConnection().bitopNot(destination, keys[0]);
-			default:
-				throw new UnsupportedOperationException("Bit operation " + op + " is not supported");
-		}
-	}
+		return connection.invoke().just(it -> {
 
-	private Long syncBitOp(BitOperation op, byte[] destination, byte[]... keys) {
-		switch (op) {
-			case AND:
-				return getConnection().bitopAnd(destination, keys);
-			case OR:
-				return getConnection().bitopOr(destination, keys);
-			case XOR:
-				return getConnection().bitopXor(destination, keys);
-			case NOT:
-				if (keys.length != 1) {
-					throw new UnsupportedOperationException("Bitop NOT should only be performed against one key");
-				}
-				return getConnection().bitopNot(destination, keys[0]);
-			default:
-				throw new UnsupportedOperationException("Bit operation " + op + " is not supported");
-		}
+			switch (op) {
+				case AND:
+					return it.bitopAnd(destination, keys);
+				case OR:
+					return it.bitopOr(destination, keys);
+				case XOR:
+					return it.bitopXor(destination, keys);
+				case NOT:
+					if (keys.length != 1) {
+						throw new UnsupportedOperationException("Bitop NOT should only be performed against one key");
+					}
+					return it.bitopNot(destination, keys[0]);
+				default:
+					throw new UnsupportedOperationException("Bit operation " + op + " is not supported");
+			}
+		});
 	}
 
 	/*
@@ -711,41 +386,17 @@ class LettuceStringCommands implements RedisStringCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(range, "Range must not be null! Use Range.unbounded() instead.");
 
-		try {
-			if (isPipelined() || isQueueing()) {
+		if (range.getLowerBound().isBounded()) {
 
-				RedisFuture<Long> futureResult;
-				RedisClusterAsyncCommands<byte[], byte[]> connection = getAsyncConnection();
-
-				if (range.getLowerBound().isBounded()) {
-					if (range.getUpperBound().isBounded()) {
-						futureResult = connection.bitpos(key, bit, getLowerValue(range), getUpperValue(range));
-					} else {
-						futureResult = connection.bitpos(key, bit, getLowerValue(range));
-					}
-				} else {
-					futureResult = connection.bitpos(key, bit);
-				}
-
-				if (isPipelined()) {
-					pipeline(this.connection.newLettuceResult(futureResult));
-				} else if (isQueueing()) {
-					transaction(this.connection.newLettuceResult(futureResult));
-				}
-				return null;
+			if (range.getUpperBound().isBounded()) {
+				return connection.invoke().just(RedisStringAsyncCommands::bitpos, key, bit, getLowerValue(range),
+						getUpperValue(range));
 			}
 
-			if (range.getLowerBound().isBounded()) {
-				if (range.getUpperBound().isBounded()) {
-					return getConnection().bitpos(key, bit, getLowerValue(range), getUpperValue(range));
-				}
-				return getConnection().bitpos(key, bit, getLowerValue(range));
-			}
-
-			return getConnection().bitpos(key, bit);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
+			return connection.invoke().just(RedisStringAsyncCommands::bitpos, key, bit, getLowerValue(range));
 		}
+
+		return connection.invoke().just(RedisStringAsyncCommands::bitpos, key, bit);
 	}
 
 	/*
@@ -757,47 +408,7 @@ class LettuceStringCommands implements RedisStringCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newLettuceResult(getAsyncConnection().strlen(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newLettuceResult(getAsyncConnection().strlen(key)));
-				return null;
-			}
-			return getConnection().strlen(key);
-		} catch (Exception ex) {
-			throw convertLettuceAccessException(ex);
-		}
-	}
-
-	private boolean isPipelined() {
-		return connection.isPipelined();
-	}
-
-	private boolean isQueueing() {
-		return connection.isQueueing();
-	}
-
-	private void pipeline(LettuceResult result) {
-		connection.pipeline(result);
-	}
-
-	private void transaction(LettuceResult result) {
-		connection.transaction(result);
-	}
-
-	RedisClusterAsyncCommands<byte[], byte[]> getAsyncConnection() {
-		return connection.getAsyncConnection();
-	}
-
-	public RedisClusterCommands<byte[], byte[]> getConnection() {
-		return connection.getConnection();
-	}
-
-	private DataAccessException convertLettuceAccessException(Exception ex) {
-		return connection.convertLettuceAccessException(ex);
+		return connection.invoke().just(RedisStringAsyncCommands::strlen, key);
 	}
 
 	private static <T extends Comparable<T>> T getUpperValue(Range<T> range) {

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -491,7 +491,6 @@ class LettuceConnectionFactoryTests {
 			connection.ping();
 			fail("Expected RedisException: Master is currently unknown");
 		} catch (RedisSystemException e) {
-
 			assertThat(e.getCause()).isInstanceOf(RedisException.class);
 			assertThat(e.getCause().getMessage()).contains("Master is currently unknown");
 		} finally {


### PR DESCRIPTION
We now use LettuceInvoker to call Lettuce API methods for synchronous, pipelining, and transactional execution models. LettuceInvoker captures the method invocation as functional utility and allows conversion of results:

```java
Long result = invoker.just(RedisGeoAsyncCommands::geoadd, key, point.getX(), point.getY(), member);

List<byte[]> result = invoker.fromMany(RedisGeoAsyncCommands::geohash, key, members)
 				.toList(it -> it.getValueOrElse(null));
```

Closes #1797 