### PR TITLE
Apply consistent `Exception` variable names to all `catch` blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-2748-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
@@ -377,13 +377,14 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 			while (doCheckLock(name, connection)) {
 				Thread.sleep(this.sleepTime.toMillis());
 			}
-		} catch (InterruptedException cause) {
+		} catch (InterruptedException ex) {
 
 			// Re-interrupt current Thread to allow other participants to react.
 			Thread.currentThread().interrupt();
 
-			throw new PessimisticLockingFailureException(String.format("Interrupted while waiting to unlock cache %s", name),
-					cause);
+			String message = String.format("Interrupted while waiting to unlock cache %s", name);
+
+			throw new PessimisticLockingFailureException(message, ex);
 		} finally {
 			this.statistics.incLockTime(name, System.nanoTime() - lockWaitTimeNs);
 		}

--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -189,8 +189,8 @@ public class RedisCache extends AbstractValueAdaptingCache {
 
 		try {
 			value = valueLoader.call();
-		} catch (Exception cause) {
-			throw new ValueRetrievalException(key, valueLoader, cause);
+		} catch (Exception ex) {
+			throw new ValueRetrievalException(key, valueLoader, ex);
 		}
 
 		put(key, value);
@@ -425,14 +425,14 @@ public class RedisCache extends AbstractValueAdaptingCache {
 		if (conversionService.canConvert(source, TypeDescriptor.valueOf(String.class))) {
 			try {
 				return conversionService.convert(key, String.class);
-			} catch (ConversionFailedException cause) {
+			} catch (ConversionFailedException ex) {
 
 				// May fail if the given key is a collection
 				if (isCollectionLikeOrMap(source)) {
 					return convertCollectionLikeOrMapKey(key, source);
 				}
 
-				throw cause;
+				throw ex;
 			}
 		}
 

--- a/src/main/java/org/springframework/data/redis/connection/AbstractRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/AbstractRedisConnection.java
@@ -114,8 +114,8 @@ public abstract class AbstractRedisConnection implements RedisConnection {
 
 			try {
 				connection.close();
-			} catch (IOException e) {
-				LOGGER.info("Failed to close sentinel connection", e);
+			} catch (IOException ex) {
+				LOGGER.info("Failed to close sentinel connection", ex);
 			}
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/connection/RedisNode.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisNode.java
@@ -101,7 +101,7 @@ public class RedisNode implements NamedNode {
 		int port = -1;
 		try {
 			port = Integer.parseInt(portString);
-		} catch (RuntimeException e) {
+		} catch (RuntimeException ignore) {
 			throw new IllegalArgumentException(String.format("Unparseable port number: %s", hostPortString));
 		}
 

--- a/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
@@ -109,8 +109,8 @@ public abstract class Converters {
 
 		try (StringReader stringReader = new StringReader(source)) {
 			info.load(stringReader);
-		} catch (Exception cause) {
-			throw new RedisSystemException("Cannot read Redis info", cause);
+		} catch (Exception ex) {
+			throw new RedisSystemException("Cannot read Redis info", ex);
 		}
 
 		return info;

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -123,8 +123,8 @@ public class JedisClusterConnection implements RedisClusterConnection {
 			Object custerCommandExecutor = executorDfa.getPropertyValue("executor");
 			DirectFieldAccessor dfa = new DirectFieldAccessor(custerCommandExecutor);
 			clusterCommandExecutor.setMaxRedirects((Integer) dfa.getPropertyValue("maxRedirects"));
-		} catch (Exception e) {
-			// ignore it and work with the executor default
+		} catch (Exception ignore) {
+			// ignore and work with the executor default
 		}
 	}
 
@@ -381,8 +381,8 @@ public class JedisClusterConnection implements RedisClusterConnection {
 			JedisMessageListener jedisPubSub = new JedisMessageListener(listener);
 			subscription = new JedisSubscription(listener, jedisPubSub, channels, null);
 			cluster.subscribe(jedisPubSub, channels);
-		} catch (Exception cause) {
-			throw convertJedisAccessException(cause);
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
 		}
 	}
 
@@ -398,8 +398,8 @@ public class JedisClusterConnection implements RedisClusterConnection {
 			JedisMessageListener jedisPubSub = new JedisMessageListener(listener);
 			subscription = new JedisSubscription(listener, jedisPubSub, null, patterns);
 			cluster.psubscribe(jedisPubSub, patterns);
-		} catch (Exception cause) {
-			throw convertJedisAccessException(cause);
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
 		}
 	}
 
@@ -643,8 +643,8 @@ public class JedisClusterConnection implements RedisClusterConnection {
 		if (!closed && disposeClusterCommandExecutorOnClose) {
 			try {
 				clusterCommandExecutor.destroy();
-			} catch (Exception cause) {
-				log.warn("Cannot properly close cluster command executor", cause);
+			} catch (Exception ex) {
+				log.warn("Cannot properly close cluster command executor", ex);
 			}
 		}
 
@@ -864,8 +864,8 @@ public class JedisClusterConnection implements RedisClusterConnection {
 
 					return cached;
 
-				} catch (Exception cause) {
-					errors.put(entry.getKey(), cause);
+				} catch (Exception ex) {
+					errors.put(entry.getKey(), ex);
 				}
 			}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -193,9 +193,9 @@ public class JedisConnection extends AbstractRedisConnection {
 		if (nodeConfig.getDatabase() != jedis.getDB()) {
 			try {
 				select(nodeConfig.getDatabase());
-			} catch (DataAccessException cause) {
+			} catch (DataAccessException ex) {
 				close();
-				throw cause;
+				throw ex;
 			}
 		}
 	}
@@ -413,17 +413,17 @@ public class JedisConnection extends AbstractRedisConnection {
 				if (!result.isStatus()) {
 					results.add(result.conversionRequired() ? result.convert(data) : data);
 				}
-			} catch (JedisDataException e) {
-				DataAccessException dataAccessException = convertJedisAccessException(e);
+			} catch (JedisDataException ex) {
+				DataAccessException dataAccessException = convertJedisAccessException(ex);
 				if (cause == null) {
 					cause = dataAccessException;
 				}
 				results.add(dataAccessException);
-			} catch (DataAccessException e) {
+			} catch (DataAccessException ex) {
 				if (cause == null) {
-					cause = e;
+					cause = ex;
 				}
-				results.add(e);
+				results.add(ex);
 			}
 		}
 
@@ -488,8 +488,8 @@ public class JedisConnection extends AbstractRedisConnection {
 					? new TransactionResultConverter<>(txResults, JedisExceptionConverter.INSTANCE).convert(results)
 					: results;
 
-		} catch (Exception cause) {
-			throw convertJedisAccessException(cause);
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
 		} finally {
 			txResults.clear();
 			transaction = null;
@@ -684,7 +684,7 @@ public class JedisConnection extends AbstractRedisConnection {
 			verification = getJedis(node);
 			verification.connect();
 			return verification.ping().equalsIgnoreCase("pong");
-		} catch (Exception cause) {
+		} catch (Exception ignore) {
 			return false;
 		} finally {
 			if (verification != null) {
@@ -708,8 +708,8 @@ public class JedisConnection extends AbstractRedisConnection {
 
 		try {
 			return callback.apply(getJedis());
-		} catch (Exception cause) {
-			throw convertJedisAccessException(cause);
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
 		}
 	}
 
@@ -717,8 +717,8 @@ public class JedisConnection extends AbstractRedisConnection {
 
 		try {
 			callback.accept(getJedis());
-		} catch (Exception cause) {
-			throw convertJedisAccessException(cause);
+		} catch (Exception ex) {
+			throw convertJedisAccessException(ex);
 		}
 	}
 
@@ -727,9 +727,9 @@ public class JedisConnection extends AbstractRedisConnection {
 		try {
 			operation.run();
 		}
-		catch (Exception cause) {
+		catch (Exception ex) {
 			if (LOGGER.isDebugEnabled()) {
-				LOGGER.debug(logMessage, cause);
+				LOGGER.debug(logMessage, ex);
 			}
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -703,8 +703,8 @@ public class JedisConnectionFactory
 				try {
 					clusterCommandExecutor.destroy();
 					this.clusterCommandExecutor = null;
-				} catch (Exception cause) {
-					throw new RuntimeException(cause);
+				} catch (Exception ex) {
+					throw new RuntimeException(ex);
 				}
 			}
 
@@ -715,8 +715,8 @@ public class JedisConnectionFactory
 				try {
 					this.cluster.close();
 					this.cluster = null;
-				} catch (Exception cause) {
-					log.warn("Cannot properly close Jedis cluster", cause);
+				} catch (Exception ex) {
+					log.warn("Cannot properly close Jedis cluster", ex);
 				}
 			}
 
@@ -869,8 +869,8 @@ public class JedisConnectionFactory
 			jedis.connect();
 
 			return jedis;
-		} catch (Exception cause) {
-			throw new RedisConnectionFailureException("Cannot get Jedis connection", cause);
+		} catch (Exception ex) {
+			throw new RedisConnectionFailureException("Cannot get Jedis connection", ex);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnection.java
@@ -382,8 +382,8 @@ public class LettuceClusterConnection extends LettuceConnection
 
 		try {
 			return getConnection().clusterCountKeysInSlot(slot);
-		} catch (Exception cause) {
-			throw this.exceptionConverter.translate(cause);
+		} catch (Exception ex) {
+			throw this.exceptionConverter.translate(ex);
 		}
 	}
 
@@ -453,8 +453,8 @@ public class LettuceClusterConnection extends LettuceConnection
 
 		try {
 			return getConnection().clusterGetKeysInSlot(slot, count);
-		} catch (Exception cause) {
-			throw this.exceptionConverter.translate(cause);
+		} catch (Exception ex) {
+			throw this.exceptionConverter.translate(ex);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -410,8 +410,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 					} else {
 						pipeline(newLettuceResult(future.get(), converter, nullDefault));
 					}
-				} catch (Exception cause) {
-					throw convertLettuceAccessException(cause);
+				} catch (Exception ex) {
+					throw convertLettuceAccessException(ex);
 				}
 
 				return null;
@@ -428,8 +428,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 					} else {
 						transaction(newLettuceResult(future.get(), converter, nullDefault));
 					}
-				} catch (Exception cause) {
-					throw convertLettuceAccessException(cause);
+				} catch (Exception ex) {
+					throw convertLettuceAccessException(ex);
 				}
 
 				return null;
@@ -443,8 +443,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 				Object result = await(future.get());
 
 				return result != null ? converter.convert(result) : nullDefault.get();
-			} catch (Exception cause) {
-				throw convertLettuceAccessException(cause);
+			} catch (Exception ex) {
+				throw convertLettuceAccessException(ex);
 			}
 		});
 	}
@@ -503,8 +503,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 		try {
 			reset();
-		} catch (RuntimeException cause) {
-			LOGGER.debug("Failed to reset connection during close", cause);
+		} catch (RuntimeException ex) {
+			LOGGER.debug("Failed to reset connection during close", ex);
 		}
 	}
 
@@ -517,8 +517,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 				}
 				this.connectionProvider.release(this.asyncDedicatedConnection);
 				this.asyncDedicatedConnection = null;
-			} catch (RuntimeException cause) {
-				throw convertLettuceAccessException(cause);
+			} catch (RuntimeException ex) {
+				throw convertLettuceAccessException(ex);
 			}
 		}
 
@@ -613,11 +613,11 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 						try {
 							results.add(result.conversionRequired() ? result.convert(result.get()) : result.get());
-						} catch (DataAccessException cause) {
+						} catch (DataAccessException ex) {
 							if (problem == null) {
-								problem = cause;
+								problem = ex;
 							}
-							results.add(cause);
+							results.add(ex);
 						}
 					}
 				}
@@ -634,8 +634,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 			}
 
 			throw new RedisPipelineException(new QueryTimeoutException("Redis command timed out"));
-		} catch (Exception cause) {
-			throw new RedisPipelineException(cause);
+		} catch (Exception ex) {
+			throw new RedisPipelineException(ex);
 		}
 	}
 
@@ -660,8 +660,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 				return;
 			}
 			getDedicatedRedisCommands().discard();
-		} catch (Exception cause) {
-			throw convertLettuceAccessException(cause);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
 		} finally {
 			txResults.clear();
 		}
@@ -695,8 +695,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 			return convertPipelineAndTxResults
 					? new LettuceTransactionResultConverter(txResults, exceptionConverter).convert(results)
 					: results;
-		} catch (Exception cause) {
-			throw convertLettuceAccessException(cause);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
 		} finally {
 			txResults.clear();
 		}
@@ -717,8 +717,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 				return;
 			}
 			getDedicatedRedisCommands().multi();
-		} catch (Exception cause) {
-			throw convertLettuceAccessException(cause);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
 		}
 	}
 
@@ -727,7 +727,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 		if (asyncSharedConnection != null) {
 			throw new InvalidDataAccessApiUsageException("Selecting a new database not supported due to shared connection;"
-					+ " Use separate ConnectionFactorys to work with multiple databases");
+					+ " Use separate ConnectionFactory instances to work with multiple databases");
 		}
 
 		this.dbIndex = dbIndex;
@@ -749,8 +749,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 				return;
 			}
 			getDedicatedRedisCommands().unwatch();
-		} catch (Exception cause) {
-			throw convertLettuceAccessException(cause);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
 		}
 	}
 
@@ -771,8 +771,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 				return;
 			}
 			getDedicatedRedisCommands().watch(keys);
-		} catch (Exception cause) {
-			throw convertLettuceAccessException(cause);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
 		}
 	}
 
@@ -808,8 +808,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 		try {
 			this.subscription = initSubscription(listener);
 			this.subscription.pSubscribe(patterns);
-		} catch (Exception cause) {
-			throw convertLettuceAccessException(cause);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
 		}
 	}
 
@@ -825,8 +825,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 		try {
 			this.subscription = initSubscription(listener);
 			this.subscription.subscribe(channels);
-		} catch (Exception cause) {
-			throw convertLettuceAccessException(cause);
+		} catch (Exception ex) {
+			throw convertLettuceAccessException(ex);
 		}
 	}
 
@@ -970,7 +970,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 		try {
 			connection = getConnection(node);
 			return connection.sync().ping().equalsIgnoreCase("pong");
-		} catch (Exception cause) {
+		} catch (Exception ignore) {
 			return false;
 		} finally {
 			if (connection != null) {
@@ -1006,8 +1006,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 		try {
 			return LettuceFutures.awaitOrCancel(cmd, timeout, TimeUnit.MILLISECONDS);
-		} catch (RuntimeException e) {
-			throw convertLettuceAccessException(e);
+		} catch (RuntimeException ex) {
+			throw convertLettuceAccessException(ex);
 		}
 	}
 
@@ -1078,9 +1078,9 @@ public class LettuceConnection extends AbstractRedisConnection {
 		if (!RedisCommand.UNKNOWN.equals(redisCommand) && redisCommand.requiresArguments()) {
 			try {
 				redisCommand.validateArgumentCount(args != null ? args.length : 0);
-			} catch (IllegalArgumentException cause) {
+			} catch (IllegalArgumentException ex) {
 				String message = String.format("Validation failed for %s command", command);
-				throw new InvalidDataAccessApiUsageException(message, cause);
+				throw new InvalidDataAccessApiUsageException(message, ex);
 			}
 		}
 	}
@@ -1089,7 +1089,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 
 		try {
 			return CommandType.valueOf(name);
-		} catch (IllegalArgumentException cause) {
+		} catch (IllegalArgumentException ignore) {
 			return new CustomCommandType(name);
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactory.java
@@ -921,9 +921,9 @@ public class LettuceConnectionFactory implements RedisConnectionFactory, Reactiv
 
 					client.shutdown(quietPeriod.toMillis(), timeout.toMillis(), TimeUnit.MILLISECONDS);
 					client = null;
-				} catch (Exception cause) {
+				} catch (Exception ex) {
 					if (log.isWarnEnabled()) {
-						log.warn(ClassUtils.getShortName(client.getClass()) + " did not shut down gracefully.", cause);
+						log.warn(ClassUtils.getShortName(client.getClass()) + " did not shut down gracefully.", ex);
 					}
 				}
 			}
@@ -972,8 +972,8 @@ public class LettuceConnectionFactory implements RedisConnectionFactory, Reactiv
 			try {
 				clusterCommandExecutor.destroy();
 				this.clusterCommandExecutor = null;
-			} catch (Exception cause) {
-				log.warn("Cannot properly close cluster command executor", cause);
+			} catch (Exception ex) {
+				log.warn("Cannot properly close cluster command executor", ex);
 			}
 		}
 
@@ -985,9 +985,9 @@ public class LettuceConnectionFactory implements RedisConnectionFactory, Reactiv
 		if (connectionProvider instanceof DisposableBean disposableBean) {
 			try {
 				disposableBean.destroy();
-			} catch (Exception cause) {
+			} catch (Exception ex) {
 				if (log.isWarnEnabled()) {
-					log.warn(connectionProvider + " did not shut down gracefully.", cause);
+					log.warn(connectionProvider + " did not shut down gracefully.", ex);
 				}
 			}
 		}
@@ -1577,8 +1577,8 @@ public class LettuceConnectionFactory implements RedisConnectionFactory, Reactiv
 
 						valid = true;
 
-					} catch (Exception cause) {
-						log.debug("Validation failed", cause);
+					} catch (Exception ex) {
+						log.debug("Validation failed", ex);
 					}
 				}
 
@@ -1732,8 +1732,8 @@ public class LettuceConnectionFactory implements RedisConnectionFactory, Reactiv
 
 			try {
 				return delegate.getConnection(connectionType);
-			} catch (RuntimeException cause) {
-				throw translateException(cause);
+			} catch (RuntimeException ex) {
+				throw translateException(ex);
 			}
 		}
 
@@ -1742,8 +1742,8 @@ public class LettuceConnectionFactory implements RedisConnectionFactory, Reactiv
 
 			try {
 				return ((TargetAware) delegate).getConnection(connectionType, redisURI);
-			} catch (RuntimeException cause) {
-				throw translateException(cause);
+			} catch (RuntimeException ex) {
+				throw translateException(ex);
 			}
 		}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceFutureUtils.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceFutureUtils.java
@@ -66,14 +66,14 @@ class LettuceFutureUtils {
 
 		try {
 			return future.toCompletableFuture().join();
-		} catch (Exception e) {
+		} catch (Exception ex) {
 
-			Throwable exceptionToUse = e;
+			Throwable exceptionToUse = ex;
 
-			if (e instanceof CompletionException) {
-				exceptionToUse = LettuceExceptionConverter.INSTANCE.convert((Exception) e.getCause());
+			if (ex instanceof CompletionException) {
+				exceptionToUse = LettuceExceptionConverter.INSTANCE.convert((Exception) ex.getCause());
 				if (exceptionToUse == null) {
-					exceptionToUse = e.getCause();
+					exceptionToUse = ex.getCause();
 				}
 			}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingConnectionProvider.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettucePoolingConnectionProvider.java
@@ -100,8 +100,8 @@ class LettucePoolingConnectionProvider implements LettuceConnectionProvider, Red
 
 			poolRef.put(connection, pool);
 			return connectionType.cast(connection);
-		} catch (Exception e) {
-			throw new PoolException("Could not get a resource from the pool", e);
+		} catch (Exception ex) {
+			throw new PoolException("Could not get a resource from the pool", ex);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelConnection.java
@@ -158,8 +158,8 @@ public class LettuceSentinelConnection implements RedisSentinelConnection {
 	public List<RedisServer> masters() {
 		try {
 			return LettuceConverters.toListOfRedisServer(getSentinelCommands().masters());
-		} catch (Exception e) {
-			throw EXCEPTION_TRANSLATION.translate(e);
+		} catch (Exception ex) {
+			throw EXCEPTION_TRANSLATION.translate(ex);
 		}
 	}
 
@@ -180,8 +180,8 @@ public class LettuceSentinelConnection implements RedisSentinelConnection {
 		Assert.hasText(masterName, "Name of redis master cannot be 'null' or empty when loading replicas.");
 		try {
 			return LettuceConverters.toListOfRedisServer(getSentinelCommands().slaves(masterName));
-		} catch (Exception e) {
-			throw EXCEPTION_TRANSLATION.translate(e);
+		} catch (Exception ex) {
+			throw EXCEPTION_TRANSLATION.translate(ex);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StreamConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StreamConverters.java
@@ -140,7 +140,7 @@ class StreamConverters {
 
 			try {
 				return NumberUtils.parseNumber(tmp, Long.class);
-			} catch (NumberFormatException e) {
+			} catch (NumberFormatException ex) {
 				return tmp;
 			}
 		}

--- a/src/main/java/org/springframework/data/redis/core/BoundOperationsProxyFactory.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundOperationsProxyFactory.java
@@ -175,9 +175,9 @@ class BoundOperationsProxyFactory {
 
 			try {
 				return backingMethod.invoke(target, args);
-			} catch (ReflectiveOperationException e) {
-				ReflectionUtils.handleReflectionException(e);
-				throw new UnsupportedOperationException("Should not happen", e);
+			} catch (ReflectiveOperationException ex) {
+				ReflectionUtils.handleReflectionException(ex);
+				throw new UnsupportedOperationException("Should not happen", ex);
 			}
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/core/CloseSuppressingInvocationHandler.java
+++ b/src/main/java/org/springframework/data/redis/core/CloseSuppressingInvocationHandler.java
@@ -58,8 +58,8 @@ class CloseSuppressingInvocationHandler implements InvocationHandler {
 
 		// Invoke method on target RedisConnection.
 		try {
-			Object retVal = method.invoke(this.target, args);
-			return retVal;
+			Object returnValue = method.invoke(this.target, args);
+			return returnValue;
 		} catch (InvocationTargetException ex) {
 			throw ex.getTargetException();
 		}

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
@@ -344,9 +344,11 @@ class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperat
 	}
 
 	private ByteBuffer rawHashKey(HK key) {
+
 		try {
 			return serializationContext.getHashKeySerializationPair().write(key);
-		} catch (IllegalStateException ignore) {}
+		} catch (IllegalStateException ignore) {
+		}
 
 		return ByteBuffer.wrap(objectMapper.getConversionService().convert(key, byte[].class));
 	}
@@ -355,7 +357,8 @@ class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperat
 
 		try {
 			return serializationContext.getHashValueSerializationPair().write(value);
-		} catch (IllegalStateException ignore) {}
+		} catch (IllegalStateException ignore) {
+		}
 
 		return ByteBuffer.wrap(objectMapper.getConversionService().convert(value, byte[].class));
 	}

--- a/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
@@ -271,7 +271,7 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 				boolean failed = false;
 				try {
 					connection.pSetEx(rawKey, timeout, rawValue);
-				} catch (UnsupportedOperationException e) {
+				} catch (UnsupportedOperationException ignore) {
 					// in case the connection does not support pSetEx return false to allow fallback to other operation.
 					failed = true;
 				}

--- a/src/main/java/org/springframework/data/redis/core/RedisConnectionUtils.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisConnectionUtils.java
@@ -497,8 +497,8 @@ public abstract class RedisConnectionUtils {
 
 			try {
 				return method.invoke(target, args);
-			} catch (InvocationTargetException e) {
-				throw e.getCause();
+			} catch (InvocationTargetException ex) {
+				throw ex.getCause();
 			}
 		}
 

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -685,7 +685,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 		return doWithKeys(connection -> {
 			try {
 				return connection.pExpire(rawKey, rawTimeout);
-			} catch (Exception e) {
+			} catch (Exception ignore) {
 				// Driver may not support pExpire or we may be running on Redis 2.4
 				return connection.expire(rawKey, TimeoutUtils.toSeconds(timeout, unit));
 			}
@@ -700,7 +700,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 		return doWithKeys(connection -> {
 			try {
 				return connection.pExpireAt(rawKey, date.getTime());
-			} catch (Exception e) {
+			} catch (Exception ignore) {
 				return connection.expireAt(rawKey, date.getTime() / 1000);
 			}
 		});
@@ -727,7 +727,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 		return doWithKeys(connection -> {
 			try {
 				return connection.pTtl(rawKey, timeUnit);
-			} catch (Exception e) {
+			} catch (Exception ignore) {
 				// Driver may not support pTtl or we may be running on Redis 2.4
 				return connection.ttl(rawKey, timeUnit);
 			}

--- a/src/main/java/org/springframework/data/redis/core/ScanCursor.java
+++ b/src/main/java/org/springframework/data/redis/core/ScanCursor.java
@@ -88,13 +88,13 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 
 		try {
 			processScanResult(doScan(cursorId, this.scanOptions));
-		} catch (RuntimeException e) {
+		} catch (RuntimeException ex) {
 			try {
 				close();
 			} catch (RuntimeException nested) {
-				e.addSuppressed(nested);
+				ex.addSuppressed(nested);
 			}
-			throw e;
+			throw ex;
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/core/convert/BinaryConverters.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/BinaryConverters.java
@@ -281,14 +281,12 @@ final class BinaryConverters {
 			String value = toString(source);
 			try {
 				return new Date(NumberUtils.parseNumber(value, Long.class));
-			} catch (NumberFormatException nfe) {
-				// ignore
+			} catch (NumberFormatException ignore) {
 			}
 
 			try {
 				return DateFormat.getInstance().parse(value);
-			} catch (ParseException e) {
-				// ignore
+			} catch (ParseException ignore) {
 			}
 
 			throw new IllegalArgumentException(String.format("Cannot parse date out of %s", Arrays.toString(source)));

--- a/src/main/java/org/springframework/data/redis/core/convert/Bucket.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/Bucket.java
@@ -306,9 +306,9 @@ public class Bucket {
 
 		try {
 			return new String(raw, CHARSET);
-		} catch (Exception e) {
-			// Ignore this one
+		} catch (Exception ignore) {
 		}
+
 		return null;
 	}
 

--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -571,8 +571,7 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 			PersistentPropertyPath<RedisPersistentProperty> persistentPropertyPath = mappingContext
 					.getPersistentPropertyPath(path, type);
 			return persistentPropertyPath.getLeafProperty();
-		} catch (Exception e) {
-			// that's just fine
+		} catch (Exception ignore) {
 		}
 
 		return null;

--- a/src/main/java/org/springframework/data/redis/core/convert/PathIndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/PathIndexResolver.java
@@ -177,9 +177,9 @@ public class PathIndexResolver implements IndexResolver {
 				if (typeHint.equals(TypeInformation.OBJECT) || typeHint.getClass().isInterface()) {
 					try {
 						typeHint = mappingContext.getRequiredPersistentEntity(propertyValue.getClass()).getTypeInformation();
-					} catch (Exception e) {
-						// ignore for cases where property value cannot be resolved as an entity, in that case the provided type
-						// hint has to be sufficient
+					} catch (Exception ignore) {
+						// ignore for cases where property value cannot be resolved as an entity, in that case
+						// the provided type hint has to be sufficient
 					}
 				}
 				return typeHint;

--- a/src/main/java/org/springframework/data/redis/core/mapping/RedisMappingContext.java
+++ b/src/main/java/org/springframework/data/redis/core/mapping/RedisMappingContext.java
@@ -240,15 +240,18 @@ public class RedisMappingContext extends KeyValueMappingContext<RedisPersistentE
 						if (timeout != null && ttl != null) {
 							return TimeUnit.SECONDS.convert(timeout.longValue(), ttl.unit());
 						}
-					} catch (IllegalAccessException e) {
-						throw new IllegalStateException(
-								"Not allowed to access method '" + timeoutMethod.getName() + "': " + e.getMessage(), e);
-					} catch (IllegalArgumentException e) {
-						throw new IllegalStateException(
-								"Cannot invoke method '" + timeoutMethod.getName() + " without arguments': " + e.getMessage(), e);
-					} catch (InvocationTargetException e) {
-						throw new IllegalStateException("Cannot access method '" + timeoutMethod.getName() + "': " + e.getMessage(),
-								e);
+					} catch (IllegalAccessException ex) {
+						String message = String.format("Not allowed to access method '%s': %s",
+								timeoutMethod.getName(), ex.getMessage());
+						throw new IllegalStateException(message, ex);
+					} catch (IllegalArgumentException ex) {
+						String message = String.format("Cannot invoke method '%s' without arguments: %s",
+								timeoutMethod.getName(), ex.getMessage());
+						throw new IllegalStateException(message, ex);
+					} catch (InvocationTargetException ex) {
+						String message = String.format("Cannot access method '%s': %s",
+								timeoutMethod.getName(), ex.getMessage());
+						throw new IllegalStateException(message, ex);
 					}
 				}
 			}

--- a/src/main/java/org/springframework/data/redis/core/script/DefaultRedisScript.java
+++ b/src/main/java/org/springframework/data/redis/core/script/DefaultRedisScript.java
@@ -105,8 +105,8 @@ public class DefaultRedisScript<T> implements RedisScript<T>, InitializingBean {
 
 		try {
 			return scriptSource.getScriptAsString();
-		} catch (IOException e) {
-			throw new ScriptingException("Error reading script text", e);
+		} catch (IOException ex) {
+			throw new ScriptingException("Error reading script text", ex);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/core/script/DefaultScriptExecutor.java
+++ b/src/main/java/org/springframework/data/redis/core/script/DefaultScriptExecutor.java
@@ -75,10 +75,11 @@ public class DefaultScriptExecutor<K> implements ScriptExecutor<K> {
 		Object result;
 		try {
 			result = connection.evalSha(script.getSha1(), returnType, numKeys, keysAndArgs);
-		} catch (Exception e) {
+		} catch (Exception ex) {
 
-			if (!ScriptUtils.exceptionContainsNoScriptError(e)) {
-				throw e instanceof RuntimeException ? (RuntimeException) e : new RedisSystemException(e.getMessage(), e);
+			if (!ScriptUtils.exceptionContainsNoScriptError(ex)) {
+				throw ex instanceof RuntimeException runtimeException ? runtimeException
+						: new RedisSystemException(ex.getMessage(), ex);
 			}
 
 			result = connection.eval(scriptBytes(script), returnType, numKeys, keysAndArgs);

--- a/src/main/java/org/springframework/data/redis/core/script/DigestUtils.java
+++ b/src/main/java/org/springframework/data/redis/core/script/DigestUtils.java
@@ -60,7 +60,8 @@ abstract public class DigestUtils {
 		try {
 			return MessageDigest.getInstance(algorithm);
 		} catch (NoSuchAlgorithmException ex) {
-			throw new IllegalStateException("Could not find MessageDigest with algorithm \"" + algorithm + "\"", ex);
+			String message = String.format("Could not find MessageDigest with algorithm \"%s\"", algorithm);
+			throw new IllegalStateException(message, ex);
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/redis/core/types/RedisClientInfo.java
+++ b/src/main/java/org/springframework/data/redis/core/types/RedisClientInfo.java
@@ -273,9 +273,9 @@ public class RedisClientInfo {
 			Properties properties = new Properties();
 			try {
 				properties.load(new StringReader(source.replace(' ', '\n')));
-			} catch (IOException e) {
-				throw new IllegalArgumentException(String.format("Properties could not be loaded from String '%s'", source),
-						e);
+			} catch (IOException ex) {
+				String message = String.format("Properties could not be loaded from String '%s'", source);
+				throw new IllegalArgumentException(message, ex);
 			}
 			return new RedisClientInfo(properties);
 		}

--- a/src/main/java/org/springframework/data/redis/hash/BeanUtilsHashMapper.java
+++ b/src/main/java/org/springframework/data/redis/hash/BeanUtilsHashMapper.java
@@ -71,7 +71,7 @@ public class BeanUtilsHashMapper<T> implements HashMapper<T, String, String> {
 
 			return result;
 		} catch (Exception ex) {
-			throw new IllegalArgumentException("Cannot describe object " + object, ex);
+			throw new IllegalArgumentException(String.format("Cannot describe object %s", object), ex);
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/redis/hash/Jackson2HashMapper.java
+++ b/src/main/java/org/springframework/data/redis/hash/Jackson2HashMapper.java
@@ -264,8 +264,8 @@ public class Jackson2HashMapper implements HashMapper<Object, String, Object> {
 
 			return this.typingMapper.treeToValue(this.untypedMapper.valueToTree(hash), Object.class);
 
-		} catch (IOException cause) {
-			throw new MappingException(cause.getMessage(), cause);
+		} catch (IOException ex) {
+			throw new MappingException(ex.getMessage(), ex);
 		}
 	}
 
@@ -424,9 +424,9 @@ public class Jackson2HashMapper implements HashMapper<Object, String, Object> {
 						try {
 							resultMap.put(propertyPrefix, next.binaryValue());
 						}
-						catch (IOException cause) {
+						catch (IOException ex) {
 							String message = String.format("Cannot read binary value of '%s'", propertyPrefix);
-							throw new IllegalStateException(message, cause);
+							throw new IllegalStateException(message, ex);
 						}
 
 						break;
@@ -526,7 +526,7 @@ public class Jackson2HashMapper implements HashMapper<Object, String, Object> {
 
 			try {
 				return ctxt.getConfig().getDateFormat().parse(value.toString());
-			} catch (ParseException cause) {
+			} catch (ParseException ignore) {
 				return new Date(NumberUtils.parseNumber(value.toString(), Long.class));
 			}
 		}

--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -374,17 +374,17 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 		try {
 			futureToAwait.get(getMaxSubscriptionRegistrationWaitingTime(), TimeUnit.MILLISECONDS);
-		} catch (InterruptedException cause) {
+		} catch (InterruptedException ex) {
 			Thread.currentThread().interrupt();
-		} catch (ExecutionException cause) {
+		} catch (ExecutionException ex) {
 
-			if (cause.getCause() instanceof DataAccessException) {
-				throw new RedisListenerExecutionFailedException(cause.getMessage(), cause.getCause());
+			if (ex.getCause() instanceof DataAccessException) {
+				throw new RedisListenerExecutionFailedException(ex.getMessage(), ex.getCause());
 			}
 
-			throw new CompletionException(cause.getCause());
-		} catch (TimeoutException cause) {
-			throw new IllegalStateException("Subscription registration timeout exceeded", cause);
+			throw new CompletionException(ex.getCause());
+		} catch (TimeoutException ex) {
+			throw new IllegalStateException("Subscription registration timeout exceeded", ex);
 		}
 	}
 
@@ -529,9 +529,10 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 		try {
 			future.get(getMaxSubscriptionRegistrationWaitingTime(), TimeUnit.MILLISECONDS);
-		} catch (InterruptedException cause) {
+		} catch (InterruptedException ex) {
 			Thread.currentThread().interrupt();
-		} catch (ExecutionException | TimeoutException ignore) {}
+		} catch (ExecutionException | TimeoutException ignore) {
+		}
 	}
 
 	@Override
@@ -690,13 +691,13 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 				try {
 					future.join();
-				} catch (CompletionException cause) {
+				} catch (CompletionException ex) {
 
-					if (cause.getCause() instanceof DataAccessException) {
-						throw new RedisListenerExecutionFailedException(cause.getMessage(), cause.getCause());
+					if (ex.getCause() instanceof DataAccessException) {
+						throw new RedisListenerExecutionFailedException(ex.getMessage(), ex.getCause());
 					}
 
-					throw cause;
+					throw ex;
 				}
 			}
 		}
@@ -932,7 +933,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 			return true;
 
-		} catch (InterruptedException ignore) {
+		} catch (InterruptedException ex) {
 			logDebug(() -> "Thread interrupted while sleeping the recovery interval");
 			Thread.currentThread().interrupt();
 			return false;
@@ -1206,8 +1207,8 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 					} catch (Throwable t) {
 						handleSubscriptionException(initFuture, backOffExecution, t);
 					}
-				} catch (RuntimeException cause) {
-					initFuture.completeExceptionally(cause);
+				} catch (RuntimeException ex) {
+					initFuture.completeExceptionally(ex);
 				}
 
 				return initFuture;
@@ -1304,8 +1305,8 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 				try {
 					subscription.close();
-				} catch (Exception cause) {
-					logger.warn("Unable to unsubscribe from subscriptions", cause);
+				} catch (Exception ex) {
+					logger.warn("Unable to unsubscribe from subscriptions", ex);
 				}
 			}
 		}
@@ -1325,8 +1326,8 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 					logTrace(() -> "Closing connection");
 					try {
 						connection.close();
-					} catch (Exception cause) {
-						logger.warn("Error closing subscription connection", cause);
+					} catch (Exception ex) {
+						logger.warn("Error closing subscription connection", ex);
 					}
 				}
 			});
@@ -1436,8 +1437,8 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 						new SynchronizingMessageListener.SubscriptionSynchronization(patterns, Collections.emptySet(), () -> {
 							try {
 								subscribeChannel(channels.toArray(new byte[0][]));
-							} catch (Exception cause) {
-								handleSubscriptionException(subscriptionDone, backOffExecution, cause);
+							} catch (Exception ex) {
+								handleSubscriptionException(subscriptionDone, backOffExecution, ex);
 							}
 						}));
 			} else {

--- a/src/main/java/org/springframework/data/redis/listener/adapter/MessageListenerAdapter.java
+++ b/src/main/java/org/springframework/data/redis/listener/adapter/MessageListenerAdapter.java
@@ -369,16 +369,19 @@ public class MessageListenerAdapter implements InitializingBean, MessageListener
 		try {
 			invoker.invoke(arguments);
 		} catch (InvocationTargetException ex) {
+
 			Throwable targetEx = ex.getTargetException();
-			if (targetEx instanceof DataAccessException) {
-				throw (DataAccessException) targetEx;
+
+			if (targetEx instanceof DataAccessException dataAccessException) {
+				throw dataAccessException;
 			} else {
-				throw new RedisListenerExecutionFailedException("Listener method '" + methodName + "' threw exception",
-						targetEx);
+				String message = String.format("Listener method '%s' threw exception", methodName);
+				throw new RedisListenerExecutionFailedException(message, targetEx);
 			}
 		} catch (Throwable ex) {
-			throw new RedisListenerExecutionFailedException("Failed to invoke target method '" + methodName
-					+ "' with arguments " + ObjectUtils.nullSafeToString(arguments), ex);
+			String message = String.format("Failed to invoke target method '%s' with arguments %s", methodName,
+					ObjectUtils.nullSafeToString(arguments));
+			throw new RedisListenerExecutionFailedException(message, ex);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/repository/cdi/RedisKeyValueAdapterBean.java
+++ b/src/main/java/org/springframework/data/redis/repository/cdi/RedisKeyValueAdapterBean.java
@@ -87,8 +87,8 @@ public class RedisKeyValueAdapterBean extends CdiBean<RedisKeyValueAdapter> {
 		if (instance instanceof DisposableBean) {
 			try {
 				instance.destroy();
-			} catch (Exception e) {
-				throw new IllegalStateException(e);
+			} catch (Exception ex) {
+				throw new IllegalStateException(ex);
 			}
 		}
 

--- a/src/main/java/org/springframework/data/redis/repository/cdi/RedisKeyValueTemplateBean.java
+++ b/src/main/java/org/springframework/data/redis/repository/cdi/RedisKeyValueTemplateBean.java
@@ -73,8 +73,8 @@ public class RedisKeyValueTemplateBean extends CdiBean<KeyValueOperations> {
 			try {
 				((DisposableBean) instance.getMappingContext()).destroy();
 				instance.destroy();
-			} catch (Exception e) {
-				throw new IllegalStateException(e);
+			} catch (Exception ex) {
+				throw new IllegalStateException(ex);
 			}
 		}
 

--- a/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
@@ -221,9 +221,9 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 
 		try {
 			return writer.write(mapper, value);
-		} catch (IOException cause) {
-			String message = String.format("Could not write JSON: %s", cause.getMessage());
-			throw new SerializationException(message, cause);
+		} catch (IOException ex) {
+			String message = String.format("Could not write JSON: %s", ex.getMessage());
+			throw new SerializationException(message, ex);
 		}
 	}
 
@@ -258,9 +258,9 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 
 		try {
 			return (T) reader.read(mapper, source, resolveType(source, type));
-		} catch (Exception cause) {
-			String message = String.format("Could not read JSON:%s ", cause.getMessage());
-			throw new SerializationException(message, cause);
+		} catch (Exception ex) {
+			String message = String.format("Could not read JSON:%s ", ex.getMessage());
+			throw new SerializationException(message, ex);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/serializer/JdkSerializationRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/JdkSerializationRedisSerializer.java
@@ -90,8 +90,8 @@ public class JdkSerializationRedisSerializer implements RedisSerializer<Object> 
 
 		try {
 			return serializer.convert(value);
-		} catch (Exception cause) {
-			throw new SerializationException("Cannot serialize", cause);
+		} catch (Exception ex) {
+			throw new SerializationException("Cannot serialize", ex);
 		}
 	}
 
@@ -104,8 +104,8 @@ public class JdkSerializationRedisSerializer implements RedisSerializer<Object> 
 
 		try {
 			return deserializer.convert(bytes);
-		} catch (Exception cause) {
-			throw new SerializationException("Cannot deserialize", cause);
+		} catch (Exception ex) {
+			throw new SerializationException("Cannot deserialize", ex);
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/redis/stream/DefaultStreamReceiver.java
+++ b/src/main/java/org/springframework/data/redis/stream/DefaultStreamReceiver.java
@@ -326,8 +326,8 @@ class DefaultStreamReceiver<K, V extends Record<K, ?>> implements StreamReceiver
 
 					try {
 						return deserializer.apply(it);
-					} catch (RuntimeException e) {
-						throw new ConversionFailedException(TypeDescriptor.forObject(it), targetType, it, e);
+					} catch (RuntimeException ex) {
+						throw new ConversionFailedException(TypeDescriptor.forObject(it), targetType, it, ex);
 					}
 				}).onErrorResume(throwable -> Flux.from(resumeFunction.apply(throwable)).then().map(it -> (V) new Object())) //
 						.subscribe(getSubscriber());

--- a/src/main/java/org/springframework/data/redis/stream/StreamPollTask.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamPollTask.java
@@ -127,17 +127,17 @@ class StreamPollTask<K, V extends Record<K, ?>> implements Task {
 				List<ByteRecord> raw = readRecords();
 				deserializeAndEmitRecords(raw);
 
-			} catch (InterruptedException e) {
+			} catch (InterruptedException ex) {
 
 				cancel();
 				Thread.currentThread().interrupt();
-			} catch (RuntimeException e) {
+			} catch (RuntimeException ex) {
 
-				if (cancelSubscriptionOnError.test(e)) {
+				if (cancelSubscriptionOnError.test(ex)) {
 					cancel();
 				}
 
-				errorHandler.handleError(e);
+				errorHandler.handleError(ex);
 			}
 		} while (pollState.isSubscriptionActive());
 	}
@@ -155,17 +155,17 @@ class StreamPollTask<K, V extends Record<K, ?>> implements Task {
 				pollState.updateReadOffset(raw.getId().getValue());
 				V record = convertRecord(raw);
 				listener.onMessage(record);
-			} catch (RuntimeException e) {
+			} catch (RuntimeException ex) {
 
-				if (cancelSubscriptionOnError.test(e)) {
+				if (cancelSubscriptionOnError.test(ex)) {
 
 					cancel();
-					errorHandler.handleError(e);
+					errorHandler.handleError(ex);
 
 					return;
 				}
 
-				errorHandler.handleError(e);
+				errorHandler.handleError(ex);
 			}
 		}
 	}
@@ -174,8 +174,8 @@ class StreamPollTask<K, V extends Record<K, ?>> implements Task {
 
 		try {
 			return deserializer.apply(record);
-		} catch (RuntimeException e) {
-			throw new ConversionFailedException(TypeDescriptor.forObject(record), targetType, record, e);
+		} catch (RuntimeException ex) {
+			throw new ConversionFailedException(TypeDescriptor.forObject(record), targetType, record, ex);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisList.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisList.java
@@ -636,8 +636,8 @@ public class DefaultRedisList<E> extends AbstractRedisCollection<E> implements R
 				this.cursor = index + 1;
 				this.lastReturnedElementIndex = index;
 				return this.lastReturnedElement;
-			} catch (IndexOutOfBoundsException cause) {
-				throw new NoSuchElementException(cause);
+			} catch (IndexOutOfBoundsException ex) {
+				throw new NoSuchElementException(ex);
 			}
 		}
 
@@ -688,7 +688,7 @@ public class DefaultRedisList<E> extends AbstractRedisCollection<E> implements R
 				this.lastReturnedElementIndex = -1;
 				this.lastReturnedElement = null;
 				this.cursor = index + 1;
-			} catch (IndexOutOfBoundsException cause) {
+			} catch (IndexOutOfBoundsException ignore) {
 				throw new ConcurrentModificationException();
 			}
 		}
@@ -702,7 +702,7 @@ public class DefaultRedisList<E> extends AbstractRedisCollection<E> implements R
 				this.lastReturnedElementIndex = index;
 				this.cursor = index;
 				return this.lastReturnedElement;
-			} catch (IndexOutOfBoundsException cause) {
+			} catch (IndexOutOfBoundsException ignore) {
 				throw new NoSuchElementException();
 			}
 		}
@@ -716,7 +716,7 @@ public class DefaultRedisList<E> extends AbstractRedisCollection<E> implements R
 
 			try {
 				DefaultRedisList.this.set(this.lastReturnedElementIndex, element);
-			} catch (IndexOutOfBoundsException cause) {
+			} catch (IndexOutOfBoundsException ignore) {
 				throw new ConcurrentModificationException();
 			}
 		}

--- a/src/test/java/org/springframework/data/redis/SettingsUtils.java
+++ b/src/test/java/org/springframework/data/redis/SettingsUtils.java
@@ -49,7 +49,7 @@ public abstract class SettingsUtils {
 
 		try {
 			SETTINGS.load(SettingsUtils.class.getResourceAsStream("/org/springframework/data/redis/test.properties"));
-		} catch (Exception e) {
+		} catch (Exception ignore) {
 			throw new IllegalArgumentException("Cannot read settings");
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
@@ -362,8 +362,8 @@ public class DefaultRedisCacheWriterTests {
 
 			try {
 				writer.put(CACHE_NAME, binaryCacheKey, binaryCacheValue, Duration.ZERO);
-			} catch (Exception cause) {
-				exceptionRef.set(cause);
+			} catch (Exception ex) {
+				exceptionRef.set(ex);
 			} finally {
 				afterWrite.countDown();
 			}

--- a/src/test/java/org/springframework/data/redis/cache/LegacyRedisCacheTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/LegacyRedisCacheTests.java
@@ -207,7 +207,7 @@ public class LegacyRedisCacheTests {
 		Runnable putCache = () -> {
 			try {
 				cache.put(key1, value1);
-			} catch (IllegalMonitorStateException e) {
+			} catch (IllegalMonitorStateException ex) {
 				monitorStateException.set(true);
 			} finally {
 				latch.countDown();
@@ -304,8 +304,7 @@ public class LegacyRedisCacheTests {
 
 		try {
 			cache.put(key, null);
-		} catch (IllegalArgumentException e) {
-			// forget this one.
+		} catch (IllegalArgumentException expected) {
 		}
 
 		assertThat(cache.get(key).get()).isEqualTo(value);

--- a/src/test/java/org/springframework/data/redis/cache/RedisCacheTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/RedisCacheTests.java
@@ -461,8 +461,8 @@ public class RedisCacheTests {
 				prepare.countDown();
 				try {
 					prepareForReturn.await(1, TimeUnit.MINUTES);
-				} catch (InterruptedException e) {
-					throw new RuntimeException(e);
+				} catch (InterruptedException ex) {
+					throw new RuntimeException(ex);
 				}
 
 				return storage.get();

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -158,9 +158,8 @@ public abstract class AbstractConnectionIntegrationTests {
 
 			// since we use more than one db we're required to flush them all
 			connection.flushAll();
-		} catch (Exception e) {
-			// Connection may be closed in certain cases, like after pub/sub
-			// tests
+		} catch (Exception ignore) {
+			// Connection may be closed in certain cases, like after pub/sub tests
 		}
 		connection.close();
 		connection = null;
@@ -584,8 +583,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		try {
 			connection.decr((String) null);
 			fail("Decrement should fail with null key");
-		} catch (Exception ex) {
-			// expected
+		} catch (Exception expected) {
 		}
 	}
 
@@ -598,8 +596,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		try {
 			connection.append(key, null);
 			fail("Append should fail with null value");
-		} catch (DataAccessException ex) {
-			// expected
+		} catch (DataAccessException expected) {
 		}
 	}
 
@@ -611,8 +608,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		try {
 			connection.hExists(key, null);
 			fail("hExists should fail with null key");
-		} catch (DataAccessException ex) {
-			// expected
+		} catch (DataAccessException expected) {
 		}
 	}
 
@@ -626,8 +622,7 @@ public abstract class AbstractConnectionIntegrationTests {
 		try {
 			connection.hSet(key, field, null);
 			fail("hSet should fail with null value");
-		} catch (DataAccessException ex) {
-			// expected
+		} catch (DataAccessException expected) {
 		}
 	}
 
@@ -665,7 +660,8 @@ public abstract class AbstractConnectionIntegrationTests {
 
 			try {
 				Thread.sleep(500);
-			} catch (InterruptedException o_O) {}
+			} catch (InterruptedException ignore) {
+			}
 
 			// open a new connection
 			RedisConnection connection2 = connectionFactory.getConnection();
@@ -708,7 +704,8 @@ public abstract class AbstractConnectionIntegrationTests {
 
 			try {
 				Thread.sleep(500);
-			} catch (InterruptedException o_O) {}
+			} catch (InterruptedException ignore) {
+			}
 
 			// open a new connection
 			RedisConnection connection2 = connectionFactory.getConnection();

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
@@ -182,8 +182,8 @@ abstract public class AbstractConnectionPipelineIntegrationTests extends Abstrac
 		try {
 			// we give redis some time to keep up
 			Thread.sleep(10);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
+		} catch (InterruptedException ex) {
+			ex.printStackTrace();
 		}
 
 		return connection.closePipeline();

--- a/src/test/java/org/springframework/data/redis/connection/ClusterCommandExecutorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterCommandExecutorUnitTests.java
@@ -252,10 +252,10 @@ class ClusterCommandExecutorUnitTests {
 
 		try {
 			executor.executeCommandOnAllNodes(COMMAND_CALLBACK);
-		} catch (ClusterCommandExecutionFailureException cause) {
+		} catch (ClusterCommandExecutionFailureException ex) {
 
-			assertThat(cause.getSuppressed()).hasSize(1);
-			assertThat(cause.getSuppressed()[0]).isInstanceOf(DataAccessException.class);
+			assertThat(ex.getSuppressed()).hasSize(1);
+			assertThat(ex.getSuppressed()[0]).isInstanceOf(DataAccessException.class);
 		}
 
 		verify(connection1).theWheelWeavesAsTheWheelWills();

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -123,8 +123,8 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		for (ConnectionPool pool : nativeConnection.getClusterNodes().values()) {
 			try (Jedis jedis = new Jedis(pool.getResource())) {
 				jedis.flushAll();
-			} catch (Exception e) {
-				// ignore this one since we cannot remove data from replicas
+			} catch (Exception ignore) {
+				// ignore since we cannot remove data from replicas
 			}
 		}
 	}
@@ -2857,8 +2857,8 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		try {
 			clusterConnection.scriptingCommands().evalSha(luaScriptBin, ReturnType.VALUE, 1, keyAndArgs);
 			fail("expected InvalidDataAccessApiUsageException");
-		} catch (InvalidDataAccessApiUsageException e) {
-			assertThat(e.getMessage()).contains("NOSCRIPT");
+		} catch (InvalidDataAccessApiUsageException ex) {
+			assertThat(ex.getMessage()).contains("NOSCRIPT");
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionIntegrationTests.java
@@ -68,17 +68,14 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 	public void tearDown() {
 		try {
 			connection.flushAll();
-		} catch (Exception e) {
-			// Jedis leaves some incomplete data in OutputStream on NPE caused
-			// by null key/value tests
-			// Attempting to flush the DB or close the connection will result in
-			// error on sending QUIT to Redis
+		} catch (Exception ignore) {
+			// Jedis leaves some incomplete data in OutputStream on NPE caused by null key/value tests
+			// Attempting to flush the DB or close the connection will result in error on sending QUIT to Redis
 		}
 
 		try {
 			connection.close();
-		} catch (Exception e) {
-			// silently close connection
+		} catch (Exception ignore) {
 		}
 
 		connection = null;
@@ -231,16 +228,16 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 				RedisConnection con = connectionFactory.getConnection();
 				try {
 					Thread.sleep(100);
-				} catch (InterruptedException e) {
-					e.printStackTrace();
+				} catch (InterruptedException ex) {
+					ex.printStackTrace();
 				}
 
 				con.publish(expectedChannel.getBytes(), expectedMessage.getBytes());
 
 				try {
 					Thread.sleep(100);
-				} catch (InterruptedException e) {
-					e.printStackTrace();
+				} catch (InterruptedException ex) {
+					ex.printStackTrace();
 				}
 
 				/*
@@ -289,8 +286,8 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 				RedisConnection con = connectionFactory.getConnection();
 				try {
 					Thread.sleep(100);
-				} catch (InterruptedException e) {
-					e.printStackTrace();
+				} catch (InterruptedException ex) {
+					ex.printStackTrace();
 				}
 
 				con.publish("channel1".getBytes(), expectedMessage.getBytes());
@@ -298,8 +295,8 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 
 				try {
 					Thread.sleep(100);
-				} catch (InterruptedException e) {
-					e.printStackTrace();
+				} catch (InterruptedException ex) {
+					ex.printStackTrace();
 				}
 
 				con.close();
@@ -341,8 +338,7 @@ public class JedisConnectionIntegrationTests extends AbstractConnectionIntegrati
 
 		try (RedisConnection conn = factory2.getConnection()) {
 			conn.get(null);
-		} catch (Exception e) {
-
+		} catch (Exception ignore) {
 		} finally {
 			// Make sure we don't end up with broken connection
 			factory2.getConnection().dbSize();

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionPipelineIntegrationTests.java
@@ -47,11 +47,9 @@ public class JedisConnectionPipelineIntegrationTests extends AbstractConnectionP
 		try {
 			connection.flushAll();
 			connection.close();
-		} catch (Exception e) {
-			// Jedis leaves some incomplete data in OutputStream on NPE caused
-			// by null key/value tests
-			// Attempting to close the connection will result in error on
-			// sending QUIT to Redis
+		} catch (Exception ignore) {
+			// Jedis leaves some incomplete data in OutputStream on NPE caused by null key/value tests
+			// Attempting to close the connection will result in error on sending QUIT to Redis
 		}
 		connection = null;
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionTransactionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionTransactionIntegrationTests.java
@@ -46,11 +46,9 @@ public class JedisConnectionTransactionIntegrationTests extends AbstractConnecti
 		try {
 			connection.flushAll();
 			connection.close();
-		} catch (Exception e) {
-			// Jedis leaves some incomplete data in OutputStream on NPE caused
-			// by null key/value tests
-			// Attempting to close the connection will result in error on
-			// sending QUIT to Redis
+		} catch (Exception ignore) {
+			// Jedis leaves some incomplete data in OutputStream on NPE caused by null key/value tests
+			// Attempting to close the connection will result in error on sending QUIT to Redis
 		}
 		connection = null;
 	}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
@@ -65,8 +65,7 @@ class JedisConnectionUnitTests {
 
 			try {
 				connection.shutdown(null);
-			} catch (InvalidDataAccessApiUsageException e) {
-				// all good. Sometimes it throws an Exception.
+			} catch (InvalidDataAccessApiUsageException ignore) {
 			}
 
 			verify(jedisSpy).shutdown();

--- a/src/test/java/org/springframework/data/redis/connection/jedis/ScanTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/ScanTests.java
@@ -100,8 +100,8 @@ public class ScanTests {
 						cursorMap.next();
 					}
 					cursorMap.close();
-				} catch (Exception e) {
-					exception.set(e);
+				} catch (Exception ex) {
+					exception.set(ex);
 				}
 			});
 		}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/extension/JedisConnectionFactoryExtension.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/extension/JedisConnectionFactoryExtension.java
@@ -227,8 +227,8 @@ public class JedisConnectionFactoryExtension implements ParameterResolver {
 			try {
 				mayClose = true;
 				destroy();
-			} catch (Exception e) {
-				e.printStackTrace();
+			} catch (Exception ex) {
+				ex.printStackTrace();
 			}
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryTests.java
@@ -101,7 +101,7 @@ class LettuceConnectionFactoryTests {
 		try {
 			connection.get("test3");
 			fail("Expected exception using natively closed conn");
-		} catch (RedisSystemException e) {
+		} catch (RedisSystemException expected) {
 			// expected, shared conn is closed
 		}
 		DefaultStringRedisConnection conn2 = new DefaultStringRedisConnection(factory.getConnection());
@@ -122,7 +122,7 @@ class LettuceConnectionFactoryTests {
 		try {
 			conn2.set("anotherkey", "anothervalue");
 			fail("Expected exception using natively closed conn");
-		} catch (RedisSystemException e) {
+		} catch (RedisSystemException expected) {
 			// expected, as we are re-using the natively closed conn
 		} finally {
 			conn2.close();
@@ -274,7 +274,8 @@ class LettuceConnectionFactoryTests {
 		try {
 			factory.getConnection();
 			fail("Expected connection failure exception");
-		} catch (RedisConnectionFailureException e) {}
+		} catch (RedisConnectionFailureException expected) {
+		}
 	}
 
 	@Test
@@ -467,9 +468,9 @@ class LettuceConnectionFactoryTests {
 		try {
 			connection.ping();
 			fail("Expected RedisException: Master is currently unknown");
-		} catch (RedisSystemException e) {
-			assertThat(e.getCause()).isInstanceOf(RedisException.class);
-			assertThat(e.getCause().getMessage()).contains("Master is currently unknown");
+		} catch (RedisSystemException ex) {
+			assertThat(ex.getCause()).isInstanceOf(RedisException.class);
+			assertThat(ex.getCause().getMessage()).contains("Master is currently unknown");
 		} finally {
 			connection.close();
 		}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionIntegrationTests.java
@@ -97,7 +97,7 @@ public class LettuceConnectionIntegrationTests extends AbstractConnectionIntegra
 		try {
 			connection.exec();
 			fail("Expected exception resuming tx");
-		} catch (RedisSystemException e) {
+		} catch (RedisSystemException expected) {
 			// expected, can't resume tx after closing conn
 		}
 	}
@@ -115,7 +115,8 @@ public class LettuceConnectionIntegrationTests extends AbstractConnectionIntegra
 			// can't do blocking ops after closing
 			connection.bLPop(1, "what".getBytes());
 			fail("Expected exception using a closed conn for dedicated ops");
-		} catch (RedisSystemException e) {}
+		} catch (RedisSystemException expected) {
+		}
 	}
 
 	@Test
@@ -134,8 +135,8 @@ public class LettuceConnectionIntegrationTests extends AbstractConnectionIntegra
 		try {
 			connection.set("foo".getBytes(), "bar".getBytes());
 			fail("Exception should be thrown trying to use a closed connection");
-		} catch (RedisSystemException e) {}
-		finally {
+		} catch (RedisSystemException expected) {
+		} finally {
 
 		factory2.destroy();
 		}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestSupport.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestSupport.java
@@ -166,8 +166,8 @@ public abstract class LettuceReactiveCommandsTestSupport {
 				if (nativeBinaryConnectionProvider instanceof DisposableBean) {
 					((DisposableBean) nativeBinaryConnectionProvider).destroy();
 				}
-			} catch (Exception e) {
-				throw new RuntimeException(e);
+			} catch (Exception ex) {
+				throw new RuntimeException(ex);
 			}
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceSentinelIntegrationTests.java
@@ -78,9 +78,8 @@ public class LettuceSentinelIntegrationTests extends AbstractConnectionIntegrati
 
 			// since we use more than one db we're required to flush them all
 			connection.flushAll();
-		} catch (Exception e) {
-			// Connection may be closed in certain cases, like after pub/sub
-			// tests
+		} catch (Exception ignore) {
+			// Connection may be closed in certain cases, like after pub/sub tests
 		}
 		connection.close();
 	}

--- a/src/test/java/org/springframework/data/redis/core/ConnectionSplittingInterceptorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ConnectionSplittingInterceptorUnitTests.java
@@ -55,8 +55,8 @@ class ConnectionSplittingInterceptorUnitTests {
 		try {
 			WRITE_METHOD = ClassUtils.getMethod(RedisConnection.class, "expire", byte[].class, long.class);
 			READONLY_METHOD = ClassUtils.getMethod(RedisConnection.class, "keys", byte[].class);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
+		} catch (Exception ex) {
+			throw new RuntimeException(ex);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsIntegrationTests.java
@@ -103,7 +103,8 @@ public class DefaultSetOperationsIntegrationTests<K, V> {
 		try {
 			setOps.randomMembers(keyFactory.instance(), -1);
 			fail("IllegalArgumentException should be thrown");
-		} catch (IllegalArgumentException e) {}
+		} catch (IllegalArgumentException expected) {
+		}
 	}
 
 	@ParameterizedRedisTest
@@ -112,7 +113,8 @@ public class DefaultSetOperationsIntegrationTests<K, V> {
 		try {
 			setOps.distinctRandomMembers(keyFactory.instance(), -2);
 			fail("IllegalArgumentException should be thrown");
-		} catch (IllegalArgumentException e) {}
+		} catch (IllegalArgumentException expected) {
+		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ReactiveRedisTemplateIntegrationTests.java
@@ -95,14 +95,10 @@ public class ReactiveRedisTemplateIntegrationTests<K, V> {
 	@EnabledOnCommand("COPY")
 	void copy() {
 
-		ReactiveRedisClusterConnection connection = null;
-		try {
-			connection = redisTemplate.getConnectionFactory().getReactiveClusterConnection();
-			assumeThat(connection == null).isTrue();
-		} catch (InvalidDataAccessApiUsageException e) {} finally {
-			if (connection != null) {
-				connection.close();
-			}
+		try (ReactiveRedisClusterConnection connection = redisTemplate.getConnectionFactory()
+				.getReactiveClusterConnection()){
+			assumeThat(connection).isNull();
+		} catch (InvalidDataAccessApiUsageException ignore) {
 		}
 
 		K key = keyFactory.instance();
@@ -397,23 +393,17 @@ public class ReactiveRedisTemplateIntegrationTests<K, V> {
 	@ParameterizedRedisTest // DATAREDIS-602
 	void move() {
 
-		ReactiveRedisClusterConnection connection = null;
-		try {
-			connection = redisTemplate.getConnectionFactory().getReactiveClusterConnection();
-			assumeThat(connection == null).isTrue();
-		} catch (InvalidDataAccessApiUsageException e) {} finally {
-			if (connection != null) {
-				connection.close();
-			}
+		try (ReactiveRedisClusterConnection connection = redisTemplate.getConnectionFactory()
+				.getReactiveClusterConnection()) {
+			assumeThat(connection).isNull();
+		} catch (InvalidDataAccessApiUsageException ignore) {
 		}
 
 		K key = keyFactory.instance();
 		V value = valueFactory.instance();
 
 		redisTemplate.opsForValue().set(key, value).as(StepVerifier::create).expectNext(true).verifyComplete();
-
 		redisTemplate.move(key, 5).as(StepVerifier::create).expectNext(true).verifyComplete();
-
 		redisTemplate.hasKey(key).as(StepVerifier::create).expectNext(false).verifyComplete();
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -102,8 +102,7 @@ public class RedisKeyValueAdapterTests {
 
 		try {
 			adapter.destroy();
-		} catch (Exception e) {
-			// ignore
+		} catch (Exception ignore) {
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateIntegrationTests.java
@@ -351,6 +351,7 @@ public class RedisTemplateIntegrationTests<K, V> {
 		V value1 = valueFactory.instance();
 		List<Object> pipelinedResults = redisTemplate.executePipelined(new SessionCallback() {
 			public Object execute(RedisOperations operations) throws DataAccessException {
+
 				operations.multi();
 				operations.opsForList().leftPush(key1, value1);
 				operations.opsForList().rightPop(key1);
@@ -360,9 +361,12 @@ public class RedisTemplateIntegrationTests<K, V> {
 				try {
 					// Await EXEC completion as it's executed on a dedicated connection.
 					Thread.sleep(100);
-				} catch (InterruptedException e) {}
+				} catch (InterruptedException ignore) {
+				}
+
 				operations.opsForValue().set(key1, value1);
 				operations.opsForValue().get(key1);
+
 				return null;
 			}
 		});
@@ -719,7 +723,8 @@ public class RedisTemplateIntegrationTests<K, V> {
 				th.start();
 				try {
 					th.join();
-				} catch (InterruptedException e) {}
+				} catch (InterruptedException ignore) {
+				}
 
 				operations.multi();
 				operations.opsForValue().set(key1, value3);
@@ -751,7 +756,8 @@ public class RedisTemplateIntegrationTests<K, V> {
 				th.start();
 				try {
 					th.join();
-				} catch (InterruptedException e) {}
+				} catch (InterruptedException ignore) {
+				}
 
 				operations.unwatch();
 				operations.multi();
@@ -788,7 +794,8 @@ public class RedisTemplateIntegrationTests<K, V> {
 				th.start();
 				try {
 					th.join();
-				} catch (InterruptedException e) {}
+				} catch (InterruptedException ignore) {
+				}
 
 				operations.multi();
 				operations.opsForValue().set(key1, value3);

--- a/src/test/java/org/springframework/data/redis/test/condition/EnabledOnRedisAvailableCondition.java
+++ b/src/test/java/org/springframework/data/redis/test/condition/EnabledOnRedisAvailableCondition.java
@@ -54,13 +54,14 @@ class EnabledOnRedisAvailableCondition implements ExecutionCondition {
 		EnabledOnRedisAvailable annotation = optional.get();
 
 		try (Socket socket = new Socket()) {
+
 			socket.connect(new InetSocketAddress(SettingsUtils.getHost(), annotation.value()), 100);
 
-			return enabled(
-					String.format("Connection successful to Redis at %s:%d", SettingsUtils.getHost(), annotation.value()));
-		} catch (IOException e) {
-			return disabled(
-					String.format("Cannot connect to Redis at %s:%d (%s)", SettingsUtils.getHost(), annotation.value(), e));
+			return enabled(String.format("Connection successful to Redis at %s:%d", SettingsUtils.getHost(),
+					annotation.value()));
+		} catch (IOException ex) {
+			return disabled(String.format("Cannot connect to Redis at %s:%d (%s)", SettingsUtils.getHost(),
+					annotation.value(), ex));
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/test/condition/RedisConditions.java
+++ b/src/test/java/org/springframework/data/redis/test/condition/RedisConditions.java
@@ -57,8 +57,8 @@ class RedisConditions {
 			p.load(inputStream);
 
 			version = Version.parse(p.getProperty("redis_version"));
-		} catch (IOException e) {
-			throw new IllegalStateException(e);
+		} catch (IOException ex) {
+			throw new IllegalStateException(ex);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/test/condition/RedisDetector.java
+++ b/src/test/java/org/springframework/data/redis/test/condition/RedisDetector.java
@@ -39,7 +39,7 @@ public class RedisDetector {
 			cluster.getConnectionFromSlot(1).close();
 
 			return true;
-		} catch (Exception e) {
+		} catch (Exception ignore) {
 			return false;
 		}
 	});
@@ -54,9 +54,8 @@ public class RedisDetector {
 			socket.connect(new InetSocketAddress(SettingsUtils.getHost(), port), 100);
 
 			return true;
-		} catch (IOException e) {
+		} catch (IOException ignore) {
 			return false;
 		}
 	}
-
 }

--- a/src/test/java/org/springframework/data/redis/test/extension/parametrized/ParameterizedRedisTestExtension.java
+++ b/src/test/java/org/springframework/data/redis/test/extension/parametrized/ParameterizedRedisTestExtension.java
@@ -147,8 +147,8 @@ class ParameterizedRedisTestExtension implements TestTemplateInvocationContextPr
 	protected static Stream<? extends Arguments> arguments(ArgumentsProvider provider, ExtensionContext context) {
 		try {
 			return provider.provideArguments(context);
-		} catch (Exception e) {
-			throw ExceptionUtils.throwAsUncheckedException(e);
+		} catch (Exception ex) {
+			throw ExceptionUtils.throwAsUncheckedException(ex);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/util/ConnectionVerifier.java
+++ b/src/test/java/org/springframework/data/redis/util/ConnectionVerifier.java
@@ -81,8 +81,8 @@ public class ConnectionVerifier<T extends RedisConnectionFactory> {
 		if (factory instanceof InitializingBean initializingBean) {
 			try {
 				initializingBean.afterPropertiesSet();
-			} catch (Exception e) {
-				throw new RuntimeException(e);
+			} catch (Exception ex) {
+				throw new RuntimeException(ex);
 			}
 		}
 		if (factory instanceof SmartLifecycle smartLifecycle) {
@@ -97,14 +97,14 @@ public class ConnectionVerifier<T extends RedisConnectionFactory> {
 		if (it instanceof DisposableBean bean) {
 			try {
 				bean.destroy();
-			} catch (Exception e) {
-				throw new DataAccessResourceFailureException("Cannot close resource", e);
+			} catch (Exception ex) {
+				throw new DataAccessResourceFailureException("Cannot close resource", ex);
 			}
 		} else if (it instanceof Closeable closeable) {
 			try {
 				closeable.close();
-			} catch (IOException e) {
-				throw new DataAccessResourceFailureException("Cannot close resource", e);
+			} catch (IOException ex) {
+				throw new DataAccessResourceFailureException("Cannot close resource", ex);
 			}
 		} else if (it instanceof SmartLifecycle smartLifecycle && smartLifecycle.isRunning()) {
 			smartLifecycle.stop();


### PR DESCRIPTION
See #2748.

It should also be NOTED that, in certain `catch (InterruptedException ex)` blocks, the `ex` Exception variable was not used or referenced. However, that does NOT mean the Exception handler did not "handle" the `InterruptedException`!

The simple invocation of `Thread.currentThread().interrupt()` IS an act of handling the `InterruptedException` and does have downstream consequences (or in other words, "side effects"). Therefore, the Exception variable name `ex` was deliberately kept in these cases.
