### PR TITLE
Use BitSet instead of LinkedHashSet to improve the performance of SlotRange construction

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/ClusterSlotHashUtil.java
+++ b/src/main/java/org/springframework/data/redis/connection/ClusterSlotHashUtil.java
@@ -28,7 +28,7 @@ import org.springframework.util.Assert;
  */
 public final class ClusterSlotHashUtil {
 
-	private static final int SLOT_COUNT = 16384;
+	public static final int SLOT_COUNT = 16384;
 
 	private static final byte SUBKEY_START = '{';
 	private static final byte SUBKEY_END = '}';

--- a/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
@@ -30,6 +30,7 @@ import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.RedisClusterNode;
 import org.springframework.data.redis.connection.RedisClusterNode.Flag;
@@ -57,6 +58,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author daihuabin
  */
 public abstract class Converters {
 
@@ -606,7 +608,7 @@ public abstract class Converters {
 
 		private SlotRange parseSlotRange(String[] args) {
 
-			Set<Integer> slots = new LinkedHashSet<>();
+			BitSet slots = new BitSet(ClusterSlotHashUtil.SLOT_COUNT);
 
 			for (int i = SLOTS_INDEX; i < args.length; i++) {
 
@@ -623,11 +625,11 @@ public abstract class Converters {
 						int from = Integer.valueOf(slotRange[0]);
 						int to = Integer.valueOf(slotRange[1]);
 						for (int slot = from; slot <= to; slot++) {
-							slots.add(slot);
+							slots.set(slot);
 						}
 					}
 				} else {
-					slots.add(Integer.valueOf(raw));
+					slots.set(Integer.valueOf(raw));
 				}
 			}
 


### PR DESCRIPTION
Here are the JMH test results for BitSet and LinkedHashSet
```
Benchmark              (slotSize)  (startFrom)   Mode  Cnt     Score     Error   Units
Scratch.bitSet                100          100  thrpt   10  6584.879 ± 178.558  ops/ms
Scratch.bitSet                100         3000  thrpt   10  5546.809 ± 216.817  ops/ms
Scratch.bitSet                100         6000  thrpt   10  4024.224 ± 111.127  ops/ms
Scratch.bitSet               3000          100  thrpt   10   197.832 ±  27.294  ops/ms
Scratch.bitSet               3000         3000  thrpt   10   201.136 ±  32.989  ops/ms
Scratch.bitSet               3000         6000  thrpt   10   203.528 ±  23.295  ops/ms
Scratch.bitSet               6000          100  thrpt   10   101.227 ±  14.600  ops/ms
Scratch.bitSet               6000         3000  thrpt   10   101.928 ±  19.558  ops/ms
Scratch.bitSet               6000         6000  thrpt   10   100.366 ±  17.370  ops/ms
Scratch.linkedHashSet         100          100  thrpt   10  1556.557 ±  95.599  ops/ms
Scratch.linkedHashSet         100         3000  thrpt   10  1553.883 ±  40.297  ops/ms
Scratch.linkedHashSet         100         6000  thrpt   10  1563.915 ±  29.968  ops/ms
Scratch.linkedHashSet        3000          100  thrpt   10    62.365 ±   2.632  ops/ms
Scratch.linkedHashSet        3000         3000  thrpt   10    61.362 ±   3.366  ops/ms
Scratch.linkedHashSet        3000         6000  thrpt   10    61.484 ±   4.668  ops/ms
Scratch.linkedHashSet        6000          100  thrpt   10    29.789 ±   1.172  ops/ms
Scratch.linkedHashSet        6000         3000  thrpt   10    29.868 ±   1.360  ops/ms
Scratch.linkedHashSet        6000         6000  thrpt   10    29.746 ±   1.843  ops/ms
```

Here is the JMH test code
```java
import org.openjdk.jmh.annotations.*;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;

import java.util.BitSet;
import java.util.LinkedHashSet;
import java.util.Set;
import java.util.concurrent.TimeUnit;

@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Thread)
@Fork(value = 1)
@Warmup(iterations = 1)
@Measurement(iterations = 10, time = 1)
@Threads(Threads.MAX)
public class Scratch {

    Set<Integer> slots;

    @Param({"100", "3000", "6000"})
    int slotSize;

    @Param({"100", "3000", "6000"})
    int startFrom;

    @Setup(Level.Iteration)
    public void init() {
        slots = new LinkedHashSet<>();
        for (int i = startFrom; i < startFrom + slotSize; i++) {
            slots.add(i);
        }
    }

    @Benchmark
    public void linkedHashSet() {
        LinkedHashSet<Integer> integers = new LinkedHashSet<>();
        for (Integer slot : slots) {
            integers.add(slot);
        }
    }

    @Benchmark
    public void bitSet() {
        BitSet set = new BitSet();
        for (Integer slot : slots) {
            set.set(slot);
        }
    }

    public static void main(String[] args) throws RunnerException {
        Options options = new OptionsBuilder().include(Scratch.class.getSimpleName()).build();
        new Runner(options).run();
    }
}
```


<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
