### PR TITLE
Revise RedisCache and documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.0-GH-1721-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/reference/redis-cache.adoc
+++ b/src/main/asciidoc/reference/redis-cache.adoc
@@ -1,0 +1,128 @@
+[[redis:support:cache-abstraction]]
+== Redis Cache
+
+NOTE: Changed in 2.0
+
+Spring Redis provides an implementation for the Spring https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/integration.html#cache[cache abstraction] through the `org.springframework.data.redis.cache` package. To use Redis as a backing implementation, add `RedisCacheManager` to your configuration, as follows:
+
+[source,java]
+----
+@Bean
+public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+	return RedisCacheManager.create(connectionFactory);
+}
+----
+
+`RedisCacheManager` behavior can be configured with `RedisCacheManagerBuilder`, letting you set the default `RedisCacheConfiguration`, transaction behavior, and predefined caches.
+
+[source,java]
+----
+RedisCacheManager cm = RedisCacheManager.builder(connectionFactory)
+	.cacheDefaults(defaultCacheConfig())
+	.withInitialCacheConfigurations(singletonMap("predefined", defaultCacheConfig().disableCachingNullValues()))
+	.transactionAware()
+	.build();
+----
+
+As shown in the preceding example, `RedisCacheManager` allows definition of configurations on a per-cache basis.
+
+The behavior of `RedisCache` created with `RedisCacheManager` is defined with `RedisCacheConfiguration`. The configuration lets you set key expiration times, prefixes, and ``RedisSerializer`` implementations for converting to and from the binary storage format, as shown in the following example:
+
+[source,java]
+----
+RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+    .entryTtl(Duration.ofSeconds(1))
+	.disableCachingNullValues();
+----
+
+`RedisCacheManager` defaults to a lock-free `RedisCacheWriter` for reading and writing binary values. Lock-free caching improves throughput. The lack of entry locking can lead to overlapping, non-atomic commands for the `putIfAbsent` and `clean` methods, as those require multiple commands to be sent to Redis. The locking counterpart prevents command overlap by setting an explicit lock key and checking against presence of this key, which leads to additional requests and potential command wait times.
+
+It is possible to opt in to the locking behavior as follows:
+
+[source,java]
+----
+RedisCacheManager cm = RedisCacheManager.build(RedisCacheWriter.lockingRedisCacheWriter(connectionFactory))
+	.cacheDefaults(defaultCacheConfig())
+	...
+----
+
+By default, any `key` for a cache entry gets prefixed with the actual cache name followed by two colons.
+This behavior can be changed to a static as well as a computed prefix.
+
+The following example shows how to set a static prefix:
+
+[source,java]
+----
+// static key prefix
+RedisCacheConfiguration.defaultCacheConfig().prefixKeysWith("( ͡° ᴥ ͡°)");
+
+The following example shows how to set a computed prefix:
+
+// computed key prefix
+RedisCacheConfiguration.defaultCacheConfig().computePrefixWith(cacheName -> "¯\_(ツ)_/¯" + cacheName);
+----
+
+The cache implementation defaults to use `KEYS` and `DEL` to clear the cache. `KEYS` can cause performance issues with large keyspaces. Therefore, the default `RedisCacheWriter` can be created with a `BatchStrategy` to switch to a `SCAN`-based batch strategy. The `SCAN` strategy requires a batch size to avoid excessive Redis command roundtrips:
+
+[source,java]
+----
+RedisCacheManager cm = RedisCacheManager.build(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory, BatchStrategy.scan(1000)))
+	.cacheDefaults(defaultCacheConfig())
+	...
+----
+
+NOTE: The `KEYS` batch strategy is fully supported using any driver and Redis operation mode (Standalone, Clustered). `SCAN` is fully supported when using the Lettuce driver. Jedis supports `SCAN` only in non-clustered modes.
+
+The following table lists the default settings for `RedisCacheManager`:
+
+.`RedisCacheManager` defaults
+[width="80%",cols="<1,<2",options="header"]
+|====
+|Setting
+|Value
+
+|Cache Writer
+|Non-locking, `KEYS` batch strategy
+
+|Cache Configuration
+|`RedisCacheConfiguration#defaultConfiguration`
+
+|Initial Caches
+|None
+
+|Transaction Aware
+|No
+|====
+
+The following table lists the default settings for `RedisCacheConfiguration`:
+
+.RedisCacheConfiguration defaults
+[width="80%",cols="<1,<2",options="header"]
+|====
+|Key Expiration
+|None
+
+|Cache `null`
+|Yes
+
+|Prefix Keys
+|Yes
+
+|Default Prefix
+|The actual cache name
+
+|Key Serializer
+|`StringRedisSerializer`
+
+|Value Serializer
+|`JdkSerializationRedisSerializer`
+
+|Conversion Service
+|`DefaultFormattingConversionService` with default cache key converters
+|====
+
+[NOTE]
+====
+By default `RedisCache`, statistics are disabled.
+Use `RedisCacheManagerBuilder.enableStatistics()` to collect local _hits_ and _misses_ through  `RedisCache#getStatistics()`, returning a snapshot of the collected data.
+====

--- a/src/main/asciidoc/reference/redis-cache.adoc
+++ b/src/main/asciidoc/reference/redis-cache.adoc
@@ -35,7 +35,11 @@ RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
 	.disableCachingNullValues();
 ----
 
-`RedisCacheManager` defaults to a lock-free `RedisCacheWriter` for reading and writing binary values. Lock-free caching improves throughput. The lack of entry locking can lead to overlapping, non-atomic commands for the `putIfAbsent` and `clean` methods, as those require multiple commands to be sent to Redis. The locking counterpart prevents command overlap by setting an explicit lock key and checking against presence of this key, which leads to additional requests and potential command wait times.
+`RedisCacheManager` defaults to a lock-free `RedisCacheWriter` for reading and writing binary values.
+Lock-free caching improves throughput.
+The lack of entry locking can lead to overlapping, non-atomic commands for the `putIfAbsent` and `clean` methods, as those require multiple commands to be sent to Redis. The locking counterpart prevents command overlap by setting an explicit lock key and checking against presence of this key, which leads to additional requests and potential command wait times.
+
+Locking applies on the *cache level*, not per *cache entry*.
 
 It is possible to opt in to the locking behavior as follows:
 

--- a/src/main/asciidoc/reference/redis-cache.adoc
+++ b/src/main/asciidoc/reference/redis-cache.adoc
@@ -26,7 +26,7 @@ RedisCacheManager cm = RedisCacheManager.builder(connectionFactory)
 
 As shown in the preceding example, `RedisCacheManager` allows definition of configurations on a per-cache basis.
 
-The behavior of `RedisCache` created with `RedisCacheManager` is defined with `RedisCacheConfiguration`. The configuration lets you set key expiration times, prefixes, and ``RedisSerializer`` implementations for converting to and from the binary storage format, as shown in the following example:
+The behavior of `RedisCache` created with `RedisCacheManager` is defined with `RedisCacheConfiguration`. The configuration lets you set key expiration times, prefixes, and `RedisSerializer` implementations for converting to and from the binary storage format, as shown in the following example:
 
 [source,java]
 ----
@@ -70,7 +70,7 @@ The cache implementation defaults to use `KEYS` and `DEL` to clear the cache. `K
 
 [source,java]
 ----
-RedisCacheManager cm = RedisCacheManager.build(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory, BatchStrategy.scan(1000)))
+RedisCacheManager cm = RedisCacheManager.build(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory, BatchStrategies.scan(1000)))
 	.cacheDefaults(defaultCacheConfig())
 	...
 ----

--- a/src/main/asciidoc/reference/redis.adoc
+++ b/src/main/asciidoc/reference/redis.adoc
@@ -652,6 +652,8 @@ include::{referenceDir}/pipelining.adoc[]
 
 include::{referenceDir}/redis-scripting.adoc[]
 
+include::{referenceDir}/redis-cache.adoc[]
+
 :leveloffset: 1
 [[redis:support]]
 == Support Classes
@@ -693,120 +695,3 @@ public class AnotherExample {
 
 As shown in the preceding example, the consuming code is decoupled from the actual storage implementation. In fact, there is no indication that Redis is used underneath. This makes moving from development to production environments transparent and highly increases testability (the Redis implementation can be replaced with an in-memory one).
 
-[[redis:support:cache-abstraction]]
-=== Support for the Spring Cache Abstraction
-
-NOTE: Changed in 2.0
-
-Spring Redis provides an implementation for the Spring https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/integration.html#cache[cache abstraction] through the `org.springframework.data.redis.cache` package. To use Redis as a backing implementation, add `RedisCacheManager` to your configuration, as follows:
-
-[source,java]
-----
-@Bean
-public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-	return RedisCacheManager.create(connectionFactory);
-}
-----
-
-`RedisCacheManager` behavior can be configured with `RedisCacheManagerBuilder`, letting you set the default `RedisCacheConfiguration`, transaction behavior, and predefined caches.
-
-[source,java]
-----
-RedisCacheManager cm = RedisCacheManager.builder(connectionFactory)
-	.cacheDefaults(defaultCacheConfig())
-	.withInitialCacheConfigurations(singletonMap("predefined", defaultCacheConfig().disableCachingNullValues()))
-	.transactionAware()
-	.build();
-----
-
-As shown in the preceding example, `RedisCacheManager` allows definition of configurations on a per-cache basis.
-
-The behavior of `RedisCache` created with `RedisCacheManager` is defined with `RedisCacheConfiguration`. The configuration lets you set key expiration times, prefixes, and ``RedisSerializer`` implementations for converting to and from the binary storage format, as shown in the following example:
-
-[source,java]
-----
-RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-    .entryTtl(Duration.ofSeconds(1))
-	.disableCachingNullValues();
-----
-
-`RedisCacheManager` defaults to a lock-free `RedisCacheWriter` for reading and writing binary values. Lock-free caching improves throughput. The lack of entry locking can lead to overlapping, non-atomic commands for the `putIfAbsent` and `clean` methods, as those require multiple commands to be sent to Redis. The locking counterpart prevents command overlap by setting an explicit lock key and checking against presence of this key, which leads to additional requests and potential command wait times.
-
-It is possible to opt in to the locking behavior as follows:
-
-[source,java]
-----
-RedisCacheManager cm = RedisCacheManager.build(RedisCacheWriter.lockingRedisCacheWriter())
-	.cacheDefaults(defaultCacheConfig())
-	...
-----
-
-By default, any `key` for a cache entry gets prefixed with the actual cache name followed by two colons.
-This behavior can be changed to a static as well as a computed prefix.
-
-The following example shows how to set a static prefix:
-
-[source,java]
-----
-// static key prefix
-RedisCacheConfiguration.defaultCacheConfig().prefixKeysWith("( ͡° ᴥ ͡°)");
-
-The following example shows how to set a computed prefix:
-
-// computed key prefix
-RedisCacheConfiguration.defaultCacheConfig().computePrefixWith(cacheName -> "¯\_(ツ)_/¯" + cacheName);
-----
-
-The following table lists the default settings for `RedisCacheManager`:
-
-.`RedisCacheManager` defaults
-[width="80%",cols="<1,<2",options="header"]
-|====
-|Setting
-|Value
-
-|Cache Writer
-|Non-locking
-
-|Cache Configuration
-|`RedisCacheConfiguration#defaultConfiguration`
-
-|Initial Caches
-|None
-
-|Transaction Aware
-|No
-|====
-
-The following table lists the default settings for `RedisCacheConfiguration`:
-
-.RedisCacheConfiguration defaults
-[width="80%",cols="<1,<2",options="header"]
-|====
-|Key Expiration
-|None
-
-|Cache `null`
-|Yes
-
-|Prefix Keys
-|Yes
-
-|Default Prefix
-|The actual cache name
-
-|Key Serializer
-|`StringRedisSerializer`
-
-|Value Serializer
-|`JdkSerializationRedisSerializer`
-
-|Conversion Service
-|`DefaultFormattingConversionService` with default cache key converters
-|====
-
-[NOTE]
-====
-By default `RedisCache`, statistics are disabled.
-Use `RedisCacheManagerBuilder.enableStatistics()` to collect local _hits_ and _misses_ through  `RedisCache#getStatistics()`, returning a snapshot of the collected data.
-====

--- a/src/main/java/org/springframework/data/redis/cache/BatchStrategies.java
+++ b/src/main/java/org/springframework/data/redis/cache/BatchStrategies.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.cache;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.util.Assert;
+
+/**
+ * A collection of predefined {@link BatchStrategy} implementations using {@code KEYS} or {@code SCAN} command.
+ *
+ * @author Mark Paluch
+ * @author Christoph Strobl
+ * @since 2.6
+ */
+public abstract class BatchStrategies {
+
+	/**
+	 * A {@link BatchStrategy} using a single {@code KEYS} and {@code DEL} command to remove all matching keys.
+	 * {@code KEYS} scans the entire keyspace of the Redis database and can block the Redis worker thread for a long time
+	 * on large keyspaces.
+	 * <p/>
+	 * {@code KEYS} is supported for standalone and clustered (sharded) Redis operation modes.
+	 *
+	 * @return batching strategy using {@code KEYS}.
+	 */
+	public static BatchStrategy keys() {
+		return Keys.INSTANCE;
+	}
+
+	/**
+	 * A {@link BatchStrategy} using a {@code SCAN} cursors and potentially multiple {@code DEL} commands to remove all
+	 * matching keys. This strategy allows a configurable batch size to optimize for scan batching.
+	 * <p/>
+	 * Note that using the {@code SCAN} strategy might be not supported on all drivers and Redis operation modes.
+	 *
+	 * @return batching strategy using {@code SCAN}.
+	 */
+	public static BatchStrategy scan(int batchSize) {
+
+		Assert.isTrue(batchSize > 0, "Batch size must be greater than zero!");
+
+		return new Scan(batchSize);
+	}
+
+	/**
+	 * {@link BatchStrategy} using {@code KEYS}.
+	 */
+	static class Keys implements BatchStrategy {
+
+		static Keys INSTANCE = new Keys();
+
+		@Override
+		public long cleanCache(RedisConnection connection, String name, byte[] pattern) {
+
+			byte[][] keys = Optional.ofNullable(connection.keys(pattern)).orElse(Collections.emptySet())
+					.toArray(new byte[0][]);
+
+			if (keys.length > 0) {
+				connection.del(keys);
+			}
+
+			return keys.length;
+		}
+	}
+
+	/**
+	 * {@link BatchStrategy} using {@code SCAN}.
+	 */
+	static class Scan implements BatchStrategy {
+
+		private final int batchSize;
+
+		Scan(int batchSize) {
+			this.batchSize = batchSize;
+		}
+
+		@Override
+		public long cleanCache(RedisConnection connection, String name, byte[] pattern) {
+
+			Cursor<byte[]> cursor = connection.scan(ScanOptions.scanOptions().count(batchSize).match(pattern).build());
+
+			long count = 0;
+
+			PartitionIterator<byte[]> partitions = new PartitionIterator<>(cursor, batchSize);
+			while (partitions.hasNext()) {
+
+				List<byte[]> keys = partitions.next();
+				count += keys.size();
+
+				if (keys.size() > 0) {
+					connection.del(keys.toArray(new byte[0][]));
+				}
+			}
+
+			return count;
+		}
+	}
+
+	/**
+	 * Utility to split and buffer outcome from a {@link Iterator} into {@link List lists} of {@code T} with a maximum
+	 * chunks {@code size}.
+	 *
+	 * @param <T>
+	 */
+	static class PartitionIterator<T> implements Iterator<List<T>> {
+
+		private final Iterator<T> iterator;
+		private final int size;
+
+		PartitionIterator(Iterator<T> iterator, int size) {
+
+			this.iterator = iterator;
+			this.size = size;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return iterator.hasNext();
+		}
+
+		@Override
+		public List<T> next() {
+
+			if (!hasNext()) {
+				throw new NoSuchElementException();
+			}
+
+			List<T> list = new ArrayList<>(size);
+			while (list.size() < size && iterator.hasNext()) {
+				list.add(iterator.next());
+			}
+
+			return list;
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/redis/cache/BatchStrategy.java
+++ b/src/main/java/org/springframework/data/redis/cache/BatchStrategy.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.cache;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.util.Assert;
+
+/**
+ * Batch strategies to be used with {@link RedisCacheWriter}.
+ * <p/>
+ * Primarily used to clear the cache.
+ *
+ * @author Mark Paluch
+ * @since 2.6
+ */
+public abstract class BatchStrategy {
+
+	/**
+	 * Batching strategy using a single {@code KEYS} and {@code DEL} command to remove all matching keys. {@code KEYS}
+	 * scans the entire keyspace of the Redis database and can block the Redis worker thread for a long time when the
+	 * keyspace has a significant size.
+	 * <p/>
+	 * {@code KEYS} is supported for standalone and clustered (sharded) Redis operation modes.
+	 *
+	 * @return batching strategy using {@code KEYS}.
+	 */
+	public static BatchStrategy keys() {
+		return Keys.INSTANCE;
+	}
+
+	/**
+	 * Batching strategy using a {@code SCAN} cursors and potentially multiple {@code DEL} commands to remove all matching
+	 * keys. This strategy allows a configurable batch size to optimize for scan batching.
+	 * <p/>
+	 * Note that using the {@code SCAN} strategy might be not supported on all drivers and Redis operation modes.
+	 *
+	 * @return batching strategy using {@code SCAN}.
+	 */
+	public static BatchStrategy scan(int batchSize) {
+
+		Assert.isTrue(batchSize > 0, "Batch size must be greater than zero");
+
+		return new Scan(batchSize);
+	}
+
+	/**
+	 * Remove all keys following the given pattern.
+	 *
+	 * @param the connection to use.
+	 * @param name The cache name must not be {@literal null}.
+	 * @param pattern The pattern for the keys to remove. Must not be {@literal null}.
+	 * @return number of removed keys.
+	 */
+	abstract int cleanCache(RedisConnection connection, String name, byte[] pattern);
+
+	/**
+	 * {@link BatchStrategy} using {@code KEYS}.
+	 */
+	static class Keys extends BatchStrategy {
+
+		static Keys INSTANCE = new Keys();
+
+		@Override
+		int cleanCache(RedisConnection connection, String name, byte[] pattern) {
+
+			byte[][] keys = Optional.ofNullable(connection.keys(pattern)).orElse(Collections.emptySet())
+					.toArray(new byte[0][]);
+
+			if (keys.length > 0) {
+				connection.del(keys);
+			}
+
+			return keys.length;
+		}
+	}
+
+	/**
+	 * {@link BatchStrategy} using {@code SCAN}.
+	 */
+	static class Scan extends BatchStrategy {
+
+		private final int batchSize;
+
+		public Scan(int batchSize) {
+			this.batchSize = batchSize;
+		}
+
+		@Override
+		int cleanCache(RedisConnection connection, String name, byte[] pattern) {
+
+			Cursor<byte[]> cursor = connection.scan(ScanOptions.scanOptions().count(batchSize).match(pattern).build());
+
+			PartitionIterator<byte[]> partitions = new PartitionIterator<>(cursor, batchSize);
+
+			int count = 0;
+
+			while (partitions.hasNext()) {
+
+				List<byte[]> keys = partitions.next();
+				count += keys.size();
+
+				if (keys.size() > 0) {
+					connection.del(keys.toArray(new byte[0][]));
+				}
+			}
+
+			return count;
+		}
+	}
+
+	/**
+	 * Utility to split and buffer outcome from a {@link Iterator} into {@link List lists} of {@code T} with a maximum
+	 * chunks {@code size}.
+	 *
+	 * @param <T>
+	 */
+	static class PartitionIterator<T> implements Iterator<List<T>> {
+
+		private final Iterator<T> iterator;
+		private final int size;
+
+		public PartitionIterator(Iterator<T> iterator, int size) {
+			this.iterator = iterator;
+			this.size = size;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return iterator.hasNext();
+		}
+
+		@Override
+		public List<T> next() {
+
+			if (!hasNext()) {
+				throw new NoSuchElementException();
+			}
+
+			List<T> list = new ArrayList<>(size);
+			while (list.size() < size && iterator.hasNext()) {
+				list.add(iterator.next());
+			}
+
+			return list;
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/cache/BatchStrategy.java
+++ b/src/main/java/org/springframework/data/redis/cache/BatchStrategy.java
@@ -15,156 +15,30 @@
  */
 package org.springframework.data.redis.cache;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-
 import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.core.Cursor;
-import org.springframework.data.redis.core.ScanOptions;
-import org.springframework.util.Assert;
 
 /**
- * Batch strategies to be used with {@link RedisCacheWriter}.
+ * A {@link BatchStrategy} to be used with {@link RedisCacheWriter}.
  * <p/>
- * Primarily used to clear the cache.
+ * Mainly used to clear the cache.
+ * <p/>
+ * Predefined strategies using the {@link BatchStrategies#keys() KEYS} or {@link BatchStrategies#scan(int) SCAN}
+ * commands can be found in {@link BatchStrategies}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @since 2.6
  */
-public abstract class BatchStrategy {
-
-	/**
-	 * Batching strategy using a single {@code KEYS} and {@code DEL} command to remove all matching keys. {@code KEYS}
-	 * scans the entire keyspace of the Redis database and can block the Redis worker thread for a long time on large
-	 * keyspaces.
-	 * <p/>
-	 * {@code KEYS} is supported for standalone and clustered (sharded) Redis operation modes.
-	 *
-	 * @return batching strategy using {@code KEYS}.
-	 */
-	public static BatchStrategy keys() {
-		return Keys.INSTANCE;
-	}
-
-	/**
-	 * Batching strategy using a {@code SCAN} cursors and potentially multiple {@code DEL} commands to remove all matching
-	 * keys. This strategy allows a configurable batch size to optimize for scan batching.
-	 * <p/>
-	 * Note that using the {@code SCAN} strategy might be not supported on all drivers and Redis operation modes.
-	 *
-	 * @return batching strategy using {@code SCAN}.
-	 */
-	public static BatchStrategy scan(int batchSize) {
-
-		Assert.isTrue(batchSize > 0, "Batch size must be greater than zero");
-
-		return new Scan(batchSize);
-	}
+public interface BatchStrategy {
 
 	/**
 	 * Remove all keys following the given pattern.
 	 *
-	 * @param the connection to use.
-	 * @param name The cache name must not be {@literal null}.
+	 * @param connection the connection to use. Must not be {@literal null}.
+	 * @param name The cache name. Must not be {@literal null}.
 	 * @param pattern The pattern for the keys to remove. Must not be {@literal null}.
 	 * @return number of removed keys.
 	 */
-	abstract int cleanCache(RedisConnection connection, String name, byte[] pattern);
-
-	/**
-	 * {@link BatchStrategy} using {@code KEYS}.
-	 */
-	static class Keys extends BatchStrategy {
-
-		static Keys INSTANCE = new Keys();
-
-		@Override
-		int cleanCache(RedisConnection connection, String name, byte[] pattern) {
-
-			byte[][] keys = Optional.ofNullable(connection.keys(pattern)).orElse(Collections.emptySet())
-					.toArray(new byte[0][]);
-
-			if (keys.length > 0) {
-				connection.del(keys);
-			}
-
-			return keys.length;
-		}
-	}
-
-	/**
-	 * {@link BatchStrategy} using {@code SCAN}.
-	 */
-	static class Scan extends BatchStrategy {
-
-		private final int batchSize;
-
-		public Scan(int batchSize) {
-			this.batchSize = batchSize;
-		}
-
-		@Override
-		int cleanCache(RedisConnection connection, String name, byte[] pattern) {
-
-			Cursor<byte[]> cursor = connection.scan(ScanOptions.scanOptions().count(batchSize).match(pattern).build());
-
-			PartitionIterator<byte[]> partitions = new PartitionIterator<>(cursor, batchSize);
-
-			int count = 0;
-
-			while (partitions.hasNext()) {
-
-				List<byte[]> keys = partitions.next();
-				count += keys.size();
-
-				if (keys.size() > 0) {
-					connection.del(keys.toArray(new byte[0][]));
-				}
-			}
-
-			return count;
-		}
-	}
-
-	/**
-	 * Utility to split and buffer outcome from a {@link Iterator} into {@link List lists} of {@code T} with a maximum
-	 * chunks {@code size}.
-	 *
-	 * @param <T>
-	 */
-	static class PartitionIterator<T> implements Iterator<List<T>> {
-
-		private final Iterator<T> iterator;
-		private final int size;
-
-		public PartitionIterator(Iterator<T> iterator, int size) {
-			this.iterator = iterator;
-			this.size = size;
-		}
-
-		@Override
-		public boolean hasNext() {
-			return iterator.hasNext();
-		}
-
-		@Override
-		public List<T> next() {
-
-			if (!hasNext()) {
-				throw new NoSuchElementException();
-			}
-
-			List<T> list = new ArrayList<>(size);
-			while (list.size() < size && iterator.hasNext()) {
-				list.add(iterator.next());
-			}
-
-			return list;
-		}
-	}
+	long cleanCache(RedisConnection connection, String name, byte[] pattern);
 
 }

--- a/src/main/java/org/springframework/data/redis/cache/BatchStrategy.java
+++ b/src/main/java/org/springframework/data/redis/cache/BatchStrategy.java
@@ -39,8 +39,8 @@ public abstract class BatchStrategy {
 
 	/**
 	 * Batching strategy using a single {@code KEYS} and {@code DEL} command to remove all matching keys. {@code KEYS}
-	 * scans the entire keyspace of the Redis database and can block the Redis worker thread for a long time when the
-	 * keyspace has a significant size.
+	 * scans the entire keyspace of the Redis database and can block the Redis worker thread for a long time on large
+	 * keyspaces.
 	 * <p/>
 	 * {@code KEYS} is supported for standalone and clustered (sharded) Redis operation modes.
 	 *

--- a/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
@@ -217,8 +217,12 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 					wasLocked = true;
 				}
 
-
-				statistics.incDeletesBy(name, batchStrategy.cleanCache(connection, name, pattern));
+				long deleteCount = batchStrategy.cleanCache(connection, name, pattern);
+				while (deleteCount > Integer.MAX_VALUE) {
+					statistics.incDeletesBy(name, Integer.MAX_VALUE);
+					deleteCount -= Integer.MAX_VALUE;
+				}
+				statistics.incDeletesBy(name, (int) deleteCount);
 
 			} finally {
 

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
@@ -186,7 +186,7 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
 
-		return new RedisCacheManager(new DefaultRedisCacheWriter(connectionFactory),
+		return new RedisCacheManager(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory),
 				RedisCacheConfiguration.defaultCacheConfig());
 	}
 
@@ -311,7 +311,7 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 
 			Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
 
-			return new RedisCacheManagerBuilder(new DefaultRedisCacheWriter(connectionFactory));
+			return new RedisCacheManagerBuilder(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory));
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
@@ -169,6 +169,8 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 	 * <dl>
 	 * <dt>locking</dt>
 	 * <dd>disabled</dd>
+	 * <dt>batch strategy</dt>
+	 * <dd>{@link BatchStrategy#keys() KEYS}</dd>
 	 * <dt>cache configuration</dt>
 	 * <dd>{@link RedisCacheConfiguration#defaultCacheConfig()}</dd>
 	 * <dt>initial caches</dt>

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
@@ -43,7 +43,7 @@ public interface RedisCacheWriter extends CacheStatisticsProvider {
 	 * @return new instance of {@link DefaultRedisCacheWriter}.
 	 */
 	static RedisCacheWriter nonLockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
-		return nonLockingRedisCacheWriter(connectionFactory, BatchStrategy.keys());
+		return nonLockingRedisCacheWriter(connectionFactory, BatchStrategies.keys());
 	}
 
 	/**
@@ -70,7 +70,7 @@ public interface RedisCacheWriter extends CacheStatisticsProvider {
 	 * @return new instance of {@link DefaultRedisCacheWriter}.
 	 */
 	static RedisCacheWriter lockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
-		return lockingRedisCacheWriter(connectionFactory, BatchStrategy.keys());
+		return lockingRedisCacheWriter(connectionFactory, BatchStrategies.keys());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
@@ -26,6 +26,9 @@ import org.springframework.util.Assert;
  * caching. <br />
  * The {@link RedisCacheWriter} may be shared by multiple cache implementations and is responsible for writing / reading
  * binary data to / from Redis. The implementation honors potential cache lock flags that might be set.
+ * <p>
+ * The default {@link RedisCacheWriter} implementation can be customized with {@link BatchStrategy} to tune performance
+ * behavior.
  *
  * @author Christoph Strobl
  * @author Mark Paluch
@@ -40,10 +43,24 @@ public interface RedisCacheWriter extends CacheStatisticsProvider {
 	 * @return new instance of {@link DefaultRedisCacheWriter}.
 	 */
 	static RedisCacheWriter nonLockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
+		return nonLockingRedisCacheWriter(connectionFactory, BatchStrategy.keys());
+	}
+
+	/**
+	 * Create new {@link RedisCacheWriter} without locking behavior.
+	 *
+	 * @param connectionFactory must not be {@literal null}.
+	 * @param batchStrategy must not be {@literal null}.
+	 * @return new instance of {@link DefaultRedisCacheWriter}.
+	 * @since 2.6
+	 */
+	static RedisCacheWriter nonLockingRedisCacheWriter(RedisConnectionFactory connectionFactory,
+			BatchStrategy batchStrategy) {
 
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
+		Assert.notNull(batchStrategy, "BatchStrategy must not be null!");
 
-		return new DefaultRedisCacheWriter(connectionFactory);
+		return new DefaultRedisCacheWriter(connectionFactory, batchStrategy);
 	}
 
 	/**
@@ -53,10 +70,23 @@ public interface RedisCacheWriter extends CacheStatisticsProvider {
 	 * @return new instance of {@link DefaultRedisCacheWriter}.
 	 */
 	static RedisCacheWriter lockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
+		return lockingRedisCacheWriter(connectionFactory, BatchStrategy.keys());
+	}
+
+	/**
+	 * Create new {@link RedisCacheWriter} with locking behavior.
+	 *
+	 * @param connectionFactory must not be {@literal null}.
+	 * @param batchStrategy must not be {@literal null}.
+	 * @return new instance of {@link DefaultRedisCacheWriter}.
+	 * @since 2.6
+	 */
+	static RedisCacheWriter lockingRedisCacheWriter(RedisConnectionFactory connectionFactory,
+			BatchStrategy batchStrategy) {
 
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null!");
 
-		return new DefaultRedisCacheWriter(connectionFactory, Duration.ofMillis(50));
+		return new DefaultRedisCacheWriter(connectionFactory, Duration.ofMillis(50), batchStrategy);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -529,8 +529,9 @@ public abstract class JedisConverters extends Converters {
 			if (options.getCount() != null) {
 				sp.count(options.getCount().intValue());
 			}
-			if (StringUtils.hasText(options.getPattern())) {
-				sp.match(options.getPattern());
+			byte[] pattern = options.getBytePattern();
+			if (pattern != null) {
+				sp.match(pattern);
 			}
 		}
 		return sp;

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -168,9 +168,10 @@ class JedisKeyCommands implements RedisKeyCommands {
 				}
 
 				ScanParams params = JedisConverters.toScanParams(options);
-				redis.clients.jedis.ScanResult<String> result = connection.getJedis().scan(Long.toString(cursorId), params);
+				redis.clients.jedis.ScanResult<byte[]> result = connection.getJedis().scan(Long.toString(cursorId).getBytes(),
+						params);
 				return new ScanIteration<>(Long.parseLong(result.getCursor()),
-						JedisConverters.stringListToByteList().convert(result.getResult()));
+						result.getResult());
 			}
 
 			protected void doClose() {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -868,8 +868,9 @@ public abstract class LettuceConverters extends Converters {
 
 		ScanArgs scanArgs = new ScanArgs();
 
-		if (options.getPattern() != null) {
-			scanArgs.match(options.getPattern());
+		byte[] pattern = options.getBytePattern();
+		if (pattern != null) {
+			scanArgs.match(pattern);
 		}
 
 		if (options.getCount() != null) {

--- a/src/main/java/org/springframework/data/redis/core/ScanOptions.java
+++ b/src/main/java/org/springframework/data/redis/core/ScanOptions.java
@@ -31,14 +31,16 @@ public class ScanOptions {
 	/**
 	 * Constant to apply default {@link ScanOptions} without setting a limit or matching a pattern.
 	 */
-	public static ScanOptions NONE = new ScanOptions(null, null);
+	public static ScanOptions NONE = new ScanOptions(null, null, null);
 
 	private final @Nullable Long count;
 	private final @Nullable String pattern;
+	private final @Nullable byte[] bytePattern;
 
-	private ScanOptions(@Nullable Long count, @Nullable String pattern) {
+	private ScanOptions(@Nullable Long count, @Nullable String pattern, @Nullable byte[] bytePattern) {
 		this.count = count;
 		this.pattern = pattern;
+		this.bytePattern = bytePattern;
 	}
 
 	/**
@@ -57,7 +59,22 @@ public class ScanOptions {
 
 	@Nullable
 	public String getPattern() {
+
+		if (bytePattern != null && pattern == null) {
+			return new String(bytePattern);
+		}
+
 		return pattern;
+	}
+
+	@Nullable
+	public byte[] getBytePattern() {
+
+		if (bytePattern == null && pattern != null) {
+			return pattern.getBytes();
+		}
+
+		return bytePattern;
 	}
 
 	public String toOptionString() {
@@ -71,7 +88,8 @@ public class ScanOptions {
 		if (this.count != null) {
 			params += (", 'count', " + count);
 		}
-		if (StringUtils.hasText(this.pattern)) {
+		String pattern = getPattern();
+		if (StringUtils.hasText(pattern)) {
 			params += (", 'match' , '" + this.pattern + "'");
 		}
 
@@ -87,6 +105,7 @@ public class ScanOptions {
 
 		private @Nullable Long count;
 		private @Nullable String pattern;
+		private @Nullable byte[] bytePattern;
 
 
 		/**
@@ -112,12 +131,24 @@ public class ScanOptions {
 		}
 
 		/**
+		 * Returns the current {@link ScanOptionsBuilder} configured with the given {@code pattern}.
+		 *
+		 * @param pattern
+		 * @return
+		 * @since 2.6
+		 */
+		public ScanOptionsBuilder match(byte[] pattern) {
+			this.bytePattern = pattern;
+			return this;
+		}
+
+		/**
 		 * Builds a new {@link ScanOptions} objects.
 		 *
 		 * @return a new {@link ScanOptions} objects.
 		 */
 		public ScanOptions build() {
-			return new ScanOptions(count, pattern);
+			return new ScanOptions(count, pattern, bytePattern);
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
@@ -306,7 +306,8 @@ public class DefaultRedisCacheWriterTests {
 
 		Thread th = new Thread(() -> {
 
-			DefaultRedisCacheWriter writer = new DefaultRedisCacheWriter(connectionFactory, Duration.ofMillis(50)) {
+			DefaultRedisCacheWriter writer = new DefaultRedisCacheWriter(connectionFactory, Duration.ofMillis(50),
+					BatchStrategy.keys()) {
 
 				@Override
 				boolean doCheckLock(String name, RedisConnection connection) {

--- a/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
@@ -307,7 +307,7 @@ public class DefaultRedisCacheWriterTests {
 		Thread th = new Thread(() -> {
 
 			DefaultRedisCacheWriter writer = new DefaultRedisCacheWriter(connectionFactory, Duration.ofMillis(50),
-					BatchStrategy.keys()) {
+					BatchStrategies.keys()) {
 
 				@Override
 				boolean doCheckLock(String name, RedisConnection connection) {

--- a/src/test/java/org/springframework/data/redis/cache/LegacyRedisCacheTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/LegacyRedisCacheTests.java
@@ -102,7 +102,8 @@ public class LegacyRedisCacheTests {
 			cacheConfiguration = cacheConfiguration.disableCachingNullValues();
 		}
 
-		return new RedisCache(CACHE_NAME, new DefaultRedisCacheWriter(connectionFactory), cacheConfiguration);
+		return new RedisCache(CACHE_NAME, RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory),
+				cacheConfiguration);
 	}
 
 	protected Object getValue() {

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheTests.java
@@ -262,7 +262,7 @@ public class RedisCacheTests {
 		}
 
 		RedisCache cache = new RedisCache("cache",
-				RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory, BatchStrategy.scan(25)),
+				RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory, BatchStrategies.scan(25)),
 				RedisCacheConfiguration.defaultCacheConfig().serializeValuesWith(SerializationPair.fromSerializer(serializer)));
 
 		doWithConnection(connection -> {

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
@@ -157,10 +157,10 @@ class JedisConnectionUnitTests {
 					Integer.MAX_VALUE, (long) Integer.MAX_VALUE + 1L));
 		}
 
-		@Test // DATAREDIS-531
+		@Test // DATAREDIS-531, GH-2006
 		public void scanShouldKeepTheConnectionOpen() {
 
-			doReturn(new ScanResult<>("0", Collections.<String> emptyList())).when(jedisSpy).scan(anyString(),
+			doReturn(new ScanResult<>("0", Collections.<String> emptyList())).when(jedisSpy).scan(any(byte[].class),
 					any(ScanParams.class));
 
 			connection.scan(ScanOptions.NONE);
@@ -168,10 +168,10 @@ class JedisConnectionUnitTests {
 			verify(jedisSpy, never()).quit();
 		}
 
-		@Test // DATAREDIS-531
+		@Test // DATAREDIS-531, GH-2006
 		public void scanShouldCloseTheConnectionWhenCursorIsClosed() throws IOException {
 
-			doReturn(new ScanResult<>("0", Collections.<String> emptyList())).when(jedisSpy).scan(anyString(),
+			doReturn(new ScanResult<>("0", Collections.<String> emptyList())).when(jedisSpy).scan(any(byte[].class),
 					any(ScanParams.class));
 
 			Cursor<byte[]> cursor = connection.scan(ScanOptions.NONE);


### PR DESCRIPTION
* Add support for configurable `BatchStrategy` to cleanup the cache via `KEYS` or `SCAN` (supersedes #547, closes #1721)
* Add support for binary keys in `ScanOptions` (closes #2006)
* Mention RedisCache locking behavior details (closes #1801) 