### PR TITLE
Fix typo in redis cache example code

### DIFF
--- a/src/main/antora/modules/ROOT/pages/redis/redis-cache.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/redis-cache.adoc
@@ -48,7 +48,7 @@ It is possible to opt in to the locking behavior as follows:
 [source,java]
 ----
 RedisCacheManager cacheManager = RedisCacheManager
-    .build(RedisCacheWriter.lockingRedisCacheWriter(connectionFactory))
+    .builder(RedisCacheWriter.lockingRedisCacheWriter(connectionFactory))
     .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig())
     ...
 ----
@@ -77,7 +77,7 @@ The `SCAN` strategy requires a batch size to avoid excessive Redis command round
 [source,java]
 ----
 RedisCacheManager cacheManager = RedisCacheManager
-    .build(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory, BatchStrategies.scan(1000)))
+    .builder(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory, BatchStrategies.scan(1000)))
     .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig())
     ...
 ----


### PR DESCRIPTION
Fixed minor typo on example code `build()` to `builder()`
[Related Docs](https://docs.spring.io/spring-data/redis/reference/redis/redis-cache.html)

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
