### PR TITLE
Add support for XCLAIM in StreamOperations

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.core;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,6 +27,7 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
@@ -130,6 +132,35 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 		ByteRecord binaryRecord = input.serialize(keySerializer(), hashKeySerializer(), hashValueSerializer());
 
 		return execute(connection -> connection.xAdd(binaryRecord));
+	}
+
+	@Override
+	public List<MapRecord<K, HK, HV>> claim(K key, String group, String newOwner, Duration minIdleTime,
+			RecordId... recordIds) {
+		byte[] rawKey = rawKey(key);
+
+		return execute(new RecordDeserializingRedisCallback() {
+
+			@Nullable
+			@Override
+			List<ByteRecord> inRedis(RedisConnection connection) {
+				return connection.streamCommands().xClaim(rawKey, group, newOwner, minIdleTime, recordIds);
+			}
+		});
+	}
+
+	@Override
+	public List<MapRecord<K, HK, HV>> claim(K key, String group, String newOwner, XClaimOptions xClaimOptions) {
+		byte[] rawKey = rawKey(key);
+
+		return execute(new RecordDeserializingRedisCallback() {
+
+			@Nullable
+			@Override
+			List<ByteRecord> inRedis(RedisConnection connection) {
+				return connection.streamCommands().xClaim(rawKey, group, newOwner, xClaimOptions);
+			}
+		});
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.core;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -25,6 +26,7 @@ import org.reactivestreams.Publisher;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
+import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.connection.stream.Record;
 import org.springframework.data.redis.connection.stream.StreamInfo.XInfoConsumer;
@@ -125,6 +127,35 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 * @see ObjectRecord
 	 */
 	Mono<RecordId> add(Record<K, ?> record);
+
+	/**
+	 * Changes the ownership of a pending message, so that the new owner is the consumer specified as the command argument.
+	 * The message is claimed only if its idle time is greater the minimum idle time specified when calling XCLAIM
+	 *
+	 * @param key the stream key.
+	 * @param group name of the consumer group.
+	 * @param newOwner name of the consumer claiming the message.
+	 * @param minIdleTime idle time required for a message to be claimed.
+	 * @param recordIds record IDs to be claimed
+	 *
+	 * @return the {@link Flux} of claimed MapRecords.
+	 * @see <a href="https://redis.io/commands/xclaim/">Redis Documentation: XCLAIM</a>
+	 */
+	Flux<MapRecord<K, HK, HV>> claim(K key, String group, String newOwner, Duration minIdleTime, RecordId... recordIds);
+
+	/**
+	 * Changes the ownership of a pending message, so that the new owner is the consumer specified as the command argument.
+	 * The message is claimed only if its idle time is greater the minimum idle time specified when calling XCLAIM
+	 *
+	 * @param key the stream key.
+	 * @param group name of the consumer group.
+	 * @param newOwner name of the consumer claiming the message.
+	 * @param xClaimOptions additional parameters for the CLAIM call.
+	 *
+	 * @return the {@link Flux} of claimed MapRecords.
+	 * @see <a href="https://redis.io/commands/xclaim/">Redis Documentation: XCLAIM</a>
+	 */
+	Flux<MapRecord<K, HK, HV>> claim(K key, String group, String newOwner, XClaimOptions xClaimOptions);
 
 	/**
 	 * Removes the specified records from the stream. Returns the number of records deleted, that may be different from

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -17,12 +17,14 @@ package org.springframework.data.redis.core;
 
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
+import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.connection.stream.Record;
 import org.springframework.data.redis.connection.stream.StreamInfo.XInfoConsumers;
@@ -118,6 +120,35 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	@SuppressWarnings("unchecked")
 	@Nullable
 	RecordId add(Record<K, ?> record);
+
+	/**
+	 * Changes the ownership of a pending message, so that the new owner is the consumer specified as the command argument.
+	 * The message is claimed only if its idle time is greater the minimum idle time specified when calling XCLAIM
+	 *
+	 * @param key the stream key.
+	 * @param group name of the consumer group.
+	 * @param newOwner name of the consumer claiming the message.
+	 * @param minIdleTime idle time required for a message to be claimed.
+	 * @param recordIds record IDs to be claimed
+	 *
+	 * @return list of claimed MapRecords.
+	 * @see <a href="https://redis.io/commands/xclaim/">Redis Documentation: XCLAIM</a>
+	 */
+	List<MapRecord<K, HK, HV>> claim(K key, String group, String newOwner, Duration minIdleTime, RecordId... recordIds);
+
+	/**
+	 * Changes the ownership of a pending message, so that the new owner is the consumer specified as the command argument.
+	 * The message is claimed only if its idle time is greater the minimum idle time specified when calling XCLAIM
+	 *
+	 * @param key the stream key.
+	 * @param group name of the consumer group.
+	 * @param newOwner name of the consumer claiming the message.
+	 * @param xClaimOptions additional parameters for the CLAIM call.
+	 *
+	 * @return list of claimed MapRecords.
+	 * @see <a href="https://redis.io/commands/xclaim/">Redis Documentation: XCLAIM</a>
+	 */
+	List<MapRecord<K, HK, HV>> claim(K key, String group, String newOwner, XClaimOptions xClaimOptions);
 
 	/**
 	 * Removes the specified records from the stream. Returns the number of records deleted, that may be different from


### PR DESCRIPTION
Adds a support for [XCLAIM](https://redis.io/commands/xclaim/) in StreamOperations allowing to simply call 
```
redisTemplate.opsForStream().claim(...)
```

Closes #2465

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
