### PR TITLE
Use Jedis SetParams.KEEPTTL instead of injecting byte[] args

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -88,6 +88,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @author Ninad Divadkar
  * @author Guy Korland
+ * @author dengliming
  */
 public abstract class JedisConverters extends Converters {
 
@@ -424,21 +425,7 @@ public abstract class JedisConverters extends Converters {
 		SetParams paramsToUse = params == null ? SetParams.setParams() : params;
 
 		if (expiration.isKeepTtl()) {
-
-			// TODO: remove once jedis supports KEEPTTL (https://github.com/xetorthio/jedis/issues/2248)
-			return new SetParams() {
-
-				@Override
-				public byte[][] getByteParams(byte[]... args) {
-
-					ArrayList<byte[]> byteParams = new ArrayList<>();
-					for (byte[] arg : paramsToUse.getByteParams(args)) {
-						byteParams.add(arg);
-					}
-					byteParams.add(SafeEncoder.encode("keepttl"));
-					return byteParams.toArray(new byte[byteParams.size()][]);
-				}
-			};
+			return paramsToUse.keepttl();
 		}
 
 		if (!expiration.isPersistent()) {
@@ -700,7 +687,7 @@ public abstract class JedisConverters extends Converters {
 	/**
 	 * Convert given {@link BitFieldSubCommands} into argument array.
 	 *
-	 * @param bitfieldOperation
+	 * @param source
 	 * @return never {@literal null}.
 	 * @since 1.8
 	 */


### PR DESCRIPTION
Currently jedis already support `KEEPTTL ` command. So we optimize the convert code.
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
