### PR TITLE
DATAREDIS-1955 - Phantom copy is not persisted when entity ttl is changed from positive to negative, causing phantom copy not updated to no expire and counting down, then RedisKeyExpiredEvent publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-DATAREDIS-1955-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -99,6 +99,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Andrey Muchnik
  * @since 1.7
  */
 public class RedisKeyValueAdapter extends AbstractKeyValueAdapter

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -248,6 +248,11 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 				}
 			}
 
+			boolean isNoExpire = rdo.getTimeToLive() == null || rdo.getTimeToLive() != null && rdo.getTimeToLive() < 0;
+			if (isNoExpire && !isNew && keepShadowCopy()){
+				connection.persist(ByteUtils.concat(objectKey, BinaryKeyspaceIdentifier.PHANTOM_SUFFIX));
+			}
+
 			connection.sAdd(toBytes(rdo.getKeyspace()), key);
 
 			IndexWriter indexWriter = new IndexWriter(connection, converter);

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -251,7 +251,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 
 			boolean isNoExpire = rdo.getTimeToLive() == null || rdo.getTimeToLive() != null && rdo.getTimeToLive() < 0;
 			if (isNoExpire && !isNew && keepShadowCopy()){
-				connection.persist(ByteUtils.concat(objectKey, BinaryKeyspaceIdentifier.PHANTOM_SUFFIX));
+				connection.del(ByteUtils.concat(objectKey, BinaryKeyspaceIdentifier.PHANTOM_SUFFIX));
 			}
 
 			connection.sAdd(toBytes(rdo.getKeyspace()), key);
@@ -498,7 +498,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 				} else {
 
 					connection.persist(redisKey);
-					connection.persist(ByteUtils.concat(redisKey, BinaryKeyspaceIdentifier.PHANTOM_SUFFIX));
+					connection.del(ByteUtils.concat(redisKey, BinaryKeyspaceIdentifier.PHANTOM_SUFFIX));
 				}
 			}
 

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -705,6 +705,22 @@ public class RedisKeyValueAdapterTests {
 		assertThat(template.hasKey("persons:1:phantom")).isTrue();
 	}
 
+	@Test // DATAREDIS-1955
+	void phantomKeyNotPersistedWhenPutWithNegativeTimeToLiveAndOldEntryTimeToLiveWasPositiveAndWhenShadowCopyIsTurnedOn() {
+		ExpiringPerson rand = new ExpiringPerson();
+		rand.ttl = 3000L;
+
+		adapter.put("1", rand, "persons");
+
+		assertThat(template.getExpire("persons:1:phantom")).isPositive();
+
+		rand.ttl = -1L;
+
+		adapter.put("1", rand, "persons");
+
+		assertThat(template.getExpire("persons:1:phantom")).isEqualTo(-1L);
+	}
+
 	/**
 	 * Wait up to 5 seconds until {@code key} is no longer available in Redis.
 	 *

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -54,6 +54,7 @@ import org.springframework.data.redis.test.condition.EnabledIfLongRunningTest;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Andrey Muchnik
  */
 @ExtendWith(LettuceConnectionFactoryExtension.class)
 public class RedisKeyValueAdapterTests {


### PR DESCRIPTION
DATAREDIS-1955 - Phantom copy is not persisted when entity ttl is changed from positive to negative, causing phantom copy not updated to no expire and counting down, then RedisKeyExpiredEvent publishing.

When updating an object that has a positive time to live to a negative time to live you must persist the phantom key.
Otherwise, after expiring time to live of the phantom, which was created when object with a positive time to live was saved - the indices are dropped and the keys are deleted from the sets as if entity is expired.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
