### PR TITLE
Prevent HashOperations MultiGet from returning null values in the collection

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
@@ -19,11 +19,12 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
 
@@ -37,6 +38,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Shane Lee
  * @since 2.0
  */
 class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations<H, HK, HV> {
@@ -283,10 +285,9 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 
 	private List<HV> deserializeHashValues(List<ByteBuffer> source) {
 
-		List<HV> values = new ArrayList<>(source.size());
-		for (ByteBuffer byteBuffer : source) {
-			values.add(readHashValue(byteBuffer));
-		}
-		return values;
+		return source.stream()
+			.filter(Objects::nonNull)
+			.map(this::readHashValue)
+			.collect(Collectors.toList());
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
@@ -48,6 +48,7 @@ import org.springframework.data.redis.test.extension.parametrized.ParameterizedR
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Shane Lee
  */
 @MethodSource("testParams")
 @SuppressWarnings("unchecked")
@@ -190,7 +191,7 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 				.verifyComplete();
 	}
 
-	@ParameterizedRedisTest // DATAREDIS-824
+	@ParameterizedRedisTest // DATAREDIS-2309
 	void multiGetAbsentKeys() {
 
 		assumeThat(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory)
@@ -199,7 +200,7 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		hashOperations.multiGet(keyFactory.instance(), Arrays.asList(hashKeyFactory.instance(), hashKeyFactory.instance()))
 				.as(StepVerifier::create) //
 				.consumeNextWith(actual -> {
-					assertThat(actual).hasSize(2).containsSequence(null, null);
+					assertThat(actual).isEmpty();
 				}) //
 				.verifyComplete();
 	}


### PR DESCRIPTION
This PR addresses issue #2309. It prevents the multi-get operation from returning null values inside the collection. This is an issue that can be very difficult to diagnose as it leads to stack traces without reference to the client code. 

I've raised this PR against `main` for now. I expect it would be better going into `2.7.x`, but happy to put it into another branch.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x ] You submit test cases (unit or integration tests) that back your changes.
- [ x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
