### PR TITLE
Modify RedisTemplate document  redisTemplate method parameter name

### DIFF
--- a/src/main/antora/modules/ROOT/pages/redis/template.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/template.adoc
@@ -140,7 +140,7 @@ class MyConfig {
   RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
 
     RedisTemplate<String, String> template = new RedisTemplate<>();
-    template.setConnectionFactory(redisConnectionFactory);
+    template.setConnectionFactory(connectionFactory);
     return template;
   }
 }


### PR DESCRIPTION
Found this problem while studying

before fixing

```java
@Configuration
class MyConfig {

  @Bean
  LettuceConnectionFactory connectionFactory() {
    return new LettuceConnectionFactory();
  }

  @Bean
  RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {

    RedisTemplate<String, String> template = new RedisTemplate<>();
    template.setConnectionFactory(redisConnectionFactory);
    return template;
  }
}
```

After modification

```java
@Configuration
class MyConfig {

  @Bean
  LettuceConnectionFactory connectionFactory() {
    return new LettuceConnectionFactory();
  }

  @Bean
  RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {

    RedisTemplate<String, String> template = new RedisTemplate<>();
    template.setConnectionFactory(connectionFactory);
    return template;
  }
}
```
