### PR TITLE
Extract creating of connection in ReactiveRedisTemplate into a separate method

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveRedisTemplate.java
@@ -192,19 +192,27 @@ public class ReactiveRedisTemplate<K, V> implements ReactiveRedisOperations<K, V
 
 		Assert.notNull(action, "Callback object must not be null");
 
-		return Flux.usingWhen(Mono.fromSupplier(() -> {
-
-			ReactiveRedisConnectionFactory factory = getConnectionFactory();
-			ReactiveRedisConnection conn = factory.getReactiveConnection();
-			ReactiveRedisConnection connToUse = preProcessConnection(conn, false);
-
-			return (exposeConnection ? connToUse : createRedisConnectionProxy(connToUse));
-		}), conn -> {
+		return Flux.usingWhen(getConnection(exposeConnection), conn -> {
 			Publisher<T> result = action.doInRedis(conn);
 
 			return postProcessResult(result, conn, false);
 
 		}, ReactiveRedisConnection::closeLater);
+	}
+
+	/**
+	 * Creates a Mono which generates a new connection. The successors of {@link ReactiveRedisTemplate} might override
+	 * the default behaviour.
+	 *
+	 * @param exposeConnection whether to enforce exposure of the native Redis Connection to callback code
+	 * return a {@link Mono} wrapping the {@link ReactiveRedisConnection}.
+	 */
+	protected Mono<ReactiveRedisConnection> getConnection(boolean exposeConnection) {
+		ReactiveRedisConnectionFactory factory = getConnectionFactory();
+		ReactiveRedisConnection conn = factory.getReactiveConnection();
+		ReactiveRedisConnection connToUse = preProcessConnection(conn, false);
+
+		return Mono.just(exposeConnection ? connToUse : createRedisConnectionProxy(connToUse));
 	}
 
 	/*


### PR DESCRIPTION
A new method, called `getConnection`, is introduced in `ReactiveRedisTemplate` to allow overriding of connection creation.

Closes #2145

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
- [ ] You submit test cases (unit or integration tests) that back your changes.
