### PR TITLE
Consider target type when calling getAllOf(…)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-1995-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 
@@ -16,7 +18,7 @@
 	</parent>
 
 	<properties>
-		<springdata.keyvalue>2.5.0-SNAPSHOT</springdata.keyvalue>
+		<springdata.keyvalue>2.5.0-GH-1995-SNAPSHOT</springdata.keyvalue>
 		<awaitility>4.0.2</awaitility>
 		<jta>1.1</jta>
 		<beanutils>1.9.2</beanutils>

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -373,16 +373,21 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 	 */
 	@Override
 	public List<?> getAllOf(String keyspace) {
-		return getAllOf(keyspace, -1, -1);
+		return getAllOf(keyspace, Object.class, -1, -1);
 	}
 
-	public List<?> getAllOf(String keyspace, long offset, int rows) {
+	@Override
+	public <T> Iterable<T> getAllOf(String keyspace, Class<T> type) {
+		return getAllOf(keyspace, type, -1, -1);
+	}
+
+	public <T> List<T> getAllOf(String keyspace, Class<T> type, long offset, int rows) {
 
 		byte[] binKeyspace = toBytes(keyspace);
 
 		Set<byte[]> ids = redisOps.execute((RedisCallback<Set<byte[]>>) connection -> connection.sMembers(binKeyspace));
 
-		List<Object> result = new ArrayList<>();
+		List<T> result = new ArrayList<>();
 		List<byte[]> keys = new ArrayList<>(ids);
 
 		if (keys.isEmpty() || keys.size() < offset) {
@@ -395,7 +400,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 		}
 
 		for (byte[] key : keys) {
-			result.add(get(key, keyspace));
+			result.add(get(key, keyspace, type));
 		}
 		return result;
 	}

--- a/src/main/java/org/springframework/data/redis/core/RedisQueryEngine.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisQueryEngine.java
@@ -80,7 +80,7 @@ class RedisQueryEngine extends QueryEngine<RedisKeyValueAdapter, RedisOperationC
 		if (criteria == null
 				|| (CollectionUtils.isEmpty(criteria.getOrSismember()) && CollectionUtils.isEmpty(criteria.getSismember()))
 						&& criteria.getNear() == null) {
-			return (Collection<T>) getAdapter().getAllOf(keyspace, offset, rows);
+			return getAdapter().getAllOf(keyspace, type, offset, rows);
 		}
 
 		RedisCallback<Map<byte[], Map<byte[], byte[]>>> callback = connection -> {


### PR DESCRIPTION
We now accept a type hint when calling `getAllOf(…)` to avoid materializing null instances when the actual type-hint cannot resolve to an entity.

Closes #1995
Depends on https://github.com/spring-projects/spring-data-keyvalue/pull/356