### PR TITLE
Fix issue#2526 BoundingBox getWidth(), should return height value, not width value.

### DIFF
--- a/src/main/java/org/springframework/data/redis/domain/geo/BoundingBox.java
+++ b/src/main/java/org/springframework/data/redis/domain/geo/BoundingBox.java
@@ -70,7 +70,7 @@ public class BoundingBox implements Shape {
 	 * @return will never be {@literal null}.
 	 */
 	public Distance getWidth() {
-		return height;
+		return width;
 	}
 
 	/**


### PR DESCRIPTION
Fix issue: #2526 