### PR TITLE
Eagerly return `null` values in `AbstractOperations.deserializeGeoResults(…)` to avoid null dereference

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/AbstractOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/AbstractOperations.java
@@ -389,6 +389,10 @@ abstract class AbstractOperations<K, V> {
 	 */
 	GeoResults<GeoLocation<V>> deserializeGeoResults(GeoResults<GeoLocation<byte[]>> source) {
 
+		if (source == null) {
+			return null;
+		}
+
 		if (valueSerializer() == null) {
 			return (GeoResults<GeoLocation<V>>) (Object) source;
 		}


### PR DESCRIPTION
In LettuceConnection pipeline mode, using DefaultGeoOperations to call geo-related methods will get null, then convert the return value by calling method deserializeGeoResults will throw NPE.
To avoid NPE,check if the source is null before deserializeGeoResults conversion.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
