### PR TITLE
refactor: remove unused method 'nullSafeDeserializedStoreValue

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCache.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCache.java
@@ -425,10 +425,6 @@ public class RedisCache extends AbstractValueAdaptingCache {
 				.thenApply(this::toValueWrapper);
 	}
 
-	@Nullable
-	private Object nullSafeDeserializedStoreValue(@Nullable byte[] value) {
-		return value != null ? fromStoreValue(deserializeCacheValue(value)) : null;
-	}
 
 	private boolean hasToStringMethod(Object target) {
 		return hasToStringMethod(target.getClass());


### PR DESCRIPTION
After reviewing the codebase, I found that the nullSafeDeserializedStoreValue method is not being used anywhere in the project. Here’s why I think it’s safe to remove it:

The method is not referenced directly or indirectly within the current codebase.
Its functionality overlaps with existing methods, making it redundant.
Removing it will improve code maintainability by reducing unused code.
I believe this change helps in keeping the codebase clean and focused.