### PR TITLE
Fix bug issues/2651 ,wrong assignment in `DefaultRedisSerializationContextBuilder.string`

### DIFF
--- a/src/main/java/org/springframework/data/redis/serializer/DefaultRedisSerializationContext.java
+++ b/src/main/java/org/springframework/data/redis/serializer/DefaultRedisSerializationContext.java
@@ -127,7 +127,7 @@ class DefaultRedisSerializationContext<K, V> implements RedisSerializationContex
 
 			Assert.notNull(tuple, "SerializationPair must not be null");
 
-			this.hashValueTuple = tuple;
+			this.stringTuple = tuple;
 			return this;
 		}
 

--- a/src/main/java/org/springframework/data/redis/serializer/DefaultRedisSerializationContext.java
+++ b/src/main/java/org/springframework/data/redis/serializer/DefaultRedisSerializationContext.java
@@ -24,6 +24,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Shyngys Sapraliyev
+ * @author Zhou KQ
  * @since 2.0
  */
 class DefaultRedisSerializationContext<K, V> implements RedisSerializationContext<K, V> {

--- a/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
@@ -20,14 +20,14 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Unit tests for {@link RedisSerializationContext}.
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Zhou KQ
  */
 class RedisSerializationContextUnitTests {
 

--- a/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/RedisSerializationContextUnitTests.java
@@ -15,11 +15,13 @@
  */
 package org.springframework.data.redis.serializer;
 
-import static org.assertj.core.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * Unit tests for {@link RedisSerializationContext}.
@@ -135,6 +137,48 @@ class RedisSerializationContextUnitTests {
 						.write("hello".getBytes()));
 
 		assertThat(deserialized).isEqualTo("hello".getBytes());
+	}
+
+	@Test
+	void shouldEncodeAndDecodeUtf8StringValue() {
+		RedisSerializationContext<String, String> serializationContext = RedisSerializationContext
+				.<String, String>newSerializationContext(StringRedisSerializer.UTF_8)
+				.string(StringRedisSerializer.UTF_8)
+				.build();
+		RedisSerializationContext.SerializationPair<String> serializationPair = serializationContext.getStringSerializationPair();
+
+		assertThat(serializationPair.write("üßØ"))
+				.isEqualTo(ByteBuffer.wrap("üßØ".getBytes(StandardCharsets.UTF_8)));
+		assertThat(serializationPair.read(ByteBuffer.wrap("üßØ".getBytes(StandardCharsets.UTF_8))))
+				.isEqualTo("üßØ");
+	}
+
+	@Test
+	void shouldEncodeAndDecodeAsciiStringValue() {
+		RedisSerializationContext<String, String> serializationContext = RedisSerializationContext
+				.<String, String>newSerializationContext(StringRedisSerializer.US_ASCII)
+				.string(StringRedisSerializer.US_ASCII)
+				.build();
+		RedisSerializationContext.SerializationPair<String> serializationPair = serializationContext.getStringSerializationPair();
+
+		assertThat(serializationPair.write("üßØ"))
+				.isEqualTo(ByteBuffer.wrap("???".getBytes(StandardCharsets.US_ASCII)));
+		assertThat(serializationPair.read(ByteBuffer.wrap("üßØ".getBytes(StandardCharsets.US_ASCII))))
+				.isEqualTo("???");
+	}
+
+	@Test
+	void shouldEncodeAndDecodeIso88591StringValue() {
+		RedisSerializationContext<String, String> serializationContext = RedisSerializationContext
+				.<String, String>newSerializationContext(StringRedisSerializer.ISO_8859_1)
+				.string(StringRedisSerializer.ISO_8859_1)
+				.build();
+		RedisSerializationContext.SerializationPair<String> serializationPair = serializationContext.getStringSerializationPair();
+
+		assertThat(serializationPair.write("üßØ"))
+				.isEqualTo(ByteBuffer.wrap("üßØ".getBytes(StandardCharsets.ISO_8859_1)));
+		assertThat(serializationPair.read(ByteBuffer.wrap("üßØ".getBytes(StandardCharsets.ISO_8859_1))))
+				.isEqualTo("üßØ");
 	}
 
 	private RedisSerializationContext<String, Long> createSerializationContext() {


### PR DESCRIPTION
`DefaultRedisSerializationContextBuilder.string()` should assign param to `stringTuple` instead of `hashValueTuple`
see #2651 

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
