### PR TITLE
Add approximate trimming to reactive stream extensions

### DIFF
--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
@@ -265,5 +265,6 @@ inline fun <K : Any, reified V : Any> ReactiveStreamOperations<K, *, *>.reverseR
  * @author Mark Paluch
  * @since 2.2
  */
-suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.trimAndAwait(key: K, count: Long): Long =
-		trim(key, count).awaitSingle()
+@JvmOverloads // Maintain compatibility with versions <= 2.6.0
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.trimAndAwait(key: K, count: Long, approximateTrimming: Boolean = false): Long =
+		trim(key, count, approximateTrimming).awaitSingle()

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
@@ -263,6 +263,7 @@ inline fun <K : Any, reified V : Any> ReactiveStreamOperations<K, *, *>.reverseR
  * Coroutines variant of [ReactiveStreamOperations.trim].
  *
  * @author Mark Paluch
+ * @author Quantum64@github
  * @since 2.2
  */
 @JvmOverloads // Maintain compatibility with versions <= 2.6.0


### PR DESCRIPTION
This change adds the `approximateTrimming` option to the reactive stream operations coroutines extension. I do not think this change warrants an additional test case since this function is already covered, but let me know if it does.

The `@JvmOverloads` annotation was added to maintain compatibility with previous versions of this class. Binary compatibility is maintained, so this change is fully compatible and non-breaking. Binary compatibility was confirmed using the `javap` command.

Before
```
public static final <K, HK, HV> java.lang.Object trimAndAwait(org.springframework.data.redis.core.ReactiveStreamOperations<K, HK, HV>, K, long, kotlin.coroutines.Continuation<? super java.lang.Long>);
```

After
```
public static final <K, HK, HV> java.lang.Object trimAndAwait(org.springframework.data.redis.core.ReactiveStreamOperations<K, HK, HV>, K, long, boolean, kotlin.coroutines.Continuation<? super java.lang.Long>);
public static java.lang.Object trimAndAwait$default(org.springframework.data.redis.core.ReactiveStreamOperations, java.lang.Object, long, boolean, kotlin.coroutines.Continuation, int, java.lang.Object);
public static final <K, HK, HV> java.lang.Object trimAndAwait(org.springframework.data.redis.core.ReactiveStreamOperations<K, HK, HV>, K, long, kotlin.coroutines.Continuation<? super java.lang.Long>);
```