### PR TITLE
Improve RedisCacheManagerBuilder to expose applied RedisCacheConfiguration

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Yanming Zhou
  * @since 2.0
  * @see RedisCacheConfiguration
  * @see RedisCacheWriter
@@ -334,6 +335,15 @@ public class RedisCacheManager extends AbstractTransactionSupportingCacheManager
 			this.defaultCacheConfiguration = defaultCacheConfiguration;
 
 			return this;
+		}
+
+		/**
+		 * Returns applied {@link RedisCacheConfiguration}, allow customization base on it.
+		 *
+		 * @return applied {@link RedisCacheConfiguration}.
+		 */
+		public RedisCacheConfiguration cacheDefaults() {
+			return this.defaultCacheConfiguration;
 		}
 
 		/**

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheManagerUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.cache;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Duration;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Yanming Zhou
  */
 @ExtendWith(MockitoExtension.class)
 class RedisCacheManagerUnitTests {
@@ -187,5 +189,17 @@ class RedisCacheManagerUnitTests {
 		RedisCacheManager.builder(cacheWriter).build();
 
 		verify(cacheWriter, never()).withStatisticsCollector(any());
+	}
+
+	@Test // DATAREDIS-481
+	void customizeRedisCacheConfigurationBaseOnApplied() {
+
+		RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig().disableKeyPrefix();
+		RedisCacheManagerBuilder cmb = RedisCacheManager.builder().cacheDefaults(configuration);
+
+		cmb.cacheDefaults(cmb.cacheDefaults().entryTtl(Duration.ofSeconds(10)));
+
+		assertThat(cmb.cacheDefaults().usePrefix()).isFalse();
+		assertThat(cmb.cacheDefaults().getTtl()).isEqualTo(Duration.ofSeconds(10));
 	}
 }


### PR DESCRIPTION
Before this commit, we need reflection if we want customization base on applied RedisCacheConfiguration, it's not conventional.

Take spring-boot `RedisCacheManagerBuilderCustomizer` for example:
```java
	@Bean
	@ConditionalOnClass(name = "org.springframework.data.redis.cache.RedisCacheConfiguration")
	RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
		return builder -> {
			RedisCacheConfiguration oldDefaultCacheConfiguration = ReflectionUtils.getFieldValue(builder,
					"defaultCacheConfiguration");
			RedisCacheConfiguration newDefaultCacheConfiguration = oldDefaultCacheConfiguration
				.serializeValuesWith(SerializationPair.fromSerializer(new CompactJdkSerializationRedisSerializer()));
			builder.cacheDefaults(newDefaultCacheConfiguration);
		};
	}
```

after this commit, it could be:
```java
	@Bean
	@ConditionalOnClass(name = "org.springframework.data.redis.cache.RedisCacheConfiguration")
	RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
		return builder -> {
			builder.cacheDefaults(builder.cacheDefaults()
				.serializeValuesWith(SerializationPair.fromSerializer(new CompactJdkSerializationRedisSerializer())));
		};
	}
```