### PR TITLE
Fixes bug in RedisCommand.requiresArguments()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-2646-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/core/RedisCommand.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisCommand.java
@@ -219,8 +219,8 @@ public enum RedisCommand {
 	private boolean write = true;
 	private Set<String> alias = new HashSet<>(1);
 
-	private int minArgs = -1;
-	private int maxArgs = -1;
+	final int minArgs;
+	final int maxArgs;
 
 	private final static Map<String, RedisCommand> commandLookup;
 
@@ -281,7 +281,7 @@ public enum RedisCommand {
 	 * @return {@literal true} if the command requires arguments
 	 */
 	public boolean requiresArguments() {
-		return minArgs >= 0;
+		return minArgs > 0;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/RedisCommandUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisCommandUnitTests.java
@@ -15,7 +15,10 @@
  */
 package org.springframework.data.redis.core;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +29,7 @@ import org.junit.jupiter.api.Test;
  * @author Thomas Darimont
  * @author Mark Paluch
  * @author Oscar Cai
+ * @author John Blum
  */
 class RedisCommandUnitTests {
 
@@ -100,5 +104,23 @@ class RedisCommandUnitTests {
 	void shouldThrowExceptionOnInvalidArgumentCountForZaddWhenExpectedMinimalMatch() {
 		assertThatIllegalArgumentException().isThrownBy(() -> RedisCommand.ZADD.validateArgumentCount(2))
 				.withMessageContaining("ZADD command requires at least 3 arguments");
+	}
+
+	@Test // GH-2646
+	void commandRequiresArgumentsIsCorrect() {
+
+		Arrays.stream(RedisCommand.values()).forEach(command ->
+			assertThat(command.requiresArguments())
+				.describedAs("Redis command [%s] failed required arguments check", command)
+				.isEqualTo(command.minArgs > 0));
+	}
+
+	@Test // GH-2646
+	void commandRequiresExactNumberOfArgumentsIsCorrect() {
+
+		Arrays.stream(RedisCommand.values()).forEach(command ->
+			assertThat(command.requiresExactNumberOfArguments())
+				.describedAs("Redis command [%s] failed requires exact arguments check")
+				.isEqualTo(command.minArgs == command.maxArgs));
 	}
 }


### PR DESCRIPTION
`RedisCommand.requiresArguments()` makes an incorrect evaluation of `minArgs` (i.e. `>= 0`; should be `> 0`).