### PR TITLE
Use Locks instead of synchronized blocks to run blocking operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-2690-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/core/script/DefaultRedisScript.java
+++ b/src/main/java/org/springframework/data/redis/core/script/DefaultRedisScript.java
@@ -72,10 +72,12 @@ public class DefaultRedisScript<T> implements RedisScript<T>, InitializingBean {
 		this.resultType = resultType;
 	}
 
+	@Override
 	public void afterPropertiesSet() {
 		Assert.state(this.scriptSource != null, "Either script, script location," + " or script source is required");
 	}
 
+	@Override
 	public String getSha1() {
 
 		lock.lock();
@@ -89,11 +91,13 @@ public class DefaultRedisScript<T> implements RedisScript<T>, InitializingBean {
 		}
 	}
 
+	@Override
 	@Nullable
 	public Class<T> getResultType() {
 		return this.resultType;
 	}
 
+	@Override
 	public String getScriptAsString() {
 
 		try {


### PR DESCRIPTION
To avoid thread pinning on virtual thread arrangements we now use ReentrantLock instead of a synchronized block.

Closes #2690