### PR TITLE
Remove superfluous try catch blocks from Jedis*Commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-1951-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/convert/SetConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/SetConverter.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
 /**
@@ -33,7 +34,7 @@ import org.springframework.util.Assert;
  */
 public class SetConverter<S, T> implements Converter<Set<S>, Set<T>> {
 
-	private Converter<S, T> itemConverter;
+	private final Converter<S, T> itemConverter;
 
 	/**
 	 * @param itemConverter The {@link Converter} to use for converting individual Set items. Must not be {@literal null}.
@@ -49,6 +50,7 @@ public class SetConverter<S, T> implements Converter<Set<S>, Set<T>> {
 	 * @see org.springframework.core.convert.converter.Converter#convert(Object)
 	 */
 	@Override
+	@NonNull
 	public Set<T> convert(Set<S> source) {
 
 		return source.stream().map(itemConverter::convert)

--- a/src/main/java/org/springframework/data/redis/connection/convert/StringToRedisClientInfoConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/StringToRedisClientInfoConverter.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.data.redis.core.types.RedisClientInfo.RedisClientInfoBuilder;
+import org.springframework.lang.NonNull;
 
 /**
  * {@link Converter} implementation to create one {@link RedisClientInfo} per line entry in given {@link String} array.
@@ -42,6 +43,7 @@ public class StringToRedisClientInfoConverter implements Converter<String[], Lis
 	 * @see org.springframework.core.convert.converter.Converter#convert(Object)
 	 */
 	@Override
+	@NonNull
 	public List<RedisClientInfo> convert(String[] lines) {
 
 		List<RedisClientInfo> clientInfoList = new ArrayList<>(lines.length);

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
@@ -24,6 +24,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.RedisZSetCommands;
+import org.springframework.data.redis.connection.convert.SetConverter;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanCursor;
 import org.springframework.data.redis.core.ScanIteration;
@@ -40,6 +41,8 @@ import org.springframework.util.Assert;
  */
 class JedisClusterZSetCommands implements RedisZSetCommands {
 
+	private static final SetConverter<redis.clients.jedis.Tuple, Tuple> TUPLE_SET_CONVERTER = new SetConverter<>(
+			JedisConverters::toTuple);
 	private final JedisClusterConnection connection;
 
 	JedisClusterZSetCommands(JedisClusterConnection connection) {
@@ -181,9 +184,9 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 
 		try {
 			if (limit.isUnlimited()) {
-				return JedisConverters.toTupleSet(connection.getCluster().zrangeByScoreWithScores(key, min, max));
+				return toTupleSet(connection.getCluster().zrangeByScoreWithScores(key, min, max));
 			}
-			return JedisConverters.toTupleSet(
+			return toTupleSet(
 					connection.getCluster().zrangeByScoreWithScores(key, min, max, limit.getOffset(), limit.getCount()));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
@@ -228,9 +231,9 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 
 		try {
 			if (limit.isUnlimited()) {
-				return JedisConverters.toTupleSet(connection.getCluster().zrevrangeByScoreWithScores(key, max, min));
+				return toTupleSet(connection.getCluster().zrevrangeByScoreWithScores(key, max, min));
 			}
-			return JedisConverters.toTupleSet(
+			return toTupleSet(
 					connection.getCluster().zrevrangeByScoreWithScores(key, max, min, limit.getOffset(), limit.getCount()));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
@@ -379,7 +382,7 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 
 		try {
-			return JedisConverters.toTupleSet(connection.getCluster().zrangeWithScores(key, start, end));
+			return toTupleSet(connection.getCluster().zrangeWithScores(key, start, end));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}
@@ -411,7 +414,7 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 
 		try {
-			return JedisConverters.toTupleSet(connection.getCluster().zrangeByScoreWithScores(key, min, max));
+			return toTupleSet(connection.getCluster().zrangeByScoreWithScores(key, min, max));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}
@@ -452,7 +455,7 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 		}
 
 		try {
-			return JedisConverters.toTupleSet(connection.getCluster().zrangeByScoreWithScores(key, min, max,
+			return toTupleSet(connection.getCluster().zrangeByScoreWithScores(key, min, max,
 					Long.valueOf(offset).intValue(), Long.valueOf(count).intValue()));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
@@ -485,7 +488,7 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 
 		try {
-			return JedisConverters.toTupleSet(connection.getCluster().zrevrangeWithScores(key, start, end));
+			return toTupleSet(connection.getCluster().zrevrangeWithScores(key, start, end));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}
@@ -517,7 +520,7 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 
 		try {
-			return JedisConverters.toTupleSet(connection.getCluster().zrevrangeByScoreWithScores(key, max, min));
+			return toTupleSet(connection.getCluster().zrevrangeByScoreWithScores(key, max, min));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}
@@ -558,7 +561,7 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 		}
 
 		try {
-			return JedisConverters.toTupleSet(connection.getCluster().zrevrangeByScoreWithScores(key, max, min,
+			return toTupleSet(connection.getCluster().zrevrangeByScoreWithScores(key, max, min,
 					Long.valueOf(offset).intValue(), Long.valueOf(count).intValue()));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
@@ -817,6 +820,10 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 
 	private DataAccessException convertJedisAccessException(Exception ex) {
 		return connection.convertJedisAccessException(ex);
+	}
+
+	private static Set<Tuple> toTupleSet(Set<redis.clients.jedis.Tuple> source) {
+		return TUPLE_SET_CONVERTER.convert(source);
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -15,10 +15,12 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.BinaryJedis;
 import redis.clients.jedis.BinaryJedisPubSub;
 import redis.clients.jedis.Client;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.MultiKeyPipelineBase;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.Transaction;
@@ -30,6 +32,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -69,18 +72,24 @@ public class JedisConnection extends AbstractRedisConnection {
 			JedisConverters.exceptionConverter());
 
 	private final Jedis jedis;
-	private @Nullable Transaction transaction;
+
+	private final JedisInvoker invoker = new JedisInvoker((directFunction, pipelineFunction, converter,
+			nullDefault) -> doInvoke(false, directFunction, pipelineFunction, converter, nullDefault));
+	private final JedisInvoker statusInvoker = new JedisInvoker((directFunction, pipelineFunction, converter,
+			nullDefault) -> doInvoke(true, directFunction, pipelineFunction, converter, nullDefault));
+
 	private final @Nullable Pool<Jedis> pool;
-	/**
-	 * flag indicating whether the connection needs to be dropped or not
-	 */
-	private volatile @Nullable JedisSubscription subscription;
-	private volatile @Nullable Pipeline pipeline;
 	private final int dbIndex;
 	private final String clientName;
-	private boolean convertPipelineAndTxResults = true;
+
 	private List<JedisResult> pipelinedResults = new ArrayList<>();
 	private Queue<FutureResult<Response<?>>> txResults = new LinkedList<>();
+
+	private volatile @Nullable JedisSubscription subscription;
+	private volatile @Nullable Transaction transaction;
+	private volatile @Nullable Pipeline pipeline;
+
+	private boolean convertPipelineAndTxResults = true;
 
 	/**
 	 * Constructs a new <code>JedisConnection</code> instance.
@@ -129,6 +138,37 @@ public class JedisConnection extends AbstractRedisConnection {
 				throw ex;
 			}
 		}
+	}
+
+	@Nullable
+	private Object doInvoke(boolean status, Function<Jedis, Object> directFunction,
+			Function<MultiKeyPipelineBase, Response<Object>> pipelineFunction, Converter<Object, Object> converter,
+			Supplier<Object> nullDefault) {
+
+		return doWithJedis(it -> {
+
+			if (isPipelined()) {
+
+				Response<Object> response = pipelineFunction.apply(getRequiredPipeline());
+				pipeline(status ? newStatusResult(response) : newJedisResult(response, converter, nullDefault));
+				return null;
+			}
+
+			if (isQueueing()) {
+
+				Response<Object> response = pipelineFunction.apply(getRequiredTransaction());
+				transaction(status ? newStatusResult(response) : newJedisResult(response, converter, nullDefault));
+				return null;
+			}
+
+			Object result = directFunction.apply(getJedis());
+
+			if (result == null) {
+				return nullDefault.get();
+			}
+
+			return converter.convert(result);
+		});
 	}
 
 	protected DataAccessException convertJedisAccessException(Exception ex) {
@@ -244,15 +284,16 @@ public class JedisConnection extends AbstractRedisConnection {
 		return execute(command, args, Connection::getOne, JedisClientUtils::getResponse);
 	}
 
+	@Nullable
 	<T> T execute(String command, byte[][] args, Function<Client, T> resultMapper,
 			Function<Object, Response<?>> pipelineResponseMapper) {
 
 		Assert.hasText(command, "A valid command needs to be specified!");
 		Assert.notNull(args, "Arguments must not be null!");
 
-		try {
+		return doWithJedis(it -> {
 
-			Client client = JedisClientUtils.sendCommand(command, args, this.jedis);
+			Client client = JedisClientUtils.sendCommand(command, args, it);
 
 			if (isQueueing() || isPipelined()) {
 
@@ -266,9 +307,7 @@ public class JedisConnection extends AbstractRedisConnection {
 				return null;
 			}
 			return resultMapper.apply(client);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		});
 	}
 
 	/*
@@ -316,11 +355,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public boolean isClosed() {
-		try {
-			return !jedis.isConnected();
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return doWithJedis(it -> !it.isConnected());
 	}
 
 	/*
@@ -418,19 +453,10 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public byte[] echo(byte[] message) {
-		try {
-			if (isPipelined()) {
-				pipeline(newJedisResult(getRequiredPipeline().echo(message)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(newJedisResult(getRequiredTransaction().echo(message)));
-				return null;
-			}
-			return jedis.echo(message);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+
+		Assert.notNull(message, "Message must not be null");
+
+		return invoke().just(BinaryJedis::echo, MultiKeyPipelineBase::echo, message);
 	}
 
 	/*
@@ -439,19 +465,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public String ping() {
-		try {
-			if (isPipelined()) {
-				pipeline(newJedisResult(getRequiredPipeline().ping()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(newJedisResult(getRequiredTransaction().ping()));
-				return null;
-			}
-			return jedis.ping();
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return invoke().just(BinaryJedis::ping, MultiKeyPipelineBase::ping);
 	}
 
 	/*
@@ -547,7 +561,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	 * @since 2.5
 	 */
 	JedisInvoker invoke() {
-		return doInvoke(jedis, false);
+		return invoker;
 	}
 
 	/**
@@ -558,52 +572,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	 * @since 2.5
 	 */
 	JedisInvoker invokeStatus() {
-		return doInvoke(jedis, true);
-	}
-
-	private JedisInvoker doInvoke(Jedis connection, boolean statusCommand) {
-
-		return new JedisInvoker((directFunction, pipelineFunction, converter, nullDefault) -> {
-
-			try {
-
-				if (isPipelined()) {
-
-					Response<Object> response = pipelineFunction.apply(getRequiredPipeline());
-
-					if (statusCommand) {
-						pipeline(newStatusResult(response));
-					} else {
-						pipeline(newJedisResult(response, converter, nullDefault));
-					}
-
-					return null;
-				}
-
-				if (isQueueing()) {
-
-					Response<Object> response = pipelineFunction.apply(getRequiredTransaction());
-
-					if (statusCommand) {
-						transaction(newStatusResult(response));
-					} else {
-						transaction(newJedisResult(response, converter, nullDefault));
-					}
-
-					return null;
-				}
-
-				Object result = directFunction.apply(connection);
-
-				if (result == null) {
-					return nullDefault.get();
-				}
-
-				return converter.convert(result);
-			} catch (Exception ex) {
-				throw convertJedisAccessException(ex);
-			}
-		});
+		return statusInvoker;
 	}
 
 	<T> JedisResult<T, T> newJedisResult(Response<T> response) {
@@ -635,15 +604,15 @@ public class JedisConnection extends AbstractRedisConnection {
 		if (isQueueing()) {
 			return;
 		}
-		try {
+
+		doWithJedis(it -> {
+
 			if (isPipelined()) {
 				getRequiredPipeline().multi();
 				return;
 			}
-			this.transaction = jedis.multi();
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+			this.transaction = it.multi();
+		});
 	}
 
 	/*
@@ -652,19 +621,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public void select(int dbIndex) {
-		try {
-			if (isPipelined()) {
-				pipeline(newStatusResult(getRequiredPipeline().select(dbIndex)));
-				return;
-			}
-			if (isQueueing()) {
-				transaction(newStatusResult(getRequiredTransaction().select(dbIndex)));
-				return;
-			}
-			jedis.select(dbIndex);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		invokeStatus().just(BinaryJedis::select, MultiKeyPipelineBase::select, dbIndex);
 	}
 
 	/*
@@ -673,11 +630,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public void unwatch() {
-		try {
-			jedis.unwatch();
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		doWithJedis((Consumer<Jedis>) BinaryJedis::unwatch);
 	}
 
 	/*
@@ -689,17 +642,16 @@ public class JedisConnection extends AbstractRedisConnection {
 		if (isQueueing()) {
 			throw new UnsupportedOperationException();
 		}
-		try {
+		doWithJedis(it -> {
+
 			for (byte[] key : keys) {
 				if (isPipelined()) {
 					pipeline(newStatusResult(getRequiredPipeline().watch(key)));
 				} else {
-					jedis.watch(key);
+					it.watch(key);
 				}
 			}
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		});
 	}
 
 	//
@@ -712,19 +664,7 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public Long publish(byte[] channel, byte[] message) {
-		try {
-			if (isPipelined()) {
-				pipeline(newJedisResult(getRequiredPipeline().publish(channel, message)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(newJedisResult(getRequiredTransaction().publish(channel, message)));
-				return null;
-			}
-			return jedis.publish(channel, message);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return invoke().just(BinaryJedis::publish, MultiKeyPipelineBase::publish, channel, message);
 	}
 
 	/*
@@ -751,26 +691,23 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public void pSubscribe(MessageListener listener, byte[]... patterns) {
+
 		if (isSubscribed()) {
 			throw new RedisSubscribedConnectionException(
 					"Connection already subscribed; use the connection Subscription to cancel or add new channels");
 		}
-		if (isQueueing()) {
-			throw new UnsupportedOperationException();
-		}
-		if (isPipelined()) {
+
+		if (isQueueing() || isPipelined()) {
 			throw new UnsupportedOperationException();
 		}
 
-		try {
+		doWithJedis(it -> {
+
 			BinaryJedisPubSub jedisPubSub = new JedisMessageListener(listener);
 
 			subscription = new JedisSubscription(listener, jedisPubSub, null, patterns);
-			jedis.psubscribe(jedisPubSub, patterns);
-
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+			it.psubscribe(jedisPubSub, patterns);
+		});
 	}
 
 	/*
@@ -779,27 +716,23 @@ public class JedisConnection extends AbstractRedisConnection {
 	 */
 	@Override
 	public void subscribe(MessageListener listener, byte[]... channels) {
+
 		if (isSubscribed()) {
 			throw new RedisSubscribedConnectionException(
 					"Connection already subscribed; use the connection Subscription to cancel or add new channels");
 		}
 
-		if (isQueueing()) {
-			throw new UnsupportedOperationException();
-		}
-		if (isPipelined()) {
+		if (isQueueing() || isPipelined()) {
 			throw new UnsupportedOperationException();
 		}
 
-		try {
+		doWithJedis(it -> {
+
 			BinaryJedisPubSub jedisPubSub = new JedisMessageListener(listener);
 
 			subscription = new JedisSubscription(listener, jedisPubSub, channels, null);
-			jedis.subscribe(jedisPubSub, channels);
-
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+			it.subscribe(jedisPubSub, channels);
+		});
 	}
 
 	/**
@@ -819,17 +752,17 @@ public class JedisConnection extends AbstractRedisConnection {
 	@Override
 	protected boolean isActive(RedisNode node) {
 
-		Jedis temp = null;
+		Jedis verification = null;
 		try {
-			temp = getJedis(node);
-			temp.connect();
-			return temp.ping().equalsIgnoreCase("pong");
+			verification = getJedis(node);
+			verification.connect();
+			return verification.ping().equalsIgnoreCase("pong");
 		} catch (Exception e) {
 			return false;
 		} finally {
-			if (temp != null) {
-				temp.disconnect();
-				temp.close();
+			if (verification != null) {
+				verification.disconnect();
+				verification.close();
 			}
 		}
 	}
@@ -852,6 +785,26 @@ public class JedisConnection extends AbstractRedisConnection {
 		}
 
 		return jedis;
+	}
+
+	@Nullable
+	private <T> T doWithJedis(Function<Jedis, T> callback) {
+
+		try {
+			return callback.apply(getJedis());
+
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
+		}
+	}
+
+	private void doWithJedis(Consumer<Jedis> callback) {
+
+		try {
+			callback.accept(getJedis());
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisGeoCommands.java
@@ -31,7 +31,6 @@ import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.connection.RedisGeoCommands;
-import org.springframework.data.redis.connection.convert.ListConverter;
 import org.springframework.util.Assert;
 
 /**
@@ -147,8 +146,8 @@ class JedisGeoCommands implements RedisGeoCommands {
 		Assert.notNull(members, "Members must not be null!");
 		Assert.noNullElements(members, "Members must not contain null!");
 
-		return connection.invoke().from(BinaryJedis::geohash, MultiKeyPipelineBase::geohash, key, members)
-				.get(JedisConverters.bytesListToStringListConverter());
+		return connection.invoke().fromMany(BinaryJedis::geohash, MultiKeyPipelineBase::geohash, key, members)
+				.toList(JedisConverters::toString);
 	}
 
 	/*
@@ -162,9 +161,9 @@ class JedisGeoCommands implements RedisGeoCommands {
 		Assert.notNull(members, "Members must not be null!");
 		Assert.noNullElements(members, "Members must not contain null!");
 
-		ListConverter<GeoCoordinate, Point> converter = JedisConverters.geoCoordinateToPointConverter();
 
-		return connection.invoke().from(BinaryJedis::geopos, MultiKeyPipelineBase::geopos, key, members).get(converter);
+		return connection.invoke().fromMany(BinaryJedis::geopos, MultiKeyPipelineBase::geopos, key, members)
+				.toList(JedisConverters::toPoint);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.MultiKeyPipelineBase;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
@@ -55,21 +57,8 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(field, "Field must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hset(key, field, value),
-						JedisConverters.longToBoolean()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hset(key, field, value),
-						JedisConverters.longToBoolean()));
-				return null;
-			}
-			return JedisConverters.toBoolean(connection.getJedis().hset(key, field, value));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().from(BinaryJedis::hset, MultiKeyPipelineBase::hset, key, field, value)
+				.get(JedisConverters.longToBoolean());
 	}
 
 	/*
@@ -83,21 +72,8 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(field, "Field must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hsetnx(key, field, value),
-						JedisConverters.longToBoolean()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hsetnx(key, field, value),
-						JedisConverters.longToBoolean()));
-				return null;
-			}
-			return JedisConverters.toBoolean(connection.getJedis().hsetnx(key, field, value));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().from(BinaryJedis::hsetnx, MultiKeyPipelineBase::hsetnx, key, field, value)
+				.get(JedisConverters.longToBoolean());
 	}
 
 	/*
@@ -110,19 +86,7 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(fields, "Fields must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hdel(key, fields)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hdel(key, fields)));
-				return null;
-			}
-			return connection.getJedis().hdel(key, fields);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hdel, MultiKeyPipelineBase::hdel, key, fields);
 	}
 
 	/*
@@ -135,19 +99,7 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Fields must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hexists(key, field)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hexists(key, field)));
-				return null;
-			}
-			return connection.getJedis().hexists(key, field);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hexists, MultiKeyPipelineBase::hexists, key, field);
 	}
 
 	/*
@@ -160,19 +112,7 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Field must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hget(key, field)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hget(key, field)));
-				return null;
-			}
-			return connection.getJedis().hget(key, field);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hget, MultiKeyPipelineBase::hget, key, field);
 	}
 
 	/*
@@ -184,19 +124,7 @@ class JedisHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hgetAll(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hgetAll(key)));
-				return null;
-			}
-			return connection.getJedis().hgetAll(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hgetAll, MultiKeyPipelineBase::hgetAll, key);
 	}
 
 	/*
@@ -209,19 +137,7 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Field must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hincrBy(key, field, delta)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hincrBy(key, field, delta)));
-				return null;
-			}
-			return connection.getJedis().hincrBy(key, field, delta);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hincrBy, MultiKeyPipelineBase::hincrBy, key, field, delta);
 	}
 
 	/*
@@ -234,19 +150,7 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Field must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hincrByFloat(key, field, delta)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hincrByFloat(key, field, delta)));
-				return null;
-			}
-			return connection.getJedis().hincrByFloat(key, field, delta);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hincrByFloat, MultiKeyPipelineBase::hincrByFloat, key, field, delta);
 	}
 
 	/*
@@ -258,19 +162,7 @@ class JedisHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hkeys(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hkeys(key)));
-				return null;
-			}
-			return connection.getJedis().hkeys(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hkeys, MultiKeyPipelineBase::hkeys, key);
 	}
 
 	/*
@@ -282,19 +174,7 @@ class JedisHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hlen(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hlen(key)));
-				return null;
-			}
-			return connection.getJedis().hlen(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hlen, MultiKeyPipelineBase::hlen, key);
 	}
 
 	/*
@@ -307,19 +187,7 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(fields, "Fields must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hmget(key, fields)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hmget(key, fields)));
-				return null;
-			}
-			return connection.getJedis().hmget(key, fields);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hmget, MultiKeyPipelineBase::hmget, key, fields);
 	}
 
 	/*
@@ -332,19 +200,7 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(hashes, "Hashes must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newStatusResult(connection.getRequiredPipeline().hmset(key, hashes)));
-				return;
-			}
-			if (isQueueing()) {
-				transaction(connection.newStatusResult(connection.getRequiredTransaction().hmset(key, hashes)));
-				return;
-			}
-			connection.getJedis().hmset(key, hashes);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		connection.invokeStatus().just(BinaryJedis::hmset, MultiKeyPipelineBase::hmset, key, hashes);
 	}
 
 	/*
@@ -356,19 +212,7 @@ class JedisHashCommands implements RedisHashCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().hvals(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().hvals(key)));
-				return null;
-			}
-			return connection.getJedis().hvals(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::hvals, MultiKeyPipelineBase::hvals, key);
 	}
 
 	/*
@@ -426,26 +270,14 @@ class JedisHashCommands implements RedisHashCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(field, "Field must not be null!");
 
-		return Long.class.cast(connection.execute("HSTRLEN", key, field));
+		return connection.invoke().just(BinaryJedis::hstrlen, MultiKeyPipelineBase::hstrlen, key, field);
 	}
 
 	private boolean isPipelined() {
 		return connection.isPipelined();
 	}
 
-	private void pipeline(JedisResult result) {
-		connection.pipeline(result);
-	}
-
 	private boolean isQueueing() {
 		return connection.isQueueing();
-	}
-
-	private void transaction(JedisResult result) {
-		connection.transaction(result);
-	}
-
-	private RuntimeException convertJedisAccessException(Exception ex) {
-		return connection.convertJedisAccessException(ex);
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisInvoker.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisInvoker.java
@@ -1,0 +1,998 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.jedis;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.MultiKeyPipelineBase;
+import redis.clients.jedis.Response;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Utility for functional invocation of Jedis methods. Typically used to express the method call as method reference and
+ * passing method arguments through one of the {@code just} or {@code from} methods.
+ * <p>
+ * {@code just} methods record the method call and evaluate the method result immediately. {@code from} methods allows
+ * composing a functional pipeline to transform the result using a {@link Converter}.
+ * <p>
+ * Usage example:
+ *
+ * <pre class="code">
+ * JedisInvoker invoker = …;
+ *
+ * Long result = invoker.just(BinaryJedisCommands::geoadd, RedisPipeline::geoadd, key, point.getX(), point.getY(), member);
+ *
+ * List&lt;byte[]&gt; result = invoker.fromMany(BinaryJedisCommands::geohash, RedisPipeline::geohash, key, members)
+ * 				.toList(it -> it.getValueOrElse(null));
+ * </pre>
+ * <p>
+ * The actual translation from {@link Response} is delegated to {@link Synchronizer} which can either await completion
+ * or record the future along {@link Converter} for further processing.
+ *
+ * @author Mark Paluch
+ * @author Christoph Strobl
+ * @since 2.5
+ */
+class JedisInvoker {
+
+	private final Synchronizer synchronizer;
+
+	JedisInvoker(Synchronizer synchronizer) {
+		this.synchronizer = synchronizer;
+	}
+
+	/**
+	 * Returns a {@link Converter} that always returns its input argument.
+	 *
+	 * @param <T> the type of the input and output objects to the function
+	 * @return a function that always returns its input argument
+	 */
+	static <T> Converter<T, T> identityConverter() {
+		return t -> t;
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction0} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 */
+	@Nullable
+	<R> R just(ConnectionFunction0<R> function, PipelineFunction0<R> pipelineFunction) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return synchronizer.invoke(function::apply, pipelineFunction::apply, identityConverter(), () -> null);
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction1} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 */
+	@Nullable
+	<R, T1> R just(ConnectionFunction1<T1, R> function, PipelineFunction1<T1, R> pipelineFunction, T1 t1) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return synchronizer.invoke(it -> function.apply(it, t1), it -> pipelineFunction.apply(it, t1));
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction2} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 */
+	@Nullable
+	<R, T1, T2> R just(ConnectionFunction2<T1, T2, R> function, PipelineFunction2<T1, T2, R> pipelineFunction, T1 t1,
+			T2 t2) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return synchronizer.invoke(it -> function.apply(it, t1, t2), it -> pipelineFunction.apply(it, t1, t2));
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction3} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 */
+	@Nullable
+	<R, T1, T2, T3> R just(ConnectionFunction3<T1, T2, T3, R> function, PipelineFunction3<T1, T2, T3, R> pipelineFunction,
+			T1 t1, T2 t2, T3 t3) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return synchronizer.invoke(it -> function.apply(it, t1, t2, t3), it -> pipelineFunction.apply(it, t1, t2, t3));
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction4} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 * @param t4 fourth argument.
+	 */
+	@Nullable
+	<R, T1, T2, T3, T4> R just(ConnectionFunction4<T1, T2, T3, T4, R> function,
+			PipelineFunction4<T1, T2, T3, T4, R> pipelineFunction, T1 t1, T2 t2, T3 t3, T4 t4) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return synchronizer.invoke(it -> function.apply(it, t1, t2, t3, t4),
+				it -> pipelineFunction.apply(it, t1, t2, t3, t4));
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction5} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 * @param t4 fourth argument.
+	 * @param t5 fifth argument.
+	 */
+	@Nullable
+	<R, T1, T2, T3, T4, T5> R just(ConnectionFunction5<T1, T2, T3, T4, T5, R> function,
+			PipelineFunction5<T1, T2, T3, T4, T5, R> pipelineFunction, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return synchronizer.invoke(it -> function.apply(it, t1, t2, t3, t4, t5),
+				it -> pipelineFunction.apply(it, t1, t2, t3, t4, t5));
+	}
+
+	/**
+	 * Invoke the {@link ConnectionFunction5} and return its result.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 * @param t4 fourth argument.
+	 * @param t5 fifth argument.
+	 * @param t6 sixth argument.
+	 */
+	@Nullable
+	<R, T1, T2, T3, T4, T5, T6> R just(ConnectionFunction6<T1, T2, T3, T4, T5, T6, R> function,
+			PipelineFunction6<T1, T2, T3, T4, T5, T6, R> pipelineFunction, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return synchronizer.invoke(it -> function.apply(it, t1, t2, t3, t4, t5, t6),
+				it -> pipelineFunction.apply(it, t1, t2, t3, t4, t5, t6));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction0} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 */
+	<R> SingleInvocationSpec<R> from(ConnectionFunction0<R> function, PipelineFunction0<R> pipelineFunction) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return new DefaultSingleInvocationSpec<>(function::apply, pipelineFunction::apply, synchronizer);
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction1} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 */
+	<R, T1> SingleInvocationSpec<R> from(ConnectionFunction1<T1, R> function, PipelineFunction1<T1, R> pipelineFunction,
+			T1 t1) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return from(it -> function.apply(it, t1), it -> pipelineFunction.apply(it, t1));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction2} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 */
+	<R, T1, T2> SingleInvocationSpec<R> from(ConnectionFunction2<T1, T2, R> function,
+			PipelineFunction2<T1, T2, R> pipelineFunction, T1 t1, T2 t2) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return from(it -> function.apply(it, t1, t2), it -> pipelineFunction.apply(it, t1, t2));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction3} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 */
+	<R, T1, T2, T3> SingleInvocationSpec<R> from(ConnectionFunction3<T1, T2, T3, R> function,
+			PipelineFunction3<T1, T2, T3, R> pipelineFunction, T1 t1, T2 t2, T3 t3) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return from(it -> function.apply(it, t1, t2, t3), it -> pipelineFunction.apply(it, t1, t2, t3));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction4} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 * @param t4 fourth argument.
+	 */
+	<R, T1, T2, T3, T4> SingleInvocationSpec<R> from(ConnectionFunction4<T1, T2, T3, T4, R> function,
+			PipelineFunction4<T1, T2, T3, T4, R> pipelineFunction, T1 t1, T2 t2, T3 t3, T4 t4) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return from(it -> function.apply(it, t1, t2, t3, t4), it -> pipelineFunction.apply(it, t1, t2, t3, t4));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction5} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 * @param t4 fourth argument.
+	 * @param t5 fifth argument.
+	 */
+	<R, T1, T2, T3, T4, T5> SingleInvocationSpec<R> from(ConnectionFunction5<T1, T2, T3, T4, T5, R> function,
+			PipelineFunction5<T1, T2, T3, T4, T5, R> pipelineFunction, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return from(it -> function.apply(it, t1, t2, t3, t4, t5), it -> pipelineFunction.apply(it, t1, t2, t3, t4, t5));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction6} and return a {@link SingleInvocationSpec} for
+	 * further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 * @param t4 fourth argument.
+	 * @param t5 fifth argument.
+	 * @param t6 sixth argument.
+	 */
+	<R, T1, T2, T3, T4, T5, T6> SingleInvocationSpec<R> from(ConnectionFunction6<T1, T2, T3, T4, T5, T6, R> function,
+			PipelineFunction6<T1, T2, T3, T4, T5, T6, R> pipelineFunction, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return from(it -> function.apply(it, t1, t2, t3, t4, t5, t6),
+				it -> pipelineFunction.apply(it, t1, t2, t3, t4, t5, t6));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction0} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 */
+	<R extends Collection<E>, E> ManyInvocationSpec<E> fromMany(ConnectionFunction0<R> function,
+			PipelineFunction0<R> pipelineFunction) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return new DefaultManyInvocationSpec<>((Function<Jedis, R>) function::apply, pipelineFunction::apply, synchronizer);
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction1} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 */
+	<R extends Collection<E>, E, T1> ManyInvocationSpec<E> fromMany(ConnectionFunction1<T1, R> function,
+			PipelineFunction1<T1, R> pipelineFunction, T1 t1) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return fromMany(it -> function.apply(it, t1), it -> pipelineFunction.apply(it, t1));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction2} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 */
+	<R extends Collection<E>, E, T1, T2> ManyInvocationSpec<E> fromMany(ConnectionFunction2<T1, T2, R> function,
+			PipelineFunction2<T1, T2, R> pipelineFunction, T1 t1, T2 t2) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return fromMany(it -> function.apply(it, t1, t2), it -> pipelineFunction.apply(it, t1, t2));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction3} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 */
+	<R extends Collection<E>, E, T1, T2, T3> ManyInvocationSpec<E> fromMany(ConnectionFunction3<T1, T2, T3, R> function,
+			PipelineFunction3<T1, T2, T3, R> pipelineFunction, T1 t1, T2 t2, T3 t3) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return fromMany(it -> function.apply(it, t1, t2, t3), it -> pipelineFunction.apply(it, t1, t2, t3));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction4} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 * @param t4 fourth argument.
+	 */
+	<R extends Collection<E>, E, T1, T2, T3, T4> ManyInvocationSpec<E> fromMany(
+			ConnectionFunction4<T1, T2, T3, T4, R> function, PipelineFunction4<T1, T2, T3, T4, R> pipelineFunction, T1 t1,
+			T2 t2, T3 t3, T4 t4) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return fromMany(it -> function.apply(it, t1, t2, t3, t4), it -> pipelineFunction.apply(it, t1, t2, t3, t4));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction5} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 * @param t4 fourth argument.
+	 * @param t5 fifth argument.
+	 */
+	<R extends Collection<E>, E, T1, T2, T3, T4, T5> ManyInvocationSpec<E> fromMany(
+			ConnectionFunction5<T1, T2, T3, T4, T5, R> function, PipelineFunction5<T1, T2, T3, T4, T5, R> pipelineFunction,
+			T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return fromMany(it -> function.apply(it, t1, t2, t3, t4, t5), it -> pipelineFunction.apply(it, t1, t2, t3, t4, t5));
+	}
+
+	/**
+	 * Compose a invocation pipeline from the {@link ConnectionFunction6} that returns a {@link Collection}-like result
+	 * and return a {@link ManyInvocationSpec} for further composition.
+	 *
+	 * @param function must not be {@literal null}.
+	 * @param pipelineFunction must not be {@literal null}.
+	 * @param t1 first argument.
+	 * @param t2 second argument.
+	 * @param t3 third argument.
+	 * @param t4 fourth argument.
+	 * @param t5 fifth argument.
+	 * @param t6 sixth argument.
+	 */
+	<R extends Collection<E>, E, T1, T2, T3, T4, T5, T6> ManyInvocationSpec<E> fromMany(
+			ConnectionFunction6<T1, T2, T3, T4, T5, T6, R> function,
+			PipelineFunction6<T1, T2, T3, T4, T5, T6, R> pipelineFunction, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
+
+		Assert.notNull(function, "ConnectionFunction must not be null!");
+		Assert.notNull(pipelineFunction, "PipelineFunction must not be null!");
+
+		return fromMany(it -> function.apply(it, t1, t2, t3, t4, t5, t6),
+				it -> pipelineFunction.apply(it, t1, t2, t3, t4, t5, t6));
+	}
+
+	/**
+	 * Represents an element in the invocation pipleline allowing consuming the result by applying a {@link Converter}.
+	 *
+	 * @param <S>
+	 */
+	interface SingleInvocationSpec<S> {
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result after applying
+		 * {@link Converter}.
+		 *
+		 * @param converter must not be {@literal null}.
+		 * @param <T> target type.
+		 * @return the converted result, can be {@literal null}.
+		 */
+		@Nullable
+		<T> T get(Converter<S, T> converter);
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result after applying
+		 * {@link Converter} or return the {@literal nullDefault} value if not present.
+		 *
+		 * @param converter must not be {@literal null}.
+		 * @param nullDefault can be {@literal null}.
+		 * @param <T> target type.
+		 * @return the converted result, can be {@literal null}.
+		 */
+		@Nullable
+		default <T> T orElse(Converter<S, T> converter, @Nullable T nullDefault) {
+			return getOrElse(converter, () -> nullDefault);
+		}
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result after applying
+		 * {@link Converter} or return the {@literal nullDefault} value if not present.
+		 *
+		 * @param converter must not be {@literal null}.
+		 * @param nullDefault must not be {@literal null}.
+		 * @param <T> target type.
+		 * @return the converted result, can be {@literal null}.
+		 */
+		@Nullable
+		<T> T getOrElse(Converter<S, T> converter, Supplier<T> nullDefault);
+	}
+
+	/**
+	 * Represents an element in the invocation pipleline for methods returning {@link Collection}-like results allowing
+	 * consuming the result by applying a {@link Converter}.
+	 *
+	 * @param <S>
+	 */
+	interface ManyInvocationSpec<S> {
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result.
+		 *
+		 * @return the result as {@link List}.
+		 */
+		default List<S> toList() {
+			return toList(identityConverter());
+		}
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result after applying
+		 * {@link Converter}.
+		 *
+		 * @param converter must not be {@literal null}.
+		 * @param <T> target type.
+		 * @return the converted {@link List}.
+		 */
+		<T> List<T> toList(Converter<S, T> converter);
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result.
+		 *
+		 * @return the result as {@link Set}.
+		 */
+		default Set<S> toSet() {
+			return toSet(identityConverter());
+		}
+
+		/**
+		 * Materialize the pipeline by invoking the {@code ConnectionFunction} and returning the result after applying
+		 * {@link Converter}.
+		 *
+		 * @param converter must not be {@literal null}.
+		 * @param <T> target type.
+		 * @return the converted {@link Set}.
+		 */
+		<T> Set<T> toSet(Converter<S, T> converter);
+	}
+
+	/**
+	 * A function accepting {@link Jedis} with 0 arguments.
+	 *
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface ConnectionFunction0<R> {
+
+		/**
+		 * Apply this function to the arguments and return a response.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 */
+		R apply(Jedis connection);
+	}
+
+	/**
+	 * A function accepting {@link Jedis} with 1 argument.
+	 *
+	 * @param <T1>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface ConnectionFunction1<T1, R> {
+
+		/**
+		 * Apply this function to the arguments and return a response.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 */
+		R apply(Jedis connection, T1 t1);
+	}
+
+	/**
+	 * A function accepting {@link Jedis} with 2 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface ConnectionFunction2<T1, T2, R> {
+
+		/**
+		 * Apply this function to the arguments and return a response.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 */
+		R apply(Jedis connection, T1 t1, T2 t2);
+	}
+
+	/**
+	 * A function accepting {@link Jedis} with 3 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface ConnectionFunction3<T1, T2, T3, R> {
+
+		/**
+		 * Apply this function to the arguments and return a response.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 * @param t3 third argument.
+		 */
+		R apply(Jedis connection, T1 t1, T2 t2, T3 t3);
+	}
+
+	/**
+	 * A function accepting {@link Jedis} with 4 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface ConnectionFunction4<T1, T2, T3, T4, R> {
+
+		/**
+		 * Apply this function to the arguments and return a response.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 * @param t3 third argument.
+		 * @param t4 fourth argument.
+		 */
+		R apply(Jedis connection, T1 t1, T2 t2, T3 t3, T4 t4);
+	}
+
+	/**
+	 * A function accepting {@link Jedis} with 5 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <T5>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface ConnectionFunction5<T1, T2, T3, T4, T5, R> {
+
+		/**
+		 * Apply this function to the arguments and return a response.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 * @param t3 third argument.
+		 * @param t4 fourth argument.
+		 * @param t5 fifth argument.
+		 */
+		R apply(Jedis connection, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
+	}
+
+	/**
+	 * A function accepting {@link Jedis} with 6 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <T5>
+	 * @param <T6>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface ConnectionFunction6<T1, T2, T3, T4, T5, T6, R> {
+
+		/**
+		 * Apply this function to the arguments and return a response.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 * @param t3 third argument.
+		 * @param t4 fourth argument.
+		 * @param t5 fifth argument.
+		 * @param t6 sixth argument.
+		 */
+		R apply(Jedis connection, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);
+	}
+
+	/**
+	 * A function accepting {@link MultiKeyPipelineBase} with 0 arguments.
+	 *
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface PipelineFunction0<R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link Response}.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 */
+		Response<R> apply(MultiKeyPipelineBase connection);
+	}
+
+	/**
+	 * A function accepting {@link MultiKeyPipelineBase} with 1 argument.
+	 *
+	 * @param <T1>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface PipelineFunction1<T1, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link Response}.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 */
+		Response<R> apply(MultiKeyPipelineBase connection, T1 t1);
+	}
+
+	/**
+	 * A function accepting {@link MultiKeyPipelineBase} with 2 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface PipelineFunction2<T1, T2, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link Response}.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 */
+		Response<R> apply(MultiKeyPipelineBase connection, T1 t1, T2 t2);
+	}
+
+	/**
+	 * A function accepting {@link MultiKeyPipelineBase} with 3 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface PipelineFunction3<T1, T2, T3, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link Response}.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 * @param t3 third argument.
+		 */
+		Response<R> apply(MultiKeyPipelineBase connection, T1 t1, T2 t2, T3 t3);
+	}
+
+	/**
+	 * A function accepting {@link MultiKeyPipelineBase} with 4 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface PipelineFunction4<T1, T2, T3, T4, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link Response}.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 * @param t3 third argument.
+		 * @param t4 fourth argument.
+		 */
+		Response<R> apply(MultiKeyPipelineBase connection, T1 t1, T2 t2, T3 t3, T4 t4);
+	}
+
+	/**
+	 * A function accepting {@link MultiKeyPipelineBase} with 5 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <T5>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface PipelineFunction5<T1, T2, T3, T4, T5, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link Response}.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 * @param t3 third argument.
+		 * @param t4 fourth argument.
+		 * @param t5 fifth argument.
+		 */
+		Response<R> apply(MultiKeyPipelineBase connection, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
+	}
+
+	/**
+	 * A function accepting {@link MultiKeyPipelineBase} with 6 arguments.
+	 *
+	 * @param <T1>
+	 * @param <T2>
+	 * @param <T3>
+	 * @param <T4>
+	 * @param <T5>
+	 * @param <T6>
+	 * @param <R>
+	 */
+	@FunctionalInterface
+	interface PipelineFunction6<T1, T2, T3, T4, T5, T6, R> {
+
+		/**
+		 * Apply this function to the arguments and return a {@link Response}.
+		 *
+		 * @param connection the connection in use. Never {@literal null}.
+		 * @param t1 first argument.
+		 * @param t2 second argument.
+		 * @param t3 third argument.
+		 * @param t4 fourth argument.
+		 * @param t5 fifth argument.
+		 * @param t6 sixth argument.
+		 */
+		Response<R> apply(MultiKeyPipelineBase connection, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);
+	}
+
+	static class DefaultSingleInvocationSpec<S> implements SingleInvocationSpec<S> {
+
+		private final Function<Jedis, S> parentFunction;
+		private final Function<MultiKeyPipelineBase, Response<S>> parentPipelineFunction;
+		private final Synchronizer synchronizer;
+
+		public DefaultSingleInvocationSpec(Function<Jedis, S> parentFunction,
+				Function<MultiKeyPipelineBase, Response<S>> parentPipelineFunction, Synchronizer synchronizer) {
+			this.parentFunction = parentFunction;
+			this.parentPipelineFunction = parentPipelineFunction;
+			this.synchronizer = synchronizer;
+		}
+
+		@Override
+		public <T> T get(Converter<S, T> converter) {
+
+			Assert.notNull(converter, "Converter must not be null");
+
+			return synchronizer.invoke(parentFunction, parentPipelineFunction, converter, () -> null);
+		}
+
+		@Nullable
+		@Override
+		public <T> T getOrElse(Converter<S, T> converter, Supplier<T> nullDefault) {
+
+			Assert.notNull(converter, "Converter must not be null!");
+
+			return synchronizer.invoke(parentFunction, parentPipelineFunction, converter, nullDefault);
+		}
+	}
+
+	static class DefaultManyInvocationSpec<S> implements ManyInvocationSpec<S> {
+
+		private final Function<Jedis, Collection<S>> parentFunction;
+		private final Function<MultiKeyPipelineBase, Response<Collection<S>>> parentPipelineFunction;
+		private final Synchronizer synchronizer;
+
+		public DefaultManyInvocationSpec(Function<Jedis, ? extends Collection<S>> parentFunction,
+				Function<MultiKeyPipelineBase, Response<? extends Collection<S>>> parentPipelineFunction,
+				Synchronizer synchronizer) {
+
+			this.parentFunction = (Function) parentFunction;
+			this.parentPipelineFunction = (Function) parentPipelineFunction;
+			this.synchronizer = synchronizer;
+		}
+
+		@Override
+		public <T> List<T> toList(Converter<S, T> converter) {
+
+			Assert.notNull(converter, "Converter must not be null!");
+
+			return synchronizer.invoke(parentFunction, parentPipelineFunction, source -> {
+
+				if (source.isEmpty()) {
+					return Collections.emptyList();
+				}
+
+				List<T> result = new ArrayList<>(source.size());
+
+				for (S s : source) {
+					result.add(converter.convert(s));
+				}
+
+				return result;
+			}, Collections::emptyList);
+		}
+
+		@Override
+		public <T> Set<T> toSet(Converter<S, T> converter) {
+
+			Assert.notNull(converter, "Converter must not be null!");
+
+			return synchronizer.invoke(parentFunction, parentPipelineFunction, source -> {
+
+				if (source.isEmpty()) {
+					return Collections.emptySet();
+				}
+
+				Set<T> result = new LinkedHashSet<>(source.size());
+
+				for (S s : source) {
+					result.add(converter.convert(s));
+				}
+
+				return result;
+			}, Collections::emptySet);
+		}
+	}
+
+	/**
+	 * Interface to define a synchronization function to evaluate the actual call.
+	 */
+	interface Synchronizer {
+
+		@Nullable
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		default <I, T> T invoke(Function<Jedis, I> callFunction,
+				Function<MultiKeyPipelineBase, Response<I>> pipelineFunction) {
+			return (T) doInvoke((Function) callFunction, (Function) pipelineFunction, identityConverter(), () -> null);
+		}
+
+		@Nullable
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		default <I, T> T invoke(Function<Jedis, I> callFunction,
+				Function<MultiKeyPipelineBase, Response<I>> pipelineFunction, Converter<I, T> converter,
+				Supplier<T> nullDefault) {
+
+			return (T) doInvoke((Function) callFunction, (Function) pipelineFunction, (Converter<Object, Object>) converter,
+					(Supplier<Object>) nullDefault);
+		}
+
+		@Nullable
+		Object doInvoke(Function<Jedis, Object> callFunction,
+				Function<MultiKeyPipelineBase, Response<Object>> pipelineFunction, Converter<Object, Object> converter,
+				Supplier<Object> nullDefault);
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -75,7 +75,6 @@ class JedisKeyCommands implements RedisKeyCommands {
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
 		return connection.invoke().just(BinaryJedis::exists, MultiKeyPipelineBase::exists, keys);
-
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisListCommands.java
@@ -15,9 +15,10 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.MultiKeyPipelineBase;
 import redis.clients.jedis.Protocol;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -47,19 +48,7 @@ class JedisListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().rpush(key, values)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().rpush(key, values)));
-				return null;
-			}
-			return connection.getJedis().rpush(key, values);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::rpush, MultiKeyPipelineBase::rpush, key, values);
 	}
 
 	/*
@@ -86,19 +75,7 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(values, "Values must not be null!");
 		Assert.noNullElements(values, "Values must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().lpush(key, values)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().lpush(key, values)));
-				return null;
-			}
-			return connection.getJedis().lpush(key, values);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::lpush, MultiKeyPipelineBase::lpush, key, values);
 	}
 
 	/*
@@ -111,19 +88,7 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().rpushx(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().rpushx(key, value)));
-				return null;
-			}
-			return connection.getJedis().rpushx(key, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::rpushx, MultiKeyPipelineBase::rpushx, key, value);
 	}
 
 	/*
@@ -136,19 +101,7 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().lpushx(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().lpushx(key, value)));
-				return null;
-			}
-			return connection.getJedis().lpushx(key, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::lpushx, MultiKeyPipelineBase::lpushx, key, value);
 	}
 
 	/*
@@ -160,19 +113,7 @@ class JedisListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().llen(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().llen(key)));
-				return null;
-			}
-			return connection.getJedis().llen(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::llen, MultiKeyPipelineBase::llen, key);
 	}
 
 	/*
@@ -184,19 +125,7 @@ class JedisListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().lrange(key, start, end)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().lrange(key, start, end)));
-				return null;
-			}
-			return connection.getJedis().lrange(key, start, end);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::lrange, MultiKeyPipelineBase::lrange, key, start, end);
 	}
 
 	/*
@@ -208,19 +137,7 @@ class JedisListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newStatusResult(connection.getRequiredPipeline().ltrim(key, start, end)));
-				return;
-			}
-			if (isQueueing()) {
-				transaction(connection.newStatusResult(connection.getRequiredTransaction().ltrim(key, start, end)));
-				return;
-			}
-			connection.getJedis().ltrim(key, start, end);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		connection.invokeStatus().just(BinaryJedis::ltrim, MultiKeyPipelineBase::ltrim, key, start, end);
 	}
 
 	/*
@@ -232,19 +149,7 @@ class JedisListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().lindex(key, index)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().lindex(key, index)));
-				return null;
-			}
-			return connection.getJedis().lindex(key, index);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::lindex, MultiKeyPipelineBase::lindex, key, index);
 	}
 
 	/*
@@ -256,21 +161,8 @@ class JedisListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(
-						connection.getRequiredPipeline().linsert(key, JedisConverters.toListPosition(where), pivot, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(
-						connection.getRequiredTransaction().linsert(key, JedisConverters.toListPosition(where), pivot, value)));
-				return null;
-			}
-			return connection.getJedis().linsert(key, JedisConverters.toListPosition(where), pivot, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::linsert, MultiKeyPipelineBase::linsert, key,
+				JedisConverters.toListPosition(where), pivot, value);
 	}
 
 	/*
@@ -283,19 +175,7 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newStatusResult(connection.getRequiredPipeline().lset(key, index, value)));
-				return;
-			}
-			if (isQueueing()) {
-				transaction(connection.newStatusResult(connection.getRequiredTransaction().lset(key, index, value)));
-				return;
-			}
-			connection.getJedis().lset(key, index, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		connection.invokeStatus().just(BinaryJedis::lset, MultiKeyPipelineBase::lset, key, index, value);
 	}
 
 	/*
@@ -308,19 +188,7 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().lrem(key, count, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().lrem(key, count, value)));
-				return null;
-			}
-			return connection.getJedis().lrem(key, count, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::lrem, MultiKeyPipelineBase::lrem, key, count, value);
 	}
 
 	/*
@@ -332,19 +200,7 @@ class JedisListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().lpop(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().lpop(key)));
-				return null;
-			}
-			return connection.getJedis().lpop(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::lpop, MultiKeyPipelineBase::lpop, key);
 	}
 
 	/*
@@ -356,20 +212,7 @@ class JedisListCommands implements RedisListCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().rpop(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().rpop(key)));
-				return null;
-			}
-			return connection.getJedis().rpop(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
-
+		return connection.invoke().just(BinaryJedis::rpop, MultiKeyPipelineBase::rpop, key);
 	}
 
 	/*
@@ -382,19 +225,7 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(keys, "Key must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().blpop(bXPopArgs(timeout, keys))));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().blpop(bXPopArgs(timeout, keys))));
-				return null;
-			}
-			return connection.getJedis().blpop(timeout, keys);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::blpop, MultiKeyPipelineBase::blpop, bXPopArgs(timeout, keys));
 	}
 
 	/*
@@ -407,19 +238,7 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(keys, "Key must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().brpop(bXPopArgs(timeout, keys))));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().brpop(bXPopArgs(timeout, keys))));
-				return null;
-			}
-			return connection.getJedis().brpop(timeout, keys);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::brpop, MultiKeyPipelineBase::brpop, bXPopArgs(timeout, keys));
 	}
 
 	/*
@@ -432,19 +251,7 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(srcKey, "Source key must not be null!");
 		Assert.notNull(dstKey, "Destination key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().rpoplpush(srcKey, dstKey)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().rpoplpush(srcKey, dstKey)));
-				return null;
-			}
-			return connection.getJedis().rpoplpush(srcKey, dstKey);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::rpoplpush, MultiKeyPipelineBase::rpoplpush, srcKey, dstKey);
 	}
 
 	/*
@@ -457,48 +264,16 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(srcKey, "Source key must not be null!");
 		Assert.notNull(dstKey, "Destination key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().brpoplpush(srcKey, dstKey, timeout)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().brpoplpush(srcKey, dstKey, timeout)));
-				return null;
-			}
-			return connection.getJedis().brpoplpush(srcKey, dstKey, timeout);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::brpoplpush, MultiKeyPipelineBase::brpoplpush, srcKey, dstKey, timeout);
 	}
 
-	private byte[][] bXPopArgs(int timeout, byte[]... keys) {
+	private static byte[][] bXPopArgs(int timeout, byte[]... keys) {
 
-		List<byte[]> args = new ArrayList<>();
-		for (byte[] arg : keys) {
-			args.add(arg);
-		}
-		args.add(Protocol.toByteArray(timeout));
-		return args.toArray(new byte[args.size()][]);
+		byte[][] args = new byte[keys.length + 1][];
+		System.arraycopy(keys, 0, args, 0, keys.length);
+
+		args[args.length - 1] = Protocol.toByteArray(timeout);
+		return args;
 	}
 
-	private boolean isPipelined() {
-		return connection.isPipelined();
-	}
-
-	private void pipeline(JedisResult result) {
-		connection.pipeline(result);
-	}
-
-	private boolean isQueueing() {
-		return connection.isQueueing();
-	}
-
-	private void transaction(JedisResult result) {
-		connection.transaction(result);
-	}
-
-	private RuntimeException convertJedisAccessException(Exception ex) {
-		return connection.convertJedisAccessException(ex);
-	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisResult.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisResult.java
@@ -159,7 +159,7 @@ class JedisResult<T, R> extends FutureResult<Response<?>> {
 		/**
 		 * @return a new {@link JedisStatusResult} wrapper for status results with configuration applied from this builder.
 		 */
-		JedisStatusResult buildStatusResult() {
+		JedisStatusResult<T, R> buildStatusResult() {
 			return new JedisStatusResult<>(response, converter);
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisScriptReturnConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisScriptReturnConverter.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.lang.Nullable;
 
 /**
  * Converts the value returned by Jedis script eval to the expected {@link ReturnType}
@@ -37,7 +38,7 @@ public class JedisScriptReturnConverter implements Converter<Object, Object> {
 	}
 
 	@SuppressWarnings("unchecked")
-	public Object convert(Object result) {
+	public Object convert(@Nullable Object result) {
 		if (result instanceof String) {
 			// evalsha converts byte[] to String. Convert back for consistency
 			return SafeEncoder.encode((String) result);

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
@@ -195,7 +195,7 @@ class JedisServerCommands implements RedisServerCommands {
 	@Override
 	public Long time() {
 		return connection.invoke().from(BinaryJedis::time, MultiKeyPipelineBase::time)
-				.get(JedisConverters.toTimeConverter());
+				.get(JedisConverters::toTime);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisSetCommands.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.MultiKeyPipelineBase;
 import redis.clients.jedis.ScanParams;
 
 import java.util.ArrayList;
@@ -52,19 +54,7 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(values, "Values must not be null!");
 		Assert.noNullElements(values, "Values must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().sadd(key, values)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().sadd(key, values)));
-				return null;
-			}
-			return connection.getJedis().sadd(key, values);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::sadd, MultiKeyPipelineBase::sadd, key, values);
 	}
 
 	/*
@@ -76,19 +66,7 @@ class JedisSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().scard(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().scard(key)));
-				return null;
-			}
-			return connection.getJedis().scard(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::scard, MultiKeyPipelineBase::scard, key);
 	}
 
 	/*
@@ -101,19 +79,7 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Keys must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().sdiff(keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().sdiff(keys)));
-				return null;
-			}
-			return connection.getJedis().sdiff(keys);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::sdiff, MultiKeyPipelineBase::sdiff, keys);
 	}
 
 	/*
@@ -127,19 +93,7 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Source keys must not be null!");
 		Assert.noNullElements(keys, "Source keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().sdiffstore(destKey, keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().sdiffstore(destKey, keys)));
-				return null;
-			}
-			return connection.getJedis().sdiffstore(destKey, keys);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::sdiffstore, MultiKeyPipelineBase::sdiffstore, destKey, keys);
 	}
 
 	/*
@@ -152,19 +106,7 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Keys must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().sinter(keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().sinter(keys)));
-				return null;
-			}
-			return connection.getJedis().sinter(keys);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::sinter, MultiKeyPipelineBase::sinter, keys);
 	}
 
 	/*
@@ -178,19 +120,7 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Source keys must not be null!");
 		Assert.noNullElements(keys, "Source keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().sinterstore(destKey, keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().sinterstore(destKey, keys)));
-				return null;
-			}
-			return connection.getJedis().sinterstore(destKey, keys);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::sinterstore, MultiKeyPipelineBase::sinterstore, destKey, keys);
 	}
 
 	/*
@@ -203,19 +133,7 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().sismember(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().sismember(key, value)));
-				return null;
-			}
-			return connection.getJedis().sismember(key, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::sismember, MultiKeyPipelineBase::sismember, key, value);
 	}
 
 	/*
@@ -227,19 +145,7 @@ class JedisSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().smembers(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().smembers(key)));
-				return null;
-			}
-			return connection.getJedis().smembers(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::smembers, MultiKeyPipelineBase::smembers, key);
 	}
 
 	/*
@@ -253,21 +159,8 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(destKey, "Destination key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().smove(srcKey, destKey, value),
-						JedisConverters.longToBoolean()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().smove(srcKey, destKey, value),
-						JedisConverters.longToBoolean()));
-				return null;
-			}
-			return JedisConverters.toBoolean(connection.getJedis().smove(srcKey, destKey, value));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().from(BinaryJedis::smove, MultiKeyPipelineBase::smove, srcKey, destKey, value)
+				.get(JedisConverters::toBoolean);
 	}
 
 	/*
@@ -279,19 +172,7 @@ class JedisSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().spop(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().spop(key)));
-				return null;
-			}
-			return connection.getJedis().spop(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::spop, MultiKeyPipelineBase::spop, key);
 	}
 
 	/*
@@ -303,19 +184,7 @@ class JedisSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().spop(key, count), ArrayList::new));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().spop(key, count), ArrayList::new));
-				return null;
-			}
-			return new ArrayList<>(connection.getJedis().spop(key, count));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().from(BinaryJedis::spop, MultiKeyPipelineBase::spop, key, count).get(ArrayList::new);
 	}
 
 	/*
@@ -327,19 +196,7 @@ class JedisSetCommands implements RedisSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().srandmember(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().srandmember(key)));
-				return null;
-			}
-			return connection.getJedis().srandmember(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::srandmember, MultiKeyPipelineBase::srandmember, key);
 	}
 
 	/*
@@ -355,19 +212,7 @@ class JedisSetCommands implements RedisSetCommands {
 			throw new IllegalArgumentException("Count must be less than Integer.MAX_VALUE for sRandMember in Jedis.");
 		}
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().srandmember(key, (int) count)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().srandmember(key, (int) count)));
-				return null;
-			}
-			return connection.getJedis().srandmember(key, (int) count);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::srandmember, MultiKeyPipelineBase::srandmember, key, (int) count);
 	}
 
 	/*
@@ -381,19 +226,7 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(values, "Values must not be null!");
 		Assert.noNullElements(values, "Values must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().srem(key, values)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().srem(key, values)));
-				return null;
-			}
-			return connection.getJedis().srem(key, values);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::srem, MultiKeyPipelineBase::srem, key, values);
 	}
 
 	/*
@@ -406,19 +239,7 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Keys must not be null!");
 		Assert.noNullElements(keys, "Keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().sunion(keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().sunion(keys)));
-				return null;
-			}
-			return connection.getJedis().sunion(keys);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::sunion, MultiKeyPipelineBase::sunion, keys);
 	}
 
 	/*
@@ -432,19 +253,7 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.notNull(keys, "Source keys must not be null!");
 		Assert.noNullElements(keys, "Source keys must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().sunionstore(destKey, keys)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().sunionstore(destKey, keys)));
-				return null;
-			}
-			return connection.getJedis().sunionstore(destKey, keys);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::sunionstore, MultiKeyPipelineBase::sunionstore, destKey, keys);
 	}
 
 	/*
@@ -493,19 +302,8 @@ class JedisSetCommands implements RedisSetCommands {
 		return connection.isPipelined();
 	}
 
-	private void pipeline(JedisResult result) {
-		connection.pipeline(result);
-	}
-
 	private boolean isQueueing() {
 		return connection.isQueueing();
 	}
 
-	private void transaction(JedisResult result) {
-		connection.transaction(result);
-	}
-
-	private RuntimeException convertJedisAccessException(Exception ex) {
-		return connection.convertJedisAccessException(ex);
-	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.MultiKeyPipelineBase;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.ZParams;
@@ -55,21 +58,8 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zadd(key, score, value),
-						JedisConverters.longToBoolean()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zadd(key, score, value),
-						JedisConverters.longToBoolean()));
-				return null;
-			}
-			return JedisConverters.toBoolean(connection.getJedis().zadd(key, score, value));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().from(BinaryJedis::zadd, MultiKeyPipelineBase::zadd, key, score, value)
+				.get(JedisConverters::toBoolean);
 	}
 
 	/*
@@ -82,21 +72,8 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(tuples, "Tuples must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(
-						connection.newJedisResult(connection.getRequiredPipeline().zadd(key, JedisConverters.toTupleMap(tuples))));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection
-						.newJedisResult(connection.getRequiredTransaction().zadd(key, JedisConverters.toTupleMap(tuples))));
-				return null;
-			}
-			return connection.getJedis().zadd(key, JedisConverters.toTupleMap(tuples));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zadd, MultiKeyPipelineBase::zadd, key,
+				JedisConverters.toTupleMap(tuples));
 	}
 
 	/*
@@ -110,19 +87,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(values, "Values must not be null!");
 		Assert.noNullElements(values, "Values must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrem(key, values)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zrem(key, values)));
-				return null;
-			}
-			return connection.getJedis().zrem(key, values);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zrem, MultiKeyPipelineBase::zrem, key, values);
 	}
 
 	/*
@@ -135,19 +100,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zincrby(key, increment, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zincrby(key, increment, value)));
-				return null;
-			}
-			return connection.getJedis().zincrby(key, increment, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zincrby, MultiKeyPipelineBase::zincrby, key, increment, value);
 	}
 
 	/*
@@ -160,19 +113,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrank(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zrank(key, value)));
-				return null;
-			}
-			return connection.getJedis().zrank(key, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zrank, MultiKeyPipelineBase::zrank, key, value);
 	}
 
 	/*
@@ -184,19 +125,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrevrank(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zrevrank(key, value)));
-				return null;
-			}
-			return connection.getJedis().zrevrank(key, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zrevrank, MultiKeyPipelineBase::zrevrank, key, value);
 	}
 
 	/*
@@ -208,19 +137,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrange(key, start, end)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zrange(key, start, end)));
-				return null;
-			}
-			return connection.getJedis().zrange(key, start, end);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zrange, MultiKeyPipelineBase::zrange, key, start, end);
 	}
 
 	/*
@@ -232,21 +149,9 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrangeWithScores(key, start, end),
-						JedisConverters.tupleSetToTupleSet()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zrangeWithScores(key, start, end),
-						JedisConverters.tupleSetToTupleSet()));
-				return null;
-			}
-			return JedisConverters.toTupleSet(connection.getJedis().zrangeWithScores(key, start, end));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke()
+				.from(BinaryJedis::zrangeWithScores, MultiKeyPipelineBase::zrangeWithScores, key, start, end)
+				.get(JedisConverters.tupleSetToTupleSet());
 	}
 
 	/*
@@ -263,38 +168,15 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] min = JedisConverters.boundaryToBytesForZRange(range.getMin(), JedisConverters.NEGATIVE_INFINITY_BYTES);
 		byte[] max = JedisConverters.boundaryToBytesForZRange(range.getMax(), JedisConverters.POSITIVE_INFINITY_BYTES);
 
-		try {
-			if (isPipelined()) {
-				if (!limit.isUnlimited()) {
-					pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrangeByScoreWithScores(key, min, max,
-							limit.getOffset(), limit.getCount()), JedisConverters.tupleSetToTupleSet()));
-				} else {
-					pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrangeByScoreWithScores(key, min, max),
-							JedisConverters.tupleSetToTupleSet()));
-				}
-				return null;
-			}
-
-			if (isQueueing()) {
-				if (!limit.isUnlimited()) {
-					transaction(connection.newJedisResult(connection.getRequiredTransaction().zrangeByScoreWithScores(key, min,
-							max, limit.getOffset(), limit.getCount()), JedisConverters.tupleSetToTupleSet()));
-				} else {
-					transaction(
-							connection.newJedisResult(connection.getRequiredTransaction().zrangeByScoreWithScores(key, min, max),
-									JedisConverters.tupleSetToTupleSet()));
-				}
-				return null;
-			}
-
-			if (!limit.isUnlimited()) {
-				return JedisConverters.toTupleSet(
-						connection.getJedis().zrangeByScoreWithScores(key, min, max, limit.getOffset(), limit.getCount()));
-			}
-			return JedisConverters.toTupleSet(connection.getJedis().zrangeByScoreWithScores(key, min, max));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
+		if (!limit.isUnlimited()) {
+			return connection.invoke().from(BinaryJedis::zrangeByScoreWithScores,
+					MultiKeyPipelineBase::zrangeByScoreWithScores, key, min, max, limit.getOffset(), limit.getCount())
+					.get(JedisConverters.tupleSetToTupleSet());
 		}
+
+		return connection.invoke()
+				.from(BinaryJedis::zrangeByScoreWithScores, MultiKeyPipelineBase::zrangeByScoreWithScores, key, min, max)
+				.get(JedisConverters.tupleSetToTupleSet());
 	}
 
 	/*
@@ -306,19 +188,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrevrange(key, start, end)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zrevrange(key, start, end)));
-				return null;
-			}
-			return connection.getJedis().zrevrange(key, start, end);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zrevrange, MultiKeyPipelineBase::zrevrange, key, start, end);
 	}
 
 	/*
@@ -330,21 +200,9 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrevrangeWithScores(key, start, end),
-						JedisConverters.tupleSetToTupleSet()));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zrevrangeWithScores(key, start, end),
-						JedisConverters.tupleSetToTupleSet()));
-				return null;
-			}
-			return JedisConverters.toTupleSet(connection.getJedis().zrevrangeWithScores(key, start, end));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke()
+				.from(BinaryJedis::zrevrangeWithScores, MultiKeyPipelineBase::zrevrangeWithScores, key, start, end)
+				.get(JedisConverters.tupleSetToTupleSet());
 	}
 
 	/*
@@ -361,34 +219,13 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] min = JedisConverters.boundaryToBytesForZRange(range.getMin(), JedisConverters.NEGATIVE_INFINITY_BYTES);
 		byte[] max = JedisConverters.boundaryToBytesForZRange(range.getMax(), JedisConverters.POSITIVE_INFINITY_BYTES);
 
-		try {
-			if (isPipelined()) {
-				if (!limit.isUnlimited()) {
-					pipeline(connection.newJedisResult(
-							connection.getRequiredPipeline().zrevrangeByScore(key, max, min, limit.getOffset(), limit.getCount())));
-				} else {
-					pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrevrangeByScore(key, max, min)));
-				}
-				return null;
-			}
-
-			if (isQueueing()) {
-				if (!limit.isUnlimited()) {
-					transaction(connection.newJedisResult(connection.getRequiredTransaction().zrevrangeByScore(key, max, min,
-							limit.getOffset(), limit.getCount())));
-				} else {
-					transaction(connection.newJedisResult(connection.getRequiredTransaction().zrevrangeByScore(key, max, min)));
-				}
-				return null;
-			}
-
-			if (!limit.isUnlimited()) {
-				return connection.getJedis().zrevrangeByScore(key, max, min, limit.getOffset(), limit.getCount());
-			}
-			return connection.getJedis().zrevrangeByScore(key, max, min);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
+		if (!limit.isUnlimited()) {
+			return connection.invoke().just(BinaryJedis::zrevrangeByScore, MultiKeyPipelineBase::zrevrangeByScore, key, max,
+					min, limit.getOffset(), limit.getCount());
 		}
+
+		return connection.invoke().just(BinaryJedis::zrevrangeByScore, MultiKeyPipelineBase::zrevrangeByScore, key, max,
+				min);
 	}
 
 	/*
@@ -405,38 +242,15 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] min = JedisConverters.boundaryToBytesForZRange(range.getMin(), JedisConverters.NEGATIVE_INFINITY_BYTES);
 		byte[] max = JedisConverters.boundaryToBytesForZRange(range.getMax(), JedisConverters.POSITIVE_INFINITY_BYTES);
 
-		try {
-			if (isPipelined()) {
-				if (!limit.isUnlimited()) {
-					pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrevrangeByScoreWithScores(key, max, min,
-							limit.getOffset(), limit.getCount()), JedisConverters.tupleSetToTupleSet()));
-				} else {
-					pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrevrangeByScoreWithScores(key, max, min),
-							JedisConverters.tupleSetToTupleSet()));
-				}
-				return null;
-			}
-
-			if (isQueueing()) {
-				if (!limit.isUnlimited()) {
-					transaction(connection.newJedisResult(connection.getRequiredTransaction().zrevrangeByScoreWithScores(key, max,
-							min, limit.getOffset(), limit.getCount()), JedisConverters.tupleSetToTupleSet()));
-				} else {
-					transaction(
-							connection.newJedisResult(connection.getRequiredTransaction().zrevrangeByScoreWithScores(key, max, min),
-									JedisConverters.tupleSetToTupleSet()));
-				}
-				return null;
-			}
-
-			if (!limit.isUnlimited()) {
-				return JedisConverters.toTupleSet(
-						connection.getJedis().zrevrangeByScoreWithScores(key, max, min, limit.getOffset(), limit.getCount()));
-			}
-			return JedisConverters.toTupleSet(connection.getJedis().zrevrangeByScoreWithScores(key, max, min));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
+		if (!limit.isUnlimited()) {
+			return connection.invoke().from(BinaryJedis::zrevrangeByScoreWithScores,
+					MultiKeyPipelineBase::zrevrangeByScoreWithScores, key, max, min, limit.getOffset(), limit.getCount())
+					.get(JedisConverters.tupleSetToTupleSet());
 		}
+
+		return connection.invoke()
+				.from(BinaryJedis::zrevrangeByScoreWithScores, MultiKeyPipelineBase::zrevrangeByScoreWithScores, key, max, min)
+				.get(JedisConverters.tupleSetToTupleSet());
 	}
 
 	/*
@@ -448,19 +262,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zcount(key, min, max)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zcount(key, min, max)));
-				return null;
-			}
-			return connection.getJedis().zcount(key, min, max);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zcount, MultiKeyPipelineBase::zcount, key, min, max);
 	}
 
 	/*
@@ -476,19 +278,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] min = JedisConverters.boundaryToBytesForZRange(range.getMin(), JedisConverters.NEGATIVE_INFINITY_BYTES);
 		byte[] max = JedisConverters.boundaryToBytesForZRange(range.getMax(), JedisConverters.POSITIVE_INFINITY_BYTES);
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zcount(key, min, max)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zcount(key, min, max)));
-				return null;
-			}
-			return connection.getJedis().zcount(key, min, max);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zcount, MultiKeyPipelineBase::zcount, key, min, max);
 	}
 
 	/*
@@ -504,19 +294,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] min = JedisConverters.boundaryToBytesForZRangeByLex(range.getMin(), JedisConverters.MINUS_BYTES);
 		byte[] max = JedisConverters.boundaryToBytesForZRangeByLex(range.getMax(), JedisConverters.PLUS_BYTES);
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zlexcount(key, min, max)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zlexcount(key, min, max)));
-				return null;
-			}
-			return connection.getJedis().zlexcount(key, min, max);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zlexcount, MultiKeyPipelineBase::zlexcount, key, min, max);
 	}
 
 	/*
@@ -528,19 +306,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zcard(key)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zcard(key)));
-				return null;
-			}
-			return connection.getJedis().zcard(key);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zcard, MultiKeyPipelineBase::zcard, key);
 	}
 
 	/*
@@ -553,19 +319,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(value, "Value must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zscore(key, value)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zscore(key, value)));
-				return null;
-			}
-			return connection.getJedis().zscore(key, value);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zscore, MultiKeyPipelineBase::zscore, key, value);
 	}
 
 	/*
@@ -577,19 +331,8 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zremrangeByRank(key, start, end)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zremrangeByRank(key, start, end)));
-				return null;
-			}
-			return connection.getJedis().zremrangeByRank(key, start, end);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zremrangeByRank, MultiKeyPipelineBase::zremrangeByRank, key, start,
+				end);
 	}
 
 	/*
@@ -605,19 +348,8 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] min = JedisConverters.boundaryToBytesForZRange(range.getMin(), JedisConverters.NEGATIVE_INFINITY_BYTES);
 		byte[] max = JedisConverters.boundaryToBytesForZRange(range.getMax(), JedisConverters.POSITIVE_INFINITY_BYTES);
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zremrangeByScore(key, min, max)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zremrangeByScore(key, min, max)));
-				return null;
-			}
-			return connection.getJedis().zremrangeByScore(key, min, max);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zremrangeByScore, MultiKeyPipelineBase::zremrangeByScore, key, min,
+				max);
 	}
 
 	/*
@@ -634,21 +366,10 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.isTrue(weights.size() == sets.length, () -> String
 				.format("The number of weights (%d) must match the number of source sets (%d)!", weights.size(), sets.length));
 
-		try {
-			ZParams zparams = new ZParams().weights(weights.toArray()).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
+		ZParams zparams = new ZParams().weights(weights.toArray()).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
 
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zunionstore(destKey, zparams, sets)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zunionstore(destKey, zparams, sets)));
-				return null;
-			}
-			return connection.getJedis().zunionstore(destKey, zparams, sets);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zunionstore, MultiKeyPipelineBase::zunionstore, destKey, zparams,
+				sets);
 	}
 
 	/*
@@ -662,19 +383,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(sets, "Source sets must not be null!");
 		Assert.noNullElements(sets, "Source sets must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zunionstore(destKey, sets)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zunionstore(destKey, sets)));
-				return null;
-			}
-			return connection.getJedis().zunionstore(destKey, sets);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zunionstore, MultiKeyPipelineBase::zunionstore, destKey, sets);
 	}
 
 	/*
@@ -690,21 +399,10 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.isTrue(weights.size() == sets.length, () -> String
 				.format("The number of weights (%d) must match the number of source sets (%d)!", weights.size(), sets.length));
 
-		try {
-			ZParams zparams = new ZParams().weights(weights.toArray()).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
+		ZParams zparams = new ZParams().weights(weights.toArray()).aggregate(ZParams.Aggregate.valueOf(aggregate.name()));
 
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zinterstore(destKey, zparams, sets)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zinterstore(destKey, zparams, sets)));
-				return null;
-			}
-			return connection.getJedis().zinterstore(destKey, zparams, sets);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zinterstore, MultiKeyPipelineBase::zinterstore, destKey, zparams,
+				sets);
 	}
 
 	/*
@@ -718,19 +416,7 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(sets, "Source sets must not be null!");
 		Assert.noNullElements(sets, "Source sets must not contain null elements!");
 
-		try {
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zinterstore(destKey, sets)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zinterstore(destKey, sets)));
-				return null;
-			}
-			return connection.getJedis().zinterstore(destKey, sets);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke().just(BinaryJedis::zinterstore, MultiKeyPipelineBase::zinterstore, destKey, sets);
 	}
 
 	/*
@@ -787,20 +473,9 @@ class JedisZSetCommands implements RedisZSetCommands {
 
 		Assert.notNull(key, "Key must not be null!");
 
-		try {
-			String keyStr = new String(key, StandardCharsets.UTF_8);
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrangeByScore(keyStr, min, max)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(connection.getRequiredTransaction().zrangeByScore(keyStr, min, max)));
-				return null;
-			}
-			return JedisConverters.stringSetToByteSet().convert(connection.getJedis().zrangeByScore(keyStr, min, max));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		String keyStr = new String(key, StandardCharsets.UTF_8);
+		return connection.invoke().from(Jedis::zrangeByScore, MultiKeyPipelineBase::zrangeByScore, keyStr, min, max)
+				.get(JedisConverters.stringSetToByteSet());
 	}
 
 	/*
@@ -817,24 +492,11 @@ class JedisZSetCommands implements RedisZSetCommands {
 			throw new IllegalArgumentException(
 					"Offset and count must be less than Integer.MAX_VALUE for zRangeByScore in Jedis.");
 		}
+		String keyStr = new String(key, StandardCharsets.UTF_8);
 
-		try {
-			String keyStr = new String(key, StandardCharsets.UTF_8);
-			if (isPipelined()) {
-				pipeline(connection.newJedisResult(
-						connection.getRequiredPipeline().zrangeByScore(keyStr, min, max, (int) offset, (int) count)));
-				return null;
-			}
-			if (isQueueing()) {
-				transaction(connection.newJedisResult(
-						connection.getRequiredTransaction().zrangeByScore(keyStr, min, max, (int) offset, (int) count)));
-				return null;
-			}
-			return JedisConverters.stringSetToByteSet()
-					.convert(connection.getJedis().zrangeByScore(keyStr, min, max, (int) offset, (int) count));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
-		}
+		return connection.invoke()
+				.from(Jedis::zrangeByScore, MultiKeyPipelineBase::zrangeByScore, keyStr, min, max, (int) offset, (int) count)
+				.get(JedisConverters.stringSetToByteSet());
 	}
 
 	/*
@@ -851,34 +513,12 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] min = JedisConverters.boundaryToBytesForZRange(range.getMin(), JedisConverters.NEGATIVE_INFINITY_BYTES);
 		byte[] max = JedisConverters.boundaryToBytesForZRange(range.getMax(), JedisConverters.POSITIVE_INFINITY_BYTES);
 
-		try {
-			if (isPipelined()) {
-				if (!limit.isUnlimited()) {
-					pipeline(connection.newJedisResult(
-							connection.getRequiredPipeline().zrangeByScore(key, min, max, limit.getOffset(), limit.getCount())));
-				} else {
-					pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrangeByScore(key, min, max)));
-				}
-				return null;
-			}
-
-			if (isQueueing()) {
-				if (!limit.isUnlimited()) {
-					transaction(connection.newJedisResult(
-							connection.getRequiredTransaction().zrangeByScore(key, min, max, limit.getOffset(), limit.getCount())));
-				} else {
-					transaction(connection.newJedisResult(connection.getRequiredTransaction().zrangeByScore(key, min, max)));
-				}
-				return null;
-			}
-
-			if (!limit.isUnlimited()) {
-				return connection.getJedis().zrangeByScore(key, min, max, limit.getOffset(), limit.getCount());
-			}
-			return connection.getJedis().zrangeByScore(key, min, max);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
+		if (!limit.isUnlimited()) {
+			return connection.invoke().just(BinaryJedis::zrangeByScore, MultiKeyPipelineBase::zrangeByScore, key, min, max,
+					limit.getOffset(), limit.getCount());
 		}
+
+		return connection.invoke().just(BinaryJedis::zrangeByScore, MultiKeyPipelineBase::zrangeByScore, key, min, max);
 	}
 
 	/*
@@ -895,34 +535,12 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] min = JedisConverters.boundaryToBytesForZRangeByLex(range.getMin(), JedisConverters.MINUS_BYTES);
 		byte[] max = JedisConverters.boundaryToBytesForZRangeByLex(range.getMax(), JedisConverters.PLUS_BYTES);
 
-		try {
-			if (isPipelined()) {
-				if (!limit.isUnlimited()) {
-					pipeline(connection.newJedisResult(
-							connection.getRequiredPipeline().zrangeByLex(key, min, max, limit.getOffset(), limit.getCount())));
-				} else {
-					pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrangeByLex(key, min, max)));
-				}
-				return null;
-			}
-
-			if (isQueueing()) {
-				if (!limit.isUnlimited()) {
-					transaction(connection.newJedisResult(
-							connection.getRequiredTransaction().zrangeByLex(key, min, max, limit.getOffset(), limit.getCount())));
-				} else {
-					transaction(connection.newJedisResult(connection.getRequiredTransaction().zrangeByLex(key, min, max)));
-				}
-				return null;
-			}
-
-			if (!limit.isUnlimited()) {
-				return connection.getJedis().zrangeByLex(key, min, max, limit.getOffset(), limit.getCount());
-			}
-			return connection.getJedis().zrangeByLex(key, min, max);
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
+		if (!limit.isUnlimited()) {
+			return connection.invoke().just(BinaryJedis::zrangeByLex, MultiKeyPipelineBase::zrangeByLex, key, min, max,
+					limit.getOffset(), limit.getCount());
 		}
+
+		return connection.invoke().just(BinaryJedis::zrangeByLex, MultiKeyPipelineBase::zrangeByLex, key, min, max);
 	}
 
 	/*
@@ -939,54 +557,22 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] min = JedisConverters.boundaryToBytesForZRangeByLex(range.getMin(), JedisConverters.MINUS_BYTES);
 		byte[] max = JedisConverters.boundaryToBytesForZRangeByLex(range.getMax(), JedisConverters.PLUS_BYTES);
 
-		try {
-			if (isPipelined()) {
-				if (!limit.isUnlimited()) {
-					pipeline(connection.newJedisResult(
-							connection.getRequiredPipeline().zrevrangeByLex(key, max, min, limit.getOffset(), limit.getCount())));
-				} else {
-					pipeline(connection.newJedisResult(connection.getRequiredPipeline().zrevrangeByLex(key, max, min)));
-				}
-				return null;
-			}
 
-			if (isQueueing()) {
-				if (!limit.isUnlimited()) {
-					transaction(connection.newJedisResult(
-							connection.getRequiredTransaction().zrevrangeByLex(key, max, min, limit.getOffset(), limit.getCount())));
-				} else {
-					transaction(connection.newJedisResult(connection.getRequiredTransaction().zrevrangeByLex(key, max, min)));
-				}
-				return null;
-			}
-
-			if (!limit.isUnlimited()) {
-				return new LinkedHashSet<>(
-						connection.getJedis().zrevrangeByLex(key, max, min, limit.getOffset(), limit.getCount()));
-			}
-			return new LinkedHashSet<>(connection.getJedis().zrevrangeByLex(key, max, min));
-		} catch (Exception ex) {
-			throw convertJedisAccessException(ex);
+		if (!limit.isUnlimited()) {
+			return connection.invoke().from(BinaryJedis::zrevrangeByLex, MultiKeyPipelineBase::zrevrangeByLex, key, max, min,
+					limit.getOffset(), limit.getCount()).get(LinkedHashSet::new);
 		}
+
+		return connection.invoke().from(BinaryJedis::zrevrangeByLex, MultiKeyPipelineBase::zrevrangeByLex, key, max, min)
+				.get(LinkedHashSet::new);
 	}
 
 	private boolean isPipelined() {
 		return connection.isPipelined();
 	}
 
-	private void pipeline(JedisResult result) {
-		connection.pipeline(result);
-	}
-
 	private boolean isQueueing() {
 		return connection.isQueueing();
 	}
 
-	private void transaction(JedisResult result) {
-		connection.transaction(result);
-	}
-
-	private RuntimeException convertJedisAccessException(Exception ex) {
-		return connection.convertJedisAccessException(ex);
-	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisZSetCommands.java
@@ -150,8 +150,8 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 
 		return connection.invoke()
-				.from(BinaryJedis::zrangeWithScores, MultiKeyPipelineBase::zrangeWithScores, key, start, end)
-				.get(JedisConverters.tupleSetToTupleSet());
+				.fromMany(BinaryJedis::zrangeWithScores, MultiKeyPipelineBase::zrangeWithScores, key, start, end)
+				.toSet(JedisConverters::toTuple);
 	}
 
 	/*
@@ -169,14 +169,14 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] max = JedisConverters.boundaryToBytesForZRange(range.getMax(), JedisConverters.POSITIVE_INFINITY_BYTES);
 
 		if (!limit.isUnlimited()) {
-			return connection.invoke().from(BinaryJedis::zrangeByScoreWithScores,
+			return connection.invoke().fromMany(BinaryJedis::zrangeByScoreWithScores,
 					MultiKeyPipelineBase::zrangeByScoreWithScores, key, min, max, limit.getOffset(), limit.getCount())
-					.get(JedisConverters.tupleSetToTupleSet());
+					.toSet(JedisConverters::toTuple);
 		}
 
 		return connection.invoke()
-				.from(BinaryJedis::zrangeByScoreWithScores, MultiKeyPipelineBase::zrangeByScoreWithScores, key, min, max)
-				.get(JedisConverters.tupleSetToTupleSet());
+				.fromMany(BinaryJedis::zrangeByScoreWithScores, MultiKeyPipelineBase::zrangeByScoreWithScores, key, min, max)
+				.toSet(JedisConverters::toTuple);
 	}
 
 	/*
@@ -201,8 +201,8 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 
 		return connection.invoke()
-				.from(BinaryJedis::zrevrangeWithScores, MultiKeyPipelineBase::zrevrangeWithScores, key, start, end)
-				.get(JedisConverters.tupleSetToTupleSet());
+				.fromMany(BinaryJedis::zrevrangeWithScores, MultiKeyPipelineBase::zrevrangeWithScores, key, start, end)
+				.toSet(JedisConverters::toTuple);
 	}
 
 	/*
@@ -243,14 +243,15 @@ class JedisZSetCommands implements RedisZSetCommands {
 		byte[] max = JedisConverters.boundaryToBytesForZRange(range.getMax(), JedisConverters.POSITIVE_INFINITY_BYTES);
 
 		if (!limit.isUnlimited()) {
-			return connection.invoke().from(BinaryJedis::zrevrangeByScoreWithScores,
+			return connection.invoke().fromMany(BinaryJedis::zrevrangeByScoreWithScores,
 					MultiKeyPipelineBase::zrevrangeByScoreWithScores, key, max, min, limit.getOffset(), limit.getCount())
-					.get(JedisConverters.tupleSetToTupleSet());
+					.toSet(JedisConverters::toTuple);
 		}
 
 		return connection.invoke()
-				.from(BinaryJedis::zrevrangeByScoreWithScores, MultiKeyPipelineBase::zrevrangeByScoreWithScores, key, max, min)
-				.get(JedisConverters.tupleSetToTupleSet());
+				.fromMany(BinaryJedis::zrevrangeByScoreWithScores, MultiKeyPipelineBase::zrevrangeByScoreWithScores, key, max,
+						min)
+				.toSet(JedisConverters::toTuple);
 	}
 
 	/*
@@ -474,8 +475,8 @@ class JedisZSetCommands implements RedisZSetCommands {
 		Assert.notNull(key, "Key must not be null!");
 
 		String keyStr = new String(key, StandardCharsets.UTF_8);
-		return connection.invoke().from(Jedis::zrangeByScore, MultiKeyPipelineBase::zrangeByScore, keyStr, min, max)
-				.get(JedisConverters.stringSetToByteSet());
+		return connection.invoke().fromMany(Jedis::zrangeByScore, MultiKeyPipelineBase::zrangeByScore, keyStr, min, max)
+				.toSet(JedisConverters::toBytes);
 	}
 
 	/*
@@ -495,8 +496,9 @@ class JedisZSetCommands implements RedisZSetCommands {
 		String keyStr = new String(key, StandardCharsets.UTF_8);
 
 		return connection.invoke()
-				.from(Jedis::zrangeByScore, MultiKeyPipelineBase::zrangeByScore, keyStr, min, max, (int) offset, (int) count)
-				.get(JedisConverters.stringSetToByteSet());
+				.fromMany(Jedis::zrangeByScore, MultiKeyPipelineBase::zrangeByScore, keyStr, min, max, (int) offset,
+						(int) count)
+				.toSet(JedisConverters::toBytes);
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
@@ -216,11 +216,6 @@ public class JedisConnectionPipelineIntegrationTests extends AbstractConnectionP
 	@Disabled
 	public void testScriptFlush() {}
 
-	@Test
-	public void testInfoBySection() {
-		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(super::testInfoBySection);
-	}
-
 	@Test // DATAREDIS-269
 	public void clientSetNameWorksCorrectly() {
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(super::clientSetNameWorksCorrectly);

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineTxIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineTxIntegrationTests.java
@@ -28,10 +28,6 @@ import org.junit.jupiter.api.Test;
  */
 public class JedisConnectionPipelineTxIntegrationTests extends JedisConnectionTransactionIntegrationTests {
 
-	@Disabled("Jedis issue: Pipeline tries to return String instead of List<String>")
-	@Test
-	public void testGetConfig() {}
-
 	@Test
 	@Disabled
 	public void testRestoreBadData() {}


### PR DESCRIPTION
Remove superfluous try catch blocks from `Jedis*Commands` with `JedisInvoker`. Refactor `Converters` and `JedisConverters` to use less indirections and use lambdas/method references where possible.

Closes #1951