### PR TITLE
Hash keys locally rather than call cluster keyslot

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
@@ -54,6 +54,7 @@ import org.springframework.util.ObjectUtils;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author ihaohong
+ * @author Dan Smith
  * @since 2.0
  */
 class JedisClusterKeyCommands implements RedisKeyCommands {
@@ -512,7 +513,7 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 			return JedisConverters.toString(this.connection.execute("RESTORE", key,
 					Arrays.asList(JedisConverters.toBytes(ttlInMillis), serializedValue, JedisConverters.toBytes("REPLACE"))));
 
-		}, connection.clusterGetNodeForKey(key));
+		}, connection.getTopologyProvider().getTopology().getKeyServingMasterNode(key));
 	}
 
 	/*
@@ -595,7 +596,7 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 
 		return connection.getClusterCommandExecutor()
 				.executeCommandOnSingleNode((JedisClusterCommandCallback<byte[]>) client -> client.objectEncoding(key),
-						connection.clusterGetNodeForKey(key))
+						connection.getTopologyProvider().getTopology().getKeyServingMasterNode(key))
 				.mapValue(JedisConverters::toEncoding);
 	}
 
@@ -611,7 +612,7 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 
 		return connection.getClusterCommandExecutor()
 				.executeCommandOnSingleNode((JedisClusterCommandCallback<Long>) client -> client.objectIdletime(key),
-						connection.clusterGetNodeForKey(key))
+						connection.getTopologyProvider().getTopology().getKeyServingMasterNode(key))
 				.mapValue(Converters::secondsToDuration);
 	}
 
@@ -627,7 +628,7 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 
 		return connection.getClusterCommandExecutor()
 				.executeCommandOnSingleNode((JedisClusterCommandCallback<Long>) client -> client.objectRefcount(key),
-						connection.clusterGetNodeForKey(key))
+						connection.getTopologyProvider().getTopology().getKeyServingMasterNode(key))
 				.getValue();
 
 	}


### PR DESCRIPTION
Changing the remaining commands in JedisClusterKeyCommands to use the
topology's getKeyServingMasterNode to find the node of key, rather than calling
connection.clusterGetNodeForKey. clusterGetNodeForKey was making a cluster
keyslot call to the server to hash the key, rather than hashing it locally.

Closes: #2156

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
