### PR TITLE
Refine Cluster pipelining using Lettuce

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.3.0-GH-2888-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/antora/modules/ROOT/pages/redis/cluster.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/cluster.adoc
@@ -129,3 +129,6 @@ clusterOps.shutdown(NODE_7379);                                              <1>
 
 <1> Shut down node at 7379 and cross fingers there is a replica in place that can take over.
 ====
+
+NOTE: Redis Cluster pipelining is currently only supported throug the Lettuce driver except for the following commands when using cross-slot keys: `rename`, `renameNX`, `sort`, `bLPop`, `bRPop`, `rPopLPush`, `bRPopLPush`, `info`, `sMove`, `sInter`, `sInterStore`, `sUnion`, `sUnionStore`, `sDiff`, `sDiffStore`.
+Same-slot keys are fully supported.

--- a/src/main/antora/modules/ROOT/pages/redis/pipelining.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/pipelining.adoc
@@ -20,7 +20,9 @@ List<Object> results = stringRedisTemplate.executePipelined(
 });
 ----
 
-The preceding example runs a bulk right pop of items from a queue in a pipeline. The `results` `List` contains all of the popped items. `RedisTemplate` uses its value, hash key, and hash value serializers to deserialize all results before returning, so the returned items in the preceding example are Strings. There are additional `executePipelined` methods that let you pass a custom serializer for pipelined results.
+The preceding example runs a bulk right pop of items from a queue in a pipeline.
+The `results` `List` contains all the popped items. `RedisTemplate` uses its value, hash key, and hash value serializers to deserialize all results before returning, so the returned items in the preceding example are Strings.
+There are additional `executePipelined` methods that let you pass a custom serializer for pipelined results.
 
 Note that the value returned from the `RedisCallback` is required to be `null`, as this value is discarded in favor of returning the results of the pipelined commands.
 
@@ -35,3 +37,7 @@ factory.setPipeliningFlushPolicy(PipeliningFlushPolicy.buffered(3)); <1>
 ----
 <1> Buffer locally and flush after every 3rd command.
 ====
+
+NOTE: Pipelining is limited to Redis Standalone.
+Redis Cluster is currently only supported through the Lettuce driver except for the following commands when using cross-slot keys: `rename`, `renameNX`, `sort`, `bLPop`, `bRPop`, `rPopLPush`, `bRPopLPush`, `info`, `sMove`, `sInter`, `sInterStore`, `sUnion`, `sUnionStore`, `sDiff`, `sDiffStore`.
+Same-slot keys are fully supported.

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterKeyCommands.java
@@ -18,11 +18,8 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.KeyScanCursor;
 import io.lettuce.core.ScanArgs;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
@@ -48,47 +45,6 @@ class LettuceClusterKeyCommands extends LettuceKeyCommands {
 
 		super(connection);
 		this.connection = connection;
-	}
-
-	@Override
-	public byte[] randomKey() {
-
-		List<RedisClusterNode> nodes = connection.clusterGetNodes();
-		Set<RedisClusterNode> inspectedNodes = new HashSet<>(nodes.size());
-
-		do {
-
-			RedisClusterNode node = nodes.get(ThreadLocalRandom.current().nextInt(nodes.size()));
-
-			while (inspectedNodes.contains(node)) {
-				node = nodes.get(ThreadLocalRandom.current().nextInt(nodes.size()));
-			}
-			inspectedNodes.add(node);
-			byte[] key = randomKey(node);
-
-			if (key != null && key.length > 0) {
-				return key;
-			}
-		} while (nodes.size() != inspectedNodes.size());
-
-		return null;
-	}
-
-	@Override
-	public Set<byte[]> keys(byte[] pattern) {
-
-		Assert.notNull(pattern, "Pattern must not be null");
-
-		Collection<List<byte[]>> keysPerNode = connection.getClusterCommandExecutor()
-				.executeCommandOnAllNodes((LettuceClusterCommandCallback<List<byte[]>>) connection -> connection.keys(pattern))
-				.resultsAsList();
-
-		Set<byte[]> keys = new HashSet<>();
-
-		for (List<byte[]> keySet : keysPerNode) {
-			keys.addAll(keySet);
-		}
-		return keys;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterServerCommands.java
@@ -18,7 +18,6 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.api.sync.RedisServerCommands;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -34,7 +33,6 @@ import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.connection.lettuce.LettuceClusterConnection.LettuceClusterCommandCallback;
 import org.springframework.data.redis.core.types.RedisClientInfo;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 
 /**
  * @author Mark Paluch
@@ -72,34 +70,8 @@ class LettuceClusterServerCommands extends LettuceServerCommands implements Redi
 	}
 
 	@Override
-	public Long dbSize() {
-
-		Collection<Long> dbSizes = executeCommandOnAllNodes(RedisServerCommands::dbsize).resultsAsList();
-
-		if (CollectionUtils.isEmpty(dbSizes)) {
-			return 0L;
-		}
-
-		Long size = 0L;
-		for (Long value : dbSizes) {
-			size += value;
-		}
-		return size;
-	}
-
-	@Override
 	public Long dbSize(RedisClusterNode node) {
 		return executeCommandOnSingleNode(RedisServerCommands::dbsize, node).getValue();
-	}
-
-	@Override
-	public void flushDb() {
-		executeCommandOnAllNodes(RedisServerCommands::flushdb);
-	}
-
-	@Override
-	public void flushDb(FlushOption option) {
-		executeCommandOnAllNodes(it -> it.flushdb(LettuceConverters.toFlushMode(option)));
 	}
 
 	@Override
@@ -110,16 +82,6 @@ class LettuceClusterServerCommands extends LettuceServerCommands implements Redi
 	@Override
 	public void flushDb(RedisClusterNode node, FlushOption option) {
 		executeCommandOnSingleNode(it -> it.flushdb(LettuceConverters.toFlushMode(option)), node);
-	}
-
-	@Override
-	public void flushAll() {
-		executeCommandOnAllNodes(RedisServerCommands::flushall);
-	}
-
-	@Override
-	public void flushAll(FlushOption option) {
-		executeCommandOnAllNodes(it -> it.flushall(LettuceConverters.toFlushMode(option)));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterStringCommands.java
@@ -15,11 +15,6 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
-import java.util.Map;
-
-import org.springframework.data.redis.connection.ClusterSlotHashUtil;
-import org.springframework.util.Assert;
-
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
@@ -31,21 +26,4 @@ class LettuceClusterStringCommands extends LettuceStringCommands {
 		super(connection);
 	}
 
-	@Override
-	public Boolean mSetNX(Map<byte[], byte[]> tuples) {
-
-		Assert.notNull(tuples, "Tuples must not be null");
-
-		if (ClusterSlotHashUtil.isSameSlotForAllKeys(tuples.keySet().toArray(new byte[tuples.keySet().size()][]))) {
-			return super.mSetNX(tuples);
-		}
-
-		boolean result = true;
-		for (Map.Entry<byte[], byte[]> entry : tuples.entrySet()) {
-			if (!setNX(entry.getKey(), entry.getValue()) && result) {
-				result = false;
-			}
-		}
-		return result;
-	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceResult.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceResult.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.data.redis.connection.lettuce;
 
-import io.lettuce.core.protocol.RedisCommand;
-
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
@@ -34,7 +33,7 @@ import org.springframework.lang.Nullable;
  * @since 2.1
  */
 @SuppressWarnings("rawtypes")
-class LettuceResult<T, R> extends FutureResult<RedisCommand<?, T, ?>> {
+class LettuceResult<T, R> extends FutureResult<CompletableFuture<T>> {
 
 	private final boolean convertPipelineAndTxResults;
 
@@ -51,7 +50,7 @@ class LettuceResult<T, R> extends FutureResult<RedisCommand<?, T, ?>> {
 	LettuceResult(Future<T> resultHolder, Supplier<R> defaultReturnValue, boolean convertPipelineAndTxResults,
 			@Nullable Converter<T, R> converter) {
 
-		super((RedisCommand) resultHolder, converter, defaultReturnValue);
+		super((CompletableFuture<T>) resultHolder, converter, defaultReturnValue);
 		this.convertPipelineAndTxResults = convertPipelineAndTxResults;
 	}
 
@@ -59,7 +58,7 @@ class LettuceResult<T, R> extends FutureResult<RedisCommand<?, T, ?>> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public T get() {
-		return (T) getResultHolder().getOutput().get();
+		return (T) getResultHolder().join();
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/connection/ClusterTestVariables.java
+++ b/src/test/java/org/springframework/data/redis/connection/ClusterTestVariables.java
@@ -25,6 +25,7 @@ public abstract class ClusterTestVariables {
 	public static final String KEY_1 = "key1";
 	public static final String KEY_2 = "key2";
 	public static final String KEY_3 = "key3";
+	public static final String KEY_4 = "key4";
 
 	public static final String VALUE_1 = "value1";
 	public static final String VALUE_2 = "value2";

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionUnitTests.java
@@ -18,7 +18,6 @@ package org.springframework.data.redis.connection.lettuce;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.redis.connection.ClusterTestVariables.*;
-import static org.springframework.data.redis.test.util.MockitoUtils.*;
 
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
@@ -46,6 +45,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
 import org.springframework.data.redis.connection.ClusterCommandExecutor;
 import org.springframework.data.redis.connection.ClusterNodeResourceProvider;
 import org.springframework.data.redis.connection.ClusterTopologyProvider;
@@ -194,22 +194,6 @@ class LettuceClusterConnectionUnitTests {
 	}
 
 	@Test // DATAREDIS-315
-	void keysShouldBeRunOnAllClusterNodes() {
-
-		when(clusterConnection1Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]> emptyList());
-		when(clusterConnection2Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]> emptyList());
-		when(clusterConnection3Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]> emptyList());
-
-		byte[] pattern = LettuceConverters.toBytes("*");
-
-		connection.keys(pattern);
-
-		verify(clusterConnection1Mock, times(1)).keys(pattern);
-		verify(clusterConnection2Mock, times(1)).keys(pattern);
-		verify(clusterConnection3Mock, times(1)).keys(pattern);
-	}
-
-	@Test // DATAREDIS-315
 	void keysShouldOnlyBeRunOnDedicatedNodeWhenPinned() {
 
 		when(clusterConnection2Mock.keys(any(byte[].class))).thenReturn(Collections.<byte[]> emptyList());
@@ -221,38 +205,6 @@ class LettuceClusterConnectionUnitTests {
 		verify(clusterConnection1Mock, never()).keys(pattern);
 		verify(clusterConnection2Mock, times(1)).keys(pattern);
 		verify(clusterConnection3Mock, never()).keys(pattern);
-	}
-
-	@Test // DATAREDIS-315
-	void randomKeyShouldReturnAnyKeyFromRandomNode() {
-
-		when(clusterConnection1Mock.randomkey()).thenReturn(KEY_1_BYTES);
-		when(clusterConnection2Mock.randomkey()).thenReturn(KEY_2_BYTES);
-		when(clusterConnection3Mock.randomkey()).thenReturn(KEY_3_BYTES);
-
-		assertThat(connection.randomKey()).isIn(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES);
-		verifyInvocationsAcross("randomkey", times(1), clusterConnection1Mock, clusterConnection2Mock,
-				clusterConnection3Mock);
-	}
-
-	@Test // DATAREDIS-315
-	void randomKeyShouldReturnKeyWhenAvailableOnAnyNode() {
-
-		when(clusterConnection3Mock.randomkey()).thenReturn(KEY_3_BYTES);
-
-		for (int i = 0; i < 100; i++) {
-			assertThat(connection.randomKey()).isEqualTo(KEY_3_BYTES);
-		}
-	}
-
-	@Test // DATAREDIS-315
-	void randomKeyShouldReturnNullWhenNoKeysPresentOnAllNodes() {
-
-		when(clusterConnection1Mock.randomkey()).thenReturn(null);
-		when(clusterConnection2Mock.randomkey()).thenReturn(null);
-		when(clusterConnection3Mock.randomkey()).thenReturn(null);
-
-		assertThat(connection.randomKey()).isNull();
 	}
 
 	@Test // DATAREDIS-315

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateIntegrationTests.java
@@ -361,8 +361,7 @@ public class RedisTemplateIntegrationTests<K, V> {
 				try {
 					// Await EXEC completion as it's executed on a dedicated connection.
 					Thread.sleep(100);
-				} catch (InterruptedException ignore) {
-				}
+				} catch (InterruptedException ignore) {}
 
 				operations.opsForValue().set(key1, value1);
 				operations.opsForValue().get(key1);
@@ -673,7 +672,16 @@ public class RedisTemplateIntegrationTests<K, V> {
 		K key1 = keyFactory.instance();
 		V value1 = valueFactory.instance();
 		redisTemplate.opsForValue().set(key1, value1);
-		assertThat(redisTemplate.randomKey()).isEqualTo(key1);
+
+		for (int i = 0; i < 20; i++) {
+
+			K k = redisTemplate.randomKey();
+			if (k == null) {
+				continue;
+			}
+
+			assertThat(k).isEqualTo(key1);
+		}
 	}
 
 	@ParameterizedRedisTest
@@ -723,8 +731,7 @@ public class RedisTemplateIntegrationTests<K, V> {
 				th.start();
 				try {
 					th.join();
-				} catch (InterruptedException ignore) {
-				}
+				} catch (InterruptedException ignore) {}
 
 				operations.multi();
 				operations.opsForValue().set(key1, value3);
@@ -756,8 +763,7 @@ public class RedisTemplateIntegrationTests<K, V> {
 				th.start();
 				try {
 					th.join();
-				} catch (InterruptedException ignore) {
-				}
+				} catch (InterruptedException ignore) {}
 
 				operations.unwatch();
 				operations.multi();
@@ -794,8 +800,7 @@ public class RedisTemplateIntegrationTests<K, V> {
 				th.start();
 				try {
 					th.join();
-				} catch (InterruptedException ignore) {
-				}
+				} catch (InterruptedException ignore) {}
 
 				operations.multi();
 				operations.opsForValue().set(key1, value3);


### PR DESCRIPTION
We now no longer require `RedisCommand` but resort to CompletableFuture as the general asynchronous result type for Lettuce pipelining to allow subtypes such as `PipelinedRedisFuture`.

Remove our own code in favor of Lettuce's advanced cluster support to leverage asynchronous functionality in pipelining.

Document pipelining restrictions regarding Redis Cluster.