### PR TITLE
Adds explicit mention of Valkey in the README.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 The primary goal of the https://spring.io/projects/spring-data/[Spring Data] project is to make it easier to build Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce frameworks, and cloud based data services.
 
-This module provides integration with the https://redis.io/[Redis] store.
+This module provides integration with the https://redis.io/[Redis] store. It is also tested to work with https://valkey.io/[Valkey].
 
 == Features
 


### PR DESCRIPTION
A Valkey community member had questions about using this module with Valkey instead of Redis, this contribution aims directly answer this question.

Since both Valkey 7.2 and Redis 7.2 have the same API and and this repo has [testing for Valkey](https://github.com/spring-projects/spring-data-redis/blob/main/Jenkinsfile#L63), this change adds an explicit mention of Valkey in the README along side Redis.


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
