### PR TITLE
DATAREDIS-1151 - change clean method keys command to scan

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
@@ -47,7 +47,7 @@ public interface RedisCacheWriter extends CacheStatisticsProvider {
 	 * @return new instance of {@link DefaultRedisCacheWriter}.
 	 */
 	static RedisCacheWriter nonLockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
-		return nonLockingRedisCacheWriter(connectionFactory, BatchStrategies.keys());
+		return nonLockingRedisCacheWriter(connectionFactory, BatchStrategies.scan(10));
 	}
 
 	/**
@@ -74,7 +74,7 @@ public interface RedisCacheWriter extends CacheStatisticsProvider {
 	 * @return new instance of {@link DefaultRedisCacheWriter}.
 	 */
 	static RedisCacheWriter lockingRedisCacheWriter(RedisConnectionFactory connectionFactory) {
-		return lockingRedisCacheWriter(connectionFactory, BatchStrategies.keys());
+		return lockingRedisCacheWriter(connectionFactory, BatchStrategies.scan(10));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
+++ b/src/test/java/org/springframework/data/redis/cache/DefaultRedisCacheWriterTests.java
@@ -18,7 +18,6 @@ package org.springframework.data.redis.cache;
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.redis.cache.RedisCacheWriter.*;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -268,7 +267,7 @@ public class DefaultRedisCacheWriterTests {
 		RedisCacheWriter writer = nonLockingRedisCacheWriter(connectionFactory)
 				.withStatisticsCollector(CacheStatisticsCollector.create());
 
-		writer.clean(CACHE_NAME, (CACHE_NAME + "::*").getBytes(Charset.forName("UTF-8")));
+		writer.clean(CACHE_NAME, (CACHE_NAME + "::*").getBytes(StandardCharsets.UTF_8));
 
 		doWithConnection(connection -> {
 			assertThat(connection.exists(binaryCacheKey)).isFalse();


### PR DESCRIPTION
`clean` method use `keys` command to get all keys which is blocked, may cause other commands timeout or block.
As the complexity of DEL is O(N), if the number of keys is huge, DEL command could timeout as well. 
Using DEL command is very risky in a production environment, right?

Use `scan` command as default `BatchStrategy` in `RedisCacheWriter`, for without locking behavior or with locking behavior.
We use this strategy in the production environment.
[Use RedisCacheWriter#clean to asynchronously scan matches online batch scan to delete cached data for spring-data-redis](https://juejin.cn/spost/7313242056742354994)

- https://jira.spring.io/browse/DATAREDIS-1151
- https://github.com/spring-projects/spring-data-redis/pull/532
- https://github.com/spring-projects/spring-data-redis/pull/2051


> Here are my own thoughts:
> Why do so many users raise issues and report that they encounter timeouts and blocks in use?
> I'm wondering how we can improve the ease of use of good products?
