### PR TITLE
feature:getSynchronized method performance update.

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/WeakHashLock.java
+++ b/src/main/java/org/springframework/data/redis/cache/WeakHashLock.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.redis.cache;
 
 import java.lang.ref.Reference;
@@ -6,44 +21,47 @@ import java.lang.ref.WeakReference;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
+/**
+ * @author lilin
+ */
 public class WeakHashLock<T> {
 
-    private final ConcurrentHashMap<T, WeakLockRef<T,ReentrantLock>> lockMap = new ConcurrentHashMap<>();
-    private final ReferenceQueue<ReentrantLock> queue = new ReferenceQueue<>();
+	private final ConcurrentHashMap<T, WeakLockRef<T, ReentrantLock>> lockMap = new ConcurrentHashMap<>();
+	private final ReferenceQueue<ReentrantLock> queue = new ReferenceQueue<>();
 
-    public ReentrantLock get(T key) {
-        if (lockMap.size() > 1000) {
-            clearEmptyRef();
-        }
-        WeakReference<ReentrantLock> lockRef = lockMap.get(key);
-        ReentrantLock lock = (lockRef == null ? null : lockRef.get());
-        while (lock == null) {
-            lockMap.putIfAbsent(key, new WeakLockRef<>(new ReentrantLock(), queue, key));
-            lockRef = lockMap.get(key);
-            lock = (lockRef == null ? null : lockRef.get());
-            if (lock != null) {
-                return lock;
-            }
-            clearEmptyRef();
-        }
-        return lock;
-    }
+	public ReentrantLock get(T key) {
+		if (lockMap.size() > 1000) {
+			clearEmptyRef();
+		}
+		WeakReference<ReentrantLock> lockRef = lockMap.get(key);
+		ReentrantLock lock = (lockRef == null ? null : lockRef.get());
+		while (lock == null) {
+			lockMap.putIfAbsent(key, new WeakLockRef<>(new ReentrantLock(), queue, key));
+			lockRef = lockMap.get(key);
+			lock = (lockRef == null ? null : lockRef.get());
+			if (lock != null) {
+				return lock;
+			}
+			clearEmptyRef();
+		}
+		return lock;
+	}
 
-    @SuppressWarnings("unchecked")
-    private void clearEmptyRef() {
-        Reference<? extends ReentrantLock> ref;
-        while ((ref = queue.poll()) != null) {
-            WeakLockRef<T, ? extends ReentrantLock> weakLockRef = (WeakLockRef<T, ? extends ReentrantLock>)ref;
-            lockMap.remove(weakLockRef.key);
-        }
-    }
+	@SuppressWarnings("unchecked")
+	private void clearEmptyRef() {
+		Reference<? extends ReentrantLock> ref;
+		while ((ref = queue.poll()) != null) {
+			WeakLockRef<T, ? extends ReentrantLock> weakLockRef = (WeakLockRef<T, ? extends ReentrantLock>) ref;
+			lockMap.remove(weakLockRef.key);
+		}
+	}
 
-    private static final class WeakLockRef<T, K> extends WeakReference<K> {
-        final T key;
+	private static final class WeakLockRef<T, K> extends WeakReference<K> {
+		final T key;
 
-        private WeakLockRef(K referent, ReferenceQueue<? super K> q, T key) {
-            super(referent, q);
-            this.key = key;
-        }
-    }
+		private WeakLockRef(K referent, ReferenceQueue<? super K> q, T key) {
+			super(referent, q);
+			this.key = key;
+		}
+	}
 }

--- a/src/main/java/org/springframework/data/redis/cache/WeakHashLock.java
+++ b/src/main/java/org/springframework/data/redis/cache/WeakHashLock.java
@@ -1,0 +1,49 @@
+package org.springframework.data.redis.cache;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class WeakHashLock<T> {
+
+    private final ConcurrentHashMap<T, WeakLockRef<T,ReentrantLock>> lockMap = new ConcurrentHashMap<>();
+    private final ReferenceQueue<ReentrantLock> queue = new ReferenceQueue<>();
+
+    public ReentrantLock get(T key) {
+        if (lockMap.size() > 1000) {
+            clearEmptyRef();
+        }
+        WeakReference<ReentrantLock> lockRef = lockMap.get(key);
+        ReentrantLock lock = (lockRef == null ? null : lockRef.get());
+        while (lock == null) {
+            lockMap.putIfAbsent(key, new WeakLockRef<>(new ReentrantLock(), queue, key));
+            lockRef = lockMap.get(key);
+            lock = (lockRef == null ? null : lockRef.get());
+            if (lock != null) {
+                return lock;
+            }
+            clearEmptyRef();
+        }
+        return lock;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void clearEmptyRef() {
+        Reference<? extends ReentrantLock> ref;
+        while ((ref = queue.poll()) != null) {
+            WeakLockRef<T, ? extends ReentrantLock> weakLockRef = (WeakLockRef<T, ? extends ReentrantLock>)ref;
+            lockMap.remove(weakLockRef.key);
+        }
+    }
+
+    private static final class WeakLockRef<T, K> extends WeakReference<K> {
+        final T key;
+
+        private WeakLockRef(K referent, ReferenceQueue<? super K> q, T key) {
+            super(referent, q);
+            this.key = key;
+        }
+    }
+}


### PR DESCRIPTION
hi，
  In my company's project,We want to use @Cacheable(...sync = true)annotations as cache.But when we find a serious problems that the method performance is very poor in multi-thread jvm env。In my project，we need to cache large number of cache key，and expect a excellent performance。So we try to read the RedisCache  code，and find the cause is from `private synchronized <T> T getSynchronized(Object key, Callable<T> valueLoader)`。This method is synchronized。If we create much cache in a short time，this method's performance will degenerate quickly.
 So we try to assign a ReentrantLock to every cache key.At the time,we want it will not expend too much stack space to store the lock,because the key's quantity is so large.We find an idea that we use weakreference to hold this lock,when the lock is not use in any thread,it will be release by gc.
  The code is running in our project,and i think it will be a good feature modify,So we report this modify to you hope to help others.
 At last,it's my first time to commit code in such excelent open source project.If having any problem，we hope to receive any reply from you.Thank you for your read.