### PR TITLE
Fix method usage in MappingRedisConverter.java

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -61,7 +61,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.comparator.NullSafeComparator;
 
@@ -109,6 +108,7 @@ import org.springframework.util.comparator.NullSafeComparator;
  * @author Greg Turnquist
  * @author Mark Paluch
  * @author Golam Mazid Sajib
+ * @author Zhixuan Wu
  * @since 1.7
  */
 public class MappingRedisConverter implements RedisConverter, InitializingBean {
@@ -317,7 +317,7 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 			return null;
 		}
 
-		if (persistentProperty.isIdProperty() && ObjectUtils.isEmpty(path.isEmpty())) {
+		if (persistentProperty.isIdProperty() && !StringUtils.hasText(path.isEmpty())) {
 			return sourceBytes != null ? fromBytes(sourceBytes, typeInformation.getType()) : source.getId();
 		}
 


### PR DESCRIPTION
Replace `ObjectUtils.isEmpty` with `StringUtils.hasText` since `ObjectUtils.isEmpty(Boolean)` is always false.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
