### PR TITLE
Respect ByteBuffer position and limits in `ByteUtils.getBytes(ByteBuffer)`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.7.0-SNAPSHOT</version>
+	<version>2.7.0-GH-2204-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/util/ByteUtils.java
+++ b/src/main/java/org/springframework/data/redis/util/ByteUtils.java
@@ -129,7 +129,8 @@ public final class ByteUtils {
 	}
 
 	/**
-	 * Extract a byte array from {@link ByteBuffer} without consuming it.
+	 * Extract a byte array from {@link ByteBuffer} without consuming it. The resulting {@code byte[]} is a copy of the
+	 * buffer's contents and not updated upon changes within the buffer.
 	 *
 	 * @param byteBuffer must not be {@literal null}.
 	 * @return
@@ -138,10 +139,6 @@ public final class ByteUtils {
 	public static byte[] getBytes(ByteBuffer byteBuffer) {
 
 		Assert.notNull(byteBuffer, "ByteBuffer must not be null!");
-
-		if (byteBuffer.hasArray()) {
-			return byteBuffer.array();
-		}
 
 		ByteBuffer duplicate = byteBuffer.duplicate();
 		byte[] bytes = new byte[duplicate.remaining()];

--- a/src/test/java/org/springframework/data/redis/util/ByteUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/util/ByteUtilsUnitTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ByteUtils}.
+ *
+ * @author Mark Paluch
+ */
+class ByteUtilsUnitTests {
+
+	@Test // GH-2204
+	void getBytesShouldUseCorrectHeapBufferSpace() {
+
+		ByteBuffer buffer = ByteBuffer.allocate(16);
+		buffer.put("hello".getBytes(StandardCharsets.US_ASCII));
+		buffer.flip();
+
+		byte[] bytes = ByteUtils.getBytes(buffer);
+
+		assertThat(bytes).hasSize(5);
+	}
+
+	@Test // GH-2204
+	void getBytesShouldUseCorrectDirectBufferSpace() {
+
+		ByteBuffer buffer = ByteBuffer.allocateDirect(16);
+		buffer.put("hello".getBytes(StandardCharsets.US_ASCII));
+		buffer.flip();
+
+		byte[] bytes = ByteUtils.getBytes(buffer);
+
+		assertThat(bytes).hasSize(5);
+	}
+}


### PR DESCRIPTION
We now properly extract the byte array from a `ByteBuffer` by copying its content respecting the read position and limits.

Closes #2204