### PR TITLE
Construct `LettuceObservationContext` with parent observation

### DIFF
--- a/src/test/java/org/springframework/data/redis/connection/lettuce/observability/SynchronousIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/observability/SynchronousIntegrationTests.java
@@ -35,6 +35,7 @@ import io.micrometer.tracing.test.SampleTestRunner;
  * Collection of tests that log metrics and tracing using the synchronous API.
  *
  * @author Mark Paluch
+ * @author Yanming Zhou
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = TestConfig.class)
@@ -77,6 +78,9 @@ public class SynchronousIntegrationTests extends SampleTestRunner {
 						.containsEntry("net.sock.peer.port", "" + SettingsUtils.getPort());
 				assertThat(finishedSpan.getTags()).containsKeys("db.operation");
 			}
+
+			assertThat(TestConfig.PARENT_OBSERVATION_NAMES_COLLECTED_IN_PREDICATE).isNotEmpty();
+			TestConfig.PARENT_OBSERVATION_NAMES_COLLECTED_IN_PREDICATE.clear();
 		};
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/observability/TestConfig.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/observability/TestConfig.java
@@ -22,6 +22,8 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.context.annotation.Bean;
@@ -33,15 +35,23 @@ import org.springframework.data.redis.test.extension.ShutdownQueue;
 
 /**
  * @author Mark Paluch
+ * @author Yanming Zhou
  */
 @Configuration
 class TestConfig {
 
 	static final MeterRegistry METER_REGISTRY = new SimpleMeterRegistry();
 	static final ObservationRegistry OBSERVATION_REGISTRY = ObservationRegistry.create();
+	static final List<String> PARENT_OBSERVATION_NAMES_COLLECTED_IN_PREDICATE = new ArrayList<>();
 
 	static {
 		OBSERVATION_REGISTRY.observationConfig().observationHandler(new DefaultMeterObservationHandler(METER_REGISTRY));
+		OBSERVATION_REGISTRY.observationConfig().observationPredicate((name, context) -> {
+			if (context.getParentObservation() != null) {
+				PARENT_OBSERVATION_NAMES_COLLECTED_IN_PREDICATE.add(context.getParentObservation().getContextView().getName());
+			}
+			return true;
+		});
 	}
 
 	@Bean(destroyMethod = "timer")


### PR DESCRIPTION
After this commit, `LettuceObservationContext.setParentObservation()` is called right after `Context` rather than `Observation` created, then `Context.getParentObservation()` could be used in `ObservationPredicate` to determine whether `Observation` should be created, for example, we can filter out parentless lettuce observations like this:

```java
	@Bean
	ObservationPredicate noParentlessLettuceObservations() {
		return (name, context) -> {
			if (context instanceof LettuceObservationContext) {
				return context.getParentObservation() != null;
			}
			return true;
		};
	}
```

Fix GH-2591

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
