### PR TITLE
Reset JedisConnectionFactory's destroyed flag when initializing bean

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -305,6 +305,7 @@ public class JedisConnectionFactory implements InitializingBean, DisposableBean,
 		}
 
 		this.initialized = true;
+		this.destroyed = false;
 	}
 
 	JedisClientConfig createSentinelClientConfig(SentinelConfiguration sentinelConfiguration) {


### PR DESCRIPTION
Reset JedisConnectionFactory's destroyed flag when initializing bean to prevent configuration hot upgrade issue.

Closes #2553 