### PR TITLE
Encapsulate Redis Scan CursorId

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,25 +41,25 @@ pipeline {
 					}
 				}
 				stage('Publish JDK 17 + Redis 7.2 Docker Image') {
-                	when {
-                		anyOf {
-                			changeset "ci/openjdk17-redis-7.2/Dockerfile"
-                			changeset "Makefile"
-                			changeset "ci/pipeline.properties"
-                		}
-                	}
-                	agent { label 'data' }
-                	options { timeout(time: 20, unit: 'MINUTES') }
+					when {
+						anyOf {
+							changeset "ci/openjdk17-redis-7.2/Dockerfile"
+							changeset "Makefile"
+							changeset "ci/pipeline.properties"
+						}
+					}
+					agent { label 'data' }
+					options { timeout(time: 20, unit: 'MINUTES') }
 
-                	steps {
-                		script {
-                			def image = docker.build("springci/spring-data-with-redis-7.2:${p['java.main.tag']}", "--build-arg BASE=${p['docker.java.main.image']} --build-arg REDIS=${p['docker.redis.7.version']} -f ci/openjdk17-redis-7.2/Dockerfile .")
-                			docker.withRegistry(p['docker.registry'], p['docker.credentials']) {
-                				image.push()
-                			}
-                		}
-                	}
-                }
+					steps {
+						script {
+							def image = docker.build("springci/spring-data-with-redis-7.2:${p['java.main.tag']}", "--build-arg BASE=${p['docker.java.main.image']} --build-arg REDIS=${p['docker.redis.7.version']} -f ci/openjdk17-redis-7.2/Dockerfile .")
+							docker.withRegistry(p['docker.registry'], p['docker.credentials']) {
+								image.push()
+							}
+						}
+					}
+				}
 				stage('Publish JDK 21 + Redis 6.2 Docker Image') {
 					when {
 						anyOf {
@@ -155,22 +155,22 @@ pipeline {
 					}
 				}
 				stage("test: Redis 7") {
-				    agent {
-                		label 'data'
-                	}
-                    options { timeout(time: 30, unit: 'MINUTES') }
-                    environment {
-                    	ARTIFACTORY = credentials("${p['artifactory.credentials']}")
-                    	DEVELOCITY_CACHE = credentials("${p['develocity.cache.credentials']}")
-                    	DEVELOCITY_ACCESS_KEY = credentials("${p['develocity.access-key']}")
-                    }
-                    steps {
-                    	script {
-                    		docker.image("harbor-repo.vmware.com/dockerhub-proxy-cache/springci/spring-data-with-redis-7.2:${p['java.main.tag']}").inside('-v $HOME:/tmp/jenkins-home') {
-                    			sh "PROFILE=none LONG_TESTS=true JENKINS_USER_NAME=${p['jenkins.user.name']} ci/test.sh"
-                    		}
-                    	}
-                    }
+					agent {
+						label 'data'
+					}
+					options { timeout(time: 30, unit: 'MINUTES') }
+					environment {
+					   	ARTIFACTORY = credentials("${p['artifactory.credentials']}")
+						DEVELOCITY_CACHE = credentials("${p['develocity.cache.credentials']}")
+						DEVELOCITY_ACCESS_KEY = credentials("${p['develocity.access-key']}")
+					}
+					steps {
+						script {
+							docker.image("harbor-repo.vmware.com/dockerhub-proxy-cache/springci/spring-data-with-redis-7.2:${p['java.main.tag']}").inside('-v $HOME:/tmp/jenkins-home') {
+								sh "PROFILE=none LONG_TESTS=true JENKINS_USER_NAME=${p['jenkins.user.name']} ci/test.sh"
+							}
+						}
+					}
 				}
 			}
 		}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,26 @@ pipeline {
 						}
 					}
 				}
+				stage('Publish JDK 17 + Redis 7.2 Docker Image') {
+                	when {
+                		anyOf {
+                			changeset "ci/openjdk17-redis-7.2/Dockerfile"
+                			changeset "Makefile"
+                			changeset "ci/pipeline.properties"
+                		}
+                	}
+                	agent { label 'data' }
+                	options { timeout(time: 20, unit: 'MINUTES') }
+
+                	steps {
+                		script {
+                			def image = docker.build("springci/spring-data-with-redis-7.2:${p['java.main.tag']}", "--build-arg BASE=${p['docker.java.main.image']} --build-arg REDIS=${p['docker.redis.7.version']} -f ci/openjdk17-redis-7.2/Dockerfile .")
+                			docker.withRegistry(p['docker.registry'], p['docker.credentials']) {
+                				image.push()
+                			}
+                		}
+                	}
+                }
 				stage('Publish JDK 21 + Redis 6.2 Docker Image') {
 					when {
 						anyOf {
@@ -133,6 +153,24 @@ pipeline {
 							}
 						}
 					}
+				}
+				stage("test: Redis 7") {
+				    agent {
+                		label 'data'
+                	}
+                    options { timeout(time: 30, unit: 'MINUTES') }
+                    environment {
+                    	ARTIFACTORY = credentials("${p['artifactory.credentials']}")
+                    	DEVELOCITY_CACHE = credentials("${p['develocity.cache.credentials']}")
+                    	DEVELOCITY_ACCESS_KEY = credentials("${p['develocity.access-key']}")
+                    }
+                    steps {
+                    	script {
+                    		docker.image("harbor-repo.vmware.com/dockerhub-proxy-cache/springci/spring-data-with-redis-7.2:${p['java.main.tag']}").inside('-v $HOME:/tmp/jenkins-home') {
+                    			sh "PROFILE=none LONG_TESTS=true JENKINS_USER_NAME=${p['jenkins.user.name']} ci/test.sh"
+                    		}
+                    	}
+                    }
 				}
 			}
 		}

--- a/Makefile
+++ b/Makefile
@@ -196,14 +196,14 @@ stop: redis-stop sentinel-stop cluster-stop
 test:
 	$(MAKE) start
 	sleep 1
-	./mvnw clean test -U -P$(SPRING_PROFILE) || (echo "maven failed $$?"; exit 1)
+	./mvnw clean test -U -P$(SPRING_PROFILE) -Dredis.server.version=$(REDIS_VERSION) || (echo "maven failed $$?"; exit 1)
 	$(MAKE) stop
 	$(MAKE) clean
 
 all-tests:
 	$(MAKE) start
 	sleep 1
-	./mvnw clean test -U -DrunLongTests=true -P$(SPRING_PROFILE) || (echo "maven failed $$?"; exit 1)
+	./mvnw clean test -U -DrunLongTests=true -P$(SPRING_PROFILE) -Dredis.server.version=$(REDIS_VERSION) || (echo "maven failed $$?"; exit 1)
 	$(MAKE) stop
 	$(MAKE) clean
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REDIS_VERSION:=6.2.6
+REDIS_VERSION:=7.2.4
 SPRING_PROFILE?=ci
 SHELL=/bin/bash -euo pipefail
 
@@ -175,7 +175,7 @@ clobber:
 work/redis/bin/redis-cli work/redis/bin/redis-server:
 	@mkdir -p work/redis
 
-	curl -sSL https://github.com/antirez/redis/archive/$(REDIS_VERSION).tar.gz | tar xzf - -C work
+	curl -sSL https://github.com/redis/redis/archive/$(REDIS_VERSION).tar.gz | tar xzf - -C work
 	$(MAKE) -C work/redis-$(REDIS_VERSION) -j
 	$(MAKE) -C work/redis-$(REDIS_VERSION) PREFIX=$(shell pwd)/work/redis install
 	rm -rf work/redis-$(REDIS_VERSION)

--- a/ci/openjdk17-redis-7.2/Dockerfile
+++ b/ci/openjdk17-redis-7.2/Dockerfile
@@ -1,0 +1,16 @@
+ARG BASE
+FROM ${BASE}
+# Any ARG statements before FROM are cleared.
+ARG REDIS
+
+# Copy Spring Data Redis's Makefile into the container
+COPY ./Makefile /
+
+RUN set -eux; \
+#	sed -i -e 's/http/https/g' /etc/apt/sources.list ; \
+	apt-get update ; \
+	apt-get install -y build-essential ; \
+	make work/redis/bin/redis-cli work/redis/bin/redis-server REDIS_VERSION=${REDIS}; \
+	chmod -R o+rw work; \
+	apt-get clean; \
+	rm -rf /var/lib/apt/lists/*;

--- a/ci/openjdk17-redis-7.2/Dockerfile
+++ b/ci/openjdk17-redis-7.2/Dockerfile
@@ -2,6 +2,7 @@ ARG BASE
 FROM ${BASE}
 # Any ARG statements before FROM are cleared.
 ARG REDIS
+ENV REDIS_VERSION=${REDIS}
 
 # Copy Spring Data Redis's Makefile into the container
 COPY ./Makefile /

--- a/ci/pipeline.properties
+++ b/ci/pipeline.properties
@@ -14,6 +14,7 @@ docker.mongodb.7.0.version=7.0.2
 
 # Supported versions of Redis
 docker.redis.6.version=6.2.13
+docker.redis.7.version=7.2.4
 
 # Supported versions of Cassandra
 docker.cassandra.3.version=3.11.16

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -18,7 +18,7 @@ export JENKINS_USER=${JENKINS_USER_NAME}
 export GRADLE_ENTERPRISE_ACCESS_KEY=${DEVELOCITY_ACCESS_KEY}
 
 # Execute maven test
-MAVEN_OPTS="-Duser.name=${JENKINS_USER} -Duser.home=/tmp/jenkins-home" ./mvnw -s settings.xml clean test -P${PROFILE} -DrunLongTests=${LONG_TESTS:-false} -Dredis.server.version=${REDIS_VERSION} -U -B
+MAVEN_OPTS="-Duser.name=${JENKINS_USER} -Duser.home=/tmp/jenkins-home" ./mvnw -s settings.xml clean test -P${PROFILE} -DrunLongTests=${LONG_TESTS:-false} -Dredis.server.version=${REDIS_VERSION:-unknown} -U -B
 
 # Capture resulting exit code from maven (pass/fail)
 RESULT=$?

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -18,7 +18,7 @@ export JENKINS_USER=${JENKINS_USER_NAME}
 export GRADLE_ENTERPRISE_ACCESS_KEY=${DEVELOCITY_ACCESS_KEY}
 
 # Execute maven test
-MAVEN_OPTS="-Duser.name=${JENKINS_USER} -Duser.home=/tmp/jenkins-home" ./mvnw -s settings.xml clean test -P${PROFILE} -DrunLongTests=${LONG_TESTS:-false} -Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=false -U -B
+MAVEN_OPTS="-Duser.name=${JENKINS_USER} -Duser.home=/tmp/jenkins-home" ./mvnw -s settings.xml clean test -P${PROFILE} -DrunLongTests=${LONG_TESTS:-false} -Dredis.server.version=${REDIS_VERSION} -U -B
 
 # Capture resulting exit code from maven (pass/fail)
 RESULT=$?

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -18,7 +18,7 @@ export JENKINS_USER=${JENKINS_USER_NAME}
 export GRADLE_ENTERPRISE_ACCESS_KEY=${DEVELOCITY_ACCESS_KEY}
 
 # Execute maven test
-MAVEN_OPTS="-Duser.name=${JENKINS_USER} -Duser.home=/tmp/jenkins-home" ./mvnw -s settings.xml clean test -P${PROFILE} -DrunLongTests=${LONG_TESTS:-false} -U -B
+MAVEN_OPTS="-Duser.name=${JENKINS_USER} -Duser.home=/tmp/jenkins-home" ./mvnw -s settings.xml clean test -P${PROFILE} -DrunLongTests=${LONG_TESTS:-false} -Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=false -U -B
 
 # Capture resulting exit code from maven (pass/fail)
 RESULT=$?

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,8 @@
 				<configuration>
 					<systemPropertyVariables>
 						<redis.server.version>${redis.server.version}</redis.server.version>
+						<lettuce>${lettuce}</lettuce>
+						<jedis>${jedis}</jedis>
 					</systemPropertyVariables>
 					<!-- Retain stack traces -->
 					<argLine>-XX:-OmitStackTraceInFastThrow</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-2796-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
+					<systemPropertyVariables>
+						<redis.server.version>${redis.server.version}</redis.server.version>
+					</systemPropertyVariables>
 					<!-- Retain stack traces -->
 					<argLine>-XX:-OmitStackTraceInFastThrow</argLine>
 					<useSystemClassLoader>false</useSystemClassLoader>

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
@@ -275,14 +275,14 @@ class JedisClusterHashCommands implements RedisHashCommands {
 		return new ScanCursor<Entry<byte[], byte[]>>(options) {
 
 			@Override
-			protected ScanIteration<Entry<byte[], byte[]>> doScan(long cursorId, ScanOptions options) {
+			protected ScanIteration<Entry<byte[], byte[]>> doScan(CursorId cursorId, ScanOptions options) {
 
 				ScanParams params = JedisConverters.toScanParams(options);
 
 				ScanResult<Entry<byte[], byte[]>> result = connection.getCluster().hscan(key,
-						JedisConverters.toBytes(Long.toUnsignedString(cursorId)),
+						JedisConverters.toBytes(cursorId),
 						params);
-				return new ScanIteration<>(Long.parseUnsignedLong(result.getCursor()), result.getResult());
+				return new ScanIteration<>(CursorId.of(result.getCursor()), result.getResult());
 			}
 		}.open();
 	}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterKeyCommands.java
@@ -177,11 +177,11 @@ class JedisClusterKeyCommands implements RedisKeyCommands {
 					return new ScanCursor<byte[]>(0, options) {
 
 						@Override
-						protected ScanIteration<byte[]> doScan(long cursorId, ScanOptions options) {
+						protected ScanIteration<byte[]> doScan(CursorId cursorId, ScanOptions options) {
 
 							ScanParams params = JedisConverters.toScanParams(options);
-							ScanResult<String> result = client.scan(Long.toUnsignedString(cursorId), params);
-							return new ScanIteration<>(Long.parseUnsignedLong(result.getCursor()),
+							ScanResult<String> result = client.scan(cursorId.getCursorId(), params);
+							return new ScanIteration<>(CursorId.of(result.getCursor()),
 									JedisConverters.stringListToByteList().convert(result.getResult()));
 						}
 					}.open();

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterSetCommands.java
@@ -394,12 +394,11 @@ class JedisClusterSetCommands implements RedisSetCommands {
 		return new ScanCursor<byte[]>(options) {
 
 			@Override
-			protected ScanIteration<byte[]> doScan(long cursorId, ScanOptions options) {
+			protected ScanIteration<byte[]> doScan(CursorId cursorId, ScanOptions options) {
 
 				ScanParams params = JedisConverters.toScanParams(options);
-				ScanResult<byte[]> result = connection.getCluster().sscan(key,
-						JedisConverters.toBytes(Long.toUnsignedString(cursorId)), params);
-				return new ScanIteration<>(Long.parseUnsignedLong(result.getCursor()), result.getResult());
+				ScanResult<byte[]> result = connection.getCluster().sscan(key, JedisConverters.toBytes(cursorId), params);
+				return new ScanIteration<>(CursorId.of(result.getCursor()), result.getResult());
 			}
 		}.open();
 	}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterZSetCommands.java
@@ -1079,13 +1079,13 @@ class JedisClusterZSetCommands implements RedisZSetCommands {
 		return new ScanCursor<Tuple>(options) {
 
 			@Override
-			protected ScanIteration<Tuple> doScan(long cursorId, ScanOptions options) {
+			protected ScanIteration<Tuple> doScan(CursorId cursorId, ScanOptions options) {
 
 				ScanParams params = JedisConverters.toScanParams(options);
 
 				ScanResult<redis.clients.jedis.resps.Tuple> result = connection.getCluster().zscan(key,
-						JedisConverters.toBytes(Long.toUnsignedString(cursorId)), params);
-				return new ScanIteration<>(Long.parseUnsignedLong(result.getCursor()),
+						JedisConverters.toBytes(cursorId), params);
+				return new ScanIteration<>(CursorId.of(result.getCursor()),
 						JedisConverters.tuplesToTuples().convert(result.getResult()));
 			}
 		}.open();

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -75,6 +75,7 @@ import org.springframework.data.redis.connection.convert.SetConverter;
 import org.springframework.data.redis.connection.convert.StringToRedisClientInfoConverter;
 import org.springframework.data.redis.connection.zset.DefaultTuple;
 import org.springframework.data.redis.connection.zset.Tuple;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
@@ -173,6 +174,17 @@ abstract class JedisConverters extends Converters {
 
 	public static byte[] toBytes(Number source) {
 		return toBytes(String.valueOf(source));
+	}
+
+	/**
+	 * Convert the given {@link org.springframework.data.redis.core.Cursor.CursorId} into its binary representation.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @return the binary representation.
+	 * @since 3.3
+	 */
+	static byte[] toBytes(Cursor.CursorId source) {
+		return toBytes(source.getCursorId());
 	}
 
 	@Nullable

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -36,6 +36,7 @@ import org.springframework.data.redis.connection.ValueEncoding;
 import org.springframework.data.redis.connection.ValueEncoding.RedisValueEncoding;
 import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.Cursor.CursorId;
 import org.springframework.data.redis.core.KeyScanOptions;
 import org.springframework.data.redis.core.ScanCursor;
 import org.springframework.data.redis.core.ScanIteration;
@@ -131,7 +132,7 @@ class JedisKeyCommands implements RedisKeyCommands {
 
 	@Override
 	public Cursor<byte[]> scan(ScanOptions options) {
-		return scan(0, options != null ? options : ScanOptions.NONE);
+		return scan(CursorId.initial(), options != null ? options : ScanOptions.NONE);
 	}
 
 	/**
@@ -140,12 +141,12 @@ class JedisKeyCommands implements RedisKeyCommands {
 	 * @param options
 	 * @return
 	 */
-	public Cursor<byte[]> scan(long cursorId, ScanOptions options) {
+	public Cursor<byte[]> scan(CursorId cursorId, ScanOptions options) {
 
 		return new ScanCursor<byte[]>(cursorId, options) {
 
 			@Override
-			protected ScanIteration<byte[]> doScan(long cursorId, ScanOptions options) {
+			protected ScanIteration<byte[]> doScan(CursorId cursorId, ScanOptions options) {
 
 				if (isQueueing() || isPipelined()) {
 					throw new InvalidDataAccessApiUsageException("'SCAN' cannot be called in pipeline / transaction mode");
@@ -165,12 +166,12 @@ class JedisKeyCommands implements RedisKeyCommands {
 				}
 
 				if (type != null) {
-					result = connection.getJedis().scan(JedisConverters.toBytes(Long.toUnsignedString(cursorId)), params, type);
+					result = connection.getJedis().scan(JedisConverters.toBytes(cursorId), params, type);
 				} else {
-					result = connection.getJedis().scan(JedisConverters.toBytes(Long.toUnsignedString(cursorId)), params);
+					result = connection.getJedis().scan(JedisConverters.toBytes(cursorId), params);
 				}
 
-				return new ScanIteration<>(Long.parseUnsignedLong(result.getCursor()), result.getResult());
+				return new ScanIteration<>(CursorId.of(result.getCursor()), result.getResult());
 			}
 
 			protected void doClose() {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisSetCommands.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.RedisSetCommands;
 import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.Cursor.CursorId;
 import org.springframework.data.redis.core.KeyBoundCursor;
 import org.springframework.data.redis.core.ScanIteration;
 import org.springframework.data.redis.core.ScanOptions;
@@ -206,24 +207,24 @@ class JedisSetCommands implements RedisSetCommands {
 
 	@Override
 	public Cursor<byte[]> sScan(byte[] key, ScanOptions options) {
-		return sScan(key, 0, options);
+		return sScan(key, CursorId.initial(), options);
 	}
 
 	/**
-	 * @since 1.4
 	 * @param key
 	 * @param cursorId
 	 * @param options
 	 * @return
+	 * @since 3.2.1
 	 */
-	public Cursor<byte[]> sScan(byte[] key, long cursorId, ScanOptions options) {
+	public Cursor<byte[]> sScan(byte[] key, CursorId cursorId, ScanOptions options) {
 
 		Assert.notNull(key, "Key must not be null");
 
 		return new KeyBoundCursor<byte[]>(key, cursorId, options) {
 
 			@Override
-			protected ScanIteration<byte[]> doScan(byte[] key, long cursorId, ScanOptions options) {
+			protected ScanIteration<byte[]> doScan(byte[] key, CursorId cursorId, ScanOptions options) {
 
 				if (isQueueing() || isPipelined()) {
 					throw new InvalidDataAccessApiUsageException("'SSCAN' cannot be called in pipeline / transaction mode");
@@ -231,9 +232,8 @@ class JedisSetCommands implements RedisSetCommands {
 
 				ScanParams params = JedisConverters.toScanParams(options);
 
-				ScanResult<byte[]> result = connection.getJedis().sscan(key,
-						JedisConverters.toBytes(Long.toUnsignedString(cursorId)), params);
-				return new ScanIteration<>(Long.parseUnsignedLong(result.getCursor()), result.getResult());
+				ScanResult<byte[]> result = connection.getJedis().sscan(key, JedisConverters.toBytes(cursorId), params);
+				return new ScanIteration<>(CursorId.of(result.getCursor()), result.getResult());
 			}
 
 			protected void doClose() {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -57,6 +57,7 @@ import java.util.function.Supplier;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.BeanUtils;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.DataAccessException;
@@ -70,6 +71,7 @@ import org.springframework.data.redis.connection.convert.TransactionResultConver
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionProvider.TargetAware;
 import org.springframework.data.redis.connection.lettuce.LettuceResult.LettuceResultBuilder;
 import org.springframework.data.redis.connection.lettuce.LettuceResult.LettuceStatusResult;
+import org.springframework.data.redis.core.Cursor.CursorId;
 import org.springframework.data.redis.core.RedisCommand;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -1060,8 +1062,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 		}
 	}
 
-	io.lettuce.core.ScanCursor getScanCursor(long cursorId) {
-		return io.lettuce.core.ScanCursor.of(Long.toUnsignedString(cursorId));
+	io.lettuce.core.ScanCursor getScanCursor(CursorId cursorId) {
+		return io.lettuce.core.ScanCursor.of(cursorId.getCursorId());
 	}
 
 	private void validateCommandIfRunningInTransactionMode(ProtocolKeyword cmd, byte[]... args) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
@@ -29,6 +29,7 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.RedisHashCommands;
 import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.Cursor.CursorId;
 import org.springframework.data.redis.core.KeyBoundCursor;
 import org.springframework.data.redis.core.ScanIteration;
 import org.springframework.data.redis.core.ScanOptions;
@@ -204,24 +205,25 @@ class LettuceHashCommands implements RedisHashCommands {
 
 	@Override
 	public Cursor<Entry<byte[], byte[]>> hScan(byte[] key, ScanOptions options) {
-		return hScan(key, 0, options);
+		return hScan(key, CursorId.initial(), options);
 	}
 
+
 	/**
-	 * @since 1.4
 	 * @param key
 	 * @param cursorId
 	 * @param options
 	 * @return
+	 * @since 1.4
 	 */
-	public Cursor<Entry<byte[], byte[]>> hScan(byte[] key, long cursorId, ScanOptions options) {
+	public Cursor<Entry<byte[], byte[]>> hScan(byte[] key, CursorId cursorId, ScanOptions options) {
 
 		Assert.notNull(key, "Key must not be null");
 
 		return new KeyBoundCursor<Entry<byte[], byte[]>>(key, cursorId, options) {
 
 			@Override
-			protected ScanIteration<Entry<byte[], byte[]>> doScan(byte[] key, long cursorId, ScanOptions options) {
+			protected ScanIteration<Entry<byte[], byte[]>> doScan(byte[] key, CursorId cursorId, ScanOptions options) {
 
 				if (connection.isQueueing() || connection.isPipelined()) {
 					throw new InvalidDataAccessApiUsageException("'HSCAN' cannot be called in pipeline / transaction mode");
@@ -235,7 +237,7 @@ class LettuceHashCommands implements RedisHashCommands {
 				String nextCursorId = mapScanCursor.getCursor();
 
 				Map<byte[], byte[]> values = mapScanCursor.getMap();
-				return new ScanIteration<>(Long.parseUnsignedLong(nextCursorId), values.entrySet());
+				return new ScanIteration<>(CursorId.of(nextCursorId), values.entrySet());
 			}
 
 			@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceScanCursor.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceScanCursor.java
@@ -46,9 +46,9 @@ abstract class LettuceScanCursor<T> extends ScanCursor<T> {
 	}
 
 	@Override
-	protected ScanIteration<T> doScan(long cursorId, ScanOptions options) {
+	protected ScanIteration<T> doScan(CursorId cursorId, ScanOptions options) {
 
-		if (state == null && cursorId == 0) {
+		if (state == null && cursorId.isInitial()) {
 			return scanAndProcessState(io.lettuce.core.ScanCursor.INITIAL, options);
 		}
 
@@ -64,7 +64,7 @@ abstract class LettuceScanCursor<T> extends ScanCursor<T> {
 	}
 
 	@Override
-	protected boolean isFinished(long cursorId) {
+	protected boolean isFinished(CursorId cursorId) {
 		return state != null && isMatchingCursor(cursorId) ? state.isFinished() : super.isFinished(cursorId);
 	}
 
@@ -76,8 +76,8 @@ abstract class LettuceScanCursor<T> extends ScanCursor<T> {
 		return iteration;
 	}
 
-	private boolean isMatchingCursor(long cursorId) {
-		return state != null && state.getCursor().equals(Long.toUnsignedString(cursorId));
+	private boolean isMatchingCursor(CursorId cursorId) {
+		return state != null && state.getCursor().equals(cursorId.getCursorId());
 	}
 
 	/**
@@ -101,7 +101,7 @@ abstract class LettuceScanCursor<T> extends ScanCursor<T> {
 
 		LettuceScanIteration(io.lettuce.core.ScanCursor cursor, Collection<T> items) {
 
-			super(Long.parseUnsignedLong(cursor.getCursor()), items);
+			super(CursorId.of(cursor.getCursor()), items);
 			this.cursor = cursor;
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceZSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceZSetCommands.java
@@ -35,6 +35,7 @@ import org.springframework.data.redis.connection.zset.Aggregate;
 import org.springframework.data.redis.connection.zset.Tuple;
 import org.springframework.data.redis.connection.zset.Weights;
 import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.Cursor.CursorId;
 import org.springframework.data.redis.core.KeyBoundCursor;
 import org.springframework.data.redis.core.ScanIteration;
 import org.springframework.data.redis.core.ScanOptions;
@@ -530,20 +531,20 @@ class LettuceZSetCommands implements RedisZSetCommands {
 
 	@Override
 	public Cursor<Tuple> zScan(byte[] key, ScanOptions options) {
-		return zScan(key, 0L, options);
+		return zScan(key, CursorId.initial(), options);
 	}
 
 	/**
 	 * @since 1.4
 	 */
-	public Cursor<Tuple> zScan(byte[] key, long cursorId, ScanOptions options) {
+	public Cursor<Tuple> zScan(byte[] key, CursorId cursorId, ScanOptions options) {
 
 		Assert.notNull(key, "Key must not be null");
 
 		return new KeyBoundCursor<Tuple>(key, cursorId, options) {
 
 			@Override
-			protected ScanIteration<Tuple> doScan(byte[] key, long cursorId, ScanOptions options) {
+			protected ScanIteration<Tuple> doScan(byte[] key, CursorId cursorId, ScanOptions options) {
 
 				if (connection.isQueueing() || connection.isPipelined()) {
 					throw new InvalidDataAccessApiUsageException("'ZSCAN' cannot be called in pipeline / transaction mode");
@@ -559,7 +560,7 @@ class LettuceZSetCommands implements RedisZSetCommands {
 				List<ScoredValue<byte[]>> result = scoredValueScanCursor.getValues();
 
 				List<Tuple> values = connection.failsafeReadScanValues(result, LettuceConverters.scoredValuesToTupleList());
-				return new ScanIteration<>(Long.parseUnsignedLong(nextCursorId), values);
+				return new ScanIteration<>(CursorId.of(nextCursorId), values);
 			}
 
 			@Override

--- a/src/main/java/org/springframework/data/redis/core/ConvertingCursor.java
+++ b/src/main/java/org/springframework/data/redis/core/ConvertingCursor.java
@@ -69,6 +69,12 @@ public class ConvertingCursor<S, T> implements Cursor<T> {
 	}
 
 	@Override
+	public CursorId getId() {
+		return delegate.getId();
+	}
+
+	@Override
+	@Deprecated
 	public long getCursorId() {
 		return delegate.getCursorId();
 	}

--- a/src/main/java/org/springframework/data/redis/core/KeyBoundCursor.java
+++ b/src/main/java/org/springframework/data/redis/core/KeyBoundCursor.java
@@ -31,17 +31,36 @@ public abstract class KeyBoundCursor<T> extends ScanCursor<T> {
 	 *
 	 * @param cursorId
 	 * @param options Defaulted to {@link ScanOptions#NONE} if nulled.
+	 * @deprecated since 3.3.0 - Use {@link KeyBoundCursor#KeyBoundCursor(byte[], CursorId, ScanOptions)} instead.
 	 */
+	@Deprecated(since = "3.3.0")
 	public KeyBoundCursor(byte[] key, long cursorId, @Nullable ScanOptions options) {
 		super(cursorId, options != null ? options : ScanOptions.NONE);
 		this.key = key;
 	}
 
+	/**
+	 * Crates new {@link ScanCursor}
+	 *
+	 * @param cursorId
+	 * @param options Defaulted to {@link ScanOptions#NONE} if nulled.
+	 * @since 3.3.0
+	 */
+	public KeyBoundCursor(byte[] key, CursorId cursorId, @Nullable ScanOptions options) {
+		super(cursorId, options != null ? options : ScanOptions.NONE);
+		this.key = key;
+	}
+
+	@Override
 	protected ScanIteration<T> doScan(long cursorId, ScanOptions options) {
+		return doScan(CursorId.of(cursorId), options);
+	}
+
+	protected ScanIteration<T> doScan(CursorId cursorId, ScanOptions options) {
 		return doScan(this.key, cursorId, options);
 	}
 
-	protected abstract ScanIteration<T> doScan(byte[] key, long cursorId, ScanOptions options);
+	protected abstract ScanIteration<T> doScan(byte[] key, CursorId cursorId, ScanOptions options);
 
 	public byte[] getKey() {
 		return key;

--- a/src/main/java/org/springframework/data/redis/core/ScanCursor.java
+++ b/src/main/java/org/springframework/data/redis/core/ScanCursor.java
@@ -40,33 +40,45 @@ import org.springframework.util.CollectionUtils;
 public abstract class ScanCursor<T> implements Cursor<T> {
 
 	private CursorState state;
-	private long cursorId;
+	private CursorId id;
 	private Iterator<T> delegate;
 	private final ScanOptions scanOptions;
 	private long position;
 
 	/**
-	 * Crates new {@link ScanCursor} with {@code id=0} and {@link ScanOptions#NONE}
+	 * Crates new {@link ScanCursor} with an initial cursor and {@link ScanOptions#NONE}
 	 */
 	public ScanCursor() {
 		this(ScanOptions.NONE);
 	}
 
 	/**
-	 * Crates new {@link ScanCursor} with {@code id=0}.
+	 * Crates new {@link ScanCursor} with an initial cursor.
 	 *
 	 * @param options the scan options to apply.
 	 */
 	public ScanCursor(ScanOptions options) {
-		this(0, options);
+		this(CursorId.initial(), options);
 	}
 
 	/**
 	 * Crates new {@link ScanCursor} with {@link ScanOptions#NONE}
 	 *
 	 * @param cursorId the cursor Id.
+	 * @deprecated since 3.3.0 - Use {@link ScanCursor#ScanCursor(CursorId)} instead.
 	 */
+	@Deprecated(since = "3.3.0")
 	public ScanCursor(long cursorId) {
+		this(cursorId, ScanOptions.NONE);
+	}
+
+	/**
+	 * Crates new {@link ScanCursor} with {@link ScanOptions#NONE}
+	 *
+	 * @param cursorId the cursor Id.
+	 * @since 3.3.0
+	 */
+	public ScanCursor(CursorId cursorId) {
 		this(cursorId, ScanOptions.NONE);
 	}
 
@@ -75,16 +87,29 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 	 *
 	 * @param cursorId the cursor Id.
 	 * @param options Defaulted to {@link ScanOptions#NONE} if {@code null}.
+	 * @deprecated since 3.3.0 - Use {@link ScanCursor#ScanCursor(CursorId, ScanOptions)} instead.
 	 */
+	@Deprecated(since = "3.3.0")
 	public ScanCursor(long cursorId, @Nullable ScanOptions options) {
+		this(CursorId.of(cursorId), options);
+	}
+
+	/**
+	 * Crates new {@link ScanCursor}
+	 *
+	 * @param cursorId the cursor Id.
+	 * @param options Defaulted to {@link ScanOptions#NONE} if {@code null}.
+	 * @since 3.3.0
+	 */
+	public ScanCursor(CursorId cursorId, @Nullable ScanOptions options) {
 
 		this.scanOptions = options != null ? options : ScanOptions.NONE;
-		this.cursorId = cursorId;
+		this.id = cursorId;
 		this.state = CursorState.READY;
 		this.delegate = Collections.emptyIterator();
 	}
 
-	private void scan(long cursorId) {
+	private void scan(CursorId cursorId) {
 
 		try {
 			processScanResult(doScan(cursorId, this.scanOptions));
@@ -105,8 +130,25 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 	 * @param cursorId
 	 * @param options
 	 * @return
+	 * @deprecated since 3.3.0, cursorId, can exceed {@link Long#MAX_VALUE}.
 	 */
-	protected abstract ScanIteration<T> doScan(long cursorId, ScanOptions options);
+	@Deprecated(since = "3.3.0")
+	protected ScanIteration<T> doScan(long cursorId, ScanOptions options) {
+		return doScan(CursorId.of(cursorId), scanOptions);
+	}
+
+	/**
+	 * Performs the actual scan command using the native client implementation. The given {@literal options} are never
+	 * {@code null}.
+	 *
+	 * @param cursorId
+	 * @param options
+	 * @return
+	 * @since 3.3.0
+	 */
+	protected ScanIteration<T> doScan(CursorId cursorId, ScanOptions options) {
+		return doScan(Long.parseLong(cursorId.getCursorId()), scanOptions);
+	}
 
 	/**
 	 * Initialize the {@link Cursor} prior to usage.
@@ -118,7 +160,7 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 		}
 
 		state = CursorState.OPEN;
-		doOpen(cursorId);
+		doOpen(getId());
 
 		return this;
 	}
@@ -127,16 +169,27 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 	 * Customization hook when calling {@link #open()}.
 	 *
 	 * @param cursorId
+	 * @deprecated since 3.3.0, use {@link #doOpen(CursorId)} instead.
 	 */
+	@Deprecated(since = "3.3.0", forRemoval = true)
 	protected void doOpen(long cursorId) {
+		doOpen(CursorId.of(cursorId));
+	}
+
+	/**
+	 * Customization hook when calling {@link #open()}.
+	 *
+	 * @param cursorId
+	 */
+	protected void doOpen(CursorId cursorId) {
 		scan(cursorId);
 	}
 
 	private void processScanResult(ScanIteration<T> result) {
 
-		cursorId = result.getCursorId();
+		id = result.getId();
 
-		if (isFinished(cursorId)) {
+		if (isFinished(id)) {
 			state = CursorState.FINISHED;
 		}
 
@@ -154,8 +207,20 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 	 * @return {@literal true} if the cursor is considered finished, {@literal false} otherwise.s
 	 * @since 2.1
 	 */
+	@Deprecated(since = "3.3.0", forRemoval = true)
 	protected boolean isFinished(long cursorId) {
 		return cursorId == 0;
+	}
+
+	/**
+	 * Check whether {@code cursorId} is finished.
+	 *
+	 * @param cursorId the cursor Id
+	 * @return {@literal true} if the cursor is considered finished, {@literal false} otherwise.s
+	 * @since 3.3.0
+	 */
+	protected boolean isFinished(CursorId cursorId) {
+		return CursorId.isInitial(cursorId.getCursorId());
 	}
 
 	private void resetDelegate() {
@@ -163,8 +228,13 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 	}
 
 	@Override
+	public CursorId getId() {
+		return id;
+	}
+
+	@Override
 	public long getCursorId() {
-		return cursorId;
+		return Long.parseUnsignedLong(getId().getCursorId());
 	}
 
 	@Override
@@ -173,14 +243,14 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 		assertCursorIsOpen();
 
 		while (!delegate.hasNext() && !CursorState.FINISHED.equals(state)) {
-			scan(cursorId);
+			scan(getId());
 		}
 
 		if (delegate.hasNext()) {
 			return true;
 		}
 
-		return cursorId > 0;
+		return !isFinished(id);
 	}
 
 	private void assertCursorIsOpen() {
@@ -196,7 +266,7 @@ public abstract class ScanCursor<T> implements Cursor<T> {
 		assertCursorIsOpen();
 
 		if (!hasNext()) {
-			throw new NoSuchElementException("No more elements available for cursor " + cursorId);
+			throw new NoSuchElementException("No more elements available for cursor " + id);
 		}
 
 		T next = moveNext(delegate);

--- a/src/main/java/org/springframework/data/redis/core/ScanIteration.java
+++ b/src/main/java/org/springframework/data/redis/core/ScanIteration.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.core;
 
+import static org.springframework.data.redis.core.Cursor.*;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,14 +34,26 @@ import org.springframework.lang.Nullable;
  */
 public class ScanIteration<T> implements Iterable<T> {
 
-	private final long cursorId;
+	private final CursorId cursorId;
 	private final Collection<T> items;
 
 	/**
 	 * @param cursorId
 	 * @param items
+	 * @deprecated since 3.3.0, use {@link ScanIteration#ScanIteration(CursorId, Collection)} instead as {@code cursorId}
+	 *             can exceed {@link Long#MAX_VALUE}.
 	 */
+	@Deprecated(since = "3.3.0")
 	public ScanIteration(long cursorId, @Nullable Collection<T> items) {
+		this(CursorId.of(cursorId), items);
+	}
+
+	/**
+	 * @param cursorId
+	 * @param items
+	 * @since 3.3.0
+	 */
+	public ScanIteration(CursorId cursorId, @Nullable Collection<T> items) {
 
 		this.cursorId = cursorId;
 		this.items = (items != null ? new ArrayList<>(items) : Collections.emptyList());
@@ -49,8 +63,20 @@ public class ScanIteration<T> implements Iterable<T> {
 	 * The cursor id to be used for subsequent requests.
 	 *
 	 * @return
+	 * @deprecated since 3.3.0, use {@link #getId()} instead as the cursorId can exceed {@link Long#MAX_VALUE}.
 	 */
+	@Deprecated(since="3.3.3")
 	public long getCursorId() {
+		return Long.parseLong(getId().getCursorId());
+	}
+
+	/**
+	 * The cursor id to be used for subsequent requests.
+	 *
+	 * @return
+	 * @since 3.3.0
+	 */
+	public CursorId getId() {
 		return cursorId;
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -28,6 +28,7 @@ import static org.springframework.data.redis.connection.RedisGeoCommands.GeoRadi
 import static org.springframework.data.redis.connection.RedisGeoCommands.GeoSearchStoreCommandArgs.*;
 import static org.springframework.data.redis.core.ScanOptions.*;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -35,6 +36,7 @@ import java.util.*;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import org.assertj.core.data.Offset;
 import org.junit.AssumptionViolatedException;
@@ -2661,10 +2663,11 @@ public abstract class AbstractConnectionIntegrationTests {
 	}
 
 	@Test // DATAREDIS-417
-	@DisabledOnOs(value = MAC, architectures = "aarch64")
-	public void scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection() {
+	public void scanShouldReadEntireValueRangeWhenIndividualScanIterationsReturnEmptyCollection() {
 
-		connection.execute("DEBUG", "POPULATE".getBytes(), "100".getBytes());
+		byteConnection.openPipeline();
+		IntStream.range(0, 100).forEach(it -> byteConnection.stringCommands().set("key:%s".formatted(it).getBytes(StandardCharsets.UTF_8), "data".getBytes(StandardCharsets.UTF_8)));
+		byteConnection.closePipeline();
 
 		Cursor<byte[]> cursor = connection.scan(ScanOptions.scanOptions().match("key*9").count(10).build());
 

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionPipelineIntegrationTests.java
@@ -149,8 +149,8 @@ abstract public class AbstractConnectionPipelineIntegrationTests extends Abstrac
 	@Test // DATAREDIS-417
 	@Disabled
 	@Override
-	public void scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection() {
-		super.scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection();
+	public void scanShouldReadEntireValueRangeWhenIndividualScanIterationsReturnEmptyCollection() {
+		super.scanShouldReadEntireValueRangeWhenIndividualScanIterationsReturnEmptyCollection();
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionTransactionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionTransactionIntegrationTests.java
@@ -144,8 +144,8 @@ abstract public class AbstractConnectionTransactionIntegrationTests extends Abst
 	@Test // DATAREDIS-417
 	@Disabled
 	@Override
-	public void scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection() {
-		super.scanShouldReadEntireValueRangeWhenIdividualScanIterationsReturnEmptyCollection();
+	public void scanShouldReadEntireValueRangeWhenIndividualScanIterationsReturnEmptyCollection() {
+		super.scanShouldReadEntireValueRangeWhenIndividualScanIterationsReturnEmptyCollection();
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterServerCommandsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterServerCommandsIntegrationTests.java
@@ -195,7 +195,7 @@ class LettuceReactiveClusterServerCommandsIntegrationTests extends LettuceReacti
 
 		connection.serverCommands().getConfig(NODE1, "*").as(StepVerifier::create) //
 				.consumeNextWith(properties -> {
-					assertThat(properties).containsEntry("databases", "16");
+					assertThat(properties).containsEntry("port", NODE1.getPort().toString());
 				}) //
 				.verifyComplete();
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveServerCommandsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveServerCommandsIntegrationTests.java
@@ -201,8 +201,7 @@ public class LettuceReactiveServerCommandsIntegrationTests extends LettuceReacti
 
 			connection.serverCommands().getConfig("*").as(StepVerifier::create) //
 					.consumeNextWith(properties -> {
-						assertThat(properties).containsEntry("127.0.0.1:7379.databases", "16");
-
+						assertThat(properties).containsEntry("127.0.0.1:7379.port", "7379");
 					}) //
 					.verifyComplete();
 		} else {

--- a/src/test/java/org/springframework/data/redis/core/ScanCursorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/ScanCursorUnitTests.java
@@ -236,9 +236,9 @@ class ScanCursorUnitTests {
 	@Test // GH-2414
 	void shouldCloseCursorOnScanFailure() {
 
-		KeyBoundCursor<String> cursor = new KeyBoundCursor<String>("foo".getBytes(), 0, null) {
+		KeyBoundCursor<String> cursor = new KeyBoundCursor<String>("foo".getBytes(), Cursor.CursorId.initial(), null) {
 			@Override
-			protected ScanIteration<String> doScan(byte[] key, long cursorId, ScanOptions options) {
+			protected ScanIteration<String> doScan(byte[] key, CursorId cursorId, ScanOptions options) {
 				throw new IllegalStateException();
 			}
 		};
@@ -255,7 +255,8 @@ class ScanCursorUnitTests {
 	}
 
 	private ScanIteration<String> createIteration(long cursorId, String... values) {
-		return new ScanIteration<>(cursorId, values.length > 0 ? Arrays.asList(values) : Collections.<String> emptyList());
+		return new ScanIteration<>(Cursor.CursorId.of(cursorId),
+				values.length > 0 ? Arrays.asList(values) : Collections.<String> emptyList());
 	}
 
 	private static class CapturingCursorDummy extends ScanCursor<String> {
@@ -267,12 +268,12 @@ class ScanCursorUnitTests {
 		}
 
 		@Override
-		protected ScanIteration<String> doScan(long cursorId, ScanOptions options) {
+		protected ScanIteration<String> doScan(CursorId cursorId, ScanOptions options) {
 
 			ScanIteration<String> iteration = this.values.poll();
 
 			if (iteration == null) {
-				iteration = new ScanIteration<>(0, Collections.emptyList());
+				iteration = new ScanIteration<>(CursorId.initial(), Collections.emptyList());
 			}
 			return iteration;
 		}


### PR DESCRIPTION
We now retain the raw cursor value without attempting to convert it into a long as Redis uses 64 bit unsigned integers exceeding `Long.MAX_VALUE`.

Closes #2796