### PR TITLE
Fix make the RedisAccessor abstract.#2494

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisAccessor.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisAccessor.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
  * @author John Blum
  * @see org.springframework.beans.factory.InitializingBean
  */
-public class RedisAccessor implements InitializingBean {
+public abstract class RedisAccessor implements InitializingBean {
 
 	/** Logger available to subclasses */
 	protected final Log logger = LogFactory.getLog(getClass());


### PR DESCRIPTION
Fix issue: #2494. 
In the comments: **Not intended to be used directly.**, abstract class is better