### PR TITLE
Avoid configuring the database number in `JedisClientConfiguration` used for Sentinels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.0-2103-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 


### PR DESCRIPTION
We now no longer configure the database number configured for data node access through `JedisClientConfiguration` instances that are used for Sentinel node connectivity. Previously, the configured database number lead to issuing a `SELECT` command on Sentinel that doesn't support database isolation.

Fixes #2103.