### PR TITLE
Fixed the  @param order of some methods of ZSetOperations

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -71,8 +71,8 @@ public interface ZSetOperations<K, V> {
 	 * Add {@code value} to a sorted set at {@code key}, or update its {@code score} if it already exists.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param score the score.
 	 * @param value the value.
+	 * @param score the score.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD</a>
 	 */
@@ -83,8 +83,8 @@ public interface ZSetOperations<K, V> {
 	 * Add {@code value} to a sorted set at {@code key} if it does not already exists.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param score the score.
 	 * @param value the value.
+	 * @param score the score.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @since 2.5
 	 * @see <a href="https://redis.io/commands/zadd">Redis Documentation: ZADD NX</a>
@@ -130,8 +130,8 @@ public interface ZSetOperations<K, V> {
 	 * Increment the score of element with {@code value} in sorted set by {@code increment}.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param delta
 	 * @param value the value.
+	 * @param delta
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
 	 */


### PR DESCRIPTION
I found that the Parameter annotation order of some methods of ZSetOperations is wrong, which may cause trouble for the use of these methods, so I fixed it.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
