### PR TITLE
Retain target type hint when deserializing Stream records

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>2.7.0-SNAPSHOT</version>
+	<version>2.7.0-GH-2198-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 

--- a/src/main/java/org/springframework/data/redis/hash/BeanUtilsHashMapper.java
+++ b/src/main/java/org/springframework/data/redis/hash/BeanUtilsHashMapper.java
@@ -21,6 +21,8 @@ import java.util.Map.Entry;
 
 import org.apache.commons.beanutils.BeanUtils;
 
+import org.springframework.util.Assert;
+
 /**
  * HashMapper based on Apache Commons BeanUtils project. Does NOT supports nested properties.
  *
@@ -28,7 +30,7 @@ import org.apache.commons.beanutils.BeanUtils;
  * @author Christoph Strobl
  * @author Mark Paluch
  */
-public class BeanUtilsHashMapper<T> implements HashMapper<T, String, String> {
+public class BeanUtilsHashMapper<T> implements HashMapper<T, String, String>, HashObjectReader<String, String> {
 
 	private final Class<T> type;
 
@@ -47,8 +49,20 @@ public class BeanUtilsHashMapper<T> implements HashMapper<T, String, String> {
 	 */
 	@Override
 	public T fromHash(Map<String, String> hash) {
+		return fromHash(type, hash);
+	}
 
-		T instance = org.springframework.beans.BeanUtils.instantiateClass(type);
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.hash.HashMapper#fromHash(java.lang.Class, java.util.Map)
+	 */
+	@Override
+	public <R> R fromHash(Class<R> type, Map<String, String> hash) {
+
+		Assert.notNull(type, "Type must not be null");
+		Assert.notNull(hash, "Hash must not be null");
+
+		R instance = org.springframework.beans.BeanUtils.instantiateClass(type);
 
 		try {
 

--- a/src/main/java/org/springframework/data/redis/hash/HashObjectReader.java
+++ b/src/main/java/org/springframework/data/redis/hash/HashObjectReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,31 +18,21 @@ package org.springframework.data.redis.hash;
 import java.util.Map;
 
 /**
- * Core mapping contract between Java types and Redis hashes/maps. It's up to the implementation to support nested
- * objects.
+ * Core mapping contract to materialize an object using particular Java class from a Redis Hash.
  *
- * @param <T> Object type
  * @param <K> Redis Hash field type
  * @param <V> Redis Hash value type
- * @author Costin Leau
  * @author Mark Paluch
- * @see HashObjectReader
+ * @since 2.7
+ * @see HashMapper
  */
-public interface HashMapper<T, K, V> {
+public interface HashObjectReader<K, V> {
 
 	/**
-	 * Convert an {@code object} to a map that can be used with Redis hashes.
+	 * Materialize an object of the {@link Class type} from a {@code hash}.
 	 *
-	 * @param object
-	 * @return
+	 * @param hash must not be {@literal null}.
+	 * @return the materialized object from the given {@code hash}.
 	 */
-	Map<K, V> toHash(T object);
-
-	/**
-	 * Convert a {@code hash} (map) to an object.
-	 *
-	 * @param hash
-	 * @return
-	 */
-	T fromHash(Map<K, V> hash);
+	<R> R fromHash(Class<R> type, Map<K, V> hash);
 }

--- a/src/main/java/org/springframework/data/redis/hash/Jackson2HashMapper.java
+++ b/src/main/java/org/springframework/data/redis/hash/Jackson2HashMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,6 +177,12 @@ public class Jackson2HashMapper implements HashMapper<Object, String, Object>, H
 						}
 
 						if (EVERYTHING.equals(_appliesFor)) {
+							// yuck! Isn't there a better way to distinguish whether there's a registered serializer so that we don't
+							// use type builders?
+							if (t.getRawClass().getPackage().getName().startsWith("java.time")) {
+								return false;
+							}
+
 							return !TreeNode.class.isAssignableFrom(t.getRawClass());
 						}
 
@@ -196,6 +202,7 @@ public class Jackson2HashMapper implements HashMapper<Object, String, Object>, H
 		typingMapper.setSerializationInclusion(Include.NON_NULL);
 		typingMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		typingMapper.registerModule(HASH_MAPPER_MODULE);
+		typingMapper.findAndRegisterModules();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/hash/ObjectHashMapper.java
+++ b/src/main/java/org/springframework/data/redis/hash/ObjectHashMapper.java
@@ -69,7 +69,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @since 1.8
  */
-public class ObjectHashMapper implements HashMapper<Object, byte[], byte[]> {
+public class ObjectHashMapper implements HashMapper<Object, byte[], byte[]>, HashObjectReader<byte[], byte[]> {
 
 	@Nullable private volatile static ObjectHashMapper sharedInstance;
 
@@ -169,12 +169,20 @@ public class ObjectHashMapper implements HashMapper<Object, byte[], byte[]> {
 	 */
 	@Override
 	public Object fromHash(Map<byte[], byte[]> hash) {
+		return fromHash(Object.class, hash);
+	}
 
-		if (hash == null || hash.isEmpty()) {
-			return null;
-		}
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.hash.HashMapper#fromHash(java.lang.Class, java.util.Map)
+	 */
+	@Override
+	public <R> R fromHash(Class<R> type, Map<byte[], byte[]> hash) {
 
-		return converter.read(Object.class, new RedisData(hash));
+		Assert.notNull(type, "Type must not be null");
+		Assert.notNull(hash, "Hash must not be null");
+
+		return converter.read(type, new RedisData(hash));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/StreamObjectMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/StreamObjectMapperUnitTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Data;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.redis.hash.Jackson2HashMapper;
+import org.springframework.data.redis.hash.ObjectHashMapper;
+
+/**
+ * Unit tests for {@link StreamObjectMapper}.
+ *
+ * @author Mark Paluch
+ */
+class StreamObjectMapperUnitTests {
+
+	@Test // GH-2198
+	void shouldRetainTypeHintUsingObjectHashMapper() {
+
+		StreamObjectMapper mapper = new StreamObjectMapper(ObjectHashMapper.getSharedInstance());
+
+		MyType result = mapper.getHashMapper(MyType.class)
+				.fromHash(Collections.singletonMap("value".getBytes(), "hello".getBytes()));
+
+		assertThat(result.value).isEqualTo("hello");
+	}
+
+	@Test // GH-2198
+	void shouldRetainTypeHintUsingJackson() {
+
+		StreamObjectMapper mapper = new StreamObjectMapper(new Jackson2HashMapper(true));
+
+		MyType result = mapper.getHashMapper(MyType.class).fromHash(Collections.singletonMap("value", "hello"));
+
+		assertThat(result.value).isEqualTo("hello");
+	}
+
+	@Data
+	static class MyType {
+		String value;
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/mapping/FlatteningJackson2HashMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/FlatteningJackson2HashMapperUnitTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.mapping;
+
+import org.springframework.data.redis.hash.Jackson2HashMapper;
+
+/**
+ * @author Mark Paluch
+ */
+public class FlatteningJackson2HashMapperUnitTests extends Jackson2HashMapperUnitTests {
+	FlatteningJackson2HashMapperUnitTests() {
+		super(new Jackson2HashMapper(true));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
@@ -42,25 +42,12 @@ import org.springframework.data.redis.hash.Jackson2HashMapper;
  * @author Christoph Strobl
  * @author Mark Paluch
  */
-public abstract class Jackson2HashMapperUnitTests extends AbstractHashMapperTests {
+abstract class Jackson2HashMapperUnitTests extends AbstractHashMapperTests {
 
 	private final Jackson2HashMapper mapper;
 
 	Jackson2HashMapperUnitTests(Jackson2HashMapper mapper) {
 		this.mapper = mapper;
-	}
-
-	public static class FlatteningJackson2HashMapperUnitTests extends Jackson2HashMapperUnitTests {
-		FlatteningJackson2HashMapperUnitTests() {
-			super(new Jackson2HashMapper(true));
-		}
-	}
-
-	public static class NonFlatteningJackson2HashMapperUnitTests extends Jackson2HashMapperUnitTests {
-
-		NonFlatteningJackson2HashMapperUnitTests() {
-			super(new Jackson2HashMapper(false));
-		}
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.springframework.data.redis.mapping;
+
+import static org.assertj.core.api.Assertions.*;
 
 import lombok.Data;
 
@@ -181,6 +183,24 @@ public abstract class Jackson2HashMapperUnitTests extends AbstractHashMapperTest
 		source.localDateTime = LocalDateTime.parse("2018-01-02T12:13:14");
 
 		assertBackAndForwardMapping(source);
+	}
+
+	@Test // GH-2198
+	void shouldDeserializeObjectWithoutClassHint() {
+
+		WithDates source = new WithDates();
+		source.string = "id-1";
+		source.date = new Date(1561543964015L);
+		source.calendar = Calendar.getInstance();
+		source.localDate = LocalDate.parse("2018-01-02");
+		source.localDateTime = LocalDateTime.parse("2018-01-02T12:13:14");
+
+		Map<String, Object> map = mapper.toHash(source);
+
+		// ensure that we remove the correct type hint
+		assertThat(map.remove("@class")).isNotNull();
+
+		assertThat(mapper.fromHash(WithDates.class, map)).isEqualTo(source);
 	}
 
 	@Test // GH-1566

--- a/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperUnitTests.java
@@ -50,13 +50,13 @@ public abstract class Jackson2HashMapperUnitTests extends AbstractHashMapperTest
 		this.mapper = mapper;
 	}
 
-	static class FlatteningJackson2HashMapperUnitTests extends Jackson2HashMapperUnitTests {
+	public static class FlatteningJackson2HashMapperUnitTests extends Jackson2HashMapperUnitTests {
 		FlatteningJackson2HashMapperUnitTests() {
 			super(new Jackson2HashMapper(true));
 		}
 	}
 
-	static class NonFlatteningJackson2HashMapperUnitTests extends Jackson2HashMapperUnitTests {
+	public static class NonFlatteningJackson2HashMapperUnitTests extends Jackson2HashMapperUnitTests {
 
 		NonFlatteningJackson2HashMapperUnitTests() {
 			super(new Jackson2HashMapper(false));

--- a/src/test/java/org/springframework/data/redis/mapping/NonFlatteningJackson2HashMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/NonFlatteningJackson2HashMapperUnitTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.mapping;
+
+import org.springframework.data.redis.hash.Jackson2HashMapper;
+
+/**
+ * @author Mark Paluch
+ */
+public class NonFlatteningJackson2HashMapperUnitTests extends Jackson2HashMapperUnitTests {
+
+	NonFlatteningJackson2HashMapperUnitTests() {
+		super(new Jackson2HashMapper(false));
+	}
+}

--- a/src/test/java/org/springframework/data/redis/mapping/ObjectHashMapperTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/ObjectHashMapperTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.*;
 import lombok.Data;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -81,6 +82,18 @@ class ObjectHashMapperTests extends AbstractHashMapperTests {
 
 		ObjectHashMapper objectHashMapper = new ObjectHashMapper(mappingRedisConverter);
 		assertThat(objectHashMapper.fromHash(hash)).isEqualTo(source);
+	}
+
+	@Test // GH-2198
+	void readHashConsidersTypeHint() {
+
+		Map<byte[], byte[]> hash = new LinkedHashMap<>();
+		hash.put("value".getBytes(), "hello".getBytes());
+
+		ObjectHashMapper objectHashMapper = ObjectHashMapper.getSharedInstance();
+		WithTypeAlias withTypeAlias = objectHashMapper.fromHash(WithTypeAlias.class, hash);
+
+		assertThat(withTypeAlias.value).isEqualTo("hello");
 	}
 
 	@TypeAlias("_42_")


### PR DESCRIPTION
We now retain the target type when obtaining a `HashMapper` through `StreamObjectMapper`. To achieve this, we introduced the `HashObjectReader` interface accepting a target type.

Closes #2198