### PR TITLE
Revise RedisKeyValueAdapter to support lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-2957-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/listener/KeyExpirationEventMessageListener.java
+++ b/src/main/java/org/springframework/data/redis/listener/KeyExpirationEventMessageListener.java
@@ -29,8 +29,8 @@ import org.springframework.lang.Nullable;
  * @author Christoph Strobl
  * @since 1.7
  */
-public class KeyExpirationEventMessageListener extends KeyspaceEventMessageListener implements
-		ApplicationEventPublisherAware {
+public class KeyExpirationEventMessageListener extends KeyspaceEventMessageListener
+		implements ApplicationEventPublisherAware {
 
 	private static final Topic KEYEVENT_EXPIRED_TOPIC = new PatternTopic("__keyevent@*__:expired");
 
@@ -43,6 +43,11 @@ public class KeyExpirationEventMessageListener extends KeyspaceEventMessageListe
 	 */
 	public KeyExpirationEventMessageListener(RedisMessageListenerContainer listenerContainer) {
 		super(listenerContainer);
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.publisher = applicationEventPublisher;
 	}
 
 	@Override
@@ -67,8 +72,4 @@ public class KeyExpirationEventMessageListener extends KeyspaceEventMessageListe
 		}
 	}
 
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
-		this.publisher = applicationEventPublisher;
-	}
 }

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyValueAdapterTests.java
@@ -82,19 +82,17 @@ public class RedisKeyValueAdapterTests {
 		adapter = new RedisKeyValueAdapter(template, mappingContext);
 		adapter.setEnableKeyspaceEvents(EnableKeyspaceEvents.ON_STARTUP);
 		adapter.afterPropertiesSet();
+		adapter.start();
 
 		template.execute((RedisCallback<Void>) connection -> {
 			connection.flushDb();
 			return null;
 		});
 
-		RedisConnection connection = template.getConnectionFactory().getConnection();
-
-		try {
+		try (RedisConnection connection = template.getConnectionFactory()
+				.getConnection()) {
 			connection.setConfig("notify-keyspace-events", "");
 			connection.setConfig("notify-keyspace-events", "KEA");
-		} finally {
-			connection.close();
 		}
 	}
 


### PR DESCRIPTION
`RedisKeyValueAdapter` is now a lifecycle bean participating in Spring's `SmartLifecycle` support. Sticking to Lifecycle aligns with lifecycle support in `RedisConnectionFactory` where connections are stopped upon shutdown.

Previously, `RedisKeyValueAdapter` stopped connections upon `destroy()` causing a delayed shutdown behavior that was out of sync with its `RedisConnectionFactory`.

Closes #2957