### PR TITLE
Support for `scan` in `RedisTemplate`

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -262,6 +262,7 @@ public interface RedisOperations<K, V> {
 
 	/**
 	 * Use a {@link Cursor} to iterate over keys.
+	 * <strong>Important:</strong> Call {@link Cursor#close()} when done to avoid resource leak.
 	 *
 	 * @param options must not be {@literal null}.
 	 * @return never {@literal null}.

--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -261,7 +261,7 @@ public interface RedisOperations<K, V> {
 	Set<K> keys(K pattern);
 
 	/**
-	 * Use a {@link Cursor} to iterate over keys.
+	 * Use a {@link Cursor} to iterate over keys. <br />
 	 * <strong>Important:</strong> Call {@link Cursor#close()} when done to avoid resource leak.
 	 *
 	 * @param options must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author ihaohong
  * @author Todd Merrill
+ * @author Chen Li
  */
 public interface RedisOperations<K, V> {
 
@@ -258,6 +259,15 @@ public interface RedisOperations<K, V> {
 	 */
 	@Nullable
 	Set<K> keys(K pattern);
+
+	/**
+	 * Use a {@link Cursor} to iterate over keys.
+	 *
+	 * @param options must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @see <a href="https://redis.io/commands/scan">Redis Documentation: SCAN</a>
+	 */
+	Cursor<K> scan(ScanOptions options);
 
 	/**
 	 * Return a random key from the keyspace.

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,7 @@ import org.springframework.util.CollectionUtils;
  * @author Mark Paluch
  * @author Denis Zavedeev
  * @author ihaohong
+ * @author Chen Li
  * @param <K> the Redis key type against which the template works (usually a String)
  * @param <V> the Redis value type against which the template works
  * @see StringRedisTemplate
@@ -895,6 +896,19 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 		Set<byte[]> rawKeys = execute(connection -> connection.keys(rawKey), true);
 
 		return keySerializer != null ? SerializationUtils.deserialize(rawKeys, keySerializer) : (Set<K>) rawKeys;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.redis.core.RedisOperations#scan(java.lang.Object)
+	 */
+	@Override
+	public Cursor<K> scan(ScanOptions options) {
+		Assert.notNull(options, "ScanOptions must not be null!");
+
+		return executeWithStickyConnection(
+				(RedisCallback<Cursor<K>>) connection -> new ConvertingCursor<>(connection.scan(options),
+						this::deserializeKey));
 	}
 
 	/*


### PR DESCRIPTION
Implementation for issue #2260.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
