### PR TITLE
Resolve element type from NodeType before falling back to reflection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.2.3-SNAPSHOT</version>
+	<version>3.2.x-2838-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/hash/Jackson2HashMapper.java
+++ b/src/main/java/org/springframework/data/redis/hash/Jackson2HashMapper.java
@@ -436,8 +436,20 @@ public class Jackson2HashMapper implements HashMapper<Object, String, Object> {
 		} else if (element.isContainerNode()) {
 			doFlatten(propertyPrefix, element.fields(), resultMap);
 		} else {
-			resultMap.put(propertyPrefix, new DirectFieldAccessFallbackBeanWrapper(element)
-					.getPropertyValue("_value"));
+
+			switch (element.getNodeType()) {
+				case STRING -> resultMap.put(propertyPrefix, element.textValue());
+				case NUMBER -> resultMap.put(propertyPrefix, element.numberValue());
+				case BOOLEAN -> resultMap.put(propertyPrefix, element.booleanValue());
+				case BINARY -> {
+					try {
+						resultMap.put(propertyPrefix, element.binaryValue());
+					} catch (IOException e) {
+						throw new IllegalStateException(e);
+					}
+				}
+				default -> resultMap.put(propertyPrefix, new DirectFieldAccessFallbackBeanWrapper(element).getPropertyValue("_value"));
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit changes the node value retrieval so that it first tries to determine the node type before falling back to reflective access of the _value field.