### PR TITLE
Allow RedisConnectionFactories to be initialized as part of the context lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-2866-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryUnitTests.java
@@ -35,6 +35,7 @@ import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
@@ -335,6 +336,21 @@ class JedisConnectionFactoryUnitTests {
 		connectionFactory.afterPropertiesSet();
 
 		assertThat(connectionFactory.isRunning()).isTrue();
+	}
+
+	@Test // GH-2866
+	void earlyStartupDoesNotStartConnectionFactory() {
+
+		JedisConnectionFactory connectionFactory = new JedisConnectionFactory(new JedisPoolConfig());
+
+		connectionFactory.setEarlyStartup(false);
+		connectionFactory.afterPropertiesSet();
+
+		assertThat(connectionFactory.isEarlyStartup()).isFalse();
+		assertThat(connectionFactory.isAutoStartup()).isTrue();
+		assertThat(connectionFactory.isRunning()).isFalse();
+
+		assertThat(ReflectionTestUtils.getField(connectionFactory, "pool")).isNull();
 	}
 
 	private JedisConnectionFactory initSpyedConnectionFactory(RedisSentinelConfiguration sentinelConfiguration,

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionFactoryUnitTests.java
@@ -1260,6 +1260,22 @@ class LettuceConnectionFactoryUnitTests {
 				.extracting(RedisStandaloneConfiguration::getPort).isEqualTo(6789);
 	}
 
+	@Test // GH-2866
+	void earlyStartupDoesNotStartConnectionFactory() {
+
+		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(),
+				LettuceTestClientConfiguration.defaultConfiguration());
+		connectionFactory.setEarlyStartup(false);
+		connectionFactory.afterPropertiesSet();
+
+		assertThat(connectionFactory.isEarlyStartup()).isFalse();
+		assertThat(connectionFactory.isAutoStartup()).isTrue();
+		assertThat(connectionFactory.isRunning()).isFalse();
+
+		AbstractRedisClient client = (AbstractRedisClient) getField(connectionFactory, "client");
+		assertThat(client).isNull();
+	}
+
 	static class CustomRedisConfiguration implements RedisConfiguration, WithHostAndPort {
 
 		private String hostName;


### PR DESCRIPTION
Lettuce and Jedis connection factories now can be configured to initialize early during afterPropertiesSet or configured whether the component should be auto-started by the container.

By default, connection factories auto-startup early.

Closes #2866