### PR TITLE
Make constant for repository module name

### DIFF
--- a/src/main/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtension.java
@@ -48,6 +48,7 @@ import org.springframework.util.StringUtils;
  */
 public class RedisRepositoryConfigurationExtension extends KeyValueRepositoryConfigurationExtension {
 
+	private static final String MODULE_NAME = "Redis";
 	private static final String REDIS_CONVERTER_BEAN_NAME = "redisConverter";
 	private static final String REDIS_REFERENCE_RESOLVER_BEAN_NAME = "redisReferenceResolver";
 	private static final String REDIS_ADAPTER_BEAN_NAME = "redisKeyValueAdapter";
@@ -56,12 +57,12 @@ public class RedisRepositoryConfigurationExtension extends KeyValueRepositoryCon
 
 	@Override
 	public String getModuleName() {
-		return "Redis";
+		return MODULE_NAME;
 	}
 
 	@Override
 	protected String getModulePrefix() {
-		return "redis";
+		return this.getModuleIdentifier();
 	}
 
 	@Override


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

In my opinion, returning the module name directly is not a good idea, 
so I modified it to handle it by declaring a constant instead.
Also, instead of returning a value directly from `getModulePrefix`, we can proxies it to `this.getModuleIdentifier.`

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
