### PR TITLE
Pass-thru byte arrays in entities into `Bucket`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-1981-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -3,6 +3,11 @@
 
 This section briefly covers items that are new and noteworthy in the latest releases.
 
+[[new-in-2.5.0]]
+== New in Spring Data Redis 2.5
+
+* `MappingRedisConverter` no longer converts <<redis.repositories.mapping,byte arrays to a collection>> representation.
+
 [[new-in-2.4.0]]
 == New in Spring Data Redis 2.4
 

--- a/src/main/asciidoc/reference/redis-repositories.adoc
+++ b/src/main/asciidoc/reference/redis-repositories.adoc
@@ -131,6 +131,10 @@ The following table describes the default mapping rules:
 | String firstname = "rand";
 | firstname = "rand"
 
+| Byte array (`byte[]`)
+| byte[] image = "rand".getBytes();
+| image = "rand"
+
 | Complex Type +
 (for example, Address)
 | Address address = new Address("emond's field");

--- a/src/main/java/org/springframework/data/redis/core/convert/Bucket.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/Bucket.java
@@ -97,7 +97,7 @@ public class Bucket {
 	/**
 	 * Get value assigned with path.
 	 *
-	 * @param path path must not be {@literal null} or {@link String#isEmpty()}.
+	 * @param path must not be {@literal null} or {@link String#isEmpty()}.
 	 * @return {@literal null} if not set.
 	 */
 	@Nullable
@@ -105,6 +105,17 @@ public class Bucket {
 
 		Assert.hasText(path, "Path to property must not be null or empty.");
 		return data.get(path);
+	}
+
+	/**
+	 * Return whether {@code path} is associated with a non-{@code null} value.
+	 *
+	 * @param path must not be {@literal null} or {@link String#isEmpty()}.
+	 * @return {@literal true} if the {@code path} is associated with a non-{@code null} value.
+	 * @since 2.5
+	 */
+	public boolean hasValue(String path) {
+		return get(path) != null;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
@@ -203,6 +203,7 @@ public class ConversionTestEntities {
 		String[] arrayOfSimpleTypes;
 		Species[] arrayOfCompexTypes;
 		int[] arrayOfPrimitives;
+		byte[] avatar;
 	}
 
 	static class TypeWithObjectValueTypes {


### PR DESCRIPTION
`MappingRedisConverter` now accepts data for byte arrays as single property to avoid flattening out binary data into a collection form. We still accept data in a collection form to retain compatibility.

Closes #1981.