### PR TITLE
Improve thread safety of RedisMessageListenerContainer.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisSubscription.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisSubscription.java
@@ -42,11 +42,13 @@ class JedisSubscription extends AbstractSubscription {
 	 */
 	@Override
 	protected void doClose() {
-		if (!getChannels().isEmpty()) {
-			jedisPubSub.unsubscribe();
-		}
-		if (!getPatterns().isEmpty()) {
-			jedisPubSub.punsubscribe();
+		synchronized (this) {
+			if (!getChannels().isEmpty()) {
+				jedisPubSub.unsubscribe();
+			}
+			if (!getPatterns().isEmpty()) {
+				jedisPubSub.punsubscribe();
+			}
 		}
 	}
 
@@ -56,7 +58,9 @@ class JedisSubscription extends AbstractSubscription {
 	 */
 	@Override
 	protected void doPsubscribe(byte[]... patterns) {
-		jedisPubSub.psubscribe(patterns);
+		synchronized (this) {
+			jedisPubSub.psubscribe(patterns);
+		}
 	}
 
 	/*
@@ -65,10 +69,12 @@ class JedisSubscription extends AbstractSubscription {
 	 */
 	@Override
 	protected void doPUnsubscribe(boolean all, byte[]... patterns) {
-		if (all) {
-			jedisPubSub.punsubscribe();
-		} else {
-			jedisPubSub.punsubscribe(patterns);
+		synchronized (this) {
+			if (all) {
+				jedisPubSub.punsubscribe();
+			} else {
+				jedisPubSub.punsubscribe(patterns);
+			}
 		}
 	}
 
@@ -78,7 +84,9 @@ class JedisSubscription extends AbstractSubscription {
 	 */
 	@Override
 	protected void doSubscribe(byte[]... channels) {
-		jedisPubSub.subscribe(channels);
+		synchronized (this) {
+			jedisPubSub.subscribe(channels);
+		}
 	}
 
 	/*
@@ -87,10 +95,12 @@ class JedisSubscription extends AbstractSubscription {
 	 */
 	@Override
 	protected void doUnsubscribe(boolean all, byte[]... channels) {
-		if (all) {
-			jedisPubSub.unsubscribe();
-		} else {
-			jedisPubSub.unsubscribe(channels);
+		synchronized (this) {
+			if (all) {
+				jedisPubSub.unsubscribe();
+			} else {
+				jedisPubSub.unsubscribe(channels);
+			}
 		}
 	}
 }


### PR DESCRIPTION
- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Hi,

As instructed in #964, a PR to fix the issues I've encountered in RedisMessageListenerContainer.

I've commented the PR inline to ease the comprehension. Let me know if you need further details.

Testing those kind of multithreaded behavior is never easy but I believe all my additions have been tested in the unit tests I've added.