### PR TITLE
Use correct output for `ZCARD` command using `LettuceConnection.execute(…)`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-GH-2473-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -1064,6 +1064,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 			COMMAND_OUTPUT_TYPE_MAPPING.put(HDEL, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(HINCRBY, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(HLEN, IntegerOutput.class);
+			COMMAND_OUTPUT_TYPE_MAPPING.put(HSTRLEN, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(INCR, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(INCRBY, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(LINSERT, IntegerOutput.class);
@@ -1086,6 +1087,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 			COMMAND_OUTPUT_TYPE_MAPPING.put(SUNIONSTORE, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(STRLEN, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(TTL, IntegerOutput.class);
+			COMMAND_OUTPUT_TYPE_MAPPING.put(XLEN, IntegerOutput.class);
+			COMMAND_OUTPUT_TYPE_MAPPING.put(XTRIM, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZADD, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZCARD, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZCOUNT, IntegerOutput.class);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -57,7 +57,6 @@ import java.util.function.Supplier;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.BeanUtils;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
@@ -1088,6 +1087,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 			COMMAND_OUTPUT_TYPE_MAPPING.put(STRLEN, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(TTL, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZADD, IntegerOutput.class);
+			COMMAND_OUTPUT_TYPE_MAPPING.put(ZCARD, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZCOUNT, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZINTERSTORE, IntegerOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZRANK, IntegerOutput.class);

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.SettingsUtils;
@@ -178,6 +177,16 @@ public class LettuceConnectionIntegrationTests extends AbstractConnectionIntegra
 				(Iterable<byte[]>) connection.execute("MGET", "spring".getBytes(), "data".getBytes(), "redis".getBytes()))
 						.isInstanceOf(List.class)
 						.contains("awesome".getBytes(), "cool".getBytes(), "supercalifragilisticexpialidocious".getBytes());
+	}
+
+	@Test // GH-2473
+	void testExecuteZcardShouldReturnNumericValue() {
+
+		connection.zAdd("spring", 1, "awesome");
+		connection.zAdd("spring", 1, "cool");
+		connection.zAdd("spring", 1, "supercalifragilisticexpialidocious");
+
+		assertThat(connection.execute("ZCARD", "spring")).isInstanceOf(Long.class).isEqualTo(3L);
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
We now provide a type hint for the `ZCARD` command.

Closes #2473