### PR TITLE
`StreamMessageListenerContainer` should wait until listeners finish processing within timeout during shutdown

### DIFF
--- a/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
@@ -19,6 +19,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
@@ -51,6 +55,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Han Li
  * @since 2.2
  */
 class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implements StreamMessageListenerContainer<K, V> {
@@ -160,9 +165,22 @@ class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implement
 		synchronized (lifecycleMonitor) {
 
 			if (this.running) {
-
-				subscriptions.forEach(Cancelable::cancel);
-
+				subscriptions.stream()
+						.map(subscription -> CompletableFuture.runAsync(() -> {
+							subscription.cancel();
+							while (subscription.isActive()) {
+								// NO-OP
+							}
+						}, taskExecutor))
+						.forEach(f -> {
+							try {
+								f.get(this.containerOptions.getShutdownTimeout().toNanos(), TimeUnit.NANOSECONDS);
+							} catch (InterruptedException e) {
+								Thread.currentThread().interrupt();
+							} catch (ExecutionException | TimeoutException e) {
+								// ignore
+							}
+						});
 				running = false;
 			}
 		}


### PR DESCRIPTION
Fix issue: #2261 

Set a new option `shutdownTimeout` for container option.   The container will wait listener with `shutdownTimeout` time to finish processing.

If any improvement can do, feel free to tell me.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
