### PR TITLE
Introduce `JacksonObjectReader` and `JacksonObjectWriter` function interfaces to customize JSON (de)serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-GH-2322-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
-import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
@@ -55,36 +54,15 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  */
 public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Object> {
 
-	private ObjectMapper mapper;
+	private final ObjectMapper mapper;
 
 	private final JacksonObjectReader reader;
 
 	private final JacksonObjectWriter writer;
 
-	private boolean internalReader = false;
+	private final Lazy<Boolean> defaultTypingEnabled;
 
 	private final TypeResolver typeResolver;
-
-	private Lazy<Boolean> defaultTypingEnabled = Lazy
-			.of(() -> mapper.getSerializationConfig().getDefaultTyper(null) != null);
-
-	private Lazy<String> typeHintPropertyName;
-
-	{
-		typeHintPropertyName = Lazy.of(() -> {
-			if (defaultTypingEnabled.get()) {
-				return null;
-			}
-
-			return mapper.getDeserializationConfig().getDefaultTyper(null)
-					.buildTypeDeserializer(mapper.getDeserializationConfig(), mapper.getTypeFactory().constructType(Object.class),
-							Collections.emptyList())
-					.getPropertyName();
-
-		}).or("@class");
-
-		typeResolver = new TypeResolver(Lazy.of(() -> mapper.getTypeFactory()), typeHintPropertyName);
-	}
 
 	/**
 	 * Creates {@link GenericJackson2JsonRedisSerializer} and configures {@link ObjectMapper} for default typing.
@@ -104,7 +82,6 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 */
 	public GenericJackson2JsonRedisSerializer(@Nullable String classPropertyTypeName) {
 		this(classPropertyTypeName, JacksonObjectReader.create(), JacksonObjectWriter.create());
-		this.internalReader = true;
 	}
 
 	/**
@@ -122,7 +99,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	public GenericJackson2JsonRedisSerializer(@Nullable String classPropertyTypeName, JacksonObjectReader reader,
 			JacksonObjectWriter writer) {
 
-		this(new ObjectMapper(), reader, writer);
+		this(new ObjectMapper(), reader, writer, classPropertyTypeName);
 
 		// simply setting {@code mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)} does not help here since we need
 		// the type hint embedded for deserialization using the default typing feature.
@@ -133,10 +110,6 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 					classPropertyTypeName);
 		} else {
 			mapper.activateDefaultTyping(mapper.getPolymorphicTypeValidator(), DefaultTyping.EVERYTHING, As.PROPERTY);
-		}
-
-		if (classPropertyTypeName != null) {
-			typeHintPropertyName = Lazy.of(classPropertyTypeName);
 		}
 	}
 
@@ -149,7 +122,6 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 */
 	public GenericJackson2JsonRedisSerializer(ObjectMapper mapper) {
 		this(mapper, JacksonObjectReader.create(), JacksonObjectWriter.create());
-		this.internalReader = true;
 	}
 
 	/**
@@ -164,6 +136,11 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 */
 	public GenericJackson2JsonRedisSerializer(ObjectMapper mapper, JacksonObjectReader reader,
 			JacksonObjectWriter writer) {
+		this(mapper, reader, writer, null);
+	}
+
+	private GenericJackson2JsonRedisSerializer(ObjectMapper mapper, JacksonObjectReader reader,
+			JacksonObjectWriter writer, @Nullable String typeHintPropertyName) {
 
 		Assert.notNull(mapper, "ObjectMapper must not be null!");
 		Assert.notNull(reader, "Reader must not be null!");
@@ -172,6 +149,29 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		this.mapper = mapper;
 		this.reader = reader;
 		this.writer = writer;
+
+		this.defaultTypingEnabled = Lazy.of(() -> mapper.getSerializationConfig().getDefaultTyper(null) != null);
+
+		Supplier<String> typeHintPropertyNameSupplier;
+
+		if (typeHintPropertyName == null) {
+
+			typeHintPropertyNameSupplier = Lazy.of(() -> {
+				if (defaultTypingEnabled.get()) {
+					return null;
+				}
+
+				return mapper.getDeserializationConfig().getDefaultTyper(null)
+						.buildTypeDeserializer(mapper.getDeserializationConfig(),
+								mapper.getTypeFactory().constructType(Object.class), Collections.emptyList())
+						.getPropertyName();
+
+			}).or("@class");
+		} else {
+			typeHintPropertyNameSupplier = () -> typeHintPropertyName;
+		}
+
+		this.typeResolver = new TypeResolver(Lazy.of(mapper::getTypeFactory), typeHintPropertyNameSupplier);
 	}
 
 	/**
@@ -233,21 +233,22 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		}
 	}
 
-	protected JavaType resolveType(byte[] source, Class<?> type) {
+	protected JavaType resolveType(byte[] source, Class<?> type) throws IOException {
 
-		if (internalReader || !type.equals(Object.class) || !defaultTypingEnabled.get()) {
+		if (!type.equals(Object.class) || !defaultTypingEnabled.get()) {
 			return typeResolver.constructType(type);
 		}
 
 		return typeResolver.resolveType(source, type);
 	}
 
-	private static class TypeResolver {
+	static class TypeResolver {
 
-		private final ObjectReader objectReader = new ObjectMapper().reader();
+		// need a separate instance to bypass class hint checks
+		private final ObjectMapper mapper = new ObjectMapper();
 
 		private final Supplier<TypeFactory> typeFactory;
-		private Supplier<String> hintName;
+		private final Supplier<String> hintName;
 
 		public TypeResolver(Supplier<TypeFactory> typeFactory, Supplier<String> hintName) {
 
@@ -259,15 +260,13 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 			return typeFactory.get().constructType(type);
 		}
 
-		protected JavaType resolveType(byte[] source, Class<?> type) {
+		protected JavaType resolveType(byte[] source, Class<?> type) throws IOException {
 
-			try {
-				TextNode typeName = (TextNode) objectReader.readValue(source, JsonNode.class).get(hintName.get());
-				if (typeName != null) {
-					return typeFactory.get().constructFromCanonical(typeName.textValue());
-				}
-			} catch (IOException e) {
-				// TODO: logging?
+			JsonNode root = mapper.readTree(source);
+			JsonNode jsonNode = root.get(hintName.get());
+
+			if (jsonNode instanceof TextNode && jsonNode.asText() != null) {
+				return typeFactory.get().constructFromCanonical(jsonNode.asText());
 			}
 
 			return constructType(type);

--- a/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
@@ -16,8 +16,11 @@
 package org.springframework.data.redis.serializer;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.function.Supplier;
 
 import org.springframework.cache.support.NullValue;
+import org.springframework.data.util.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -25,14 +28,19 @@ import org.springframework.util.StringUtils;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.ser.SerializerFactory;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 /**
  * Generic Jackson 2-based {@link RedisSerializer} that maps {@link Object objects} to JSON using dynamic typing.
@@ -47,11 +55,36 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
  */
 public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Object> {
 
-	private final ObjectMapper mapper;
+	private ObjectMapper mapper;
 
 	private final JacksonObjectReader reader;
 
 	private final JacksonObjectWriter writer;
+
+	private boolean internalReader = false;
+
+	private final TypeResolver typeResolver;
+
+	private Lazy<Boolean> defaultTypingEnabled = Lazy
+			.of(() -> mapper.getSerializationConfig().getDefaultTyper(null) != null);
+
+	private Lazy<String> typeHintPropertyName;
+
+	{
+		typeHintPropertyName = Lazy.of(() -> {
+			if (defaultTypingEnabled.get()) {
+				return null;
+			}
+
+			return mapper.getDeserializationConfig().getDefaultTyper(null)
+					.buildTypeDeserializer(mapper.getDeserializationConfig(), mapper.getTypeFactory().constructType(Object.class),
+							Collections.emptyList())
+					.getPropertyName();
+
+		}).or("@class");
+
+		typeResolver = new TypeResolver(Lazy.of(() -> mapper.getTypeFactory()), typeHintPropertyName);
+	}
 
 	/**
 	 * Creates {@link GenericJackson2JsonRedisSerializer} and configures {@link ObjectMapper} for default typing.
@@ -71,6 +104,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 */
 	public GenericJackson2JsonRedisSerializer(@Nullable String classPropertyTypeName) {
 		this(classPropertyTypeName, JacksonObjectReader.create(), JacksonObjectWriter.create());
+		this.internalReader = true;
 	}
 
 	/**
@@ -100,6 +134,10 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		} else {
 			mapper.activateDefaultTyping(mapper.getPolymorphicTypeValidator(), DefaultTyping.EVERYTHING, As.PROPERTY);
 		}
+
+		if (classPropertyTypeName != null) {
+			typeHintPropertyName = Lazy.of(classPropertyTypeName);
+		}
 	}
 
 	/**
@@ -111,6 +149,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 */
 	public GenericJackson2JsonRedisSerializer(ObjectMapper mapper) {
 		this(mapper, JacksonObjectReader.create(), JacksonObjectWriter.create());
+		this.internalReader = true;
 	}
 
 	/**
@@ -188,10 +227,52 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		}
 
 		try {
-			return (T) reader.read(mapper, source, mapper.getTypeFactory().constructType(type));
+			return (T) reader.read(mapper, source, resolveType(source, type));
 		} catch (Exception ex) {
 			throw new SerializationException("Could not read JSON: " + ex.getMessage(), ex);
 		}
+	}
+
+	protected JavaType resolveType(byte[] source, Class<?> type) {
+
+		if (internalReader || !type.equals(Object.class) || !defaultTypingEnabled.get()) {
+			return typeResolver.constructType(type);
+		}
+
+		return typeResolver.resolveType(source, type);
+	}
+
+	private static class TypeResolver {
+
+		private final ObjectReader objectReader = new ObjectMapper().reader();
+
+		private final Supplier<TypeFactory> typeFactory;
+		private Supplier<String> hintName;
+
+		public TypeResolver(Supplier<TypeFactory> typeFactory, Supplier<String> hintName) {
+
+			this.typeFactory = typeFactory;
+			this.hintName = hintName;
+		}
+
+		protected JavaType constructType(Class<?> type) {
+			return typeFactory.get().constructType(type);
+		}
+
+		protected JavaType resolveType(byte[] source, Class<?> type) {
+
+			try {
+				TextNode typeName = (TextNode) objectReader.readValue(source, JsonNode.class).get(hintName.get());
+				if (typeName != null) {
+					return typeFactory.get().constructFromCanonical(typeName.textValue());
+				}
+			} catch (IOException e) {
+				// TODO: logging?
+			}
+
+			return constructType(type);
+		}
+
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
@@ -25,7 +25,6 @@ import org.springframework.util.StringUtils;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -37,6 +36,9 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 /**
  * Generic Jackson 2-based {@link RedisSerializer} that maps {@link Object objects} to JSON using dynamic typing.
+ * <p>
+ * JSON reading and writing can be customized by configuring {@link JacksonObjectReader} respective
+ * {@link JacksonObjectWriter}.
  *
  * @author Christoph Strobl
  * @author Mark Paluch
@@ -46,6 +48,10 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Object> {
 
 	private final ObjectMapper mapper;
+
+	private final JacksonObjectReader reader;
+
+	private final JacksonObjectWriter writer;
 
 	/**
 	 * Creates {@link GenericJackson2JsonRedisSerializer} and configures {@link ObjectMapper} for default typing.
@@ -59,13 +65,30 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 * given {@literal name}. In case of an {@literal empty} or {@literal null} String the default
 	 * {@link JsonTypeInfo.Id#CLASS} will be used.
 	 *
-	 * @param classPropertyTypeName Name of the JSON property holding type information. Can be {@literal null}.
+	 * @param classPropertyTypeName name of the JSON property holding type information. Can be {@literal null}.
 	 * @see ObjectMapper#activateDefaultTypingAsProperty(PolymorphicTypeValidator, DefaultTyping, String)
 	 * @see ObjectMapper#activateDefaultTyping(PolymorphicTypeValidator, DefaultTyping, As)
 	 */
 	public GenericJackson2JsonRedisSerializer(@Nullable String classPropertyTypeName) {
+		this(classPropertyTypeName, JacksonObjectReader.create(), JacksonObjectWriter.create());
+	}
 
-		this(new ObjectMapper());
+	/**
+	 * Creates {@link GenericJackson2JsonRedisSerializer} and configures {@link ObjectMapper} for default typing using the
+	 * given {@literal name}. In case of an {@literal empty} or {@literal null} String the default
+	 * {@link JsonTypeInfo.Id#CLASS} will be used.
+	 *
+	 * @param classPropertyTypeName name of the JSON property holding type information. Can be {@literal null}.
+	 * @param reader the {@link JacksonObjectReader} function to read objects using {@link ObjectMapper}.
+	 * @param writer the {@link JacksonObjectWriter} function to write objects using {@link ObjectMapper}.
+	 * @see ObjectMapper#activateDefaultTypingAsProperty(PolymorphicTypeValidator, DefaultTyping, String)
+	 * @see ObjectMapper#activateDefaultTyping(PolymorphicTypeValidator, DefaultTyping, As)
+	 * @since 3.0
+	 */
+	public GenericJackson2JsonRedisSerializer(@Nullable String classPropertyTypeName, JacksonObjectReader reader,
+			JacksonObjectWriter writer) {
+
+		this(new ObjectMapper(), reader, writer);
 
 		// simply setting {@code mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)} does not help here since we need
 		// the type hint embedded for deserialization using the default typing feature.
@@ -87,9 +110,29 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 * @param mapper must not be {@literal null}.
 	 */
 	public GenericJackson2JsonRedisSerializer(ObjectMapper mapper) {
+		this(mapper, JacksonObjectReader.create(), JacksonObjectWriter.create());
+	}
+
+	/**
+	 * Setting a custom-configured {@link ObjectMapper} is one way to take further control of the JSON serialization
+	 * process. For example, an extended {@link SerializerFactory} can be configured that provides custom serializers for
+	 * specific types.
+	 *
+	 * @param mapper must not be {@literal null}.
+	 * @param reader the {@link JacksonObjectReader} function to read objects using {@link ObjectMapper}.
+	 * @param writer the {@link JacksonObjectWriter} function to write objects using {@link ObjectMapper}.
+	 * @since 3.0
+	 */
+	public GenericJackson2JsonRedisSerializer(ObjectMapper mapper, JacksonObjectReader reader,
+			JacksonObjectWriter writer) {
 
 		Assert.notNull(mapper, "ObjectMapper must not be null!");
+		Assert.notNull(reader, "Reader must not be null!");
+		Assert.notNull(writer, "Writer must not be null!");
+
 		this.mapper = mapper;
+		this.reader = reader;
+		this.writer = writer;
 	}
 
 	/**
@@ -116,8 +159,8 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		}
 
 		try {
-			return mapper.writeValueAsBytes(source);
-		} catch (JsonProcessingException e) {
+			return writer.write(mapper, source);
+		} catch (IOException e) {
 			throw new SerializationException("Could not write JSON: " + e.getMessage(), e);
 		}
 	}
@@ -134,6 +177,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 * @throws SerializationException
 	 */
 	@Nullable
+	@SuppressWarnings("unchecked")
 	public <T> T deserialize(@Nullable byte[] source, Class<T> type) throws SerializationException {
 
 		Assert.notNull(type,
@@ -144,7 +188,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		}
 
 		try {
-			return mapper.readValue(source, type);
+			return (T) reader.read(mapper, source, mapper.getTypeFactory().constructType(type));
 		} catch (Exception ex) {
 			throw new SerializationException("Could not read JSON: " + ex.getMessage(), ex);
 		}
@@ -172,8 +216,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		}
 
 		@Override
-		public void serialize(NullValue value, JsonGenerator jgen, SerializerProvider provider)
-				throws IOException {
+		public void serialize(NullValue value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
 
 			jgen.writeStartObject();
 			jgen.writeStringField(classIdentifier, NullValue.class.getName());
@@ -186,4 +229,5 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 			serialize(value, gen, serializers);
 		}
 	}
+
 }

--- a/src/main/java/org/springframework/data/redis/serializer/JacksonObjectReader.java
+++ b/src/main/java/org/springframework/data/redis/serializer/JacksonObjectReader.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.serializer;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Defines the contract for Object Mapping readers. Implementations of this interface can deserialize a given byte array
+ * holding JSON to an Object considering the target type.
+ * <p>
+ * Reader functions can customize how the actual JSON is being deserialized by e.g. obtaining a customized
+ * {@link com.fasterxml.jackson.databind.ObjectReader} applying serialization features, date formats, or views.
+ *
+ * @author Mark Paluch
+ * @since 3.0
+ */
+@FunctionalInterface
+public interface JacksonObjectReader {
+
+	/**
+	 * Read an object graph from the given root JSON into a Java object considering the {@link JavaType}.
+	 *
+	 * @param mapper the object mapper to use.
+	 * @param source the JSON to deserialize.
+	 * @param type the Java target type
+	 * @return the deserialized Java object.
+	 * @throws IOException if an I/O error or JSON deserialization error occurs.
+	 */
+	Object read(ObjectMapper mapper, byte[] source, JavaType type) throws IOException;
+
+	/**
+	 * Create a default {@link JacksonObjectReader} delegating to {@link ObjectMapper#readValue(InputStream, JavaType)}.
+	 *
+	 * @return the default {@link JacksonObjectReader}.
+	 */
+	static JacksonObjectReader create() {
+		return (mapper, source, type) -> mapper.readValue(source, 0, source.length, type);
+	}
+
+}

--- a/src/main/java/org/springframework/data/redis/serializer/JacksonObjectWriter.java
+++ b/src/main/java/org/springframework/data/redis/serializer/JacksonObjectWriter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.serializer;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Defines the contract for Object Mapping writers. Implementations of this interface can serialize a given Object to a
+ * {@code byte[]} containing JSON.
+ * <p>
+ * Writer functions can customize how the actual JSON is being written by e.g. obtaining a customized
+ * {@link com.fasterxml.jackson.databind.ObjectWriter} applying serialization features, date formats, or views.
+ *
+ * @author Mark Paluch
+ * @since 3.0
+ */
+@FunctionalInterface
+public interface JacksonObjectWriter {
+
+	/**
+	 * Write the object graph with the given root {@code source} as byte array.
+	 *
+	 * @param mapper the object mapper to use.
+	 * @param source the root of the object graph to marshal.
+	 * @return a byte array containing the serialized object graph.
+	 * @throws IOException if an I/O error or JSON serialization error occurs.
+	 */
+	byte[] write(ObjectMapper mapper, Object source) throws IOException;
+
+	/**
+	 * Create a default {@link JacksonObjectWriter} delegating to {@link ObjectMapper#writeValueAsBytes(Object)}.
+	 *
+	 * @return the default {@link JacksonObjectWriter}.
+	 */
+	static JacksonObjectWriter create() {
+		return ObjectMapper::writeValueAsBytes;
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/serializer/Jackson2JsonRedisSerializerTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/Jackson2JsonRedisSerializerTests.java
@@ -25,8 +25,11 @@ import org.springframework.data.redis.Person;
 import org.springframework.data.redis.PersonObjectFactory;
 
 /**
+ * Unit tests for {@link Jackson2JsonRedisSerializer}.
+ *
  * @author Thomas Darimont
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 class Jackson2JsonRedisSerializerTests {
 
@@ -62,6 +65,14 @@ class Jackson2JsonRedisSerializerTests {
 	@Test // DTATREDIS-241
 	void testJackson2JsonSerilizerThrowsExceptionWhenSettingNullObjectMapper() {
 		assertThatIllegalArgumentException().isThrownBy(() -> serializer.setObjectMapper(null));
+	}
+
+	@Test // GH-2322
+	void shouldConsiderWriter() {
+
+		Person person = new PersonObjectFactory().instance();
+		serializer.setWriter((mapper, source) -> "foo".getBytes());
+		assertThat(serializer.serialize(person)).isEqualTo("foo".getBytes());
 	}
 
 }

--- a/src/test/java/org/springframework/data/redis/serializer/Jackson2JsonRedisSerializerTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/Jackson2JsonRedisSerializerTests.java
@@ -24,6 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.Person;
 import org.springframework.data.redis.PersonObjectFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
 /**
  * Unit tests for {@link Jackson2JsonRedisSerializer}.
  *
@@ -70,8 +73,10 @@ class Jackson2JsonRedisSerializerTests {
 	@Test // GH-2322
 	void shouldConsiderWriter() {
 
+		serializer = new Jackson2JsonRedisSerializer<>(new ObjectMapper(),
+				TypeFactory.defaultInstance().constructType(Person.class), JacksonObjectReader.create(),
+				(mapper, source) -> "foo".getBytes());
 		Person person = new PersonObjectFactory().instance();
-		serializer.setWriter((mapper, source) -> "foo".getBytes());
 		assertThat(serializer.serialize(person)).isEqualTo("foo".getBytes());
 	}
 


### PR DESCRIPTION
We now encapsulate serialization and deserialization operations as `JacksonObjectWriter` and `JacksonObjectReader` functions to allow customization of Jackson serialization.

Closes #2322 