### PR TITLE
Add support for deserializing objects with generics.

### DIFF
--- a/src/main/java/org/springframework/data/redis/serializer/JacksonTypeReference2JsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/JacksonTypeReference2JsonRedisSerializer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.serializer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.springframework.lang.Nullable;
+
+/**
+ * <p>{@link RedisSerializer} that can serialize and deserialize objects that contain generics.</p>
+ * <p>Example usage for {@literal Set<Person>}:</p>
+ * <pre>{@code
+ * JacksonTypeReference2JsonRedisSerializer<Set<Person>> personSetSerializer =
+ *     new JacksonTypeReference2JsonRedisSerializer<>(new TypeReference<>() {});
+ * }
+ * </pre>
+ * <b>Note:</b>Null objects are serialized as empty arrays and vice versa.
+ *
+ * @author Jos Roseboom
+ * @since 3.0
+ */
+public class JacksonTypeReference2JsonRedisSerializer<T> implements RedisSerializer<T> {
+    private final TypeReference<T> typeReference;
+    private final ObjectMapper objectMapper;
+
+    public JacksonTypeReference2JsonRedisSerializer(TypeReference<T> typeReference, ObjectMapper objectMapper) {
+        this.typeReference = typeReference;
+        this.objectMapper = objectMapper;
+    }
+
+    public JacksonTypeReference2JsonRedisSerializer(TypeReference<T> typeReference) {
+        this(typeReference, JsonMapper.builder().findAndAddModules().build());
+    }
+
+    @Override
+    public byte[] serialize(@Nullable Object t) throws SerializationException {
+
+        if (t == null) {
+            return SerializationUtils.EMPTY_ARRAY;
+        }
+        try {
+            return this.objectMapper.writeValueAsBytes(t);
+        } catch (Exception ex) {
+            throw new SerializationException("Could not write JSON: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public T deserialize(@Nullable byte[] bytes) throws SerializationException {
+        if (SerializationUtils.isEmpty(bytes)) {
+            return null;
+        }
+        try {
+            return this.objectMapper.readValue(bytes, typeReference);
+        } catch (Exception ex) {
+            throw new SerializationException("Could not read JSON: " + ex.getMessage(), ex);
+        }
+    }
+}

--- a/src/test/java/org/springframework/data/redis/serializer/JacksonTypeReference2JsonRedisSerializerTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/JacksonTypeReference2JsonRedisSerializerTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.serializer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.Person;
+import org.springframework.data.redis.PersonObjectFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit tests for {@link JacksonTypeReference2JsonRedisSerializer}
+ *
+ * @author Jos Roseboom
+ */
+class JacksonTypeReference2JsonRedisSerializerTests {
+
+	private JacksonTypeReference2JsonRedisSerializer<Person> personSerializer;
+
+	@BeforeEach public void setup() {
+		personSerializer = new JacksonTypeReference2JsonRedisSerializer<>(new TypeReference<>() {
+		});
+	}
+
+	@Test // GH-2374: should behave like required for Jackson2JsonRedisSerializer in DATAREDIS-241
+	void testJackson2JsonSerializer() {
+		Person person = new PersonObjectFactory().instance();
+		assertThat(personSerializer.deserialize(personSerializer.serialize(person))).isEqualTo(person);
+	}
+
+	@Test // GH-2374: should behave like required for Jackson2JsonRedisSerializer in DATAREDIS-241
+	void testJackson2JsonSerializerShouldReturnEmptyByteArrayWhenSerializingNull() {
+		assertThat(personSerializer.serialize(null)).isEqualTo(new byte[0]);
+	}
+
+	@Test // GH-2374: should behave like required for Jackson2JsonRedisSerializer in DATAREDIS-241
+	void testJackson2JsonSerializerShouldReturnNullWhenDerserializingEmtyByteArray() {
+		assertThat(personSerializer.deserialize(new byte[0])).isNull();
+	}
+
+	@Test // GH-2374: should behave like required for Jackson2JsonRedisSerializer in DATAREDIS-241
+	void testJackson2JsonSerilizerShouldThrowExceptionWhenDeserializingInvalidByteArray() {
+
+		Person person = new PersonObjectFactory().instance();
+		byte[] serializedValue = personSerializer.serialize(person);
+		Arrays.sort(serializedValue); // corrupt serialization result
+
+		assertThatExceptionOfType(SerializationException.class).isThrownBy(
+				() -> personSerializer.deserialize(serializedValue));
+	}
+
+	@Test // GH-2374
+	void testSetOfPersons() {
+		PersonObjectFactory personFactory = new PersonObjectFactory();
+		Set<Person> personSet = Set.of(personFactory.instance(), personFactory.instance());
+		JacksonTypeReference2JsonRedisSerializer<Set<Person>> personSetSerializer = new JacksonTypeReference2JsonRedisSerializer<>(
+				new TypeReference<>() {
+				});
+
+		assertThat(personSetSerializer.deserialize(personSetSerializer.serialize(personSet))).isEqualTo(personSet);
+	}
+
+	@Test // GH-2374
+	void testMultipleLevelNesting() {
+		final Map<Integer, Set<List<String>>> nestedGenerics = Map.of(3, Set.of(List.of("MyString")));
+		JacksonTypeReference2JsonRedisSerializer<Map<Integer, Set<List<String>>>> personSetSerializer = new JacksonTypeReference2JsonRedisSerializer<>(
+				new TypeReference<>() {
+				});
+
+		assertThat(personSetSerializer.deserialize(personSetSerializer.serialize(nestedGenerics))).isEqualTo(
+				nestedGenerics);
+	}
+
+	@Test // GH-2374
+	void testNotSerializableGeneric() {
+		final Set<NotSerializableClass> notSerializableClasses = Set.of(new NotSerializableClass("John"),
+				new NotSerializableClass("Jane"));
+		JacksonTypeReference2JsonRedisSerializer<Set<NotSerializableClass>> personSetSerializer = new JacksonTypeReference2JsonRedisSerializer<>(
+				new TypeReference<>() {
+				});
+
+		assertThat(personSetSerializer.deserialize(personSetSerializer.serialize(notSerializableClasses))).isEqualTo(
+				notSerializableClasses);
+	}
+
+}

--- a/src/test/java/org/springframework/data/redis/serializer/NotSerializableClass.java
+++ b/src/test/java/org/springframework/data/redis/serializer/NotSerializableClass.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.serializer;
+
+import java.util.Objects;
+/*
+ * @author Jos Roseboom
+ */
+public class NotSerializableClass {
+
+	public String name;
+
+	public NotSerializableClass() {
+	}
+
+	public NotSerializableClass(String name) {
+		this();
+		this.name = name;
+	}
+
+	@Override public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof NotSerializableClass))
+			return false;
+		NotSerializableClass that = (NotSerializableClass) o;
+		return Objects.equals(name, that.name);
+	}
+
+	@Override public int hashCode() {
+		return Objects.hash(name);
+	}
+}


### PR DESCRIPTION
Currently there is no RedisSerializer that can deserialize an object with generics like Set\<Person>. This is for example a problem when using redis as cache in spring boot. See #2374 

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
