### PR TITLE
Fixed the URL for the Spring Data Commons documentation

### DIFF
--- a/src/main/antora/resources/antora-resources/antora.yml
+++ b/src/main/antora/resources/antora-resources/antora.yml
@@ -12,7 +12,7 @@ asciidoc:
     lettuce: ${lettuce}
     jedis: ${jedis}
     include-xml-namespaces: false
-    spring-data-commons-docs-url: https://docs.spring.io/spring-data-commons/reference
+    spring-data-commons-docs-url: https://docs.spring.io/spring-data/commons/reference
     spring-data-commons-javadoc-base: https://docs.spring.io/spring-data/commons/docs/${springdata.commons}/api/
     springdocsurl: https://docs.spring.io/spring-framework/reference/{springversionshort}
     springjavadocurl: https://docs.spring.io/spring-framework/docs/${spring}/javadoc-api


### PR DESCRIPTION
I fixed an incorrect URL in the **antora.yml** file that was preventing other pages from linking to the Spring Data Commons documentation.