### PR TITLE
Guard `RedisConnectionFactory.getConnection()` against usage without initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.0-GH-2057-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactorySentinelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactorySentinelIntegrationTests.java
@@ -90,6 +90,14 @@ class JedisConnectionFactorySentinelIntegrationTests {
 				.sentinel("127.0.0.1", 1).sentinel("127.0.0.1", 26379);
 
 		factory = new JedisConnectionFactory(oneDownSentinelConfig);
+		factory.afterPropertiesSet();
 		assertThat(factory.getSentinelConnection().isOpen()).isTrue();
+	}
+
+	@Test // GH-2057
+	void uninitializedUsageShouldFail() {
+
+		factory = new JedisConnectionFactory(SENTINEL_CONFIG);
+		assertThatIllegalStateException().isThrownBy(() -> factory.getSentinelConnection());
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
@@ -346,6 +346,22 @@ class JedisConnectionFactoryUnitTests {
 		assertThatIllegalStateException().isThrownBy(() -> connectionFactory.setClientName("foo"));
 	}
 
+	@Test // GH-2057
+	void uninitializedUsageShouldFail() {
+
+		connectionFactory = new JedisConnectionFactory(new RedisStandaloneConfiguration(),
+				JedisClientConfiguration.defaultConfiguration());
+		assertThatIllegalStateException().isThrownBy(connectionFactory::getConnection);
+	}
+
+	@Test // GH-2057
+	void uninitializedClusterUsageShouldFail() {
+
+		connectionFactory = new JedisConnectionFactory(new RedisClusterConfiguration(),
+				JedisClientConfiguration.defaultConfiguration());
+		assertThatIllegalStateException().isThrownBy(connectionFactory::getClusterConnection);
+	}
+
 	private JedisConnectionFactory initSpyedConnectionFactory(RedisSentinelConfiguration sentinelConfig,
 			JedisPoolConfig poolConfig) {
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -1014,6 +1014,29 @@ class LettuceConnectionFactoryUnitTests {
 				.withMessageContaining("Client not yet initialized");
 	}
 
+	@Test // GH-2057
+	void uninitializedUsageShouldFail() {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisStandaloneConfiguration());
+		assertThatIllegalStateException().isThrownBy(connectionFactory::getConnection);
+		assertThatIllegalStateException().isThrownBy(connectionFactory::getReactiveConnection);
+	}
+
+	@Test // GH-2057
+	void uninitializedSentinelUsageShouldFail() {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisSentinelConfiguration());
+		assertThatIllegalStateException().isThrownBy(connectionFactory::getSentinelConnection);
+	}
+
+	@Test // GH-2057
+	void uninitializedClusterUsageShouldFail() {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisClusterConfiguration());
+		assertThatIllegalStateException().isThrownBy(connectionFactory::getClusterConnection);
+		assertThatIllegalStateException().isThrownBy(connectionFactory::getReactiveClusterConnection);
+	}
+
 	@Data
 	@AllArgsConstructor
 	static class CustomRedisConfiguration implements RedisConfiguration, WithHostAndPort {


### PR DESCRIPTION
Implementations of `getConnection()` and their cluster, sentinel and reactive variants on `JedisConnectionFactory` and `LettuceConnectionFactory` now throw `IllegalStateException` if the connection factory was not initialized with `afterPropertiesSet()`. This change prevents the usage of partially configured clients.

Closes #2056 
Should be backported to 2.5.x.