### PR TITLE
Fix quoted variable reference in documentation

### DIFF
--- a/src/main/antora/modules/ROOT/pages/redis/hash-mappers.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/hash-mappers.adoc
@@ -44,7 +44,7 @@ public class HashMapping {
 
   public Person loadHash(String key) {
 
-    Map<byte[], byte[]> loadedHash = hashOperations.entries("key");
+    Map<byte[], byte[]> loadedHash = hashOperations.entries(key);
     return (Person) mapper.fromHash(loadedHash);
   }
 }


### PR DESCRIPTION
Overview
This PR addresses a small issue in the loadHash method of the HashMapping class where the hardcoded string "key" was used instead of the parameter key when retrieving a hash from Redis.

Description
In the loadHash method of the HashMapping class, the hardcoded string "key" was used to retrieve the hash from Redis instead of utilizing the parameter key provided to the method. This PR corrects this issue by modifying the method call to use the provided key parameter, ensuring the correct hash is loaded.

Changes Made
Updated the loadHash method in the HashMapping class to use the provided key parameter when retrieving the hash from Redis, replacing the hardcoded string "key". Testing
No new functionality is introduced with this change, and existing unit tests cover the modified method. Tests have been run locally to ensure that the correct hash is loaded using the provided key parameter.

Request for Review
I kindly request a review of this PR. Your feedback is greatly appreciated. Thank you for your time and consideration.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
