### PR TITLE
Connect build to ge.spring.io.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules
 node
 package.json
 package-lock.json
+.mvn/.gradle-enterprise

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>gradle-enterprise-maven-extension</artifactId>
+		<version>1.19.2</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>1.12.4</version>
+	</extension>
+</extensions>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<gradleEnterprise
+		xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+	<server>
+		<url>https://ge.spring.io</url>
+	</server>
+	<buildScan>
+		<backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+		<captureGoalInputFiles>true</captureGoalInputFiles>
+		<publishIfAuthenticated>true</publishIfAuthenticated>
+		<obfuscation>
+			<ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+		</obfuscation>
+	</buildScan>
+	<buildCache>
+		<local>
+			<enabled>true</enabled>
+		</local>
+		<remote>
+			<server>
+				<credentials>
+					<username>${env.GRADLE_ENTERPRISE_CACHE_USERNAME}</username>
+					<password>${env.GRADLE_ENTERPRISE_CACHE_PASSWORD}</password>
+				</credentials>
+			</server>
+			<enabled>true</enabled>
+			<storeEnabled>#{env['GRADLE_ENTERPRISE_CACHE_USERNAME'] != null and env['GRADLE_ENTERPRISE_CACHE_PASSWORD'] != null}</storeEnabled>
+		</remote>
+	</buildCache>
+</gradleEnterprise>

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 image:https://spring.io/badges/spring-data-redis/ga.svg[Spring Data Redis,link=https://spring.io/projects/spring-data-redis/#quick-start]
 image:https://spring.io/badges/spring-data-redis/snapshot.svg[Spring Data Redis,link=https://spring.io/projects/spring-data-redis/#quick-start]
 
-= Spring Data Redis image:https://jenkins.spring.io/buildStatus/icon?job=spring-data-redis%2Fmain&subject=Build[link=https://jenkins.spring.io/view/SpringData/job/spring-data-redis/] https://gitter.im/spring-projects/spring-data[image:https://badges.gitter.im/spring-projects/spring-data.svg[Gitter]]
+= Spring Data Redis image:https://jenkins.spring.io/buildStatus/icon?job=spring-data-redis%2Fmain&subject=Build[link=https://jenkins.spring.io/view/SpringData/job/spring-data-redis/] https://gitter.im/spring-projects/spring-data[image:https://badges.gitter.im/spring-projects/spring-data.svg[Gitter]] image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Gradle Enterprise", link="https://ge.spring.io/scans?search.rootProjectNames=Spring Data Redis"]
 
 The primary goal of the https://spring.io/projects/spring-data/[Spring Data] project is to make it easier to build Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce frameworks, and cloud based data services.
 


### PR DESCRIPTION
This pull request connects the build to the Gradle Enterprise instance at https://ge.spring.io/. This allows the Spring Data Redis project to benefit from deep build insights provided by build scans and faster build speeds for all contributors as a result of local and remote build caching. 

This Gradle Enterprise instance has all features and extensions enabled and is freely available for use by Spring Data Redis and all other Spring projects. On this Gradle Enterprise instance, Spring Data Redis will have access not only to all of the published build scans, but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

[Spring Boot](https://ge.spring.io/scans?search.rootProjectNames=spring-boot-build), [Spring Framework](https://ge.spring.io/scans?search.rootProjectNames=spring), and [Spring Security](https://ge.spring.io/scans?search.rootProjectNames=spring-security) are already connected to https://ge.spring.io/ and are benefiting from these features. 

Appropriate access must be configured to publish build scans. To provision a Gradle Enterprise access key for local development, you can invoke the following Maven goal:

```shell
./mvnw gradle-enterprise:provision-access-key
```

For instructions to connect CI to the remote build cache and to publish build scans, please follow the instructions here in [Gradle Enterprise Conventions](https://github.com/spring-io/gradle-enterprise-conventions#gradle-enterprise-conventions). You can disregard that this is a Gradle plugin, the instructions in the README work the same.

Please let me know if there are any questions about the value of Gradle Enterprise or the changes in this pull request and I’d be happy to address them.