### PR TITLE
Correct 'Redis Cache' reference document title.

### DIFF
--- a/src/main/asciidoc/reference/redis-cache.adoc
+++ b/src/main/asciidoc/reference/redis-cache.adoc
@@ -1,5 +1,5 @@
 [[redis:support:cache-abstraction]]
-== Redis Cache
+= Redis Cache
 
 NOTE: Changed in 2.0
 


### PR DESCRIPTION
Change redis-cache.adoc document title from '==' to '=' to appear as section 10.15 instead of 10.14.1, which currently places the 'Redis Cache' ref doc under 'Redis Scripting'.

Closes #2458

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
