### PR TITLE
Introduce `JedisClientConfigBuilderCustomizer` to support client config customization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-GH-3007-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.lang.Nullable;
  */
 class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 
+	private final Optional<JedisClientConfigBuilderCustomizer> customizer;
 	private final boolean useSsl;
 	private final Optional<SSLSocketFactory> sslSocketFactory;
 	private final Optional<SSLParameters> sslParameters;
@@ -44,11 +45,13 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	private final Duration readTimeout;
 	private final Duration connectTimeout;
 
-	DefaultJedisClientConfiguration(boolean useSsl, @Nullable SSLSocketFactory sslSocketFactory,
+	DefaultJedisClientConfiguration(@Nullable JedisClientConfigBuilderCustomizer customizer, boolean useSsl,
+			@Nullable SSLSocketFactory sslSocketFactory,
 			@Nullable SSLParameters sslParameters, @Nullable HostnameVerifier hostnameVerifier, boolean usePooling,
 			@Nullable GenericObjectPoolConfig poolConfig, @Nullable String clientName, Duration readTimeout,
 			Duration connectTimeout) {
 
+		this.customizer = Optional.ofNullable(customizer);
 		this.useSsl = useSsl;
 		this.sslSocketFactory = Optional.ofNullable(sslSocketFactory);
 		this.sslParameters = Optional.ofNullable(sslParameters);
@@ -58,6 +61,11 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 		this.clientName = Optional.ofNullable(clientName);
 		this.readTimeout = readTimeout;
 		this.connectTimeout = connectTimeout;
+	}
+
+	@Override
+	public Optional<JedisClientConfigBuilderCustomizer> getCustomizer() {
+		return customizer;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfigBuilderCustomizer.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfigBuilderCustomizer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.jedis;
+
+import redis.clients.jedis.DefaultJedisClientConfig;
+
+/**
+ * Strategy interface for customizing {@link DefaultJedisClientConfig.Builder JedisClientConfig}. Any ClientConfig will
+ * be used to call this interface implementation so you can set the protocol, client name, etc. after Spring has applies
+ * its defaults.
+ *
+ * @author Mark Paluch
+ * @since 3.4
+ * @see redis.clients.jedis.DefaultJedisClientConfig.Builder
+ */
+@FunctionalInterface
+public interface JedisClientConfigBuilderCustomizer {
+
+	/**
+	 * Customize the {@link DefaultJedisClientConfig.Builder}.
+	 *
+	 * @param builder the builder to customize.
+	 */
+	void customize(DefaultJedisClientConfig.Builder builder);
+
+}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -711,6 +711,8 @@ public class JedisConnectionFactory
 			this.clientConfiguration.getSslParameters().ifPresent(builder::sslParameters);
 		}
 
+		this.clientConfiguration.getCustomizer().ifPresent(customizer -> customizer.customize(builder));
+
 		return builder.build();
 	}
 
@@ -1085,6 +1087,11 @@ public class JedisConnectionFactory
 			MutableJedisClientConfiguration configuration = new MutableJedisClientConfiguration();
 			configuration.setPoolConfig(jedisPoolConfig);
 			return configuration;
+		}
+
+		@Override
+		public Optional<JedisClientConfigBuilderCustomizer> getCustomizer() {
+			return Optional.empty();
 		}
 
 		@Override


### PR DESCRIPTION
We now support customization of Jedis' `JedisClientConfig` that is used for various client configurations for setting extended properties that Spring Data Redis doesn't configure itself.

Closes #3007