### PR TITLE
Add overloads for XAddOptions in StreamOperations

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
@@ -33,6 +33,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.ReactiveStreamCommands;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
 import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.connection.stream.ByteBufferRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
@@ -60,6 +61,7 @@ import org.springframework.util.ClassUtils;
  * @author Christoph Strobl
  * @author Marcin Zielinski
  * @author John Blum
+ * @author jinkshower
  * @since 2.2
  */
 class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperations<K, HK, HV> {
@@ -144,6 +146,18 @@ class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperat
 		MapRecord<K, HK, HV> input = StreamObjectMapper.toMapRecord(this, record);
 
 		return createMono(streamCommands -> streamCommands.xAdd(serializeRecord(input)));
+	}
+
+	@Override
+	public Mono<RecordId> add(Record<K, ?> record, XAddOptions xAddOptions) {
+
+		Assert.notNull(record.getStream(), "Key must not be null");
+		Assert.notNull(record.getValue(), "Body must not be null");
+		Assert.notNull(xAddOptions, "XAddOptions must not be null");
+
+		MapRecord<K, HK, HV> input = StreamObjectMapper.toMapRecord(this, record);
+
+		return createMono(streamCommands -> streamCommands.xAdd(serializeRecord(input), xAddOptions));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -26,6 +26,7 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
@@ -54,6 +55,7 @@ import org.springframework.util.ClassUtils;
  * @author Christoph Strobl
  * @author Marcin Zielinski
  * @author John Blum
+ * @author jinkshower
  * @since 2.2
  */
 class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> implements StreamOperations<K, HK, HV> {
@@ -134,6 +136,21 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 		ByteRecord binaryRecord = input.serialize(keySerializer(), hashKeySerializer(), hashValueSerializer());
 
 		return execute(connection -> connection.xAdd(binaryRecord));
+	}
+
+	@Nullable
+	@Override
+	@SuppressWarnings("unchecked")
+	public RecordId add(Record<K , ?> record, XAddOptions options) {
+
+		Assert.notNull(record, "Record must not be null");
+		Assert.notNull(options, "XAddOptions must not be null");
+
+		MapRecord<K, HK, HV> input = StreamObjectMapper.toMapRecord(this, record);
+
+		ByteRecord binaryRecord = input.serialize(keySerializer(), hashKeySerializer(), hashValueSerializer());
+
+		return execute(connection -> connection.streamCommands().xAdd(binaryRecord, options));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
 import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
@@ -53,6 +54,7 @@ import org.springframework.util.Assert;
  * @author Dengliming
  * @author Marcin Zielinski
  * @author John Blum
+ * @author jinkshower
  * @since 2.2
  */
 public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> {
@@ -94,6 +96,53 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	default Long acknowledge(String group, Record<K, ?> record) {
 		return acknowledge(record.getRequiredStream(), group, record.getId());
 	}
+
+	/**
+	 * Append a record to the stream {@code key} with the specified options.
+	 *
+	 * @param key the stream key.
+	 * @param content record content as Map.
+	 * @param xAddOptions additional parameters for the {@literal XADD} call.
+	 * @return the record Id. {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @since 3.3
+	 */
+	@SuppressWarnings("unchecked")
+	@Nullable
+	default RecordId add(K key, Map<? extends HK, ? extends HV> content, XAddOptions xAddOptions) {
+		return add(StreamRecords.newRecord().in(key).ofMap(content), xAddOptions);
+	}
+
+	/**
+	 * Append a record, backed by a {@link Map} holding the field/value pairs, to the stream with the specified options.
+	 *
+	 * @param record the record to append.
+	 * @param xAddOptions additional parameters for the {@literal XADD} call.
+	 * @return the record Id. {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @since 3.3
+	 */
+	@SuppressWarnings("unchecked")
+	@Nullable
+	default RecordId add(MapRecord<K, ? extends HK, ? extends HV> record, XAddOptions xAddOptions) {
+		return add((Record) record, xAddOptions);
+	}
+
+	/**
+	 * Append the record, backed by the given value, to the stream with the specified options.
+	 * The value will be hashed and serialized.
+	 *
+	 * @param record must not be {@literal null}.
+	 * @param xAddOptions parameters for the {@literal XADD} call. Must not be {@literal null}.
+	 * @return the record Id. {@literal null} when used in pipeline / transaction.
+	 * @see MapRecord
+	 * @see ObjectRecord
+	 * @see <a href="https://redis.io/commands/xadd">Redis Documentation: XADD</a>
+	 * @since 3.3
+	 */
+	@SuppressWarnings("unchecked")
+	@Nullable
+	RecordId add(Record<K, ?> record, XAddOptions xAddOptions);
 
 	/**
 	 * Append a record to the stream {@code key}.

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveStreamOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveStreamOperationsIntegrationTests.java
@@ -35,6 +35,7 @@ import org.springframework.data.redis.PersonObjectFactory;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.ReadOffset;
@@ -61,6 +62,7 @@ import org.springframework.data.redis.test.extension.parametrized.ParameterizedR
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Marcin Zielinski
+ * @author jinkshower
  */
 @MethodSource("testParams")
 @SuppressWarnings("unchecked")
@@ -190,6 +192,170 @@ public class DefaultReactiveStreamOperationsIntegrationTests<K, HK, HV> {
 					assertThat(it.getValue()).isEqualTo(value);
 				}) //
 				.verifyComplete();
+	}
+
+	@ParameterizedRedisTest // GH-2915
+	void addMaxLenShouldLimitMessagesSize() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = valueFactory.instance();
+
+		streamOperations.add(key, Collections.singletonMap(hashKey, value)).block();
+
+		HV newValue = valueFactory.instance();
+		XAddOptions options = XAddOptions.maxlen(1).approximateTrimming(false);
+
+		RecordId messageId = streamOperations.add(key, Collections.singletonMap(hashKey, newValue), options).block();
+
+		streamOperations.range(key, Range.unbounded()).as(StepVerifier::create)
+			.consumeNextWith(actual -> {
+
+				assertThat(actual.getId()).isEqualTo(messageId);
+				assertThat(actual.getStream()).isEqualTo(key);
+				assertThat(actual).hasSize(1);
+
+				if (!(key instanceof byte[] || value instanceof byte[])) {
+					assertThat(actual.getValue()).containsEntry(hashKey, newValue);
+				}
+
+			})
+			.verifyComplete();
+	}
+
+	@ParameterizedRedisTest // GH-2915
+	void addMaxLenShouldLimitSimpleMessagesSize() {
+
+		assumeTrue(!(serializer instanceof Jackson2JsonRedisSerializer)
+			&& !(serializer instanceof GenericJackson2JsonRedisSerializer)
+			&& !(serializer instanceof JdkSerializationRedisSerializer) && !(serializer instanceof OxmSerializer));
+
+		K key = keyFactory.instance();
+		HV value = valueFactory.instance();
+
+		streamOperations.add(StreamRecords.objectBacked(value).withStreamKey(key)).block();
+
+		HV newValue = valueFactory.instance();
+		XAddOptions options = XAddOptions.maxlen(1).approximateTrimming(false);
+
+		RecordId messageId = streamOperations.add(StreamRecords.objectBacked(newValue).withStreamKey(key), options).block();
+
+		streamOperations.range((Class<HV>) value.getClass(), key, Range.unbounded()).as(StepVerifier::create)
+			.consumeNextWith(actual -> {
+
+				assertThat(actual.getId()).isEqualTo(messageId);
+				assertThat(actual.getStream()).isEqualTo(key);
+				assertThat(actual.getValue()).isEqualTo(newValue);
+
+			})
+			.expectNextCount(0)
+			.verifyComplete();
+	}
+
+	@ParameterizedRedisTest // GH-2915
+	void addMaxLenShouldLimitSimpleMessageWithRawSerializerSize() {
+
+		assumeTrue(!(serializer instanceof Jackson2JsonRedisSerializer)
+			&& !(serializer instanceof GenericJackson2JsonRedisSerializer));
+
+		SerializationPair<K> keySerializer = redisTemplate.getSerializationContext().getKeySerializationPair();
+
+		RedisSerializationContext<K, String> serializationContext = RedisSerializationContext
+			.<K, String> newSerializationContext(StringRedisSerializer.UTF_8).key(keySerializer)
+			.hashValue(SerializationPair.raw()).hashKey(SerializationPair.raw()).build();
+
+		ReactiveRedisTemplate<K, String> raw = new ReactiveRedisTemplate<>(redisTemplate.getConnectionFactory(),
+			serializationContext);
+
+		K key = keyFactory.instance();
+		Person value = new PersonObjectFactory().instance();
+
+		raw.opsForStream().add(StreamRecords.objectBacked(value).withStreamKey(key)).block();
+
+		Person newValue = new PersonObjectFactory().instance();
+		XAddOptions options = XAddOptions.maxlen(1).approximateTrimming(false);
+
+		RecordId messageId = raw.opsForStream().add(StreamRecords.objectBacked(newValue).withStreamKey(key), options).block();
+
+		raw.opsForStream().range((Class<HV>) value.getClass(), key, Range.unbounded()).as(StepVerifier::create)
+			.consumeNextWith(it -> {
+
+				assertThat(it.getId()).isEqualTo(messageId);
+				assertThat(it.getStream()).isEqualTo(key);
+				assertThat(it.getValue()).isEqualTo(newValue);
+
+			})
+			.expectNextCount(0)
+			.verifyComplete();
+	}
+
+	@ParameterizedRedisTest // GH-2915
+	void addMinIdShouldEvictLowerIdMessages() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = valueFactory.instance();
+
+		streamOperations.add(key, Collections.singletonMap(hashKey, value)).block();
+		RecordId messageId1 = streamOperations.add(key, Collections.singletonMap(hashKey, value)).block();
+
+		XAddOptions options = XAddOptions.none().minId(messageId1);
+
+		RecordId messageId2 = streamOperations.add(key, Collections.singletonMap(hashKey, value), options).block();
+
+		streamOperations.range(key, Range.unbounded()).as(StepVerifier::create)
+			.consumeNextWith(actual -> {
+				assertThat(actual.getId()).isEqualTo(messageId1);
+				assertThat(actual.getStream()).isEqualTo(key);
+			})
+			.consumeNextWith(actual -> {
+				assertThat(actual.getId()).isEqualTo(messageId2);
+				assertThat(actual.getStream()).isEqualTo(key);
+			})
+			.expectNextCount(0)
+			.verifyComplete();
+	}
+
+	@ParameterizedRedisTest // GH-2915
+	void addMakeNoStreamShouldNotCreateStreamWhenNoStreamExists() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = valueFactory.instance();
+
+		XAddOptions options = XAddOptions.makeNoStream();
+
+		streamOperations.add(key, Collections.singletonMap(hashKey, value), options).block();
+
+		streamOperations.size(key).as(StepVerifier::create)
+			.expectNext(0L)
+			.verifyComplete();
+
+		streamOperations.range(key, Range.unbounded()).as(StepVerifier::create)
+			.expectNextCount(0L)
+			.verifyComplete();
+	}
+
+	@ParameterizedRedisTest // GH-2915
+	void addMakeNoStreamShouldCreateStreamWhenStreamExists() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = valueFactory.instance();
+
+		streamOperations.add(key, Collections.singletonMap(hashKey, value)).block();
+
+		XAddOptions options = XAddOptions.makeNoStream();
+
+		streamOperations.add(key, Collections.singletonMap(hashKey, value), options).block();
+
+		streamOperations.size(key).as(StepVerifier::create)
+			.expectNext(2L)
+			.verifyComplete();
+
+		streamOperations.range(key, Range.unbounded()).as(StepVerifier::create)
+			.expectNextCount(2L)
+			.verifyComplete();
 	}
 
 	@ParameterizedRedisTest // DATAREDIS-864


### PR DESCRIPTION
Closes #2915

After this change, the client can use `XAddOptions` as an additional parameter for `opsForStream.add()`

TO-BE
```java
XAddOptions options = XAddOptions.maxlen(1).approximateTrimming(false);
redisTemplate.opsForStream.add("myStream", Map.of("key", "value), options);
```

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
