### PR TITLE
Add support for `GETEX` and `GETDEL` through `getAndExpire(…)`, `getAndPersist(…)` and `getAndDelete(…)` methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.0-2050-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -7,7 +7,7 @@ This section briefly covers items that are new and noteworthy in the latest rele
 == New in Spring Data Redis 2.6
 
 * Support for `SubscriptionListener` when using `MessageListener` for subscription confirmation callbacks. `ReactiveRedisMessageListenerContainer` and `ReactiveRedisOperations` provide `receiveLater(…)` and `listenToLater(…)` methods to await until Redis acknowledges the subscription.
-* Support Redis 6.2 commands (`LPOP`/`RPOP` with `count`, `COPY`).
+* Support Redis 6.2 commands (`LPOP`/`RPOP` with `count`, `COPY`, `GETEX`, `GETDEL`).
 
 [[new-in-2.5.0]]
 == New in Spring Data Redis 2.5

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -412,6 +412,46 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#getDel(byte[])
+	 */
+	@Nullable
+	@Override
+	public byte[] getDel(byte[] key) {
+		return convertAndReturn(delegate.getDel(key), Converters.identityConverter());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#getDel(byte[])
+	 */
+	@Nullable
+	@Override
+	public String getDel(String key) {
+		return convertAndReturn(delegate.getDel(serialize(key)), bytesToString);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#get(byte[], org.springframework.data.redis.core.types.Expiration)
+	 */
+	@Nullable
+	@Override
+	public byte[] getEx(byte[] key, Expiration expiration) {
+		return convertAndReturn(delegate.getEx(key, expiration), Converters.identityConverter());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#get(byte[], org.springframework.data.redis.core.types.Expiration)
+	 */
+	@Nullable
+	@Override
+	public String getEx(String key, Expiration expiration) {
+		return convertAndReturn(delegate.getEx(serialize(key), expiration), bytesToString);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisStringCommands#getBit(byte[], long)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -279,6 +279,20 @@ public interface DefaultedRedisConnection extends RedisConnection {
 	/** @deprecated in favor of {@link RedisConnection#stringCommands()}}. */
 	@Override
 	@Deprecated
+	default byte[] getEx(byte[] key, Expiration expiration) {
+		return stringCommands().getEx(key, expiration);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#stringCommands()}}. */
+	@Override
+	@Deprecated
+	default byte[] getDel(byte[] key) {
+		return stringCommands().getDel(key);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#stringCommands()}}. */
+	@Override
+	@Deprecated
 	default byte[] getSet(byte[] key, byte[] value) {
 		return stringCommands().getSet(key, value);
 	}

--- a/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
@@ -46,6 +46,30 @@ public interface RedisStringCommands {
 	byte[] get(byte[] key);
 
 	/**
+	 * Return the value at {@code key} and delete the key.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getdel">Redis Documentation: GETDEL</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	byte[] getDel(byte[] key);
+
+	/**
+	 * Return the value at {@code key} and expire the key by applying {@link Expiration}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param expiration must not be {@literal null}.
+	 * @param unit must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	byte[] getEx(byte[] key, Expiration expiration);
+
+	/**
 	 * Set {@code value} of {@code key} and return its old value.
 	 *
 	 * @param key must not be {@literal null}.
@@ -403,4 +427,5 @@ public interface RedisStringCommands {
 			return SET_IF_ABSENT;
 		}
 	}
+
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.connection;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.core.types.Expiration;
@@ -58,10 +59,13 @@ public interface RedisStringCommands {
 
 	/**
 	 * Return the value at {@code key} and expire the key by applying {@link Expiration}.
+	 * <p />
+	 * Use {@link Expiration#seconds(long)} for {@code EX}. <br />
+	 * Use {@link Expiration#milliseconds(long)} for {@code PX}. <br />
+	 * Use {@link Expiration#unixTimestamp(long, TimeUnit)} for {@code EXAT | PXAT}. <br />
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param expiration must not be {@literal null}.
-	 * @param unit must not be {@literal null}.
 	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
 	 * @since 2.6

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -398,6 +398,29 @@ public interface StringRedisConnection extends RedisConnection {
 	String get(String key);
 
 	/**
+	 * Return the value at {@code key} and delete the key.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getdel">Redis Documentation: GETDEL</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	String getDel(String key);
+
+	/**
+	 * Return the value at {@code key} and expire the key by applying {@link Expiration}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param expiration must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	String getEx(String key, Expiration expiration);
+
+	/**
 	 * Set {@code value} of {@code key} and return its old value.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStringCommands.java
@@ -35,6 +35,7 @@ import org.springframework.data.redis.connection.jedis.JedisClusterConnection.Je
 import org.springframework.data.redis.connection.lettuce.LettuceConverters;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.util.ByteUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -63,6 +64,41 @@ class JedisClusterStringCommands implements RedisStringCommands {
 
 		try {
 			return connection.getCluster().get(key);
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#getDel(byte[])
+	 */
+	@Nullable
+	@Override
+	public byte[] getDel(byte[] key) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		try {
+			return connection.getCluster().getDel(key);
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#getEx(byte[], org.springframework.data.redis.core.types.Expiration)
+	 */
+	@Nullable
+	@Override
+	public byte[] getEx(byte[] key, Expiration expiration) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(expiration, "Expiration must not be null!");
+
+		try {
+			return connection.getCluster().getEx(key, JedisConverters.toGetExParams(expiration));
 		} catch (Exception ex) {
 			throw convertJedisAccessException(ex);
 		}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -23,6 +23,7 @@ import redis.clients.jedis.ListPosition;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.GetExParams;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
 import redis.clients.jedis.util.SafeEncoder;
@@ -439,6 +440,34 @@ public abstract class JedisConverters extends Converters {
 		}
 
 		return params;
+	}
+
+	/**
+	 * Converts a given {@link Expiration} to the according {@code GETEX} command argument.
+	 * <dl>
+	 * <dt>{@link TimeUnit#MILLISECONDS}</dt>
+	 * <dd>{@code PX}</dd>
+	 * <dt>{@link TimeUnit#SECONDS}</dt>
+	 * <dd>{@code EX}</dd>
+	 * </dl>
+	 *
+	 * @param expiration must not be {@literal null}.
+	 * @return
+	 * @since 2.6
+	 */
+	static GetExParams toGetExParams(Expiration expiration) {
+
+		GetExParams params = new GetExParams();
+
+		if (expiration.isPersistent()) {
+			return params.persist();
+		}
+
+		if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
+			return params.px(expiration.getExpirationTime());
+		}
+
+		return params.ex((int) expiration.getExpirationTime());
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -431,15 +431,15 @@ public abstract class JedisConverters extends Converters {
 			return paramsToUse.keepttl();
 		}
 
-		if (!expiration.isPersistent()) {
-			if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
-				return paramsToUse.px(expiration.getExpirationTime());
-			}
-
-			return paramsToUse.ex((int) expiration.getExpirationTime());
+		if (expiration.isPersistent()) {
+			return paramsToUse;
 		}
 
-		return params;
+		if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
+			return expiration.isUnixTimestamp() ? paramsToUse.pxAt(expiration.getExpirationTime()) : paramsToUse.px(expiration.getExpirationTime());
+		}
+
+		return expiration.isUnixTimestamp() ? paramsToUse.exAt(expiration.getConverted(TimeUnit.SECONDS)) : paramsToUse.ex(expiration.getConverted(TimeUnit.SECONDS));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisStringCommands.java
@@ -58,6 +58,34 @@ class JedisStringCommands implements RedisStringCommands {
 	}
 
 	/*
+	* (non-Javadoc)
+	* @see org.springframework.data.redis.connection.RedisStringCommands#getDel(byte[])
+	*/
+	@Nullable
+	@Override
+	public byte[] getDel(byte[] key) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return connection.invoke().just(BinaryJedis::getDel, MultiKeyPipelineBase::getDel, key);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#getEx(byte[], org.springframework.data.redis.core.types.Expiration)
+	 */
+	@Nullable
+	@Override
+	public byte[] getEx(byte[] key, Expiration expiration) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(expiration, "Expiration must not be null!");
+
+		return connection.invoke().just(BinaryJedis::getEx, MultiKeyPipelineBase::getEx, key,
+				JedisConverters.toGetExParams(expiration));
+	}
+
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisStringCommands#getSet(byte[], byte[])
 	 */

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -725,6 +725,37 @@ public abstract class LettuceConverters extends Converters {
 		return args;
 	}
 
+	/**
+	 * Convert {@link Expiration} to {@link GetExArgs}.
+	 *
+	 * @param expiration
+	 * @return
+	 * @since 2.6
+	 */
+	static GetExArgs toGetExArgs(Expiration expiration) {
+
+		GetExArgs args = new GetExArgs();
+
+		if (expiration != null) {
+
+			if (expiration.isPersistent()) {
+				args.persist();
+			} else if (!expiration.isPersistent()) {
+
+				switch (expiration.getTimeUnit()) {
+					case SECONDS:
+						args.ex(expiration.getExpirationTime());
+						break;
+					default:
+						args.px(expiration.getConverted(TimeUnit.MILLISECONDS));
+						break;
+				}
+			}
+		}
+
+		return args;
+	}
+
 	static Converter<List<byte[]>, Long> toTimeConverter(TimeUnit timeUnit) {
 
 		return source -> {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -699,11 +699,19 @@ public abstract class LettuceConverters extends Converters {
 			} else if (!expiration.isPersistent()) {
 
 				switch (expiration.getTimeUnit()) {
-					case SECONDS:
-						args.ex(expiration.getExpirationTime());
+					case MILLISECONDS:
+						if (expiration.isUnixTimestamp()) {
+							args.pxAt(expiration.getConverted(TimeUnit.MILLISECONDS));
+						} else {
+							args.px(expiration.getConverted(TimeUnit.MILLISECONDS));
+						}
 						break;
 					default:
-						args.px(expiration.getConverted(TimeUnit.MILLISECONDS));
+						if (expiration.isUnixTimestamp()) {
+							args.exAt(expiration.getConverted(TimeUnit.SECONDS));
+						} else {
+							args.ex(expiration.getConverted(TimeUnit.SECONDS));
+						}
 						break;
 				}
 			}
@@ -740,7 +748,7 @@ public abstract class LettuceConverters extends Converters {
 			return args;
 		}
 
-		if(expiration.isPersistent()) {
+		if (expiration.isPersistent()) {
 			return args.persist();
 		}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStringCommands.java
@@ -57,6 +57,33 @@ class LettuceStringCommands implements RedisStringCommands {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#getDel(byte[])
+	 */
+	@Nullable
+	@Override
+	public byte[] getDel(byte[] key) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return connection.invoke().just(RedisStringAsyncCommands::getdel, key);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.connection.RedisStringCommands#getEx(byte[], org.springframework.data.redis.core.types.Expiration)
+	 */
+	@Nullable
+	@Override
+	public byte[] getEx(byte[] key, Expiration expiration) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(expiration, "Expiration must not be null!");
+
+		return connection.invoke().just(RedisStringAsyncCommands::getex, key, LettuceConverters.toGetExArgs(expiration));
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.connection.RedisStringCommands#getSet(byte[], byte[])
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
@@ -93,7 +93,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	Boolean setIfAbsent(V value, long timeout, TimeUnit unit);
 
 	/**
-	 * Set bound key to hold the string {@code value} and expiration {@code timeout} if {@code key} is absent.
+	 * Set bound key to hold the string {@code value} and expiration {@code timeout} if the bound key is absent.
 	 *
 	 * @param value must not be {@literal null}.
 	 * @param timeout must not be {@literal null}.
@@ -115,7 +115,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	}
 
 	/**
-	 * Set the bound key to hold the string {@code value} if {@code key} is present.
+	 * Set the bound key to hold the string {@code value} if the bound key is present.
 	 *
 	 * @param value must not be {@literal null}.
 	 * @return command result indicating if the key has been set.
@@ -127,7 +127,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	Boolean setIfPresent(V value);
 
 	/**
-	 * Set the bound key to hold the string {@code value} and expiration {@code timeout} if {@code key} is present.
+	 * Set the bound key to hold the string {@code value} and expiration {@code timeout} if the bound key is present.
 	 *
 	 * @param value must not be {@literal null}.
 	 * @param timeout the key expiration timeout.
@@ -141,7 +141,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	Boolean setIfPresent(V value, long timeout, TimeUnit unit);
 
 	/**
-	 * Set the bound key to hold the string {@code value} and expiration {@code timeout} if {@code key} is present.
+	 * Set the bound key to hold the string {@code value} and expiration {@code timeout} if the bound key is present.
 	 *
 	 * @param value must not be {@literal null}.
 	 * @param timeout must not be {@literal null}.
@@ -165,11 +165,56 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	/**
 	 * Get the value of the bound key.
 	 *
-	 * @return {@literal null} when used in pipeline / transaction.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/get">Redis Documentation: GET</a>
 	 */
 	@Nullable
 	V get();
+
+	/**
+	 * Return the value at the bound key and delete the key.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getdel">Redis Documentation: GETDEL</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	V getAndDelete();
+
+	/**
+	 * Return the value at the bound key and expire the key by applying {@code timeout}.
+	 *
+	 * @param timeout
+	 * @param unit must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	V getAndExpire(long timeout, TimeUnit unit);
+
+	/**
+	 * Return the value at the bound key and expire the key by applying {@code timeout}.
+	 *
+	 * @param timeout must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	V getAndExpire(Duration timeout);
+
+	/**
+	 * Return the value at the bound key and persist the key. This operation removes any TTL that is associated with the
+	 * bound key.
+	 *
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	V getAndPersist();
 
 	/**
 	 * Set {@code value} of the bound key and return its old value.

--- a/src/main/java/org/springframework/data/redis/core/DefaultBoundValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultBoundValueOperations.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.core;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.connection.DataType;
@@ -48,6 +49,46 @@ class DefaultBoundValueOperations<K, V> extends DefaultBoundKeyOperations<K> imp
 	@Override
 	public V get() {
 		return ops.get(getKey());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.BoundValueOperations#get()
+	 */
+	@Nullable
+	@Override
+	public V getAndDelete() {
+		return ops.getAndDelete(getKey());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.BoundValueOperations#get(long, java.util.concurrent.TimeUnit)
+	 */
+	@Nullable
+	@Override
+	public V getAndExpire(long timeout, TimeUnit unit) {
+		return ops.getAndExpire(getKey(), timeout, unit);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.BoundValueOperations#get(java.time.Duration)
+	 */
+	@Nullable
+	@Override
+	public V getAndExpire(Duration timeout) {
+		return ops.getAndExpire(getKey(), timeout);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.BoundValueOperations#getAndPersist()
+	 */
+	@Nullable
+	@Override
+	public V getAndPersist() {
+		return ops.getAndPersist(getKey());
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveValueOperations.java
@@ -177,6 +177,43 @@ class DefaultReactiveValueOperations<K, V> implements ReactiveValueOperations<K,
 	}
 
 	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveValueOperations#getAndDelete(java.lang.Object)
+	 */
+	@Override
+	public Mono<V> getAndDelete(K key) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return createMono(connection -> connection.getDel(rawKey(key)) //
+				.map(this::readValue));
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveValueOperations#getAndExpire(java.lang.Object, java.time.Duration)
+	 */
+	@Override
+	public Mono<V> getAndExpire(K key, Duration timeout) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(timeout, "Timeout must not be null!");
+
+		return createMono(connection -> connection.getEx(rawKey(key), Expiration.from(timeout)) //
+				.map(this::readValue));
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveValueOperations#getAndPersist(java.lang.Object)
+	 */
+	@Override
+	public Mono<V> getAndPersist(K key) {
+
+		Assert.notNull(key, "Key must not be null!");
+
+		return createMono(connection -> connection.getEx(rawKey(key), Expiration.persistent()) //
+				.map(this::readValue));
+	}
+
+	/* (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveValueOperations#getAndSet(java.lang.Object, java.lang.Object)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.core;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -55,6 +56,74 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 			@Override
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.get(rawKey);
+			}
+		}, true);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ValueOperations#getAndDelete(java.lang.Object)
+	 */
+	@Nullable
+	@Override
+	public V getAndDelete(K key) {
+
+		return execute(new ValueDeserializingRedisCallback(key) {
+
+			@Override
+			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
+				return connection.getDel(rawKey);
+			}
+		}, true);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ValueOperations#getAndPersist(java.lang.Object, long, java.util.concurrent.TimeUnit)
+	 */
+	@Nullable
+	@Override
+	public V getAndExpire(K key, long timeout, TimeUnit unit) {
+
+		return execute(new ValueDeserializingRedisCallback(key) {
+
+			@Override
+			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
+				return connection.getEx(rawKey, Expiration.from(timeout, unit));
+			}
+		}, true);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ValueOperations#getAndPersist(java.lang.Object, java.time.Duration)
+	 */
+	@Nullable
+	@Override
+	public V getAndExpire(K key, Duration timeout) {
+
+		return execute(new ValueDeserializingRedisCallback(key) {
+
+			@Override
+			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
+				return connection.getEx(rawKey, Expiration.from(timeout));
+			}
+		}, true);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ValueOperations#getAndPersist(java.lang.Object)
+	 */
+	@Nullable
+	@Override
+	public V getAndPersist(K key) {
+
+		return execute(new ValueDeserializingRedisCallback(key) {
+
+			@Override
+			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
+				return connection.getEx(rawKey, Expiration.persistent());
 			}
 		}, true);
 	}

--- a/src/main/java/org/springframework/data/redis/core/ReactiveValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveValueOperations.java
@@ -118,6 +118,35 @@ public interface ReactiveValueOperations<K, V> {
 	Mono<V> get(Object key);
 
 	/**
+	 * Return the value at {@code key} and delete the key.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/getdel">Redis Documentation: GETDEL</a>
+	 * @since 2.6
+	 */
+	Mono<V> getAndDelete(K key);
+
+	/**
+	 * Return the value at {@code key} and expire the key by applying {@code timeout}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param timeout must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	Mono<V> getAndExpire(K key, Duration timeout);
+
+	/**
+	 * Return the value at {@code key} and persist the key. This operation removes any TTL that is associated with
+	 * {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	Mono<V> getAndPersist(K key);
+
+	/**
 	 * Set {@code value} of {@code key} and return its old value.
 	 *
 	 * @param key must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/core/ValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ValueOperations.java
@@ -198,17 +198,65 @@ public interface ValueOperations<K, V> {
 	 * Get the value of {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @return {@literal null} when used in pipeline / transaction.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/get">Redis Documentation: GET</a>
 	 */
 	@Nullable
 	V get(Object key);
 
 	/**
+	 * Return the value at {@code key} and delete the key.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getdel">Redis Documentation: GETDEL</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	V getAndDelete(K key);
+
+	/**
+	 * Return the value at {@code key} and expire the key by applying {@code timeout}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param timeout
+	 * @param unit must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	V getAndExpire(K key, long timeout, TimeUnit unit);
+
+	/**
+	 * Return the value at {@code key} and expire the key by applying {@code timeout}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param timeout must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	V getAndExpire(K key, Duration timeout);
+
+	/**
+	 * Return the value at {@code key} and persist the key. This operation removes any TTL that is associated with
+	 * {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 2.6
+	 */
+	@Nullable
+	V getAndPersist(K key);
+
+	/**
 	 * Set {@code value} of {@code key} and return its old value.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @return {@literal null} when used in pipeline / transaction.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/getset">Redis Documentation: GETSET</a>
 	 */
 	@Nullable

--- a/src/main/java/org/springframework/data/redis/core/types/Expiration.java
+++ b/src/main/java/org/springframework/data/redis/core/types/Expiration.java
@@ -116,6 +116,17 @@ public class Expiration {
 	}
 
 	/**
+	 * Creates new {@link Expiration} with the given {@literal unix timestamp} and {@link TimeUnit}.
+	 *
+	 * @param unixTimestamp the unix timestamp at which the key will expire.
+	 * @param timeUnit must not be {@literal null}.
+	 * @return new instance of {@link Expiration}.
+	 */
+	public static Expiration unixTimestamp(long unixTimestamp, TimeUnit timeUnit) {
+		return new ExpireAt(unixTimestamp, timeUnit);
+	}
+
+	/**
 	 * Obtain an {@link Expiration} that indicates to keep the existing one. Eg. when sending a {@code SET} command.
 	 * <p />
 	 * <strong>NOTE: </strong>Please follow the documentation of the individual commands to see if {@link #keepTtl()} is
@@ -198,6 +209,14 @@ public class Expiration {
 	}
 
 	/**
+	 * @return {@literal true} if {@link Expiration} is set to a specified Unix time at which the key will expire.
+	 * @since 2.6
+	 */
+	public boolean isUnixTimestamp() {
+		return false;
+	}
+
+	/**
 	 * @author Christoph Strobl
 	 * @since 2.4
 	 */
@@ -211,6 +230,21 @@ public class Expiration {
 
 		@Override
 		public boolean isKeepTtl() {
+			return true;
+		}
+	}
+
+	/**
+	 * @author Christoph Strobl
+	 * @since 2.6
+	 */
+	private static class ExpireAt extends Expiration {
+
+		private ExpireAt(long expirationTime, @Nullable TimeUnit timeUnit) {
+			super(expirationTime, timeUnit);
+		}
+
+		public boolean isUnixTimestamp() {
 			return true;
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -1135,6 +1135,28 @@ public abstract class AbstractConnectionIntegrationTests {
 		verifyResults(Arrays.asList(true, DataType.STRING));
 	}
 
+	@Test // GH-2050
+	@EnabledOnCommand("GETEX")
+	void testGetEx() {
+		actual.add(connection.set("testGS", "1"));
+		actual.add(connection.getEx("testGS", Expiration.seconds(10)));
+		actual.add(connection.ttl("testGS"));
+
+		Long ttl = (Long) getResults().get(2);
+
+		assertThat(ttl).isGreaterThan(1);
+	}
+
+	@Test // GH-2050
+	@EnabledOnCommand("GETDEL")
+	void testGetDel() {
+		actual.add(connection.set("testGS", "1"));
+		actual.add(connection.getDel("testGS"));
+		actual.add(connection.exists("testGS"));
+
+		verifyResults(Arrays.asList(true, "1", false));
+	}
+
 	@Test
 	void testGetSet() {
 		actual.add(connection.set("testGS", "1"));

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -1138,6 +1138,7 @@ public abstract class AbstractConnectionIntegrationTests {
 	@Test // GH-2050
 	@EnabledOnCommand("GETEX")
 	void testGetEx() {
+
 		actual.add(connection.set("testGS", "1"));
 		actual.add(connection.getEx("testGS", Expiration.seconds(10)));
 		actual.add(connection.ttl("testGS"));
@@ -1150,6 +1151,7 @@ public abstract class AbstractConnectionIntegrationTests {
 	@Test // GH-2050
 	@EnabledOnCommand("GETDEL")
 	void testGetDel() {
+
 		actual.add(connection.set("testGS", "1"));
 		actual.add(connection.getDel("testGS"));
 		actual.add(connection.exists("testGS"));
@@ -1159,6 +1161,7 @@ public abstract class AbstractConnectionIntegrationTests {
 
 	@Test
 	void testGetSet() {
+
 		actual.add(connection.set("testGS", "1"));
 		actual.add(connection.getSet("testGS", "2"));
 		actual.add(connection.get("testGS"));
@@ -1167,6 +1170,7 @@ public abstract class AbstractConnectionIntegrationTests {
 
 	@Test
 	void testMSet() {
+
 		Map<String, String> vals = new HashMap<>();
 		vals.put("color", "orange");
 		vals.put("size", "1");
@@ -1178,6 +1182,7 @@ public abstract class AbstractConnectionIntegrationTests {
 
 	@Test
 	void testMSetNx() {
+
 		Map<String, String> vals = new HashMap<>();
 		vals.put("height", "5");
 		vals.put("width", "1");
@@ -1188,6 +1193,7 @@ public abstract class AbstractConnectionIntegrationTests {
 
 	@Test
 	void testMSetNxFailure() {
+
 		actual.add(connection.set("height", "2"));
 		Map<String, String> vals = new HashMap<>();
 		vals.put("height", "5");
@@ -1199,6 +1205,7 @@ public abstract class AbstractConnectionIntegrationTests {
 
 	@Test
 	void testSetNx() {
+
 		actual.add(connection.setNX("notaround", "54"));
 		actual.add(connection.get("notaround"));
 		actual.add(connection.setNX("notaround", "55"));

--- a/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterConnectionTests.java
@@ -186,6 +186,12 @@ public interface ClusterConnectionTests {
 	// DATAREDIS-315
 	void getRangeShouldReturnValueCorrectly();
 
+	// GH-2050
+	void getExShouldWorkCorrectly();
+
+	// GH-2050
+	void getDelShouldWorkCorrectly();
+
 	// DATAREDIS-315
 	void getSetShouldWorkCorrectly();
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -696,6 +696,26 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.getRange(KEY_1_BYTES, 0, 2)).isEqualTo(JedisConverters.toBytes("val"));
 	}
 
+	@Test // GH-2050
+	@EnabledOnCommand("GETEX")
+	public void getExShouldWorkCorrectly() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+
+		assertThat(clusterConnection.getEx(KEY_1_BYTES, Expiration.seconds(10))).isEqualTo(VALUE_1_BYTES);
+		assertThat(clusterConnection.ttl(KEY_1_BYTES)).isGreaterThan(1);
+	}
+
+	@Test // GH-2050
+	@EnabledOnCommand("GETDEL")
+	public void getDelShouldWorkCorrectly() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+
+		assertThat(clusterConnection.getDel(KEY_1_BYTES)).isEqualTo(VALUE_1_BYTES);
+		assertThat(clusterConnection.exists(KEY_1_BYTES)).isFalse();
+	}
+
 	@Test // DATAREDIS-315
 	public void getSetShouldWorkCorrectly() {
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
@@ -213,6 +213,22 @@ class JedisConvertersUnitTests {
 		assertThat(toString(JedisConverters.toSetCommandExPxArgument(Expiration.milliseconds(100)))).isEqualTo("px 100");
 	}
 
+	@Test // GH-2050
+	void convertsExpirationToSetPXAT() {
+
+		assertThat(JedisConverters.toSetCommandExPxArgument(Expiration.unixTimestamp(10, TimeUnit.MILLISECONDS)))
+				.extracting(SetParams::toString)
+				.isEqualTo(SetParams.setParams().pxAt(10).toString());
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToSetEXAT() {
+
+		assertThat(JedisConverters.toSetCommandExPxArgument(Expiration.unixTimestamp(1, TimeUnit.MINUTES)))
+				.extracting(SetParams::toString)
+				.isEqualTo(SetParams.setParams().exAt(60).toString());
+	}
+
 	@Test // DATAREDIS-316, DATAREDIS-749
 	void toSetCommandNxXxOptionShouldReturnNXforAbsent() {
 		assertThat(toString(JedisConverters.toSetCommandNxXxArgument(SetOption.ifAbsent()))).isEqualTo("nx");

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConvertersUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.jedis;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+import redis.clients.jedis.params.GetExParams;
 import redis.clients.jedis.params.SetParams;
 
 import java.util.Arrays;
@@ -26,6 +27,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.connection.RedisServer;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
@@ -224,6 +226,54 @@ class JedisConvertersUnitTests {
 	@Test // DATAREDIS-316, DATAREDIS-749
 	void toSetCommandNxXxOptionShouldReturnEmptyArrayforUpsert() {
 		assertThat(toString(JedisConverters.toSetCommandNxXxArgument(SetOption.upsert()))).isEqualTo("");
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToGetExEX() {
+
+		assertThat(JedisConverters.toGetExParams(Expiration.seconds(10)))
+				.extracting(GetExParams::toString)
+				.isEqualTo(new GetExParams().ex(10).toString());
+	}
+
+	@Test // GH-2050
+	void convertsExpirationWithTimeUnitToGetExEX() {
+
+		assertThat(JedisConverters.toGetExParams(Expiration.from(1, TimeUnit.MINUTES)))
+				.extracting(GetExParams::toString)
+				.isEqualTo(new GetExParams().ex(60).toString());
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToGetExPEX() {
+
+		assertThat(JedisConverters.toGetExParams(Expiration.milliseconds(10)))
+				.extracting(GetExParams::toString)
+				.isEqualTo(new GetExParams().px(10).toString());
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToGetExEXAT() {
+
+		assertThat(JedisConverters.toGetExParams(Expiration.unixTimestamp(10, TimeUnit.SECONDS)))
+				.extracting(GetExParams::toString)
+				.isEqualTo(new GetExParams().exAt(10).toString());
+	}
+
+	@Test // GH-2050
+	void convertsExpirationWithTimeUnitToGetExEXAT() {
+
+		assertThat(JedisConverters.toGetExParams(Expiration.unixTimestamp(1, TimeUnit.MINUTES)))
+				.extracting(GetExParams::toString)
+				.isEqualTo(new GetExParams().exAt(60).toString());
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToGetExPXAT() {
+
+		assertThat(JedisConverters.toGetExParams(Expiration.unixTimestamp(10, TimeUnit.MILLISECONDS)))
+				.extracting(GetExParams::toString)
+				.isEqualTo(new GetExParams().pxAt(10).toString());
 	}
 
 	private void verifyRedisServerInfo(RedisServer server, Map<String, String> values) {

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -58,6 +58,7 @@ import org.springframework.data.redis.connection.ValueEncoding.RedisValueEncodin
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.types.Expiration;
+import org.springframework.data.redis.test.condition.EnabledOnCommand;
 import org.springframework.data.redis.test.condition.EnabledOnRedisClusterAvailable;
 import org.springframework.data.redis.test.extension.LettuceExtension;
 import org.springframework.data.redis.test.extension.LettuceTestClientResources;
@@ -725,6 +726,26 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		nativeConnection.set(KEY_1, VALUE_1);
 
 		assertThat(clusterConnection.getRange(KEY_1_BYTES, 0, 2)).isEqualTo(LettuceConverters.toBytes("val"));
+	}
+
+	@Test // GH-2050
+	@EnabledOnCommand("GETEX")
+	public void getExShouldWorkCorrectly() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+
+		assertThat(clusterConnection.getEx(KEY_1_BYTES, Expiration.seconds(10))).isEqualTo(VALUE_1_BYTES);
+		assertThat(clusterConnection.ttl(KEY_1_BYTES)).isGreaterThan(1);
+	}
+
+	@Test // GH-2050
+	@EnabledOnCommand("GETDEL")
+	public void getDelShouldWorkCorrectly() {
+
+		nativeConnection.set(KEY_1, VALUE_1);
+
+		assertThat(clusterConnection.getDel(KEY_1_BYTES)).isEqualTo(VALUE_1_BYTES);
+		assertThat(clusterConnection.exists(KEY_1_BYTES)).isFalse();
 	}
 
 	@Test // DATAREDIS-315

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceCommandArgsComparator.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceCommandArgsComparator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.lettuce;
+
+import io.lettuce.core.CompositeArgument;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.protocol.CommandArgs;
+
+import org.assertj.core.api.Assertions;
+
+/**
+ * @author Christoph Strobl
+ */
+public class LettuceCommandArgsComparator {
+
+	static void argsEqual(CompositeArgument args1, CompositeArgument args2) {
+
+		CommandArgs<String, String> stringStringCommandArgs1 = new CommandArgs<>(StringCodec.UTF8);
+		args1.build(stringStringCommandArgs1);
+
+		CommandArgs<String, String> stringStringCommandArgs2 = new CommandArgs<>(StringCodec.UTF8);
+		args2.build(stringStringCommandArgs2);
+
+		Assertions.assertThat(stringStringCommandArgs1.toCommandString())
+				.isEqualTo(stringStringCommandArgs2.toCommandString());
+	}
+
+	static LettuceCompositeArgumentAssert assertThatCommandArgument(CompositeArgument command) {
+		return new LettuceCompositeArgumentAssert() {
+
+			@Override
+			public LettuceCompositeArgumentAssert isEqualTo(CompositeArgument expected) {
+
+				argsEqual(command, expected);
+				return this;
+			}
+		};
+	}
+
+	interface LettuceCompositeArgumentAssert {
+		LettuceCompositeArgumentAssert isEqualTo(CompositeArgument command);
+	}
+}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
@@ -17,8 +17,10 @@ package org.springframework.data.redis.connection.lettuce;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.redis.connection.ClusterTestVariables.*;
+import static org.springframework.data.redis.connection.lettuce.LettuceCommandArgsComparator.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
+import io.lettuce.core.GetExArgs;
 import io.lettuce.core.Limit;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.SetArgs;
@@ -29,9 +31,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.data.redis.connection.RedisClusterNode;
 import org.springframework.data.redis.connection.RedisClusterNode.Flag;
 import org.springframework.data.redis.connection.RedisClusterNode.LinkState;
@@ -192,5 +194,46 @@ class LettuceConvertersUnitTests {
 		limit = LettuceConverters.toLimit(RedisZSetCommands.Limit.limit().count(5));
 		assertThat(limit.isLimited()).isTrue();
 		assertThat(limit.getCount()).isEqualTo(5L);
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToGetExEX() {
+
+		assertThatCommandArgument(LettuceConverters.toGetExArgs(Expiration.seconds(10))).isEqualTo(new GetExArgs().ex(10));
+	}
+
+	@Test // GH-2050
+	void convertsExpirationWithTimeUnitToGetExEX() {
+
+		assertThatCommandArgument(LettuceConverters.toGetExArgs(Expiration.from(1, TimeUnit.MINUTES)))
+				.isEqualTo(new GetExArgs().ex(60));
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToGetExPEX() {
+
+		assertThatCommandArgument(LettuceConverters.toGetExArgs(Expiration.milliseconds(10)))
+				.isEqualTo(new GetExArgs().px(10));
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToGetExEXAT() {
+
+		assertThatCommandArgument(LettuceConverters.toGetExArgs(Expiration.unixTimestamp(10, TimeUnit.SECONDS)))
+				.isEqualTo(new GetExArgs().exAt(10));
+	}
+
+	@Test // GH-2050
+	void convertsExpirationWithTimeUnitToGetExEXAT() {
+
+		assertThatCommandArgument(LettuceConverters.toGetExArgs(Expiration.unixTimestamp(1, TimeUnit.MINUTES)))
+				.isEqualTo(new GetExArgs().exAt(60));
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToGetExPXAT() {
+
+		assertThatCommandArgument(LettuceConverters.toGetExArgs(Expiration.unixTimestamp(10, TimeUnit.MILLISECONDS)))
+				.isEqualTo(new GetExArgs().pxAt(10));
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
@@ -39,8 +39,10 @@ import org.springframework.data.redis.connection.RedisClusterNode.Flag;
 import org.springframework.data.redis.connection.RedisClusterNode.LinkState;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.connection.RedisZSetCommands;
+import org.springframework.data.redis.connection.jedis.JedisConverters;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
+import redis.clients.jedis.params.SetParams;
 
 /**
  * @author Christoph Strobl
@@ -134,6 +136,20 @@ class LettuceConvertersUnitTests {
 		assertThat(getField(args, "px")).isNull();
 		assertThat((Boolean) getField(args, "nx")).isEqualTo(Boolean.FALSE);
 		assertThat((Boolean) getField(args, "xx")).isEqualTo(Boolean.FALSE);
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToSetPXAT() {
+
+		assertThatCommandArgument(LettuceConverters.toSetArgs(Expiration.unixTimestamp(10, TimeUnit.MILLISECONDS), null))
+				.isEqualTo(SetArgs.Builder.pxAt(10));
+	}
+
+	@Test // GH-2050
+	void convertsExpirationToSetEXAT() {
+
+		assertThatCommandArgument(LettuceConverters.toSetArgs(Expiration.unixTimestamp(1, TimeUnit.MINUTES), null))
+				.isEqualTo(SetArgs.Builder.exAt(60));
 	}
 
 	@Test // DATAREDIS-316

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsIntegrationTests.java
@@ -51,6 +51,7 @@ import org.springframework.data.redis.connection.ReactiveStringCommands.SetComma
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
 import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
 import org.springframework.data.redis.core.types.Expiration;
+import org.springframework.data.redis.test.condition.EnabledOnCommand;
 import org.springframework.data.redis.test.extension.parametrized.ParameterizedRedisTest;
 import org.springframework.data.redis.test.util.HexStringUtils;
 import org.springframework.data.redis.util.ByteUtils;
@@ -64,6 +65,32 @@ public class LettuceReactiveStringCommandsIntegrationTests extends LettuceReacti
 
 	public LettuceReactiveStringCommandsIntegrationTests(Fixture fixture) {
 		super(fixture);
+	}
+
+	@ParameterizedRedisTest // GH-2050
+	@EnabledOnCommand("GETEX")
+	void getExShouldWorkCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		connection.stringCommands().getEx(KEY_1_BBUFFER, Expiration.seconds(10)).as(StepVerifier::create) //
+				.expectNext(VALUE_1_BBUFFER) //
+				.verifyComplete();
+
+		assertThat(nativeCommands.ttl(KEY_1)).isGreaterThan(1L);
+	}
+
+	@ParameterizedRedisTest // GH-2050
+	@EnabledOnCommand("GETDEL")
+	void getDelShouldWorkCorrectly() {
+
+		nativeCommands.set(KEY_1, VALUE_1);
+
+		connection.stringCommands().getDel(KEY_1_BBUFFER).as(StepVerifier::create) //
+				.expectNext(VALUE_1_BBUFFER) //
+				.verifyComplete();
+
+		assertThat(nativeCommands.exists(KEY_1)).isZero();
 	}
 
 	@ParameterizedRedisTest // DATAREDIS-525


### PR DESCRIPTION
We now support Redis 6.2 `GETEX` and `GETDEL` commands through the Template API and on the connection level for all drivers.

Closes #2050