### PR TITLE
Refactor Tests to `instanceof` pattern variable

### DIFF
--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionUnitTestBase.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionUnitTestBase.java
@@ -55,8 +55,7 @@ public abstract class AbstractConnectionUnitTestBase<T> {
 	private ParameterizedType resolveReturnedClassFromGernericType(Class<?> clazz) {
 
 		Object genericSuperclass = clazz.getGenericSuperclass();
-		if (genericSuperclass instanceof ParameterizedType) {
-			ParameterizedType parameterizedType = (ParameterizedType) genericSuperclass;
+		if (genericSuperclass instanceof ParameterizedType parameterizedType) {
 			Type rawtype = parameterizedType.getRawType();
 			if (AbstractConnectionUnitTestBase.class.equals(rawtype)) {
 				return parameterizedType;

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterTestSupport.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterTestSupport.java
@@ -52,12 +52,12 @@ public abstract class LettuceReactiveClusterTestSupport {
 		if (nativeCommands != null) {
 			nativeCommands.flushall();
 
-			if (nativeCommands instanceof RedisCommands) {
-				((RedisCommands) nativeCommands).getStatefulConnection().close();
+			if (nativeCommands instanceof RedisCommands redisCommands) {
+				redisCommands.getStatefulConnection().close();
 			}
 
-			if (nativeCommands instanceof RedisAdvancedClusterCommands) {
-				((RedisAdvancedClusterCommands) nativeCommands).getStatefulConnection().close();
+			if (nativeCommands instanceof RedisAdvancedClusterCommands redisAdvancedClusterCommands) {
+				redisAdvancedClusterCommands.getStatefulConnection().close();
 			}
 		}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestSupport.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveCommandsTestSupport.java
@@ -155,16 +155,16 @@ public abstract class LettuceReactiveCommandsTestSupport {
 		public void close() throws IOException {
 
 			try {
-				if (connectionProvider instanceof DisposableBean) {
-					((DisposableBean) connectionProvider).destroy();
+				if (connectionProvider instanceof DisposableBean disposableBean) {
+					disposableBean.destroy();
 				}
 
-				if (nativeConnectionProvider instanceof DisposableBean) {
-					((DisposableBean) nativeConnectionProvider).destroy();
+				if (nativeConnectionProvider instanceof DisposableBean disposableBean) {
+					disposableBean.destroy();
 				}
 
-				if (nativeBinaryConnectionProvider instanceof DisposableBean) {
-					((DisposableBean) nativeBinaryConnectionProvider).destroy();
+				if (nativeBinaryConnectionProvider instanceof DisposableBean disposableBean) {
+					disposableBean.destroy();
 				}
 			} catch (Exception ex) {
 				throw new RuntimeException(ex);
@@ -198,21 +198,21 @@ public abstract class LettuceReactiveCommandsTestSupport {
 		if (nativeCommands != null) {
 			flushAll();
 
-			if (nativeCommands instanceof RedisCommands) {
-				nativeConnectionProvider.release(((RedisCommands) nativeCommands).getStatefulConnection());
+			if (nativeCommands instanceof RedisCommands redisCommands) {
+				nativeConnectionProvider.release((redisCommands).getStatefulConnection());
 			}
 
-			if (nativeCommands instanceof RedisAdvancedClusterCommands) {
-				nativeConnectionProvider.release(((RedisAdvancedClusterCommands) nativeCommands).getStatefulConnection());
+			if (nativeCommands instanceof RedisAdvancedClusterCommands redisAdvancedClusterCommands) {
+				nativeConnectionProvider.release((redisAdvancedClusterCommands).getStatefulConnection());
 			}
 
-			if (nativeBinaryCommands instanceof RedisCommands) {
-				nativeBinaryConnectionProvider.release(((RedisCommands) nativeBinaryCommands).getStatefulConnection());
+			if (nativeBinaryCommands instanceof RedisCommands redisCommands) {
+				nativeBinaryConnectionProvider.release((redisCommands).getStatefulConnection());
 			}
 
-			if (nativeBinaryCommands instanceof RedisAdvancedClusterCommands) {
+			if (nativeBinaryCommands instanceof RedisAdvancedClusterCommands redisAdvancedClusterCommands) {
 				nativeBinaryConnectionProvider
-						.release(((RedisAdvancedClusterCommands) nativeBinaryCommands).getStatefulConnection());
+						.release((redisAdvancedClusterCommands).getStatefulConnection());
 			}
 		}
 

--- a/src/test/java/org/springframework/data/redis/core/convert/DefaultRedisTypeMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/DefaultRedisTypeMapperUnitTests.java
@@ -215,7 +215,7 @@ class DefaultRedisTypeMapperUnitTests {
 			assertThat(bucket.keySet()).isEmpty();
 		} else {
 
-			byte[] expected = value instanceof Class ? ((Class) value).getName().getBytes() : value.toString().getBytes();
+			byte[] expected = value instanceof Class javaClass ? javaClass.getName().getBytes() : value.toString().getBytes();
 
 			assertThat(bucket.asMap()).containsKey(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY);
 			assertThat(bucket.get(DefaultRedisTypeMapper.DEFAULT_TYPE_KEY)).isEqualTo(expected);

--- a/src/test/java/org/springframework/data/redis/listener/PubSubAwaitUtil.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubAwaitUtil.java
@@ -87,8 +87,8 @@ class PubSubAwaitUtil {
 
 	private static long numPat(RedisConnection connection) {
 
-		if (connection instanceof LettuceConnection) {
-			return ((Number) ((LettuceConnection) connection).execute("PUBSUB", new IntegerOutput<>(ByteArrayCodec.INSTANCE),
+		if (connection instanceof LettuceConnection lettuceConnection) {
+			return ((Number) lettuceConnection.execute("PUBSUB", new IntegerOutput<>(ByteArrayCodec.INSTANCE),
 					"NUMPAT".getBytes())).longValue();
 		}
 
@@ -98,8 +98,8 @@ class PubSubAwaitUtil {
 	private static long numSub(RedisConnection connection, String channel) {
 
 		List<?> pubsub;
-		if (connection instanceof LettuceConnection) {
-			pubsub = (List<?>) ((LettuceConnection) connection).execute("PUBSUB", new ArrayOutput<>(ByteArrayCodec.INSTANCE),
+		if (connection instanceof LettuceConnection lettuceConnection) {
+			pubsub = (List<?>) lettuceConnection.execute("PUBSUB", new ArrayOutput<>(ByteArrayCodec.INSTANCE),
 					"NUMSUB".getBytes(), channel.getBytes());
 		} else {
 			pubsub = (List<?>) connection.execute("PUBSUB", "NUMSUB".getBytes(), channel.getBytes());

--- a/src/test/java/org/springframework/data/redis/listener/PubSubResubscribeTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubResubscribeTests.java
@@ -236,10 +236,10 @@ public class PubSubResubscribeTests {
 
 	private static boolean isClusterAware(RedisConnectionFactory connectionFactory) {
 
-		if (connectionFactory instanceof LettuceConnectionFactory) {
-			return ((LettuceConnectionFactory) connectionFactory).isClusterAware();
-		} else if (connectionFactory instanceof JedisConnectionFactory) {
-			return ((JedisConnectionFactory) connectionFactory).isRedisClusterAware();
+		if (connectionFactory instanceof LettuceConnectionFactory lettuceConnectionFactory) {
+			return lettuceConnectionFactory.isClusterAware();
+		} else if (connectionFactory instanceof JedisConnectionFactory jedisConnectionFactory) {
+			return jedisConnectionFactory.isRedisClusterAware();
 		}
 		return false;
 	}

--- a/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/PubSubTests.java
@@ -170,10 +170,10 @@ public class PubSubTests<T> {
 
 	private static boolean isClusterAware(RedisConnectionFactory connectionFactory) {
 
-		if (connectionFactory instanceof LettuceConnectionFactory) {
-			return ((LettuceConnectionFactory) connectionFactory).isClusterAware();
-		} else if (connectionFactory instanceof JedisConnectionFactory) {
-			return ((JedisConnectionFactory) connectionFactory).isRedisClusterAware();
+		if (connectionFactory instanceof LettuceConnectionFactory lettuceConnectionFactory) {
+			return lettuceConnectionFactory.isClusterAware();
+		} else if (connectionFactory instanceof JedisConnectionFactory jedisConnectionFactory) {
+			return jedisConnectionFactory.isRedisClusterAware();
 		}
 		return false;
 	}

--- a/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/mapping/Jackson2HashMapperIntegrationTests.java
@@ -54,8 +54,8 @@ public class Jackson2HashMapperIntegrationTests {
 	public Jackson2HashMapperIntegrationTests(RedisConnectionFactory factory) throws Exception {
 
 		this.factory = factory;
-		if (factory instanceof InitializingBean) {
-			((InitializingBean) factory).afterPropertiesSet();
+		if (factory instanceof InitializingBean initializingBean) {
+			initializingBean.afterPropertiesSet();
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/repository/cdi/Person.java
+++ b/src/test/java/org/springframework/data/redis/repository/cdi/Person.java
@@ -50,10 +50,8 @@ class Person {
 	public boolean equals(@Nullable Object o) {
 		if (this == o)
 			return true;
-		if (!(o instanceof Person))
+		if (!(o instanceof Person person))
 			return false;
-
-		Person person = (Person) o;
 
 		if (id != null ? !id.equals(person.id) : person.id != null)
 			return false;

--- a/src/test/java/org/springframework/data/redis/repository/cdi/RedisCdiDependenciesProducer.java
+++ b/src/test/java/org/springframework/data/redis/repository/cdi/RedisCdiDependenciesProducer.java
@@ -63,8 +63,8 @@ public class RedisCdiDependenciesProducer {
 
 	public void closeRedisOperations(@Disposes RedisOperations<byte[], byte[]> redisOperations) throws Exception {
 
-		if (redisOperations instanceof DisposableBean) {
-			((DisposableBean) redisOperations).destroy();
+		if (redisOperations instanceof DisposableBean disposableBean) {
+			disposableBean.destroy();
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializerUnitTests.java
@@ -614,10 +614,9 @@ class GenericJackson2JsonRedisSerializerUnitTests {
 			if (obj == null) {
 				return false;
 			}
-			if (!(obj instanceof SimpleObject)) {
+			if (!(obj instanceof SimpleObject other)) {
 				return false;
 			}
-			SimpleObject other = (SimpleObject) obj;
 			return nullSafeEquals(this.longValue, other.longValue);
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
@@ -395,9 +395,9 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 
 		RedisConnection connection = connectionFactory.getConnection();
 
-		if (connection instanceof LettuceConnection) {
+		if (connection instanceof LettuceConnection lettuceConnection) {
 
-			String value = ((List) ((LettuceConnection) connectionFactory.getConnection()).execute("XPENDING",
+			String value = ((List) lettuceConnection.execute("XPENDING",
 					new NestedMultiOutput<>(StringCodec.UTF8), new byte[][] { stream.getBytes(), group.getBytes() })).get(0)
 							.toString();
 			return NumberUtils.parseNumber(value, Integer.class);

--- a/src/test/java/org/springframework/data/redis/support/BoundKeyOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/support/BoundKeyOperationsIntegrationTests.java
@@ -119,14 +119,14 @@ public class BoundKeyOperationsIntegrationTests {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private void populateBoundKey() {
-		if (keyOps instanceof Collection) {
-			((Collection) keyOps).add("dummy");
-		} else if (keyOps instanceof Map) {
-			((Map) keyOps).put("dummy", "dummy");
-		} else if (keyOps instanceof RedisAtomicInteger) {
-			((RedisAtomicInteger) keyOps).set(42);
-		} else if (keyOps instanceof RedisAtomicLong) {
-			((RedisAtomicLong) keyOps).set(42L);
+		if (keyOps instanceof Collection collection) {
+			collection.add("dummy");
+		} else if (keyOps instanceof Map map) {
+			map.put("dummy", "dummy");
+		} else if (keyOps instanceof RedisAtomicInteger redisAtomicInteger) {
+			redisAtomicInteger.set(42);
+		} else if (keyOps instanceof RedisAtomicLong redisAtomicLong) {
+			redisAtomicLong.set(42L);
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/redis/test/util/CollectionAwareComparator.java
+++ b/src/test/java/org/springframework/data/redis/test/util/CollectionAwareComparator.java
@@ -34,10 +34,7 @@ public enum CollectionAwareComparator implements Comparator<Object> {
 	@Override
 	public int compare(Object o1, Object o2) {
 
-		if (o1 instanceof Collection && o2 instanceof Collection) {
-
-			Collection<?> c1 = (Collection<?>) o1;
-			Collection<?> c2 = (Collection<?>) o2;
+		if (o1 instanceof Collection<?> c1 && o2 instanceof Collection<?> c2) {
 
 			if (c1.size() != c2.size()) {
 				return 1;


### PR DESCRIPTION
In some of our test cases, we are currently using the traditional instanceof checks followed by explicit type casting. With the introduction of Pattern Matching in recent Java versions, we can refactor these checks to make the code more concise and readable.

[issues](https://github.com/spring-projects/spring-data-redis/issues/2967)