### PR TITLE
Set the RedisTemplate#execute(SessionCallback) method to nullable.

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -83,6 +83,7 @@ import org.springframework.util.CollectionUtils;
  * @author Mark Paluch
  * @author Denis Zavedeev
  * @author ihaohong
+ * @author Jihoon Cha
  * @param <K> the Redis key type against which the template works (usually a String)
  * @param <V> the Redis value type against which the template works
  * @see StringRedisTemplate
@@ -238,6 +239,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	 * @see org.springframework.data.redis.core.RedisOperations#execute(org.springframework.data.redis.core.SessionCallback)
 	 */
 	@Override
+	@Nullable
 	public <T> T execute(SessionCallback<T> session) {
 
 		Assert.isTrue(initialized, "template not initialized; call afterPropertiesSet() before using it");


### PR DESCRIPTION
There is a type issue in Kotlin due to the missing @Nullable annotation.