### PR TITLE
Add missing `@Override` annotation to `useForType` in `GenericJackson2JsonRedisSerializer`

### DIFF
--- a/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
@@ -636,6 +636,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		 * Boolean, Integer, Double) will never use typing; that is both due to them being concrete and final, and since
 		 * actual serializers and deserializers will also ignore any attempts to enforce typing.
 		 */
+		@Override
 		public boolean useForType(JavaType javaType) {
 
 			if (javaType.isJavaLangObject()) {


### PR DESCRIPTION
- This PR resolves #3053 .

The `useForType` method in `GenericJackson2JsonRedisSerializer` overrides `DefaultTypeResolverBuilder.useForType` but was missing the `@Override` annotation.
so I added `@Override` to `useForType` in `GenericJackson2JsonRedisSerializer`.

(Since this is a minor change that only adds an annotation, I did not add myself as an author in the class header... but, if it is considered necessary, I am happy to update the PR.)
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
