### PR TITLE
StreamMessageListenerContainer should wait for cancellation to complete on shutdown

### DIFF
--- a/src/main/java/org/springframework/data/redis/stream/StreamPollTask.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamPollTask.java
@@ -139,6 +139,7 @@ class StreamPollTask<K, V extends Record<K, ?>> implements Task {
 
 			} catch (InterruptedException ex) {
 
+				cancelLatch.countDown();
 				cancel();
 				Thread.currentThread().interrupt();
 			} catch (RuntimeException ex) {


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

Fix issue: #2261 

Referring to pull request #2563 , modified the logic to use CountDownLatch to wait for completion on cancel without busy-spin.

If there are any improvements or suggestions, please feel free to let me know.
Thank you for reviewing this pull request!

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
