### PR TITLE
Support LPOS command via Jedis. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-1957-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterListCommands.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.params.LPosParams;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.springframework.dao.DataAccessException;
-import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.RedisListCommands;
 import org.springframework.data.redis.connection.jedis.JedisClusterConnection.JedisMultiKeyClusterCommandCallback;
@@ -68,7 +69,22 @@ class JedisClusterListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(element, "Element must not be null!");
 
-		throw new InvalidDataAccessApiUsageException("LPOS is not supported by jedis.");
+		LPosParams params = new LPosParams();
+		if (rank != null) {
+			params.rank(rank);
+		}
+
+		try {
+
+			if (count != null) {
+				return connection.getCluster().lpos(key, element, params, count);
+			}
+
+			Long value = connection.getCluster().lpos(key, element, params);
+			return value != null ? Collections.singletonList(value) : Collections.emptyList();
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
+		}
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisListCommands.java
@@ -19,12 +19,14 @@ import redis.clients.jedis.BinaryJedis;
 import redis.clients.jedis.MultiKeyPipelineBase;
 import redis.clients.jedis.Protocol;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.RedisListCommands;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import redis.clients.jedis.params.LPosParams;
 
 /**
  * @author Christoph Strobl
@@ -61,7 +63,16 @@ class JedisListCommands implements RedisListCommands {
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(element, "Element must not be null!");
 
-		throw new InvalidDataAccessApiUsageException("LPOS is not supported by jedis.");
+		LPosParams params = new LPosParams();
+		if(rank != null) {
+			params.rank(rank);
+		}
+
+		if(count != null) {
+			return connection.invoke().just(BinaryJedis::lpos, MultiKeyPipelineBase::lpos, key, element, params, count);
+		}
+
+		return connection.invoke().from(BinaryJedis::lpos, MultiKeyPipelineBase::lpos, key, element, params).get(Collections::singletonList);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisListCommands.java
@@ -72,7 +72,7 @@ class JedisListCommands implements RedisListCommands {
 			return connection.invoke().just(BinaryJedis::lpos, MultiKeyPipelineBase::lpos, key, element, params, count);
 		}
 
-		return connection.invoke().from(BinaryJedis::lpos, MultiKeyPipelineBase::lpos, key, element, params).get(Collections::singletonList);
+		return connection.invoke().from(BinaryJedis::lpos, MultiKeyPipelineBase::lpos, key, element, params).getOrElse(Collections::singletonList, Collections::emptyList);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceListCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceListCommands.java
@@ -71,7 +71,7 @@ class LettuceListCommands implements RedisListCommands {
 			return connection.invoke().just(RedisListAsyncCommands::lpos, key, element, count, args);
 		}
 
-		return connection.invoke().from(RedisListAsyncCommands::lpos, key, element, args).get(Collections::singletonList);
+		return connection.invoke().from(RedisListAsyncCommands::lpos, key, element, args).getOrElse(Collections::singletonList, Collections::emptyList);
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -1464,6 +1464,16 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((List<Long>) getResults().get(1)).containsExactly(2L, 6L, 7L);
 	}
 
+	@Test // GH-1957
+	@EnabledOnCommand("LPOS")
+	void lPosNonExisting() {
+
+		actual.add(connection.rPush("mylist", "a", "b", "c", "1", "2", "3", "c", "c"));
+		actual.add(connection.lPos("mylist", "x", null, null));
+
+		assertThat((List<Long>) getResults().get(1)).isEmpty();
+	}
+
 	// Set operations
 
 	@Test

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -1404,9 +1404,8 @@ public abstract class AbstractConnectionIntegrationTests {
 		verifyResults(Arrays.asList(2L, Arrays.asList("baz", "bar")));
 	}
 
-	@Test // DATAREDIS-1196
+	@Test // DATAREDIS-1196, GH-1957
 	@EnabledOnCommand("LPOS")
-	@EnabledOnRedisDriver({ RedisDriver.LETTUCE })
 	void lPos() {
 
 		actual.add(connection.rPush("mylist", "a", "b", "c", "1", "2", "3", "c", "c"));
@@ -1415,9 +1414,8 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((List<Long>) getResults().get(1)).containsOnly(2L);
 	}
 
-	@Test // DATAREDIS-1196
+	@Test // DATAREDIS-1196, GH-1957
 	@EnabledOnCommand("LPOS")
-	@EnabledOnRedisDriver({ RedisDriver.LETTUCE })
 	void lPosRank() {
 
 		actual.add(connection.rPush("mylist", "a", "b", "c", "1", "2", "3", "c", "c"));
@@ -1426,9 +1424,8 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((List<Long>) getResults().get(1)).containsExactly(6L);
 	}
 
-	@Test // DATAREDIS-1196
+	@Test // DATAREDIS-1196, GH-1957
 	@EnabledOnCommand("LPOS")
-	@EnabledOnRedisDriver({ RedisDriver.LETTUCE })
 	void lPosNegativeRank() {
 
 		actual.add(connection.rPush("mylist", "a", "b", "c", "1", "2", "3", "c", "c"));
@@ -1437,9 +1434,8 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((List<Long>) getResults().get(1)).containsExactly(7L);
 	}
 
-	@Test // DATAREDIS-1196
+	@Test // DATAREDIS-1196, GH-1957
 	@EnabledOnCommand("LPOS")
-	@EnabledOnRedisDriver({ RedisDriver.LETTUCE })
 	void lPosCount() {
 
 		actual.add(connection.rPush("mylist", "a", "b", "c", "1", "2", "3", "c", "c"));
@@ -1448,9 +1444,8 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((List<Long>) getResults().get(1)).containsExactly(2L, 6L);
 	}
 
-	@Test // DATAREDIS-1196
+	@Test // DATAREDIS-1196, GH-1957
 	@EnabledOnCommand("LPOS")
-	@EnabledOnRedisDriver({ RedisDriver.LETTUCE })
 	void lPosRankCount() {
 
 		actual.add(connection.rPush("mylist", "a", "b", "c", "1", "2", "3", "c", "c"));
@@ -1459,9 +1454,8 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat((List<Long>) getResults().get(1)).containsExactly(7L, 6L);
 	}
 
-	@Test // DATAREDIS-1196
+	@Test // DATAREDIS-1196, GH-1957
 	@EnabledOnCommand("LPOS")
-	@EnabledOnRedisDriver({ RedisDriver.LETTUCE })
 	void lPosCountZero() {
 
 		actual.add(connection.rPush("mylist", "a", "b", "c", "1", "2", "3", "c", "c"));

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -2534,4 +2534,14 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 
 		assertThat(result).containsExactly(2L, 6L, 7L);
 	}
+
+	@Test // GH-1957
+	@EnabledOnCommand("LPOS")
+	void lPosNonExisting() {
+
+		nativeConnection.rpush(KEY_1, "a", "b", "c", "1", "2", "3", "c", "c");
+		List<Long> result = clusterConnection.listCommands().lPos(KEY_1_BYTES, "x".getBytes(StandardCharsets.UTF_8), null, null);
+
+		assertThat(result).isEmpty();
+	}
 }


### PR DESCRIPTION
This PR introduces support for the `LPOS` command when using the Jedis Redis driver and ensures an empty `List` is returned in the case the member does not exist in the target key.

Closes: #1957 