### PR TITLE
remove duplicate map key of TypeHints

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -1038,7 +1038,6 @@ public class LettuceConnection extends AbstractRedisConnection {
 			COMMAND_OUTPUT_TYPE_MAPPING.put(DECR, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(DECRBY, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(DEL, IntegerOutput.class);
-			COMMAND_OUTPUT_TYPE_MAPPING.put(COPY, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(GETBIT, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(HDEL, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(HINCRBY, IntegerOutput.class);
@@ -1081,7 +1080,6 @@ public class LettuceConnection extends AbstractRedisConnection {
 			// DOUBLE
 			COMMAND_OUTPUT_TYPE_MAPPING.put(HINCRBYFLOAT, DoubleOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(INCRBYFLOAT, DoubleOutput.class);
-			COMMAND_OUTPUT_TYPE_MAPPING.put(MGET, ValueListOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZINCRBY, DoubleOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZSCORE, DoubleOutput.class);
 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

Duplicate key about COMMAND_OUTPUT_TYPE_MAPPING,  COPY should be return bolean & MGET is duplicate


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
