### PR TITLE
Introduce session callback, reduce connection allocation overhead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.0-GH-2110-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/core/AbstractOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/AbstractOperations.java
@@ -93,8 +93,8 @@ abstract class AbstractOperations<K, V> {
 	}
 
 	@Nullable
-	<T> T execute(RedisCallback<T> callback, boolean exposeConnection) {
-		return template.execute(callback, exposeConnection);
+	<T> T execute(RedisCallback<T> callback) {
+		return template.execute(callback, true);
 	}
 
 	public RedisOperations<K, V> getOperations() {

--- a/src/main/java/org/springframework/data/redis/core/DefaultGeoOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultGeoOperations.java
@@ -61,7 +61,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 		byte[] rawKey = rawKey(key);
 		byte[] rawMember = rawValue(member);
 
-		return execute(connection -> connection.geoAdd(rawKey, point, rawMember), true);
+		return execute(connection -> connection.geoAdd(rawKey, point, rawMember));
 	}
 
 	/*
@@ -88,7 +88,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 			rawMemberCoordinateMap.put(rawMember, memberCoordinateMap.get(member));
 		}
 
-		return execute(connection -> connection.geoAdd(rawKey, rawMemberCoordinateMap), true);
+		return execute(connection -> connection.geoAdd(rawKey, rawMemberCoordinateMap));
 	}
 
 	/*
@@ -117,7 +117,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 		byte[] rawMember1 = rawValue(member1);
 		byte[] rawMember2 = rawValue(member2);
 
-		return execute(connection -> connection.geoDist(rawKey, rawMember1, rawMember2), true);
+		return execute(connection -> connection.geoDist(rawKey, rawMember1, rawMember2));
 	}
 
 	/*
@@ -131,7 +131,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 		byte[] rawMember1 = rawValue(member1);
 		byte[] rawMember2 = rawValue(member2);
 
-		return execute(connection -> connection.geoDist(rawKey, rawMember1, rawMember2, metric), true);
+		return execute(connection -> connection.geoDist(rawKey, rawMember1, rawMember2, metric));
 	}
 
 	/*
@@ -144,7 +144,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 		byte[] rawKey = rawKey(key);
 		byte[][] rawMembers = rawValues(members);
 
-		return execute(connection -> connection.geoHash(rawKey, rawMembers), true);
+		return execute(connection -> connection.geoHash(rawKey, rawMembers));
 	}
 
 	/*
@@ -156,7 +156,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 		byte[] rawKey = rawKey(key);
 		byte[][] rawMembers = rawValues(members);
 
-		return execute(connection -> connection.geoPos(rawKey, rawMembers), true);
+		return execute(connection -> connection.geoPos(rawKey, rawMembers));
 	}
 
 	/*
@@ -168,7 +168,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 		byte[] rawKey = rawKey(key);
 
-		GeoResults<GeoLocation<byte[]>> raw = execute(connection -> connection.geoRadius(rawKey, within), true);
+		GeoResults<GeoLocation<byte[]>> raw = execute(connection -> connection.geoRadius(rawKey, within));
 
 		return deserializeGeoResults(raw);
 	}
@@ -182,7 +182,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 		byte[] rawKey = rawKey(key);
 
-		GeoResults<GeoLocation<byte[]>> raw = execute(connection -> connection.geoRadius(rawKey, within, args), true);
+		GeoResults<GeoLocation<byte[]>> raw = execute(connection -> connection.geoRadius(rawKey, within, args));
 
 		return deserializeGeoResults(raw);
 	}
@@ -196,8 +196,8 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawMember = rawValue(member);
-		GeoResults<GeoLocation<byte[]>> raw = execute(connection -> connection.geoRadiusByMember(rawKey, rawMember, radius),
-				true);
+		GeoResults<GeoLocation<byte[]>> raw = execute(
+				connection -> connection.geoRadiusByMember(rawKey, rawMember, radius));
 
 		return deserializeGeoResults(raw);
 	}
@@ -213,7 +213,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 		byte[] rawMember = rawValue(member);
 
 		GeoResults<GeoLocation<byte[]>> raw = execute(
-				connection -> connection.geoRadiusByMember(rawKey, rawMember, distance), true);
+				connection -> connection.geoRadiusByMember(rawKey, rawMember, distance));
 
 		return deserializeGeoResults(raw);
 	}
@@ -229,7 +229,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 		byte[] rawMember = rawValue(member);
 
 		GeoResults<GeoLocation<byte[]>> raw = execute(
-				connection -> connection.geoRadiusByMember(rawKey, rawMember, distance, param), true);
+				connection -> connection.geoRadiusByMember(rawKey, rawMember, distance, param));
 
 		return deserializeGeoResults(raw);
 	}
@@ -243,10 +243,10 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawMembers = rawValues(members);
-		return execute(connection -> connection.zRem(rawKey, rawMembers), true);
+		return execute(connection -> connection.zRem(rawKey, rawMembers));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.GeoOperations#search(java.lang.Object, org.springframework.data.redis.connection.RedisGeoCommands.GeoReference, org.springframework.data.redis.connection.RedisGeoCommands.GeoShape, org.springframework.data.redis.connection.RedisGeoCommands.GeoSearchCommandArgs)
 	 */
@@ -258,12 +258,12 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 		GeoReference<byte[]> rawMember = getGeoReference(reference);
 
 		GeoResults<GeoLocation<byte[]>> raw = execute(
-				connection -> connection.geoSearch(rawKey, rawMember, geoPredicate, args), true);
+				connection -> connection.geoSearch(rawKey, rawMember, geoPredicate, args));
 
 		return deserializeGeoResults(raw);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.GeoOperations#searchAndStore(java.lang.Object, java.lang.Object, org.springframework.data.redis.connection.RedisGeoCommands.GeoReference, org.springframework.data.redis.connection.RedisGeoCommands.GeoShape, org.springframework.data.redis.connection.RedisGeoCommands.GeoSearchStoreCommandArgs)
 	 */
@@ -275,7 +275,7 @@ class DefaultGeoOperations<K, M> extends AbstractOperations<K, M> implements Geo
 		byte[] rawDestKey = rawKey(destKey);
 		GeoReference<byte[]> rawMember = getGeoReference(reference);
 
-		return execute(connection -> connection.geoSearchStore(rawDestKey, rawKey, rawMember, geoPredicate, args), true);
+		return execute(connection -> connection.geoSearchStore(rawDestKey, rawKey, rawMember, geoPredicate, args));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
@@ -52,7 +52,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawHashKey = rawHashKey(hashKey);
-		byte[] rawHashValue = execute(connection -> connection.hGet(rawKey, rawHashKey), true);
+		byte[] rawHashValue = execute(connection -> connection.hGet(rawKey, rawHashKey));
 
 		return (HV) rawHashValue != null ? deserializeHashValue(rawHashValue) : null;
 	}
@@ -66,7 +66,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawHashKey = rawHashKey(hashKey);
-		return execute(connection -> connection.hExists(rawKey, rawHashKey), true);
+		return execute(connection -> connection.hExists(rawKey, rawHashKey));
 	}
 
 	/*
@@ -78,7 +78,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawHashKey = rawHashKey(hashKey);
-		return execute(connection -> connection.hIncrBy(rawKey, rawHashKey, delta), true);
+		return execute(connection -> connection.hIncrBy(rawKey, rawHashKey, delta));
 	}
 
 	/*
@@ -90,10 +90,10 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawHashKey = rawHashKey(hashKey);
-		return execute(connection -> connection.hIncrBy(rawKey, rawHashKey, delta), true);
+		return execute(connection -> connection.hIncrBy(rawKey, rawHashKey, delta));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.HashOperations#randomField(java.lang.Object)
 	 */
@@ -102,10 +102,10 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 	public HK randomKey(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return deserializeHashKey(execute(connection -> connection.hRandField(rawKey), true));
+		return deserializeHashKey(execute(connection -> connection.hRandField(rawKey)));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.HashOperations#randomValue(java.lang.Object)
 	 */
@@ -114,12 +114,12 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 	public Entry<HK, HV> randomEntry(K key) {
 
 		byte[] rawKey = rawKey(key);
-		Entry<byte[], byte[]> rawEntry = execute(connection -> connection.hRandFieldWithValues(rawKey), true);
+		Entry<byte[], byte[]> rawEntry = execute(connection -> connection.hRandFieldWithValues(rawKey));
 		return rawEntry == null ? null
 				: Converters.entryOf(deserializeHashKey(rawEntry.getKey()), deserializeHashValue(rawEntry.getValue()));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.HashOperations#randomFields(java.lang.Object, long)
 	 */
@@ -128,11 +128,11 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 	public List<HK> randomKeys(K key, long count) {
 
 		byte[] rawKey = rawKey(key);
-		List<byte[]> rawValues = execute(connection -> connection.hRandField(rawKey, count), true);
+		List<byte[]> rawValues = execute(connection -> connection.hRandField(rawKey, count));
 		return deserializeHashKeys(rawValues);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.HashOperations#randomValues(java.lang.Object, long)
 	 */
@@ -142,8 +142,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 
 		Assert.isTrue(count > 0, "Count must not be negative");
 		byte[] rawKey = rawKey(key);
-		List<Entry<byte[], byte[]>> rawEntries = execute(connection -> connection.hRandFieldWithValues(rawKey, count),
-				true);
+		List<Entry<byte[], byte[]>> rawEntries = execute(connection -> connection.hRandFieldWithValues(rawKey, count));
 
 		if (rawEntries == null) {
 			return null;
@@ -162,7 +161,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 	public Set<HK> keys(K key) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.hKeys(rawKey), true);
+		Set<byte[]> rawValues = execute(connection -> connection.hKeys(rawKey));
 
 		return rawValues != null ? deserializeHashKeys(rawValues) : Collections.emptySet();
 	}
@@ -175,7 +174,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 	public Long size(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.hLen(rawKey), true);
+		return execute(connection -> connection.hLen(rawKey));
 	}
 
 	/*
@@ -188,7 +187,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawHashKey = rawHashKey(hashKey);
-		return execute(connection -> connection.hStrLen(rawKey, rawHashKey), true);
+		return execute(connection -> connection.hStrLen(rawKey, rawHashKey));
 	}
 
 	/*
@@ -213,7 +212,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 		execute(connection -> {
 			connection.hMSet(rawKey, hashes);
 			return null;
-		}, true);
+		});
 	}
 
 	/*
@@ -235,7 +234,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 			rawHashKeys[counter++] = rawHashKey(hashKey);
 		}
 
-		List<byte[]> rawValues = execute(connection -> connection.hMGet(rawKey, rawHashKeys), true);
+		List<byte[]> rawValues = execute(connection -> connection.hMGet(rawKey, rawHashKeys));
 
 		return deserializeHashValues(rawValues);
 	}
@@ -254,7 +253,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 		execute(connection -> {
 			connection.hSet(rawKey, rawHashKey, rawHashValue);
 			return null;
-		}, true);
+		});
 	}
 
 	/*
@@ -268,7 +267,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 		byte[] rawHashKey = rawHashKey(hashKey);
 		byte[] rawHashValue = rawHashValue(value);
 
-		return execute(connection -> connection.hSetNX(rawKey, rawHashKey, rawHashValue), true);
+		return execute(connection -> connection.hSetNX(rawKey, rawHashKey, rawHashValue));
 	}
 
 	/*
@@ -279,7 +278,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 	public List<HV> values(K key) {
 
 		byte[] rawKey = rawKey(key);
-		List<byte[]> rawValues = execute(connection -> connection.hVals(rawKey), true);
+		List<byte[]> rawValues = execute(connection -> connection.hVals(rawKey));
 
 		return rawValues != null ? deserializeHashValues(rawValues) : Collections.emptyList();
 	}
@@ -294,7 +293,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 		byte[] rawKey = rawKey(key);
 		byte[][] rawHashKeys = rawHashKeys(hashKeys);
 
-		return execute(connection -> connection.hDel(rawKey, rawHashKeys), true);
+		return execute(connection -> connection.hDel(rawKey, rawHashKeys));
 	}
 
 	/*
@@ -305,7 +304,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 	public Map<HK, HV> entries(K key) {
 
 		byte[] rawKey = rawKey(key);
-		Map<byte[], byte[]> entries = execute(connection -> connection.hGetAll(rawKey), true);
+		Map<byte[], byte[]> entries = execute(connection -> connection.hGetAll(rawKey));
 
 		return entries != null ? deserializeHashMap(entries) : Collections.emptyMap();
 	}

--- a/src/main/java/org/springframework/data/redis/core/DefaultHyperLogLogOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultHyperLogLogOperations.java
@@ -38,7 +38,7 @@ class DefaultHyperLogLogOperations<K, V> extends AbstractOperations<K, V> implem
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(values);
-		return execute(connection -> connection.pfAdd(rawKey, rawValues), true);
+		return execute(connection -> connection.pfAdd(rawKey, rawValues));
 	}
 
 	/*
@@ -49,7 +49,7 @@ class DefaultHyperLogLogOperations<K, V> extends AbstractOperations<K, V> implem
 	public Long size(K... keys) {
 
 		byte[][] rawKeys = rawKeys(Arrays.asList(keys));
-		return execute(connection -> connection.pfCount(rawKeys), true);
+		return execute(connection -> connection.pfCount(rawKeys));
 	}
 
 	/*
@@ -65,7 +65,7 @@ class DefaultHyperLogLogOperations<K, V> extends AbstractOperations<K, V> implem
 
 			connection.pfMerge(rawDestinationKey, rawSourceKeys);
 			return connection.pfCount(rawDestinationKey);
-		}, true);
+		});
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
@@ -52,7 +52,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.lIndex(rawKey, index);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -64,7 +64,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.lPos(rawKey, rawValue), true);
+		return execute(connection -> connection.lPos(rawKey, rawValue));
 	}
 
 	/*
@@ -80,7 +80,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 			List<Long> indexes = connection.lPos(rawKey, rawValue, -1, null);
 			return CollectionUtils.firstElement(indexes);
-		}, true);
+		});
 	}
 
 	/*
@@ -96,7 +96,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.lPop(rawKey);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -106,7 +106,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 	@Override
 	public List<V> leftPop(K key, long count) {
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> deserializeValues(connection.lPop(rawKey, count)), true);
+		return execute(connection -> deserializeValues(connection.lPop(rawKey, count)));
 	}
 
 	/*
@@ -124,7 +124,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 				List<byte[]> lPop = connection.bLPop(tm, rawKey);
 				return (CollectionUtils.isEmpty(lPop) ? null : lPop.get(1));
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -136,7 +136,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.lPush(rawKey, rawValue), true);
+		return execute(connection -> connection.lPush(rawKey, rawValue));
 	}
 
 	/*
@@ -148,7 +148,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(values);
-		return execute(connection -> connection.lPush(rawKey, rawValues), true);
+		return execute(connection -> connection.lPush(rawKey, rawValues));
 	}
 
 	/*
@@ -161,7 +161,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(values);
 
-		return execute(connection -> connection.lPush(rawKey, rawValues), true);
+		return execute(connection -> connection.lPush(rawKey, rawValues));
 	}
 
 	/*
@@ -173,7 +173,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.lPushX(rawKey, rawValue), true);
+		return execute(connection -> connection.lPushX(rawKey, rawValue));
 	}
 
 	/*
@@ -186,7 +186,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 		byte[] rawKey = rawKey(key);
 		byte[] rawPivot = rawValue(pivot);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.lInsert(rawKey, Position.BEFORE, rawPivot, rawValue), true);
+		return execute(connection -> connection.lInsert(rawKey, Position.BEFORE, rawPivot, rawValue));
 	}
 
 	/*
@@ -197,7 +197,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 	public Long size(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.lLen(rawKey), true);
+		return execute(connection -> connection.lLen(rawKey));
 	}
 
 	/*
@@ -208,7 +208,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 	public List<V> range(K key, long start, long end) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> deserializeValues(connection.lRange(rawKey, start, end)), true);
+		return execute(connection -> deserializeValues(connection.lRange(rawKey, start, end)));
 	}
 
 	/*
@@ -220,7 +220,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.lRem(rawKey, count, rawValue), true);
+		return execute(connection -> connection.lRem(rawKey, count, rawValue));
 	}
 
 	/*
@@ -236,7 +236,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.rPop(rawKey);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -246,7 +246,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 	@Override
 	public List<V> rightPop(K key, long count) {
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> deserializeValues(connection.rPop(rawKey, count)), true);
+		return execute(connection -> deserializeValues(connection.rPop(rawKey, count)));
 	}
 
 	/*
@@ -265,7 +265,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 				List<byte[]> bRPop = connection.bRPop(tm, rawKey);
 				return (CollectionUtils.isEmpty(bRPop) ? null : bRPop.get(1));
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -277,7 +277,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.rPush(rawKey, rawValue), true);
+		return execute(connection -> connection.rPush(rawKey, rawValue));
 	}
 
 	/*
@@ -289,7 +289,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(values);
-		return execute(connection -> connection.rPush(rawKey, rawValues), true);
+		return execute(connection -> connection.rPush(rawKey, rawValues));
 	}
 
 	/*
@@ -301,7 +301,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(values);
-		return execute(connection -> connection.rPush(rawKey, rawValues), true);
+		return execute(connection -> connection.rPush(rawKey, rawValues));
 	}
 
 	/*
@@ -313,7 +313,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.rPushX(rawKey, rawValue), true);
+		return execute(connection -> connection.rPushX(rawKey, rawValue));
 	}
 
 	/*
@@ -326,7 +326,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 		byte[] rawKey = rawKey(key);
 		byte[] rawPivot = rawValue(pivot);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.lInsert(rawKey, Position.AFTER, rawPivot, rawValue), true);
+		return execute(connection -> connection.lInsert(rawKey, Position.AFTER, rawPivot, rawValue));
 	}
 
 	/*
@@ -343,7 +343,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 			protected byte[] inRedis(byte[] rawSourceKey, RedisConnection connection) {
 				return connection.rPopLPush(rawSourceKey, rawDestKey);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -361,10 +361,10 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 			protected byte[] inRedis(byte[] rawSourceKey, RedisConnection connection) {
 				return connection.bRPopLPush(tm, rawSourceKey, rawDestKey);
 			}
-		}, true);
+		});
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ListOperations#move(java.lang.Object, org.springframework.data.redis.connection.RedisListCommands.Direction, java.lang.Object, org.springframework.data.redis.connection.RedisListCommands.Direction)
 	 */
@@ -378,10 +378,10 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 			protected byte[] inRedis(byte[] rawSourceKey, RedisConnection connection) {
 				return connection.lMove(rawSourceKey, rawDestKey, from, to);
 			}
-		}, true);
+		});
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ListOperations#move(java.lang.Object, org.springframework.data.redis.connection.RedisListCommands.Direction, java.lang.Object, org.springframework.data.redis.connection.RedisListCommands.Direction, long, java.util.concurrent.TimeUnit)
 	 */
@@ -395,7 +395,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 			protected byte[] inRedis(byte[] rawSourceKey, RedisConnection connection) {
 				return connection.bLMove(rawSourceKey, rawDestKey, from, to, TimeoutUtils.toDoubleSeconds(timeout, unit));
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -413,7 +413,7 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 				connection.lSet(rawKey, index, rawValue);
 				return null;
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -430,6 +430,6 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 				connection.lTrim(rawKey, start, end);
 				return null;
 			}
-		}, true);
+		});
 	}
 }

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
@@ -15,20 +15,20 @@
  */
 package org.springframework.data.redis.core;
 
-import org.springframework.data.redis.connection.convert.Converters;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
+
 import org.springframework.data.redis.connection.ReactiveHashCommands;
+import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.util.Assert;
 
@@ -125,7 +125,7 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(hashKey, "Hash key must not be null!");
 
-		return template.createMono(connection -> connection //
+		return template.doCreateMono(connection -> connection //
 				.numberCommands() //
 				.hIncrBy(rawKey(key), rawHashKey(hashKey), delta));
 	}
@@ -140,7 +140,7 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 		Assert.notNull(key, "Key must not be null!");
 		Assert.notNull(hashKey, "Hash key must not be null!");
 
-		return template.createMono(connection -> connection //
+		return template.doCreateMono(connection -> connection //
 				.numberCommands() //
 				.hIncrBy(rawKey(key), rawHashKey(hashKey), delta));
 	}
@@ -154,7 +154,7 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection //
+		return template.doCreateMono(connection -> connection //
 				.hashCommands().hRandField(rawKey(key))).map(this::readHashKey);
 	}
 
@@ -167,7 +167,7 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection //
+		return template.doCreateMono(connection -> connection //
 				.hashCommands().hRandFieldWithValues(rawKey(key))).map(this::deserializeHashEntry);
 	}
 
@@ -180,7 +180,7 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createFlux(connection -> connection //
+		return template.doCreateFlux(connection -> connection //
 				.hashCommands().hRandField(rawKey(key), count)).map(this::readHashKey);
 	}
 
@@ -193,7 +193,7 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createFlux(connection -> connection //
+		return template.doCreateFlux(connection -> connection //
 				.hashCommands().hRandFieldWithValues(rawKey(key), count)).map(this::deserializeHashEntry);
 	}
 
@@ -314,21 +314,21 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
+		return template.doCreateMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
 	}
 
 	private <T> Mono<T> createMono(Function<ReactiveHashCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createMono(connection -> function.apply(connection.hashCommands()));
+		return template.doCreateMono(connection -> function.apply(connection.hashCommands()));
 	}
 
 	private <T> Flux<T> createFlux(Function<ReactiveHashCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createFlux(connection -> function.apply(connection.hashCommands()));
+		return template.doCreateFlux(connection -> function.apply(connection.hashCommands()));
 	}
 
 	private ByteBuffer rawKey(H key) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveHyperLogLogOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveHyperLogLogOperations.java
@@ -103,14 +103,14 @@ class DefaultReactiveHyperLogLogOperations<K, V> implements ReactiveHyperLogLogO
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
+		return template.doCreateMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
 	}
 
 	private <T> Mono<T> createMono(Function<ReactiveHyperLogLogCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createMono(connection -> function.apply(connection.hyperLogLogCommands()));
+		return template.doCreateMono(connection -> function.apply(connection.hyperLogLogCommands()));
 	}
 
 	private ByteBuffer rawKey(K key) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveListOperations.java
@@ -200,7 +200,7 @@ class DefaultReactiveListOperations<K, V> implements ReactiveListOperations<K, V
 		return createMono(connection -> connection.lInsert(rawKey(key), Position.AFTER, rawValue(pivot), rawValue(value)));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveListOperations#move(K, Direction, K, Direction)
 	 */
@@ -216,7 +216,7 @@ class DefaultReactiveListOperations<K, V> implements ReactiveListOperations<K, V
 				connection -> connection.lMove(rawKey(sourceKey), rawKey(destinationKey), from, to).map(this::readValue));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveListOperations#move(K, Direction, K, Direction, Duration)
 	 */
@@ -378,21 +378,21 @@ class DefaultReactiveListOperations<K, V> implements ReactiveListOperations<K, V
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
+		return template.doCreateMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
 	}
 
 	private <T> Mono<T> createMono(Function<ReactiveListCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createMono(connection -> function.apply(connection.listCommands()));
+		return template.doCreateMono(connection -> function.apply(connection.listCommands()));
 	}
 
 	private <T> Flux<T> createFlux(Function<ReactiveListCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createFlux(connection -> function.apply(connection.listCommands()));
+		return template.doCreateFlux(connection -> function.apply(connection.listCommands()));
 	}
 
 	private boolean isZeroOrGreater1Second(Duration timeout) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveSetOperations.java
@@ -508,21 +508,21 @@ class DefaultReactiveSetOperations<K, V> implements ReactiveSetOperations<K, V> 
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
+		return template.doCreateMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
 	}
 
 	private <T> Mono<T> createMono(Function<ReactiveSetCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createMono(connection -> function.apply(connection.setCommands()));
+		return template.doCreateMono(connection -> function.apply(connection.setCommands()));
 	}
 
 	private <T> Flux<T> createFlux(Function<ReactiveSetCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createFlux(connection -> function.apply(connection.setCommands()));
+		return template.doCreateFlux(connection -> function.apply(connection.setCommands()));
 	}
 
 	private ByteBuffer rawKey(K key) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.redis.core;
 
-import org.springframework.data.redis.connection.convert.Converters;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -28,10 +27,12 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
+
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.ReactiveStreamCommands;
 import org.springframework.data.redis.connection.RedisZSetCommands.Limit;
+import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.connection.stream.ByteBufferRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
@@ -372,14 +373,14 @@ class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperat
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createMono(connection -> function.apply(connection.streamCommands()));
+		return template.doCreateMono(connection -> function.apply(connection.streamCommands()));
 	}
 
 	private <T> Flux<T> createFlux(Function<ReactiveStreamCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createFlux(connection -> function.apply(connection.streamCommands()));
+		return template.doCreateFlux(connection -> function.apply(connection.streamCommands()));
 	}
 
 	private ByteBuffer rawKey(K key) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveValueOperations.java
@@ -244,7 +244,7 @@ class DefaultReactiveValueOperations<K, V> implements ReactiveValueOperations<K,
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.numberCommands().incr(rawKey(key)));
+		return template.doCreateMono(connection -> connection.numberCommands().incr(rawKey(key)));
 	}
 
 	/* (non-Javadoc)
@@ -255,7 +255,7 @@ class DefaultReactiveValueOperations<K, V> implements ReactiveValueOperations<K,
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.numberCommands().incrBy(rawKey(key), delta));
+		return template.doCreateMono(connection -> connection.numberCommands().incrBy(rawKey(key), delta));
 	}
 
 	/* (non-Javadoc)
@@ -266,7 +266,7 @@ class DefaultReactiveValueOperations<K, V> implements ReactiveValueOperations<K,
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.numberCommands().incrBy(rawKey(key), delta));
+		return template.doCreateMono(connection -> connection.numberCommands().incrBy(rawKey(key), delta));
 	}
 
 	/* (non-Javadoc)
@@ -277,7 +277,7 @@ class DefaultReactiveValueOperations<K, V> implements ReactiveValueOperations<K,
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.numberCommands().decr(rawKey(key)));
+		return template.doCreateMono(connection -> connection.numberCommands().decr(rawKey(key)));
 	}
 
 	/* (non-Javadoc)
@@ -288,7 +288,7 @@ class DefaultReactiveValueOperations<K, V> implements ReactiveValueOperations<K,
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.numberCommands().decrBy(rawKey(key), delta));
+		return template.doCreateMono(connection -> connection.numberCommands().decrBy(rawKey(key), delta));
 	}
 
 	/* (non-Javadoc)
@@ -380,14 +380,14 @@ class DefaultReactiveValueOperations<K, V> implements ReactiveValueOperations<K,
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
+		return template.doCreateMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
 	}
 
 	private <T> Mono<T> createMono(Function<ReactiveStringCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createMono(connection -> function.apply(connection.stringCommands()));
+		return template.doCreateMono(connection -> function.apply(connection.stringCommands()));
 	}
 
 	private ByteBuffer rawKey(K key) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveZSetOperations.java
@@ -120,7 +120,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 		return createMono(connection -> connection.zIncrBy(rawKey(key), delta, rawValue(value)));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#randomMember(K)
 	 */
@@ -132,7 +132,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 		return createMono(connection -> connection.zRandMember(rawKey(key))).map(this::readValue);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#distinctRandomMembers(K, long)
 	 */
@@ -145,7 +145,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 		return createFlux(connection -> connection.zRandMember(rawKey(key), count)).map(this::readValue);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#randomMembers(K, long)
 	 */
@@ -158,7 +158,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 		return createFlux(connection -> connection.zRandMember(rawKey(key), -count)).map(this::readValue);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#randomMemberWithScore(K)
 	 */
@@ -170,7 +170,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 		return createMono(connection -> connection.zRandMemberWithScore(rawKey(key))).map(this::readTypedTuple);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#distinctRandomMembersWithScore(K, long)
 	 */
@@ -183,7 +183,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 		return createFlux(connection -> connection.zRandMemberWithScore(rawKey(key), count)).map(this::readTypedTuple);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#randomMembersWithScore(K, long)
 	 */
@@ -576,7 +576,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 		return createMono(connection -> connection.zRemRangeByScore(rawKey(key), range));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#difference(K, Collection)
 	 */
@@ -592,7 +592,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 				.flatMapMany(connection::zDiff).map(this::readValue));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#differenceWithScores(K, Collection)
 	 */
@@ -608,7 +608,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 				.flatMapMany(connection::zDiffWithScores).map(this::readTypedTuple));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#differenceAndStore(K, Collection, K)
 	 */
@@ -626,7 +626,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#intersect(K, Collection)
 	 */
@@ -642,7 +642,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 				.flatMapMany(connection::zInter).map(this::readValue));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#intersectWithScores(K, Collection)
 	 */
@@ -658,7 +658,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 				.flatMapMany(connection::zInterWithScores).map(this::readTypedTuple));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#intersectWithScores(K, Collection, Aggregate, Weights)
 	 */
@@ -714,7 +714,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 				.flatMap(serialized -> connection.zInterStore(rawKey(destKey), serialized, weights, aggregate)));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#union(K, Collection)
 	 */
@@ -730,7 +730,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 				.flatMapMany(connection::zUnion).map(this::readValue));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#unionWithScores(K, Collection)
 	 */
@@ -746,7 +746,7 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 				.flatMapMany(connection::zUnionWithScores).map(this::readTypedTuple));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.redis.core.ReactiveZSetOperations#unionWithScores(K, Collection, Aggregate, Weights)
 	 */
@@ -877,21 +877,21 @@ class DefaultReactiveZSetOperations<K, V> implements ReactiveZSetOperations<K, V
 
 		Assert.notNull(key, "Key must not be null!");
 
-		return template.createMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
+		return template.doCreateMono(connection -> connection.keyCommands().del(rawKey(key))).map(l -> l != 0);
 	}
 
 	private <T> Mono<T> createMono(Function<ReactiveZSetCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createMono(connection -> function.apply(connection.zSetCommands()));
+		return template.doCreateMono(connection -> function.apply(connection.zSetCommands()));
 	}
 
 	private <T> Flux<T> createFlux(Function<ReactiveZSetCommands, Publisher<T>> function) {
 
 		Assert.notNull(function, "Function must not be null!");
 
-		return template.createFlux(connection -> function.apply(connection.zSetCommands()));
+		return template.doCreateFlux(connection -> function.apply(connection.zSetCommands()));
 	}
 
 	private ByteBuffer rawKey(K key) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultSetOperations.java
@@ -49,7 +49,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues((Object[]) values);
-		return execute(connection -> connection.sAdd(rawKey, rawValues), true);
+		return execute(connection -> connection.sAdd(rawKey, rawValues));
 	}
 
 	/*
@@ -69,7 +69,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	public Set<V> difference(K key, Collection<K> otherKeys) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<byte[]> rawValues = execute(connection -> connection.sDiff(rawKeys), true);
+		Set<byte[]> rawValues = execute(connection -> connection.sDiff(rawKeys));
 
 		return deserializeValues(rawValues);
 	}
@@ -82,7 +82,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	public Set<V> difference(Collection<K> keys) {
 
 		byte[][] rawKeys = rawKeys(keys);
-		Set<byte[]> rawValues = execute(connection -> connection.sDiff(rawKeys), true);
+		Set<byte[]> rawValues = execute(connection -> connection.sDiff(rawKeys));
 
 		return deserializeValues(rawValues);
 	}
@@ -106,7 +106,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 		byte[][] rawKeys = rawKeys(key, otherKeys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.sDiffStore(rawDestKey, rawKeys), true);
+		return execute(connection -> connection.sDiffStore(rawDestKey, rawKeys));
 	}
 
 	/*
@@ -119,7 +119,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 		byte[][] rawKeys = rawKeys(keys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.sDiffStore(rawDestKey, rawKeys), true);
+		return execute(connection -> connection.sDiffStore(rawDestKey, rawKeys));
 	}
 
 	/*
@@ -139,7 +139,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	public Set<V> intersect(K key, Collection<K> otherKeys) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<byte[]> rawValues = execute(connection -> connection.sInter(rawKeys), true);
+		Set<byte[]> rawValues = execute(connection -> connection.sInter(rawKeys));
 
 		return deserializeValues(rawValues);
 	}
@@ -152,7 +152,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	public Set<V> intersect(Collection<K> keys) {
 
 		byte[][] rawKeys = rawKeys(keys);
-		Set<byte[]> rawValues = execute(connection -> connection.sInter(rawKeys), true);
+		Set<byte[]> rawValues = execute(connection -> connection.sInter(rawKeys));
 
 		return deserializeValues(rawValues);
 	}
@@ -176,7 +176,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 		byte[][] rawKeys = rawKeys(key, otherKeys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.sInterStore(rawDestKey, rawKeys), true);
+		return execute(connection -> connection.sInterStore(rawDestKey, rawKeys));
 	}
 
 	/*
@@ -189,7 +189,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 		byte[][] rawKeys = rawKeys(keys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.sInterStore(rawDestKey, rawKeys), true);
+		return execute(connection -> connection.sInterStore(rawDestKey, rawKeys));
 	}
 
 	/*
@@ -202,7 +202,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(o);
 
-		return execute(connection -> connection.sIsMember(rawKey, rawValue), true);
+		return execute(connection -> connection.sIsMember(rawKey, rawValue));
 	}
 
 	/*
@@ -230,7 +230,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 			}
 
 			return isMember;
-		}, true);
+		});
 	}
 
 	/*
@@ -241,7 +241,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	public Set<V> members(K key) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.sMembers(rawKey), true);
+		Set<byte[]> rawValues = execute(connection -> connection.sMembers(rawKey));
 
 		return deserializeValues(rawValues);
 	}
@@ -257,7 +257,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 		byte[] rawDestKey = rawKey(destKey);
 		byte[] rawValue = rawValue(value);
 
-		return execute(connection -> connection.sMove(rawKey, rawDestKey, rawValue), true);
+		return execute(connection -> connection.sMove(rawKey, rawDestKey, rawValue));
 	}
 
 	/*
@@ -273,7 +273,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.sRandMember(rawKey);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -287,7 +287,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 
 		byte[] rawKey = rawKey(key);
 		Set<byte[]> rawValues = execute(
-				(RedisCallback<Set<byte[]>>) connection -> new HashSet<>(connection.sRandMember(rawKey, count)), true);
+				(RedisCallback<Set<byte[]>>) connection -> new HashSet<>(connection.sRandMember(rawKey, count)));
 
 		return deserializeValues(rawValues);
 	}
@@ -303,7 +303,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 				"Use a positive number for count. " + "This method is already allowing duplicate elements.");
 
 		byte[] rawKey = rawKey(key);
-		List<byte[]> rawValues = execute(connection -> connection.sRandMember(rawKey, -count), true);
+		List<byte[]> rawValues = execute(connection -> connection.sRandMember(rawKey, -count));
 
 		return deserializeValues(rawValues);
 	}
@@ -317,7 +317,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(values);
-		return execute(connection -> connection.sRem(rawKey, rawValues), true);
+		return execute(connection -> connection.sRem(rawKey, rawValues));
 	}
 
 	/*
@@ -333,7 +333,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.sPop(rawKey);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -344,7 +344,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	public List<V> pop(K key, long count) {
 
 		byte[] rawKey = rawKey(key);
-		List<byte[]> rawValues = execute(connection -> connection.sPop(rawKey, count), true);
+		List<byte[]> rawValues = execute(connection -> connection.sPop(rawKey, count));
 
 		return deserializeValues(rawValues);
 	}
@@ -357,7 +357,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	public Long size(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.sCard(rawKey), true);
+		return execute(connection -> connection.sCard(rawKey));
 	}
 
 	/*
@@ -377,7 +377,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	public Set<V> union(K key, Collection<K> otherKeys) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<byte[]> rawValues = execute(connection -> connection.sUnion(rawKeys), true);
+		Set<byte[]> rawValues = execute(connection -> connection.sUnion(rawKeys));
 
 		return deserializeValues(rawValues);
 	}
@@ -390,7 +390,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	public Set<V> union(Collection<K> keys) {
 
 		byte[][] rawKeys = rawKeys(keys);
-		Set<byte[]> rawValues = execute(connection -> connection.sUnion(rawKeys), true);
+		Set<byte[]> rawValues = execute(connection -> connection.sUnion(rawKeys));
 
 		return deserializeValues(rawValues);
 	}
@@ -414,7 +414,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 		byte[][] rawKeys = rawKeys(key, otherKeys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.sUnionStore(rawDestKey, rawKeys), true);
+		return execute(connection -> connection.sUnionStore(rawDestKey, rawKeys));
 	}
 
 	/*
@@ -427,7 +427,7 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 		byte[][] rawKeys = rawKeys(keys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.sUnionStore(rawDestKey, rawKeys), true);
+		return execute(connection -> connection.sUnionStore(rawDestKey, rawKeys));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -119,7 +119,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public Long acknowledge(K key, String group, String... recordIds) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xAck(rawKey, group, recordIds), true);
+		return execute(connection -> connection.xAck(rawKey, group, recordIds));
 	}
 
 	/*
@@ -137,7 +137,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 
 		ByteRecord binaryRecord = input.serialize(keySerializer(), hashKeySerializer(), hashValueSerializer());
 
-		return execute(connection -> connection.xAdd(binaryRecord), true);
+		return execute(connection -> connection.xAdd(binaryRecord));
 	}
 
 	/*
@@ -148,7 +148,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public Long delete(K key, RecordId... recordIds) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xDel(rawKey, recordIds), true);
+		return execute(connection -> connection.xDel(rawKey, recordIds));
 	}
 
 	/*
@@ -159,7 +159,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public String createGroup(K key, ReadOffset readOffset, String group) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xGroupCreate(rawKey, group, readOffset, true), true);
+		return execute(connection -> connection.xGroupCreate(rawKey, group, readOffset, true));
 	}
 
 	/*
@@ -170,7 +170,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public Boolean deleteConsumer(K key, Consumer consumer) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xGroupDelConsumer(rawKey, consumer), true);
+		return execute(connection -> connection.xGroupDelConsumer(rawKey, consumer));
 	}
 
 	/*
@@ -181,7 +181,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public Boolean destroyGroup(K key, String group) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xGroupDestroy(rawKey, group), true);
+		return execute(connection -> connection.xGroupDestroy(rawKey, group));
 	}
 
 	/*
@@ -192,7 +192,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public XInfoStream info(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xInfo(rawKey), true);
+		return execute(connection -> connection.xInfo(rawKey));
 	}
 
 	/*
@@ -203,7 +203,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public XInfoConsumers consumers(K key, String group) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xInfoConsumers(rawKey, group), true);
+		return execute(connection -> connection.xInfoConsumers(rawKey, group));
 	}
 
 	/*
@@ -214,7 +214,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public XInfoGroups groups(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xInfoGroups(rawKey), true);
+		return execute(connection -> connection.xInfoGroups(rawKey));
 	}
 
 	/*
@@ -225,7 +225,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public PendingMessages pending(K key, String group, Range<?> range, long count) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xPending(rawKey, group, range, count), true);
+		return execute(connection -> connection.xPending(rawKey, group, range, count));
 	}
 
 	/*
@@ -236,7 +236,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public PendingMessages pending(K key, Consumer consumer, Range<?> range, long count) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xPending(rawKey, consumer, range, count), true);
+		return execute(connection -> connection.xPending(rawKey, consumer, range, count));
 	}
 
 	/*
@@ -247,7 +247,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public PendingMessagesSummary pending(K key, String group) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xPending(rawKey, group), true);
+		return execute(connection -> connection.xPending(rawKey, group));
 	}
 
 	/*
@@ -258,7 +258,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	public Long size(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xLen(rawKey), true);
+		return execute(connection -> connection.xLen(rawKey));
 	}
 
 	/*
@@ -275,7 +275,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 			List<ByteRecord> inRedis(RedisConnection connection) {
 				return connection.xRange(rawKey(key), range, limit);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -292,7 +292,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 			List<ByteRecord> inRedis(RedisConnection connection) {
 				return connection.xRead(readOptions, rawStreamOffsets(streams));
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -309,7 +309,7 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 			List<ByteRecord> inRedis(RedisConnection connection) {
 				return connection.xReadGroup(consumer, readOptions, rawStreamOffsets(streams));
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -326,20 +326,20 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 			List<ByteRecord> inRedis(RedisConnection connection) {
 				return connection.xRevRange(rawKey(key), range, limit);
 			}
-		}, true);
+		});
 	}
 
 	@Override
 	public Long trim(K key, long count) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xTrim(rawKey, count), true);
+		return execute(connection -> connection.xTrim(rawKey, count));
 	}
 
 	@Override
 	public Long trim(K key, long count, boolean approximateTrimming) {
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.xTrim(rawKey, count, approximateTrimming), true);
+		return execute(connection -> connection.xTrim(rawKey, count, approximateTrimming));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
@@ -57,7 +57,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.get(rawKey);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -74,7 +74,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.getDel(rawKey);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -91,7 +91,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.getEx(rawKey, Expiration.from(timeout, unit));
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -108,7 +108,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.getEx(rawKey, Expiration.from(timeout));
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -125,7 +125,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.getEx(rawKey, Expiration.persistent());
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -142,7 +142,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 			protected byte[] inRedis(byte[] rawKey, RedisConnection connection) {
 				return connection.getSet(rawKey, rawValue);
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -153,7 +153,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	public Long increment(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.incr(rawKey), true);
+		return execute(connection -> connection.incr(rawKey));
 	}
 
 	/*
@@ -164,7 +164,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	public Long increment(K key, long delta) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.incrBy(rawKey, delta), true);
+		return execute(connection -> connection.incrBy(rawKey, delta));
 	}
 
 	/*
@@ -175,7 +175,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	public Double increment(K key, double delta) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.incrBy(rawKey, delta), true);
+		return execute(connection -> connection.incrBy(rawKey, delta));
 	}
 
 	/*
@@ -186,7 +186,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	public Long decrement(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.decr(rawKey), true);
+		return execute(connection -> connection.decr(rawKey));
 	}
 
 	/*
@@ -197,7 +197,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	public Long decrement(K key, long delta) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.decrBy(rawKey, delta), true);
+		return execute(connection -> connection.decrBy(rawKey, delta));
 	}
 
 	/*
@@ -213,7 +213,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 		return execute(connection -> {
 			Long result = connection.append(rawKey, rawString);
 			return (result != null) ? result.intValue() : null;
-		}, true);
+		});
 	}
 
 	/*
@@ -223,7 +223,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	@Override
 	public String get(K key, long start, long end) {
 		byte[] rawKey = rawKey(key);
-		byte[] rawReturn = execute(connection -> connection.getRange(rawKey, start, end), true);
+		byte[] rawReturn = execute(connection -> connection.getRange(rawKey, start, end));
 
 		return deserializeString(rawReturn);
 	}
@@ -246,7 +246,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 			rawKeys[counter++] = rawKey(hashKey);
 		}
 
-		List<byte[]> rawValues = execute(connection -> connection.mGet(rawKeys), true);
+		List<byte[]> rawValues = execute(connection -> connection.mGet(rawKeys));
 
 		return deserializeValues(rawValues);
 	}
@@ -271,7 +271,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 		execute(connection -> {
 			connection.mSet(rawKeys);
 			return null;
-		}, true);
+		});
 	}
 
 	/*
@@ -291,7 +291,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 			rawKeys.put(rawKey(entry.getKey()), rawValue(entry.getValue()));
 		}
 
-		return execute(connection -> connection.mSetNX(rawKeys), true);
+		return execute(connection -> connection.mSetNX(rawKeys));
 	}
 
 	/*
@@ -309,7 +309,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 				connection.set(rawKey, rawValue);
 				return null;
 			}
-		}, true);
+		});
 	}
 
 	/*
@@ -350,7 +350,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 				return !failed;
 			}
 
-		}, true);
+		});
 	}
 
 	/*
@@ -362,7 +362,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.setNX(rawKey, rawValue), true);
+		return execute(connection -> connection.setNX(rawKey, rawValue));
 	}
 
 	/*
@@ -376,7 +376,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 		byte[] rawValue = rawValue(value);
 
 		Expiration expiration = Expiration.from(timeout, unit);
-		return execute(connection -> connection.set(rawKey, rawValue, expiration, SetOption.ifAbsent()), true);
+		return execute(connection -> connection.set(rawKey, rawValue, expiration, SetOption.ifAbsent()));
 	}
 
 	/*
@@ -390,7 +390,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
 
-		return execute(connection -> connection.set(rawKey, rawValue, Expiration.persistent(), SetOption.ifPresent()), true);
+		return execute(connection -> connection.set(rawKey, rawValue, Expiration.persistent(), SetOption.ifPresent()));
 	}
 
 	/*
@@ -405,7 +405,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 		byte[] rawValue = rawValue(value);
 
 		Expiration expiration = Expiration.from(timeout, unit);
-		return execute(connection -> connection.set(rawKey, rawValue, expiration, SetOption.ifPresent()), true);
+		return execute(connection -> connection.set(rawKey, rawValue, expiration, SetOption.ifPresent()));
 	}
 
 	/*
@@ -421,7 +421,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 		execute(connection -> {
 			connection.setRange(rawKey, rawValue, offset);
 			return null;
-		}, true);
+		});
 	}
 
 	/*
@@ -432,7 +432,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	public Long size(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.strLen(rawKey), true);
+		return execute(connection -> connection.strLen(rawKey));
 	}
 
 	/*
@@ -443,7 +443,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	public Boolean setBit(K key, long offset, boolean value) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.setBit(rawKey, offset, value), true);
+		return execute(connection -> connection.setBit(rawKey, offset, value));
 	}
 
 	/*
@@ -454,7 +454,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	public Boolean getBit(K key, long offset) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.getBit(rawKey, offset), true);
+		return execute(connection -> connection.getBit(rawKey, offset));
 	}
 
 	/*
@@ -465,6 +465,6 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	public List<Long> bitField(K key, final BitFieldSubCommands subCommands) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.bitField(rawKey, subCommands), true);
+		return execute(connection -> connection.bitField(rawKey, subCommands));
 	}
 }

--- a/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
@@ -57,7 +57,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.zAdd(rawKey, score, rawValue), true);
+		return execute(connection -> connection.zAdd(rawKey, score, rawValue));
 	}
 
 	/*
@@ -81,7 +81,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.zAdd(rawKey, score, rawValue, args), true);
+		return execute(connection -> connection.zAdd(rawKey, score, rawValue, args));
 	}
 
 	/*
@@ -93,7 +93,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 		Set<Tuple> rawValues = rawTupleValues(tuples);
-		return execute(connection -> connection.zAdd(rawKey, rawValues), true);
+		return execute(connection -> connection.zAdd(rawKey, rawValues));
 	}
 
 	/*
@@ -117,7 +117,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 		Set<Tuple> rawValues = rawTupleValues(tuples);
-		return execute(connection -> connection.zAdd(rawKey, rawValues, args), true);
+		return execute(connection -> connection.zAdd(rawKey, rawValues, args));
 	}
 
 	/*
@@ -129,7 +129,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(value);
-		return execute(connection -> connection.zIncrBy(rawKey, delta, rawValue), true);
+		return execute(connection -> connection.zIncrBy(rawKey, delta, rawValue));
 	}
 
 	/*
@@ -141,7 +141,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 
-		return deserializeValue(execute(connection -> connection.zRandMember(rawKey), true));
+		return deserializeValue(execute(connection -> connection.zRandMember(rawKey)));
 	}
 
 	/*
@@ -155,7 +155,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 
-		List<byte[]> result = execute(connection -> connection.zRandMember(rawKey, count), true);
+		List<byte[]> result = execute(connection -> connection.zRandMember(rawKey, count));
 		return result != null ? deserializeValues(new LinkedHashSet<>(result)) : null;
 	}
 
@@ -170,7 +170,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 
-		List<byte[]> result = execute(connection -> connection.zRandMember(rawKey, count), true);
+		List<byte[]> result = execute(connection -> connection.zRandMember(rawKey, count));
 		return deserializeValues(result);
 	}
 
@@ -183,7 +183,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 
-		return deserializeTuple(execute(connection -> connection.zRandMemberWithScore(rawKey), true));
+		return deserializeTuple(execute(connection -> connection.zRandMemberWithScore(rawKey)));
 	}
 
 	/*
@@ -197,7 +197,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 
-		List<Tuple> result = execute(connection -> connection.zRandMemberWithScore(rawKey, count), true);
+		List<Tuple> result = execute(connection -> connection.zRandMemberWithScore(rawKey, count));
 		return result != null ? deserializeTupleValues(new LinkedHashSet<>(result)) : null;
 	}
 
@@ -212,7 +212,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 
-		List<Tuple> result = execute(connection -> connection.zRandMemberWithScore(rawKey, count), true);
+		List<Tuple> result = execute(connection -> connection.zRandMemberWithScore(rawKey, count));
 		return result != null ? deserializeTupleValues(result) : null;
 	}
 
@@ -224,7 +224,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> range(K key, long start, long end) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.zRange(rawKey, start, end), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zRange(rawKey, start, end));
 
 		return deserializeValues(rawValues);
 	}
@@ -237,7 +237,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> reverseRange(K key, long start, long end) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.zRevRange(rawKey, start, end), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zRevRange(rawKey, start, end));
 
 		return deserializeValues(rawValues);
 	}
@@ -250,7 +250,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> rangeWithScores(K key, long start, long end) {
 
 		byte[] rawKey = rawKey(key);
-		Set<Tuple> rawValues = execute(connection -> connection.zRangeWithScores(rawKey, start, end), true);
+		Set<Tuple> rawValues = execute(connection -> connection.zRangeWithScores(rawKey, start, end));
 
 		return deserializeTupleValues(rawValues);
 	}
@@ -263,7 +263,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> reverseRangeWithScores(K key, long start, long end) {
 
 		byte[] rawKey = rawKey(key);
-		Set<Tuple> rawValues = execute(connection -> connection.zRevRangeWithScores(rawKey, start, end), true);
+		Set<Tuple> rawValues = execute(connection -> connection.zRevRangeWithScores(rawKey, start, end));
 
 		return deserializeTupleValues(rawValues);
 	}
@@ -276,7 +276,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> rangeByLex(K key, Range range, Limit limit) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.zRangeByLex(rawKey, range, limit), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zRangeByLex(rawKey, range, limit));
 
 		return deserializeValues(rawValues);
 	}
@@ -289,7 +289,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> reverseRangeByLex(K key, Range range, Limit limit) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.zRevRangeByLex(rawKey, range, limit), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zRevRangeByLex(rawKey, range, limit));
 
 		return deserializeValues(rawValues);
 	}
@@ -302,7 +302,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> rangeByScore(K key, double min, double max) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.zRangeByScore(rawKey, min, max), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zRangeByScore(rawKey, min, max));
 
 		return deserializeValues(rawValues);
 	}
@@ -315,7 +315,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> rangeByScore(K key, double min, double max, long offset, long count) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.zRangeByScore(rawKey, min, max, offset, count), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zRangeByScore(rawKey, min, max, offset, count));
 
 		return deserializeValues(rawValues);
 	}
@@ -328,7 +328,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> reverseRangeByScore(K key, double min, double max) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.zRevRangeByScore(rawKey, min, max), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zRevRangeByScore(rawKey, min, max));
 
 		return deserializeValues(rawValues);
 	}
@@ -341,7 +341,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> reverseRangeByScore(K key, double min, double max, long offset, long count) {
 
 		byte[] rawKey = rawKey(key);
-		Set<byte[]> rawValues = execute(connection -> connection.zRevRangeByScore(rawKey, min, max, offset, count), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zRevRangeByScore(rawKey, min, max, offset, count));
 
 		return deserializeValues(rawValues);
 	}
@@ -354,7 +354,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> rangeByScoreWithScores(K key, double min, double max) {
 
 		byte[] rawKey = rawKey(key);
-		Set<Tuple> rawValues = execute(connection -> connection.zRangeByScoreWithScores(rawKey, min, max), true);
+		Set<Tuple> rawValues = execute(connection -> connection.zRangeByScoreWithScores(rawKey, min, max));
 
 		return deserializeTupleValues(rawValues);
 	}
@@ -367,8 +367,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> rangeByScoreWithScores(K key, double min, double max, long offset, long count) {
 
 		byte[] rawKey = rawKey(key);
-		Set<Tuple> rawValues = execute(connection -> connection.zRangeByScoreWithScores(rawKey, min, max, offset, count),
-				true);
+		Set<Tuple> rawValues = execute(connection -> connection.zRangeByScoreWithScores(rawKey, min, max, offset, count));
 
 		return deserializeTupleValues(rawValues);
 	}
@@ -381,7 +380,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, double min, double max) {
 
 		byte[] rawKey = rawKey(key);
-		Set<Tuple> rawValues = execute(connection -> connection.zRevRangeByScoreWithScores(rawKey, min, max), true);
+		Set<Tuple> rawValues = execute(connection -> connection.zRevRangeByScoreWithScores(rawKey, min, max));
 
 		return deserializeTupleValues(rawValues);
 	}
@@ -394,8 +393,8 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, double min, double max, long offset, long count) {
 
 		byte[] rawKey = rawKey(key);
-		Set<Tuple> rawValues = execute(connection -> connection.zRevRangeByScoreWithScores(rawKey, min, max, offset, count),
-				true);
+		Set<Tuple> rawValues = execute(
+				connection -> connection.zRevRangeByScoreWithScores(rawKey, min, max, offset, count));
 
 		return deserializeTupleValues(rawValues);
 	}
@@ -413,7 +412,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		return execute(connection -> {
 			Long zRank = connection.zRank(rawKey, rawValue);
 			return (zRank != null && zRank.longValue() >= 0 ? zRank : null);
-		}, true);
+		});
 	}
 
 	/*
@@ -429,7 +428,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		return execute(connection -> {
 			Long zRank = connection.zRevRank(rawKey, rawValue);
 			return (zRank != null && zRank.longValue() >= 0 ? zRank : null);
-		}, true);
+		});
 	}
 
 	/*
@@ -442,7 +441,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(values);
 
-		return execute(connection -> connection.zRem(rawKey, rawValues), true);
+		return execute(connection -> connection.zRem(rawKey, rawValues));
 	}
 
 	/*
@@ -453,7 +452,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Long removeRange(K key, long start, long end) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.zRemRange(rawKey, start, end), true);
+		return execute(connection -> connection.zRemRange(rawKey, start, end));
 	}
 
 	/*
@@ -464,7 +463,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Long removeRangeByLex(K key, Range range) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.zRemRangeByLex(rawKey, range), true);
+		return execute(connection -> connection.zRemRangeByLex(rawKey, range));
 	}
 
 	/*
@@ -475,7 +474,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Long removeRangeByScore(K key, double min, double max) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.zRemRangeByScore(rawKey, min, max), true);
+		return execute(connection -> connection.zRemRangeByScore(rawKey, min, max));
 	}
 
 	/*
@@ -487,7 +486,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 		byte[] rawValue = rawValue(o);
-		return execute(connection -> connection.zScore(rawKey, rawValue), true);
+		return execute(connection -> connection.zScore(rawKey, rawValue));
 	}
 
 	/*
@@ -499,7 +498,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(o);
-		return execute(connection -> connection.zMScore(rawKey, rawValues), true);
+		return execute(connection -> connection.zMScore(rawKey, rawValues));
 	}
 
 	/*
@@ -510,7 +509,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Long count(K key, double min, double max) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.zCount(rawKey, min, max), true);
+		return execute(connection -> connection.zCount(rawKey, min, max));
 	}
 
 	/*
@@ -521,7 +520,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Long lexCount(K key, Range range) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.zLexCount(rawKey, range), true);
+		return execute(connection -> connection.zLexCount(rawKey, range));
 	}
 
 	/*
@@ -533,7 +532,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public TypedTuple<V> popMin(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return deserializeTuple(execute(connection -> connection.zPopMin(rawKey), true));
+		return deserializeTuple(execute(connection -> connection.zPopMin(rawKey)));
 	}
 
 	/*
@@ -545,7 +544,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> popMin(K key, long count) {
 
 		byte[] rawKey = rawKey(key);
-		Set<Tuple> result = execute(connection -> connection.zPopMin(rawKey, count), true);
+		Set<Tuple> result = execute(connection -> connection.zPopMin(rawKey, count));
 		return deserializeTupleValues(new LinkedHashSet<> (result));
 	}
 
@@ -558,7 +557,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public TypedTuple<V> popMin(K key, long timeout, TimeUnit unit) {
 
 		byte[] rawKey = rawKey(key);
-		return deserializeTuple(execute(connection -> connection.bZPopMin(rawKey, timeout, unit), true));
+		return deserializeTuple(execute(connection -> connection.bZPopMin(rawKey, timeout, unit)));
 	}
 
 	/*
@@ -570,7 +569,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public TypedTuple<V> popMax(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return deserializeTuple(execute(connection -> connection.zPopMax(rawKey), true));
+		return deserializeTuple(execute(connection -> connection.zPopMax(rawKey)));
 	}
 
 	/*
@@ -582,7 +581,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> popMax(K key, long count) {
 
 		byte[] rawKey = rawKey(key);
-		Set<Tuple> result =execute(connection -> connection.zPopMax(rawKey, count), true);
+		Set<Tuple> result = execute(connection -> connection.zPopMax(rawKey, count));
 		return deserializeTupleValues(new LinkedHashSet<>(result));
 	}
 
@@ -595,7 +594,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public TypedTuple<V> popMax(K key, long timeout, TimeUnit unit) {
 
 		byte[] rawKey = rawKey(key);
-		return deserializeTuple(execute(connection -> connection.bZPopMax(rawKey, timeout, unit), true));
+		return deserializeTuple(execute(connection -> connection.bZPopMax(rawKey, timeout, unit)));
 	}
 
 	/*
@@ -615,7 +614,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Long zCard(K key) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.zCard(rawKey), true);
+		return execute(connection -> connection.zCard(rawKey));
 	}
 
 	/*
@@ -626,7 +625,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> difference(K key, Collection<K> otherKeys) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<byte[]> rawValues = execute(connection -> connection.zDiff(rawKeys), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zDiff(rawKeys));
 		return deserializeValues(rawValues);
 	}
 
@@ -638,7 +637,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> differenceWithScores(K key, Collection<K> otherKeys) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<Tuple> result = execute(connection -> connection.zDiffWithScores(rawKeys), true);
+		Set<Tuple> result = execute(connection -> connection.zDiffWithScores(rawKeys));
 		return deserializeTupleValues(new LinkedHashSet<>(result));
 	}
 
@@ -652,7 +651,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		byte[][] rawKeys = rawKeys(key, otherKeys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.zDiffStore(rawDestKey, rawKeys), true);
+		return execute(connection -> connection.zDiffStore(rawDestKey, rawKeys));
 	}
 
 	/*
@@ -663,7 +662,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> intersect(K key, Collection<K> otherKeys) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<byte[]> rawValues = execute(connection -> connection.zInter(rawKeys), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zInter(rawKeys));
 		return deserializeValues(rawValues);
 	}
 
@@ -675,7 +674,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> intersectWithScores(K key, Collection<K> otherKeys) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<Tuple> result = execute(connection -> connection.zInterWithScores(rawKeys), true);
+		Set<Tuple> result = execute(connection -> connection.zInterWithScores(rawKeys));
 		return deserializeTupleValues(result);
 	}
 
@@ -687,7 +686,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> intersectWithScores(K key, Collection<K> otherKeys, Aggregate aggregate, Weights weights) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<Tuple> result = execute(connection -> connection.zInterWithScores(aggregate, weights, rawKeys), true);
+		Set<Tuple> result = execute(connection -> connection.zInterWithScores(aggregate, weights, rawKeys));
 		return deserializeTupleValues(result);
 	}
 
@@ -710,7 +709,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		byte[][] rawKeys = rawKeys(key, otherKeys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.zInterStore(rawDestKey, rawKeys), true);
+		return execute(connection -> connection.zInterStore(rawDestKey, rawKeys));
 	}
 
 	/*
@@ -723,7 +722,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		byte[][] rawKeys = rawKeys(key, otherKeys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.zInterStore(rawDestKey, aggregate, weights, rawKeys), true);
+		return execute(connection -> connection.zInterStore(rawDestKey, aggregate, weights, rawKeys));
 	}
 
 	/*
@@ -734,7 +733,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<V> union(K key, Collection<K> otherKeys) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<byte[]> rawValues = execute(connection -> connection.zUnion(rawKeys), true);
+		Set<byte[]> rawValues = execute(connection -> connection.zUnion(rawKeys));
 		return deserializeValues(rawValues);
 	}
 
@@ -746,7 +745,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> unionWithScores(K key, Collection<K> otherKeys) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<Tuple> result =  execute(connection -> connection.zUnionWithScores(rawKeys), true);
+		Set<Tuple> result = execute(connection -> connection.zUnionWithScores(rawKeys));
 		return deserializeTupleValues(result);
 	}
 
@@ -758,7 +757,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<TypedTuple<V>> unionWithScores(K key, Collection<K> otherKeys, Aggregate aggregate, Weights weights) {
 
 		byte[][] rawKeys = rawKeys(key, otherKeys);
-		Set<Tuple> result = execute(connection -> connection.zUnionWithScores(aggregate, weights, rawKeys), true);
+		Set<Tuple> result = execute(connection -> connection.zUnionWithScores(aggregate, weights, rawKeys));
 		return deserializeTupleValues(
 				result);
 	}
@@ -782,7 +781,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		byte[][] rawKeys = rawKeys(key, otherKeys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.zUnionStore(rawDestKey, rawKeys), true);
+		return execute(connection -> connection.zUnionStore(rawDestKey, rawKeys));
 	}
 
 	/*
@@ -795,7 +794,7 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		byte[][] rawKeys = rawKeys(key, otherKeys);
 		byte[] rawDestKey = rawKey(destKey);
 
-		return execute(connection -> connection.zUnionStore(rawDestKey, aggregate, weights, rawKeys), true);
+		return execute(connection -> connection.zUnionStore(rawDestKey, aggregate, weights, rawKeys));
 	}
 
 	/*
@@ -814,14 +813,14 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	public Set<byte[]> rangeByScore(K key, String min, String max) {
 
 		byte[] rawKey = rawKey(key);
-		return execute(connection -> connection.zRangeByScore(rawKey, min, max), true);
+		return execute(connection -> connection.zRangeByScore(rawKey, min, max));
 	}
 
 	public Set<byte[]> rangeByScore(K key, String min, String max, long offset, long count) {
 
 		byte[] rawKey = rawKey(key);
 
-		return execute(connection -> connection.zRangeByScore(rawKey, min, max, offset, count), true);
+		return execute(connection -> connection.zRangeByScore(rawKey, min, max, offset, count));
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisOperations.java
@@ -63,6 +63,23 @@ public interface ReactiveRedisOperations<K, V> {
 	 */
 	<T> Flux<T> execute(ReactiveRedisCallback<T> action);
 
+	/**
+	 * Executes the given action within a Redis session using the same
+	 * {@link org.springframework.data.redis.connection.ReactiveRedisConnection}. Application exceptions thrown by the
+	 * action object get propagated to the caller (can only be unchecked) whenever possible. Redis exceptions are
+	 * transformed into appropriate DAO ones. Allows for returning a result object, that is a domain object or a
+	 * collection of domain objects. Performs automatic serialization/deserialization for the given objects to and from
+	 * binary data suitable for the Redis storage. Note: Callback code is not supposed to handle transactions itself! Use
+	 * an appropriate transaction manager. Generally, callback code must not touch any Connection lifecycle methods, like
+	 * close, to let the template do its work.
+	 *
+	 * @param <T> return type
+	 * @param action callback object that specifies the Redis action
+	 * @return a result object returned by the action or {@link Flux#empty()}.
+	 * @since 2.6
+	 */
+	<T> Flux<T> executeInSession(ReactiveRedisSessionCallback<K, V, T> action);
+
 	// -------------------------------------------------------------------------
 	// Methods dealing with Redis Pub/Sub
 	// -------------------------------------------------------------------------

--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisSessionCallback.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisSessionCallback.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import org.reactivestreams.Publisher;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.connection.ReactiveRedisConnection;
+
+/**
+ * Generic callback interface for code that wants to use the same {@link ReactiveRedisConnection} avoiding connection
+ * allocation overhead upon each Template API method call. Allows to execute any number of operations on a single
+ * {@link ReactiveRedisConnection}, using any type and number of commands.
+ * <p>
+ * This is particularly useful for issuing multiple calls on the same connection.
+ *
+ * @param <T>
+ * @author Mark Paluch
+ * @since 2.6
+ * @see ReactiveRedisOperations#executeInSession(ReactiveRedisSessionCallback)
+ */
+public interface ReactiveRedisSessionCallback<K, V, T> {
+
+	/**
+	 * Gets called by {@link ReactiveRedisOperations#executeInSession(ReactiveRedisSessionCallback)} with an active Redis
+	 * connection. Does not need to care about activating or closing the {@link ReactiveRedisConnection}.
+	 * <p>
+	 * Allows for returning a result object created within the callback, i.e. a domain object or a collection of domain
+	 * objects.
+	 *
+	 * @param operations template associated with a connection.
+	 * @return a result object publisher
+	 * @throws DataAccessException in case of custom exceptions
+	 */
+	Publisher<T> doWithOperations(ReactiveRedisOperations<K, V> operations) throws DataAccessException;
+}

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensions.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 import org.springframework.data.redis.connection.DataType
 import org.springframework.data.redis.connection.ReactiveRedisConnection
-import org.springframework.data.redis.connection.ReactiveSubscription.*
+import org.springframework.data.redis.connection.ReactiveSubscription.Message
 import org.springframework.data.redis.core.script.RedisScript
 import org.springframework.data.redis.listener.Topic
 import org.springframework.data.redis.serializer.RedisElementReader
@@ -36,8 +36,20 @@ import java.time.Instant
  * @author Sebastien Deleuze
  * @since 2.2
  */
-fun <K : Any, V : Any, T : Any> ReactiveRedisOperations<K, V>.executeAsFlow(action: (ReactiveRedisConnection) -> Flow<T>): Flow<T> =
-		execute { action(it).asPublisher() }.asFlow()
+fun <K : Any, V : Any, T : Any> ReactiveRedisOperations<K, V>.executeAsFlow(action: (ReactiveRedisConnection) -> Flow<T>): Flow<T> {
+	return execute { action(it).asPublisher() }.asFlow()
+}
+
+/**
+ * Coroutines variant of [ReactiveRedisOperations.execute].
+ *
+ * @author Mark Paluch
+ * @since 2.6
+ */
+fun <K : Any, V : Any, T : Any> ReactiveRedisOperations<K, V>.executeInSessionAsFlow(
+	action: (ReactiveRedisOperations<K, V>) -> Flow<T>
+): Flow<T> =
+	executeInSession { action(it).asPublisher() }.asFlow()
 
 /**
  * Coroutines variant of [ReactiveRedisOperations.execute].
@@ -45,8 +57,12 @@ fun <K : Any, V : Any, T : Any> ReactiveRedisOperations<K, V>.executeAsFlow(acti
  * @author Sebastien Deleuze
  * @since 2.2
  */
-fun <K : Any, V : Any, T : Any> ReactiveRedisOperations<K, V>.executeAsFlow(script: RedisScript<T>, keys: List<K> = emptyList(), args: List<*> = emptyList<Any>()): Flow<T> =
-		execute(script, keys, args).asFlow()
+fun <K : Any, V : Any, T : Any> ReactiveRedisOperations<K, V>.executeAsFlow(
+	script: RedisScript<T>,
+	keys: List<K> = emptyList(),
+	args: List<*> = emptyList<Any>()
+): Flow<T> =
+	execute(script, keys, args).asFlow()
 
 /**
  * Coroutines variant of [ReactiveRedisOperations.execute].

--- a/src/test/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensionsUnitTests.kt
+++ b/src/test/kotlin/org/springframework/data/redis/core/ReactiveRedisOperationsExtensionsUnitTests.kt
@@ -50,11 +50,30 @@ class ReactiveRedisOperationsExtensionsUnitTests {
 		every { operations.execute(any<ReactiveRedisCallback<*>>()) } returns Flux.just("foo")
 
 		runBlocking {
-			assertThat(operations.executeAsFlow { flow { emit("foo")} }.toList()).contains("foo")
+			assertThat(operations.executeAsFlow { flow { emit("foo") } }
+				.toList()).contains("foo")
 		}
 
 		verify {
 			operations.execute(any<ReactiveRedisCallback<*>>())
+		}
+	}
+
+	@Test // GH-2110
+	fun `executeInSession with calllback`() {
+
+		val operations = mockk<ReactiveRedisOperations<String, String>>()
+		every { operations.executeInSession(any<ReactiveRedisSessionCallback<String, String, *>>()) } returns Flux.just(
+			"foo"
+		)
+
+		runBlocking {
+			assertThat(operations.executeInSessionAsFlow { flow { emit("foo") } }
+				.toList()).contains("foo")
+		}
+
+		verify {
+			operations.executeInSession(any<ReactiveRedisSessionCallback<String, String, *>>())
 		}
 	}
 
@@ -63,7 +82,13 @@ class ReactiveRedisOperationsExtensionsUnitTests {
 
 		val script = RedisScript.of<String>("foo")
 		val operations = mockk<ReactiveRedisOperations<String, String>>()
-		every { operations.execute(any<RedisScript<*>>(), any(), any()) } returns Flux.just("foo")
+		every {
+			operations.execute(
+				any<RedisScript<*>>(),
+				any(),
+				any()
+			)
+		} returns Flux.just("foo")
 
 		runBlocking {
 			assertThat(operations.executeAsFlow(script).toList()).contains("foo")


### PR DESCRIPTION
```
Benchmark                                                  Mode  Cnt       Score       Error  Units
ReactiveRedisTemplateBenchmark.clientOnly                 thrpt   10   21845,692 ±   828,334  ops/s
ReactiveRedisTemplateBenchmark.clientReactiveConcatMap    thrpt   10   30100,343 ±   975,742  ops/s
ReactiveRedisTemplateBenchmark.clientReactiveFlatMap      thrpt   10  115879,389 ± 13242,159  ops/s
ReactiveRedisTemplateBenchmark.templateReactiveConcatMap  thrpt   10   26251,948 ±  1976,017  ops/s
ReactiveRedisTemplateBenchmark.templateReactiveFlatMap    thrpt   10   83184,567 ±  6757,851  ops/s
```

Baseline -> Spring Data overhead concatMap ~ 14%, flatMap 38%


```
Benchmark                                                                  Mode  Cnt       Score       Error  Units
ReactiveRedisTemplateBenchmark.clientOnly                                 thrpt   10   21428,707 ±   298,980  ops/s
ReactiveRedisTemplateBenchmark.clientReactiveConcatMap                    thrpt   10   29572,175 ±  1361,993  ops/s
ReactiveRedisTemplateBenchmark.clientReactiveFlatMap                      thrpt   10  113934,534 ± 11596,009  ops/s
ReactiveRedisTemplateBenchmark.templateReactiveConcatMap                  thrpt   10   25357,874 ±  1533,066  ops/s
ReactiveRedisTemplateBenchmark.templateReactiveFlatMap                    thrpt   10   94296,062 ±  3511,329  ops/s
ReactiveRedisTemplateBenchmark.templateReactiveExecuteInSessionConcatMap  thrpt   10   26102,247 ±  2329,574  ops/s
ReactiveRedisTemplateBenchmark.templateReactiveExecuteInSessionFlatMap    thrpt   10  101181,742 ±  3725,708  ops/s
```

After changes -> Spring Data overhead concatMap ~ 13%, flatMap 18% (de-optimized 20%)

Benchmark code: https://gist.github.com/mp911de/38166322a80d6f925a9c43a0a61001c0