### PR TITLE
Fix database selection on dedicated connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-2984-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/RedisSystemException.java
+++ b/src/main/java/org/springframework/data/redis/RedisSystemException.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis;
 
 import org.springframework.dao.UncategorizedDataAccessException;
+import org.springframework.lang.Nullable;
 
 /**
  * Exception thrown when we can't classify a Redis exception into one of Spring generic data access exceptions.
@@ -28,7 +29,7 @@ public class RedisSystemException extends UncategorizedDataAccessException {
 	 * @param msg the detail message.
 	 * @param cause the root cause from the data access API in use.
 	 */
-	public RedisSystemException(String msg, Throwable cause) {
+	public RedisSystemException(String msg, @Nullable Throwable cause) {
 		super(msg, cause);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -512,7 +512,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 		if (this.asyncDedicatedConnection != null) {
 			try {
 				if (customizedDatabaseIndex()) {
-					potentiallySelectDatabase(this.defaultDbIndex);
+					potentiallySelectDatabase(this.asyncDedicatedConnection, this.defaultDbIndex);
 				}
 				this.connectionProvider.release(this.asyncDedicatedConnection);
 				this.asyncDedicatedConnection = null;
@@ -965,7 +965,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 		StatefulConnection<byte[], byte[]> connection = getConnectionProvider().getConnection(StatefulConnection.class);
 
 		if (customizedDatabaseIndex()) {
-			potentiallySelectDatabase(this.dbIndex);
+			potentiallySelectDatabase(connection, this.dbIndex);
 		}
 
 		return connection;
@@ -1062,9 +1062,9 @@ public class LettuceConnection extends AbstractRedisConnection {
 		return defaultDbIndex != dbIndex;
 	}
 
-	private void potentiallySelectDatabase(int dbIndex) {
+	private static void potentiallySelectDatabase(StatefulConnection<byte[], byte[]> connection, int dbIndex) {
 
-		if (asyncDedicatedConnection instanceof StatefulRedisConnection<byte[], byte[]> statefulConnection) {
+		if (connection instanceof StatefulRedisConnection<byte[], byte[]> statefulConnection) {
 			statefulConnection.sync().select(dbIndex);
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionUnitTests.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 import io.lettuce.core.*;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
@@ -68,6 +69,7 @@ public class LettuceConnectionUnitTests {
 		private RedisClient clientMock;
 		StatefulRedisConnection<byte[], byte[]> statefulConnectionMock;
 		RedisAsyncCommands<byte[], byte[]> asyncCommandsMock;
+		RedisCommands<byte[], byte[]> commandsMock;
 
 		@SuppressWarnings({ "unchecked" })
 		@BeforeEach
@@ -89,8 +91,10 @@ public class LettuceConnectionUnitTests {
 				}
 				return null;
 			});
+			commandsMock = Mockito.mock(RedisCommands.class);
 
 			when(statefulConnectionMock.async()).thenReturn(asyncCommandsMock);
+			when(statefulConnectionMock.sync()).thenReturn(commandsMock);
 			connection = new LettuceConnection(0, clientMock);
 		}
 
@@ -155,7 +159,7 @@ public class LettuceConnectionUnitTests {
 					.isThrownBy(() -> connection.getSentinelConnection());
 		}
 
-		@Test // DATAREDIS-431
+		@Test // DATAREDIS-431, GH-2984
 		void dbIndexShouldBeSetWhenObtainingConnection() {
 
 			connection = new LettuceConnection(null, 0, clientMock, 0);
@@ -163,6 +167,7 @@ public class LettuceConnectionUnitTests {
 			connection.getNativeConnection();
 
 			verify(asyncCommandsMock).dispatch(eq(CommandType.SELECT), any(), any());
+			verify(commandsMock).select(1);
 		}
 
 		@Test // DATAREDIS-603


### PR DESCRIPTION
We now select the database on the dedicated connection. Previously, this call never happened on the dedicated connection and the only way a database could be selected is through the ConnectionFactory configuration.

Closes #2984