### PR TITLE
Replace poll and assert with await for Pub/Sub tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.0-GH-1834-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
+++ b/src/test/java/org/springframework/data/redis/core/AbstractOperationsTestParams.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.data.redis.core;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.springframework.data.redis.DoubleObjectFactory;
 import org.springframework.data.redis.LongObjectFactory;
@@ -27,6 +29,8 @@ import org.springframework.data.redis.RawObjectFactory;
 import org.springframework.data.redis.StringObjectFactory;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.extension.JedisConnectionFactoryExtension;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.extension.LettuceConnectionFactoryExtension;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
@@ -47,7 +51,11 @@ abstract public class AbstractOperationsTestParams {
 
 	// DATAREDIS-241
 	public static Collection<Object[]> testParams() {
-		return testParams(JedisConnectionFactoryExtension.getConnectionFactory(RedisStanalone.class));
+
+		List<Object[]> params = new ArrayList<>();
+		params.addAll(testParams(LettuceConnectionFactoryExtension.getConnectionFactory(RedisStanalone.class)));
+		params.addAll(testParams(JedisConnectionFactoryExtension.getConnectionFactory(RedisStanalone.class)));
+		return params;
 	}
 
 	// DATAREDIS-241

--- a/src/test/java/org/springframework/data/redis/listener/PubSubTestParams.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubTestParams.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import org.springframework.data.redis.ObjectFactory;
 import org.springframework.data.redis.Person;
 import org.springframework.data.redis.PersonObjectFactory;
-import org.springframework.data.redis.RawObjectFactory;
 import org.springframework.data.redis.StringObjectFactory;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.extension.JedisConnectionFactoryExtension;
@@ -44,7 +43,6 @@ public class PubSubTestParams {
 		// create Jedis Factory
 		ObjectFactory<String> stringFactory = new StringObjectFactory();
 		ObjectFactory<Person> personFactory = new PersonObjectFactory();
-		ObjectFactory<byte[]> rawFactory = new RawObjectFactory();
 
 		JedisConnectionFactory jedisConnFactory = JedisConnectionFactoryExtension
 				.getNewConnectionFactory(RedisStanalone.class);
@@ -78,7 +76,6 @@ public class PubSubTestParams {
 		parameters.add(new Object[] { personFactory, personTemplate });
 		parameters.add(new Object[] { stringFactory, stringTemplateLtc });
 		parameters.add(new Object[] { personFactory, personTemplateLtc });
-		parameters.add(new Object[] { rawFactory, rawTemplateLtc });
 
 		if (clusterAvailable()) {
 

--- a/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
@@ -17,12 +17,12 @@ package org.springframework.data.redis.listener;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assumptions.*;
+import static org.awaitility.Awaitility.*;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.Phaser;
@@ -108,7 +108,7 @@ public class PubSubTests<T> {
 		container.start();
 
 		phaser.arriveAndAwaitAdvance();
-		Thread.sleep(50);
+		Thread.sleep(250);
 	}
 
 	@AfterEach
@@ -134,11 +134,7 @@ public class PubSubTests<T> {
 		template.convertAndSend(CHANNEL, payload1);
 		template.convertAndSend(CHANNEL, payload2);
 
-		Set<T> set = new LinkedHashSet<>();
-		set.add((T) bag.poll(1, TimeUnit.SECONDS));
-		set.add((T) bag.poll(1, TimeUnit.SECONDS));
-
-		assertThat(set).contains(payload1, payload2);
+		await().atMost(Duration.ofSeconds(2)).until(() -> bag.contains(payload1) && bag.contains(payload2));
 	}
 
 	@ParameterizedRedisTest
@@ -192,10 +188,7 @@ public class PubSubTests<T> {
 
 		template.convertAndSend(CHANNEL, payload);
 
-		Set<T> set = new LinkedHashSet<>();
-		set.add((T) bag.poll(3, TimeUnit.SECONDS));
-
-		assertThat(set).contains(payload);
+		await().atMost(Duration.ofSeconds(2)).until(() -> bag.contains(payload));
 	}
 
 	private static boolean isClusterAware(RedisConnectionFactory connectionFactory) {


### PR DESCRIPTION
We now await until a message has arrived in our pub/sub tests. Previously, we polled the message listener which could lead to false positives by delayed messages.

We also exclude raw (byte-array) cases as byte arrays cannot be easily checked for equality without further instrumentation.