### PR TITLE
Add allow cache configuration from file

### DIFF
--- a/src/main/resources/redis-cache.properties
+++ b/src/main/resources/redis-cache.properties
@@ -1,0 +1,6 @@
+ttl=100
+nullValues=false
+keyPrefix=none
+serializer=json
+key.serializer=string
+value.serializer=json


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->
Fixes #1510 

This PR adds the functionality to read cache configuration from a properties file. A global (default) configuration file, redis-cache.properties, has been implemented as the first step.

As a future enhancement, I plan to add support for additional individual cache configuration files, such as person.redis-cache.properties, as mentioned in the issue, which can override the defaults.

If you have any suggestions or ideas for implementing this enhancement, please feel free to share!


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
