### PR TITLE
Enhance right/leftPushAll(key, E...) to account for type-mismatched value arguments based on user-declared RedisTemplate<?, ?> type signature

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
@@ -32,6 +32,7 @@ import org.springframework.util.CollectionUtils;
  * @author Thomas Darimont
  * @author Christoph Strobl
  * @author dengliming
+ * @author Koy Zhuang
  */
 class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements ListOperations<K, V> {
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.core;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.connection.RedisConnection;
@@ -113,6 +114,12 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 	@Override
 	public Long leftPushAll(K key, V... values) {
+		if (values.length == 1) {
+			V val = values[0];
+			if (values[0] instanceof Collection) {
+				return leftPushAll(key, (Collection) val);
+			}
+		}
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(values);
@@ -210,6 +217,12 @@ class DefaultListOperations<K, V> extends AbstractOperations<K, V> implements Li
 
 	@Override
 	public Long rightPushAll(K key, V... values) {
+		if (values.length == 1) {
+			V val = values[0];
+			if (values[0] instanceof Collection) {
+				return rightPushAll(key, (Collection) val);
+			}
+		}
 
 		byte[] rawKey = rawKey(key);
 		byte[][] rawValues = rawValues(values);

--- a/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultListOperations.java
@@ -17,7 +17,6 @@ package org.springframework.data.redis.core;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.connection.RedisConnection;

--- a/src/test/java/org/springframework/data/redis/core/DefaultListOperationsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultListOperationsUnitTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Koy Zhuang
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DefaultListOperationsUnitTests<K, V> {
+    @Mock RedisConnectionFactory connectionFactoryMock;
+    @Mock RedisConnection connectionMock;
+
+    @Test
+    void shouldCallPushToAllCollectionGivenRedisTemplateObject() {
+        when(connectionFactoryMock.getConnection()).thenReturn(connectionMock);
+
+        final StringRedisSerializer keySerializer = mock(StringRedisSerializer.class);
+        final JdkSerializationRedisSerializer valueSerializer = mock(JdkSerializationRedisSerializer.class);
+        doReturn("any".getBytes()).when(keySerializer).serialize(anyString());
+        doReturn("any".getBytes()).when(valueSerializer).serialize(any());
+
+        // setup RedisTemplate<String, Object>
+        RedisTemplate<String, Object> template = new RedisTemplate<String, Object>();
+        template.setConnectionFactory(connectionFactoryMock);
+        template.setKeySerializer(keySerializer);
+        template.setValueSerializer(valueSerializer);
+        template.afterPropertiesSet();
+
+        final ListOperations<String, Object> listOperations = template.opsForList();
+        final ListOperations<String, Object> spyTarget = spy(listOperations);
+
+        List<V> values = List.of((V) (new Object()));
+        spyTarget.leftPushAll("key", values);
+        // should call leftPushAll(K key, V... values)
+        verify(spyTarget, times(1)).leftPushAll(anyString(), any(Object.class));
+        // forward to leftPushAll(K key, Collection<V> values)
+        verify(spyTarget, times(1)).leftPushAll(anyString(), anyCollection());
+    }
+}


### PR DESCRIPTION
The `left/rightPushAll` has two methods.
- `public Long rightPushAll(K key, V... values) `
- `public Long rightPushAll(K key, Collection<V> values)`

---
In this case it may lead to an unexpected result when using a `RedisTemplate<String, Object> redisTemplate`. e.g.
```java
@AllArgsConstructor
public class Reproduce<T> {
    private final RedisTemplate<String, Object> redisTemplate;

    public void pushAll(List<T> value) {
        String key = "any";
        redisTemplate.opsForList().leftPushAll(key, value);
    }

}
```

It gonna use the first method `rightPushAll(K key, V... values)` instead of `rightPushAll(K key, Collection<V> values)` to save the List<T> as a single value.
<img width="636" alt="image" src="https://github.com/spring-projects/spring-data-redis/assets/33706142/e36f4778-ab9e-4511-a61e-31fee566cc91">

---
I know that if we use `RedisTemplate<String, Object>`, the value type is all promote to Object , it treats all things as a single value, hence it uses the `rightPushAll(K key, V... values)`.

If I change to use 
```java
RedisTemplate<String, T> redisTemplate
``` 
or 
```java
redisTemplate.opsForList().leftPushAll(key, value.toArray(new Object[0]))
```
It should work as expected.



TBH, I'm not quite sure whether it should be a user code design issue or should be handled by this lib.
Personally, I wish it could be solved in here to make the `pushToAll` methods more closed to what it is real do on the `RedisTemplate<String, Object>` like other opts.





