### PR TITLE
Nullability annotations for indexOf methods in ListOperations

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/ListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ListOperations.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author dengliming
+ * @author Alen Turkovic
  */
 public interface ListOperations<K, V> {
 
@@ -388,6 +389,7 @@ public interface ListOperations<K, V> {
 	 * @since 2.4
 	 * @see <a href="https://redis.io/commands/lpos">Redis Documentation: LPOS</a>
 	 */
+	@Nullable
 	Long indexOf(K key, V value);
 
 	/**
@@ -400,6 +402,7 @@ public interface ListOperations<K, V> {
 	 * @since 2.4
 	 * @see <a href="https://redis.io/commands/lpos">Redis Documentation: LPOS</a>
 	 */
+	@Nullable
 	Long lastIndexOf(K key, V value);
 
 	/**


### PR DESCRIPTION
`indexOf` and `lastIndexOf` methods are missing the `@Nullable` annotation causing issues for nullability checks in Kotlin.