### PR TITLE
Upgrade to Jedis 3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.0-2153-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<xstream>1.4.18</xstream>
 		<pool>2.9.0</pool>
 		<lettuce>6.1.4.RELEASE</lettuce>
-		<jedis>3.6.3</jedis>
+		<jedis>3.7.0</jedis>
 		<multithreadedtc>1.01</multithreadedtc>
 		<netty>4.1.65.Final</netty>
 		<java-module-name>spring.data.redis</java-module-name>

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.jedis;
 import redis.clients.jedis.BinaryJedis;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.MultiKeyPipelineBase;
+import redis.clients.jedis.args.SaveMode;
 
 import java.util.List;
 import java.util.Properties;
@@ -25,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.RedisServerCommands;
-import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.lang.Nullable;
@@ -151,7 +151,9 @@ class JedisServerCommands implements RedisServerCommands {
 			return;
 		}
 
-		connection.eval(String.format(SHUTDOWN_SCRIPT, option.name()).getBytes(), ReturnType.STATUS, 0);
+		SaveMode saveMode = (option == ShutdownOption.NOSAVE) ? SaveMode.NOSAVE : SaveMode.SAVE;
+
+		connection.getJedis().shutdown(saveMode);
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -2600,8 +2600,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		assertThat(i).isEqualTo(itemCount);
 	}
 
-	@Test // GH-2089
-	@EnabledOnRedisDriver(RedisDriver.LETTUCE)
+	@Test // GH-2089, GH-2153
 	@EnabledOnRedisVersion("6.0")
 	void scanWithType() {
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
@@ -61,9 +61,6 @@ public class JedisConnectionPipelineIntegrationTests extends AbstractConnectionP
 		connection = null;
 	}
 
-	@Disabled("Jedis issue: Pipeline tries to return String instead of List<String>")
-	public void testGetConfig() {}
-
 	@Test
 	public void testWatch() {
 		connection.set("testitnow", "willdo");

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
@@ -22,6 +22,8 @@ import redis.clients.jedis.Client;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
+import redis.clients.jedis.args.SaveMode;
+import redis.clients.jedis.exceptions.JedisException;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -30,8 +32,8 @@ import java.util.Map.Entry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.redis.connection.AbstractConnectionUnitTestBase;
 import org.springframework.data.redis.connection.RedisServerCommands.ShutdownOption;
@@ -58,34 +60,32 @@ class JedisConnectionUnitTests {
 			connection = new JedisConnection(jedisSpy);
 		}
 
-		@Test // DATAREDIS-184
+		@Test // DATAREDIS-184, GH-2153
 		void shutdownWithNullShouldDelegateCommandCorrectly() {
 
-			connection.shutdown(null);
+			try {
+				connection.shutdown(null);
+			} catch (InvalidDataAccessApiUsageException e) {
+				// all good. Sometimes it throws an Exception.s
+			}
 
 			verifyNativeConnectionInvocation().shutdown();
 		}
 
-		@Test // DATAREDIS-184
-		public void shutdownNosaveShouldBeSentCorrectlyUsingLuaScript() {
+		@Test // DATAREDIS-184, GH-2153
+		void shutdownNosaveShouldBeSentCorrectly() {
 
-			connection.shutdown(ShutdownOption.NOSAVE);
+			assertThatExceptionOfType(JedisException.class).isThrownBy(() -> connection.shutdown(ShutdownOption.NOSAVE));
 
-			ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
-			verifyNativeConnectionInvocation().eval(captor.capture(), any(byte[].class), any(byte[][].class));
-
-			assertThat(captor.getValue()).isEqualTo("return redis.call('SHUTDOWN','NOSAVE')".getBytes());
+			verifyNativeConnectionInvocation().shutdown(SaveMode.NOSAVE);
 		}
 
-		@Test // DATAREDIS-184
-		public void shutdownSaveShouldBeSentCorrectlyUsingLuaScript() {
+		@Test // DATAREDIS-184, GH-2153
+		void shutdownSaveShouldBeSentCorrectly() {
 
-			connection.shutdown(ShutdownOption.SAVE);
+			assertThatExceptionOfType(JedisException.class).isThrownBy(() -> connection.shutdown(ShutdownOption.SAVE));
 
-			ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
-			verifyNativeConnectionInvocation().eval(captor.capture(), any(byte[].class), any(byte[][].class));
-
-			assertThat(captor.getValue()).isEqualTo("return redis.call('SHUTDOWN','SAVE')".getBytes());
+			verifyNativeConnectionInvocation().shutdown(SaveMode.SAVE);
 		}
 
 		@Test // DATAREDIS-267
@@ -277,22 +277,6 @@ class JedisConnectionUnitTests {
 		public void setUp() {
 			super.setUp();
 			connection.openPipeline();
-		}
-
-		@Test
-		@Override
-		// DATAREDIS-184
-		public void shutdownNosaveShouldBeSentCorrectlyUsingLuaScript() {
-			assertThatExceptionOfType(UnsupportedOperationException.class)
-					.isThrownBy(() -> super.shutdownNosaveShouldBeSentCorrectlyUsingLuaScript());
-		}
-
-		@Test
-		@Override
-		// DATAREDIS-184
-		public void shutdownSaveShouldBeSentCorrectlyUsingLuaScript() {
-			assertThatExceptionOfType(UnsupportedOperationException.class)
-					.isThrownBy(() -> super.shutdownSaveShouldBeSentCorrectlyUsingLuaScript());
 		}
 
 		@Test // DATAREDIS-267


### PR DESCRIPTION
Enable support for `SCAN` with type, call appropriate shutdown methods with save/nosave flags.

Closes #2153