### PR TITLE
Fix potential `NullPointerException` when using Jedis Cluster `BZPOP*`

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
@@ -1020,7 +1020,7 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 	@SuppressWarnings("unchecked")
 	private static Tuple toTuple(List<?> bytes) {
 
-		if (bytes.isEmpty()) {
+		if (bytes == null || bytes.isEmpty()) {
 			return null;
 		}
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -2274,6 +2274,9 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 	@EnabledOnCommand("BZPOPMIN")
 	public void bzPopMinShouldWorkCorrectly() {
 
+		assertThat(clusterConnection.bZPopMin(KEY_1_BYTES, 1, TimeUnit.MILLISECONDS))
+				.isNull();
+
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
 		nativeConnection.zadd(KEY_1_BYTES, 20D, VALUE_2_BYTES);
 		nativeConnection.zadd(KEY_1_BYTES, 30D, VALUE_3_BYTES);
@@ -2298,6 +2301,9 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 	@Test // GH-2007
 	@EnabledOnCommand("BZPOPMAX")
 	public void bzPopMaxShouldWorkCorrectly() {
+
+		assertThat(clusterConnection.bZPopMax(KEY_1_BYTES, 1, TimeUnit.MILLISECONDS))
+				.isNull();
 
 		nativeConnection.zadd(KEY_1_BYTES, 10D, VALUE_1_BYTES);
 		nativeConnection.zadd(KEY_1_BYTES, 20D, VALUE_2_BYTES);


### PR DESCRIPTION
- For the Jedis-based implementations of bzpopmin and bzpopmax, a NPE is
  thrown if the provided timeout elapses and the server responds with a
  null array.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
