### PR TITLE
Optimize duplicate code in `StringToPropertiesConverter.convert(String source)`

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
@@ -15,29 +15,22 @@
  */
 package org.springframework.data.redis.connection.convert;
 
-import java.io.StringReader;
 import java.util.Properties;
 
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.redis.RedisSystemException;
 
 /**
  * Converts Strings to {@link Properties}
  *
  * @author Jennifer Hickey
  * @author Christoph Strobl
+ * @author Jeff Tao
  */
 public class StringToPropertiesConverter implements Converter<String, Properties> {
 
 	@Override
 	public Properties convert(String source) {
 
-		Properties info = new Properties();
-		try (StringReader stringReader = new StringReader(source)) {
-			info.load(stringReader);
-		} catch (Exception ex) {
-			throw new RedisSystemException("Cannot read Redis info", ex);
-		}
-		return info;
+		return Converters.toProperties(source);
 	}
 }


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Converting String type content into Properties has been defined in `Converters.toProperties(String source)`, replacing the duplicate content of the `convert` method of `StringToPropertiesConverter`.

Closes #3020 
