### PR TITLE
BZPOPMAX returns minimum value when called with a Duration

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -525,7 +525,7 @@ public interface ZSetOperations<K, V> {
 		Assert.notNull(timeout, "Timeout must not be null");
 		Assert.isTrue(!timeout.isNegative(), "Timeout must not be negative");
 
-		return popMin(key, TimeoutUtils.toSeconds(timeout), TimeUnit.SECONDS);
+		return popMax(key, TimeoutUtils.toSeconds(timeout), TimeUnit.SECONDS);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/DefaultZSetOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultZSetOperationsIntegrationTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assumptions.*;
 import static org.assertj.core.data.Offset.offset;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -138,16 +139,19 @@ public class DefaultZSetOperationsIntegrationTests<K, V> {
 	void testPopMin() {
 
 		K key = keyFactory.instance();
+		V value0 = valueFactory.instance();
 		V value1 = valueFactory.instance();
 		V value2 = valueFactory.instance();
 		V value3 = valueFactory.instance();
 		V value4 = valueFactory.instance();
 
+		zSetOps.add(key, value0, 0);
 		zSetOps.add(key, value1, 1);
 		zSetOps.add(key, value2, 2);
 		zSetOps.add(key, value3, 3);
 		zSetOps.add(key, value4, 4);
 
+		assertThat(zSetOps.popMin(key, Duration.ofSeconds(1))).isEqualTo(new DefaultTypedTuple<>(value0, 0d));
 		assertThat(zSetOps.popMin(key)).isEqualTo(new DefaultTypedTuple<>(value1, 1d));
 		assertThat(zSetOps.popMin(key, 2)).containsExactly(new DefaultTypedTuple<>(value2, 2d),
 				new DefaultTypedTuple<>(value3, 3d));
@@ -163,12 +167,15 @@ public class DefaultZSetOperationsIntegrationTests<K, V> {
 		V value2 = valueFactory.instance();
 		V value3 = valueFactory.instance();
 		V value4 = valueFactory.instance();
+		V value5 = valueFactory.instance();
 
 		zSetOps.add(key, value1, 1);
 		zSetOps.add(key, value2, 2);
 		zSetOps.add(key, value3, 3);
 		zSetOps.add(key, value4, 4);
+		zSetOps.add(key, value5, 5);
 
+		assertThat(zSetOps.popMax(key, Duration.ofSeconds(1))).isEqualTo(new DefaultTypedTuple<>(value5, 5d));
 		assertThat(zSetOps.popMax(key)).isEqualTo(new DefaultTypedTuple<>(value4, 4d));
 		assertThat(zSetOps.popMax(key, 2)).containsExactly(new DefaultTypedTuple<>(value3, 3d),
 				new DefaultTypedTuple<>(value2, 2d));


### PR DESCRIPTION
- Specifically, usage of the API `ZSetOperations.popMax(K key, Duration timeout)`
  will produce incorrect results.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
