### PR TITLE
Consider intermediate command interface in `ConnectionSplittingInterceptor`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-2886SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/test/java/org/springframework/data/redis/connection/AbstractTransactionalTestBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractTransactionalTestBase.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.annotation.Rollback;
@@ -130,6 +131,18 @@ public abstract class AbstractTransactionalTestBase {
 		for (String key : KEYS) {
 			template.opsForValue().set(key, key + "-value");
 		}
+	}
+
+	@Rollback(false)
+	@Test // GH-2886
+	public void shouldReturnReadOnlyCommandResultInTransaction() {
+
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(factory);
+		template.setEnableTransactionSupport(true);
+		template.afterPropertiesSet();
+
+		assertThat(template.hasKey("foo")).isFalse();
 	}
 
 	@Test // DATAREDIS-548

--- a/src/test/java/org/springframework/data/redis/core/RedisConnectionUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisConnectionUtilsUnitTests.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisKeyCommands;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
@@ -199,6 +200,45 @@ class RedisConnectionUtilsUnitTests {
 
 		verifyNoMoreInteractions(factoryMock);
 		assertThat(TransactionSynchronizationManager.hasResource(factoryMock)).isFalse();
+	}
+
+	@Test // GH-2886
+	void connectionProxyShouldInvokeReadOnlyMethods() {
+
+		TransactionTemplate template = new TransactionTemplate(new DummyTransactionManager());
+
+		byte[] anyBytes = new byte[] { 1, 2, 3 };
+		when(connectionMock2.exists(anyBytes)).thenReturn(true);
+
+		template.executeWithoutResult(status -> {
+
+			RedisConnection connection = RedisConnectionUtils.getConnection(factoryMock, true);
+
+			assertThat(connection.exists(anyBytes)).isEqualTo(true);
+		});
+	}
+
+	@Test // GH-2886
+	void connectionProxyShouldConsiderCommandInterfaces() {
+
+		TransactionTemplate template = new TransactionTemplate(new DummyTransactionManager());
+
+		byte[] anyBytes = new byte[] { 1, 2, 3 };
+
+		RedisKeyCommands commandsMock = mock(RedisKeyCommands.class);
+
+		when(connectionMock1.keyCommands()).thenReturn(commandsMock);
+		when(connectionMock2.keyCommands()).thenReturn(commandsMock);
+		when(commandsMock.exists(anyBytes)).thenReturn(true);
+		when(commandsMock.del(anyBytes)).thenReturn(42L);
+
+		template.executeWithoutResult(status -> {
+
+			RedisConnection connection = RedisConnectionUtils.getConnection(factoryMock, true);
+
+			assertThat(connection.keyCommands().exists(anyBytes)).isEqualTo(true);
+			assertThat(connection.keyCommands().del(anyBytes)).isEqualTo(42L);
+		});
 	}
 
 	static class DummyTransactionManager extends AbstractPlatformTransactionManager {


### PR DESCRIPTION
We now consider requests to command API objects such as `RedisConnection.keyCommands()` in `ConnectionSplittingInterceptor` to identify the correct command and route it accordingly.

Closes #2886