### PR TITLE
Add trimming support for xAdd

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
@@ -56,6 +56,7 @@ import org.springframework.util.Assert;
  * @author Tugdual Grall
  * @author Dengliming
  * @author Mark John Moreno
+ * @author Quantum64@github
  * @since 2.2
  */
 class LettuceReactiveStreamCommands implements ReactiveStreamCommands {
@@ -110,6 +111,7 @@ class LettuceReactiveStreamCommands implements ReactiveStreamCommands {
 			}
 			if (command.hasMaxlen()) {
 				args.maxlen(command.getMaxlen());
+				args.approximateTrimming(command.isApproximateTrimming());
 			}
 			args.nomkstream(command.isNoMkStream());
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
@@ -57,6 +57,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Quantum64@github
  * @since 2.2
  */
 class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperations<K, HK, HV> {
@@ -147,6 +148,21 @@ class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperat
 		MapRecord<K, HK, HV> input = StreamObjectMapper.toMapRecord(this, record);
 
 		return createMono(connection -> connection.xAdd(serializeRecord(input)));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.ReactiveStreamOperations#add(java.lang.Object, java.util.Map, java.lang.Long, java.lang.Boolean)
+	 */
+	@Override
+	public Mono<RecordId> add(Record<K, ?> record, long count, boolean approximateTrimming) {
+
+		Assert.notNull(record.getStream(), "Key must not be null!");
+		Assert.notNull(record.getValue(), "Body must not be null!");
+
+		MapRecord<K, HK, HV> input = StreamObjectMapper.toMapRecord(this, record);
+
+		return createMono(connection -> connection.xAdd(serializeRecord(input), count, approximateTrimming));
 	}
 
 	/*

--- a/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/redis/core/ReactiveStreamOperationsExtensions.kt
@@ -62,6 +62,15 @@ fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.add(key: K
 /**
  * Coroutines variant of [ReactiveStreamOperations.add].
  *
+ * @author Quantum64@github
+ * @since 2.7
+ */
+fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.add(key: K, bodyFlow: Flow<Map<HK, HV>>, length: Long, approximateTrimming: Boolean = false): Flow<RecordId> =
+	add(key, bodyFlow.asPublisher(), length, approximateTrimming).asFlow()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.add].
+ *
  * @author Mark Paluch
  * @since 2.2
  */
@@ -71,11 +80,29 @@ suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.ad
 /**
  * Coroutines variant of [ReactiveStreamOperations.add].
  *
+ * @author Quantum64@github
+ * @since 2.7
+ */
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.addAndAwait(record: MapRecord<K, HK, HV>, length: Long, approximateTrimming: Boolean = false): RecordId =
+	add(record, length, approximateTrimming).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.add].
+ *
  * @author Mark Paluch
  * @since 2.2
  */
 suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.addAndAwait(record: Record<K, *>): RecordId =
 		add(record).awaitSingle()
+
+/**
+ * Coroutines variant of [ReactiveStreamOperations.add].
+ *
+ * @author Quantum64@github
+ * @since 2.7
+ */
+suspend fun <K : Any, HK : Any, HV : Any> ReactiveStreamOperations<K, HK, HV>.addAndAwait(record: Record<K, *>, length: Long, approximateTrimming: Boolean = false): RecordId =
+	add(record, length, approximateTrimming).awaitSingle()
 
 /**
  * Coroutines variant of [ReactiveStreamOperations.delete].


### PR DESCRIPTION
This change adds support for trimming and approximate trimming to reactive stream commands. This is beneficial for the common use case of adding and immediately trimming a stream because it reduces the number of Redis commands needed for the operation from two to one.

Test cases will be added shortly.