### PR TITLE
Add `IDLE` argument to `XPENDING` command

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
@@ -60,6 +60,7 @@ import org.springframework.util.StringUtils;
  * @author Dengliming
  * @author Mark John Moreno
  * @author jinkshower
+ * @author Jeonggyu Choi
  * @since 2.2
  */
 public interface ReactiveStreamCommands {
@@ -748,6 +749,25 @@ public interface ReactiveStreamCommands {
 	}
 
 	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} within a
+	 * {@literal consumer group} and over a given {@link Duration} of idle time.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @param idle the minimum idle time to filter pending messages. Must not be {@literal null}.
+	 * @return pending messages for the given {@literal consumer group} or {@literal null} when used in pipeline /
+	 *         transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 3.5
+	 */
+	default Mono<PendingMessages> xPending(ByteBuffer key, String groupName, Range<?> range, Long count, Duration idle) {
+		return xPending(Mono.just(PendingRecordsCommand.pending(key, groupName).range(range, count).idle(idle))).next()
+				.map(CommandResponse::getOutput);
+	}
+
+	/**
 	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} and
 	 * {@link Consumer} within a {@literal consumer group}.
 	 *
@@ -761,6 +781,23 @@ public interface ReactiveStreamCommands {
 	 */
 	default Mono<PendingMessages> xPending(ByteBuffer key, Consumer consumer, Range<?> range, Long count) {
 		return xPending(key, consumer.getGroup(), consumer.getName(), range, count);
+	}
+
+	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} and
+	 * {@link Consumer} within a {@literal consumer group} and over a given {@link Duration} of idle time.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param consumer the name of the {@link Consumer}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @param idle the minimum idle time to filter pending messages. Must not be {@literal null}.
+	 * @return pending messages for the given {@link Consumer} or {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 3.5
+	 */
+	default Mono<PendingMessages> xPending(ByteBuffer key, Consumer consumer, Range<?> range, Long count, Duration idle) {
+		return xPending(key, consumer.getGroup(), consumer.getName(), range, count, idle);
 	}
 
 	/**
@@ -784,6 +821,27 @@ public interface ReactiveStreamCommands {
 	}
 
 	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} and
+	 * {@literal consumer} within a {@literal consumer group} and over a given {@link Duration} of idle time.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @param consumerName the name of the {@literal consumer}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @param idle the minimum idle time to filter pending messages. Must not be {@literal null}.
+	 * @return pending messages for the given {@literal consumer} in given {@literal consumer group} or {@literal null}
+	 *         when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 3.5
+	 */
+	default Mono<PendingMessages> xPending(ByteBuffer key, String groupName, String consumerName, Range<?> range,
+			Long count, Duration idle) {
+		return xPending(Mono.just(PendingRecordsCommand.pending(key, groupName).consumer(consumerName).range(range, count)
+				.idle(idle))).next().map(CommandResponse::getOutput);
+	}
+
+	/**
 	 * Obtain detailed information about pending {@link PendingMessage messages} applying given {@link XPendingOptions
 	 * options}.
 	 *
@@ -798,6 +856,7 @@ public interface ReactiveStreamCommands {
 	 * Value Object holding parameters for obtaining pending messages.
 	 *
 	 * @author Christoph Strobl
+	 * @author Jeonggyu Choi
 	 * @since 2.3
 	 */
 	class PendingRecordsCommand extends KeyCommand {
@@ -806,9 +865,10 @@ public interface ReactiveStreamCommands {
 		private final @Nullable String consumerName;
 		private final Range<?> range;
 		private final @Nullable Long count;
+		private final @Nullable Duration idle;
 
 		private PendingRecordsCommand(ByteBuffer key, String groupName, @Nullable String consumerName, Range<?> range,
-				@Nullable Long count) {
+				@Nullable Long count, @Nullable Duration idle) {
 
 			super(key);
 
@@ -816,6 +876,7 @@ public interface ReactiveStreamCommands {
 			this.consumerName = consumerName;
 			this.range = range;
 			this.count = count;
+			this.idle = idle;
 		}
 
 		/**
@@ -826,7 +887,7 @@ public interface ReactiveStreamCommands {
 		 * @return new instance of {@link PendingRecordsCommand}.
 		 */
 		static PendingRecordsCommand pending(ByteBuffer key, String groupName) {
-			return new PendingRecordsCommand(key, groupName, null, Range.unbounded(), null);
+			return new PendingRecordsCommand(key, groupName, null, Range.unbounded(), null, null);
 		}
 
 		/**
@@ -841,7 +902,7 @@ public interface ReactiveStreamCommands {
 			Assert.notNull(range, "Range must not be null");
 			Assert.isTrue(count > -1, "Count must not be negative");
 
-			return new PendingRecordsCommand(getKey(), groupName, consumerName, range, count);
+			return new PendingRecordsCommand(getKey(), groupName, consumerName, range, count, null);
 		}
 
 		/**
@@ -851,7 +912,20 @@ public interface ReactiveStreamCommands {
 		 * @return new instance of {@link PendingRecordsCommand}.
 		 */
 		public PendingRecordsCommand consumer(String consumerName) {
-			return new PendingRecordsCommand(getKey(), groupName, consumerName, range, count);
+			return new PendingRecordsCommand(getKey(), groupName, consumerName, range, count, idle);
+		}
+
+		/**
+		 * Append given idle time.
+		 *
+		 * @param idle must not be {@literal null}.
+		 * @return new instance of {@link PendingRecordsCommand}.
+		 */
+		public PendingRecordsCommand idle(Duration idle) {
+
+			Assert.notNull(idle, "Idle must not be null");
+
+			return new PendingRecordsCommand(getKey(), groupName, consumerName, range, count, idle);
 		}
 
 		public String getGroupName() {
@@ -882,6 +956,14 @@ public interface ReactiveStreamCommands {
 		}
 
 		/**
+		 * @return can be {@literal null}.
+		 */
+		@Nullable
+		public Duration getIdle() {
+			return idle;
+		}
+
+		/**
 		 * @return {@literal true} if a consumer name is present.
 		 */
 		public boolean hasConsumer() {
@@ -893,6 +975,13 @@ public interface ReactiveStreamCommands {
 		 */
 		public boolean isLimited() {
 			return count != null;
+		}
+
+		/**
+		 * @return {@literal true} if idle is set.
+		 */
+		public boolean hasIdle() {
+			return idle != null;
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
@@ -922,11 +922,17 @@ public interface RedisStreamCommands {
 			return consumerName;
 		}
 
+		/**
+		 * @return can be {@literal null}.
+		 */
 		@Nullable
 		public Duration getIdle() {
 			return idle;
 		}
 
+		/**
+		 * @return can be {@literal null}.
+		 */
 		@Nullable
 		public Long getIdleMillis() {
 			if (idle == null) {

--- a/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
  * @author Tugdual Grall
  * @author Dengliming
  * @author Mark John Moreno
+ * @author Jeonggyu Choi
  * @see <a href="https://redis.io/topics/streams-intro">Redis Documentation - Streams</a>
  * @since 2.2
  */
@@ -707,6 +708,25 @@ public interface RedisStreamCommands {
 	}
 
 	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} within a
+	 * {@literal consumer group} and over a given {@link Duration} of idle time.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @param idle the minimum idle time to filter pending messages. Must not be {@literal null}.
+	 * @return pending messages for the given {@literal consumer group} or {@literal null} when used in pipeline /
+	 *         transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 3.5
+	 */
+	@Nullable
+	default PendingMessages xPending(byte[] key, String groupName, Range<?> range, Long count, Duration idle) {
+		return xPending(key, groupName, XPendingOptions.range(range, count).idle(idle));
+	}
+
+	/**
 	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} and
 	 * {@link Consumer} within a {@literal consumer group}.
 	 *
@@ -721,6 +741,24 @@ public interface RedisStreamCommands {
 	@Nullable
 	default PendingMessages xPending(byte[] key, Consumer consumer, Range<?> range, Long count) {
 		return xPending(key, consumer.getGroup(), consumer.getName(), range, count);
+	}
+
+	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} and
+	 * {@link Consumer} within a {@literal consumer group} and over a given {@link Duration} of idle time.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param consumer the name of the {@link Consumer}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @param idle the minimum idle time to filter pending messages. Must not be {@literal null}.
+	 * @return pending messages for the given {@link Consumer} or {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 3.5
+	 */
+	@Nullable
+	default PendingMessages xPending(byte[] key, Consumer consumer, Range<?> range, Long count, Duration idle) {
+		return xPending(key, consumer.getGroup(), consumer.getName(), range, count, idle);
 	}
 
 	/**
@@ -743,6 +781,27 @@ public interface RedisStreamCommands {
 	}
 
 	/**
+	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} and
+	 * {@literal consumer} within a {@literal consumer group} and over a given {@link Duration} of idle time.
+	 *
+	 * @param key the {@literal key} the stream is stored at. Must not be {@literal null}.
+	 * @param groupName the name of the {@literal consumer group}. Must not be {@literal null}.
+	 * @param consumerName the name of the {@literal consumer}. Must not be {@literal null}.
+	 * @param range the range of messages ids to search within. Must not be {@literal null}.
+	 * @param count limit the number of results. Must not be {@literal null}.
+	 * @param idle the minimum idle time to filter pending messages. Must not be {@literal null}.
+	 * @return pending messages for the given {@literal consumer} in given {@literal consumer group} or {@literal null}
+	 *         when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xpending">Redis Documentation: xpending</a>
+	 * @since 3.5
+	 */
+	@Nullable
+	default PendingMessages xPending(byte[] key, String groupName, String consumerName, Range<?> range, Long count,
+			Duration idle) {
+		return xPending(key, groupName, XPendingOptions.range(range, count).consumer(consumerName).idle(idle));
+	}
+
+	/**
 	 * Obtain detailed information about pending {@link PendingMessage messages} applying given {@link XPendingOptions
 	 * options}.
 	 *
@@ -761,6 +820,7 @@ public interface RedisStreamCommands {
 	 * Value Object holding parameters for obtaining pending messages.
 	 *
 	 * @author Christoph Strobl
+	 * @author Jeonggyu Choi
 	 * @since 2.3
 	 */
 	class XPendingOptions {
@@ -768,12 +828,15 @@ public interface RedisStreamCommands {
 		private final @Nullable String consumerName;
 		private final Range<?> range;
 		private final @Nullable Long count;
+		private final @Nullable Duration idle;
 
-		private XPendingOptions(@Nullable String consumerName, Range<?> range, @Nullable Long count) {
+		private XPendingOptions(@Nullable String consumerName, Range<?> range, @Nullable Long count,
+				@Nullable Duration idle) {
 
 			this.range = range;
 			this.count = count;
 			this.consumerName = consumerName;
+			this.idle = idle;
 		}
 
 		/**
@@ -782,7 +845,7 @@ public interface RedisStreamCommands {
 		 * @return new instance of {@link XPendingOptions}.
 		 */
 		public static XPendingOptions unbounded() {
-			return new XPendingOptions(null, Range.unbounded(), null);
+			return new XPendingOptions(null, Range.unbounded(), null, null);
 		}
 
 		/**
@@ -795,7 +858,7 @@ public interface RedisStreamCommands {
 
 			Assert.isTrue(count > -1, "Count must not be negative");
 
-			return new XPendingOptions(null, Range.unbounded(), count);
+			return new XPendingOptions(null, Range.unbounded(), count, null);
 		}
 
 		/**
@@ -810,7 +873,7 @@ public interface RedisStreamCommands {
 			Assert.notNull(range, "Range must not be null");
 			Assert.isTrue(count > -1, "Count must not be negative");
 
-			return new XPendingOptions(null, range, count);
+			return new XPendingOptions(null, range, count, null);
 		}
 
 		/**
@@ -820,7 +883,20 @@ public interface RedisStreamCommands {
 		 * @return new instance of {@link XPendingOptions}.
 		 */
 		public XPendingOptions consumer(String consumerName) {
-			return new XPendingOptions(consumerName, range, count);
+			return new XPendingOptions(consumerName, range, count, idle);
+		}
+
+		/**
+		 * Append given idle time.
+		 *
+		 * @param idle must not be {@literal null}.
+		 * @return new instance of {@link} XPendingOptions}.
+		 */
+		public XPendingOptions idle(Duration idle) {
+
+			Assert.notNull(idle, "Idle must not be null");
+
+			return new XPendingOptions(consumerName, range, count, idle);
 		}
 
 		/**
@@ -846,6 +922,20 @@ public interface RedisStreamCommands {
 			return consumerName;
 		}
 
+		@Nullable
+		public Duration getIdle() {
+			return idle;
+		}
+
+		@Nullable
+		public Long getIdleMillis() {
+			if (idle == null) {
+				return null;
+			}
+
+			return idle.toMillis();
+		}
+
 		/**
 		 * @return {@literal true} if a consumer name is present.
 		 */
@@ -858,6 +948,13 @@ public interface RedisStreamCommands {
 		 */
 		public boolean isLimited() {
 			return count != null;
+		}
+
+		/**
+		 * @return {@literal true} if idle time is set.
+		 */
+		public boolean hasIdle() {
+			return idle != null;
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterStreamCommands.java
@@ -48,6 +48,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Dengliming
+ * @author Jeonggyu Choi
  * @since 2.3
  */
 class JedisClusterStreamCommands implements RedisStreamCommands {
@@ -281,6 +282,10 @@ class JedisClusterStreamCommands implements RedisStreamCommands {
 
 			if (StringUtils.hasText(consumerName)) {
 				pendingParams = pendingParams.consumer(consumerName);
+			}
+
+			if (options.hasIdle()) {
+				pendingParams = pendingParams.idle(options.getIdleMillis());
 			}
 
 			List<Object> response = connection.getCluster().xpending(key, group, pendingParams);

--- a/src/main/java/org/springframework/data/redis/connection/jedis/StreamConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/StreamConverters.java
@@ -55,6 +55,7 @@ import org.springframework.data.redis.connection.stream.StreamRecords;
  *
  * @author dengliming
  * @author Mark Paluch
+ * @author Jeonggyu Choi
  * @since 2.3
  */
 class StreamConverters {
@@ -305,6 +306,9 @@ class StreamConverters {
 
 		if (options.hasConsumer()) {
 			xPendingParams.consumer(options.getConsumerName());
+		}
+		if (options.hasIdle()) {
+			xPendingParams.idle(options.getIdleMillis());
 		}
 
 		return xPendingParams;

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.XAddArgs;
 import io.lettuce.core.XClaimArgs;
 import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XPendingArgs;
 import io.lettuce.core.XReadArgs;
 import io.lettuce.core.XReadArgs.StreamOffset;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
@@ -56,6 +57,7 @@ import org.springframework.util.Assert;
  * @author Tugdual Grall
  * @author Dengliming
  * @author Mark John Moreno
+ * @author Jeonggyu Choi
  * @since 2.2
  */
 class LettuceReactiveStreamCommands implements ReactiveStreamCommands {
@@ -235,9 +237,16 @@ class LettuceReactiveStreamCommands implements ReactiveStreamCommands {
 			io.lettuce.core.Limit limit = command.isLimited() ? io.lettuce.core.Limit.from(command.getCount())
 					: io.lettuce.core.Limit.unlimited();
 
-			Flux<PendingMessage> publisher = command.hasConsumer() ? cmd.xpending(command.getKey(),
-					io.lettuce.core.Consumer.from(groupName, ByteUtils.getByteBuffer(command.getConsumerName())), range, limit)
-					: cmd.xpending(command.getKey(), groupName, range, limit);
+			XPendingArgs<ByteBuffer> xPendingArgs = XPendingArgs.Builder.xpending(groupName, range, limit);
+			if (command.hasConsumer()) {
+				io.lettuce.core.Consumer<ByteBuffer> consumer = io.lettuce.core.Consumer.from(groupName, ByteUtils.getByteBuffer(command.getConsumerName()));
+				xPendingArgs.consumer(consumer);
+			}
+			if (command.hasIdle()) {
+				xPendingArgs.idle(command.getIdle());
+			}
+
+			Flux<PendingMessage> publisher = cmd.xpending(command.getKey(), xPendingArgs);
 
 			return publisher.collectList().map(it -> {
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.XAddArgs;
 import io.lettuce.core.XClaimArgs;
 import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XPendingArgs;
 import io.lettuce.core.XReadArgs;
 import io.lettuce.core.api.async.RedisStreamAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
@@ -50,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Dejan Jankov
  * @author Dengliming
  * @author Mark John Moreno
+ * @author Jeonggyu Choi
  * @since 2.2
  */
 class LettuceStreamCommands implements RedisStreamCommands {
@@ -217,15 +219,17 @@ class LettuceStreamCommands implements RedisStreamCommands {
 		io.lettuce.core.Limit limit = options.isLimited() ? io.lettuce.core.Limit.from(options.getCount())
 				: io.lettuce.core.Limit.unlimited();
 
+		XPendingArgs<byte[]> xPendingArgs = XPendingArgs.Builder.xpending(group, range, limit);
 		if (options.hasConsumer()) {
-
-			return connection.invoke()
-					.from(RedisStreamAsyncCommands::xpending, key,
-							io.lettuce.core.Consumer.from(group, LettuceConverters.toBytes(options.getConsumerName())), range, limit)
-					.get(it -> StreamConverters.toPendingMessages(groupName, options.getRange(), it));
+			io.lettuce.core.Consumer<byte[]> consumer = io.lettuce.core.Consumer.from(group,
+					LettuceConverters.toBytes(options.getConsumerName()));
+			xPendingArgs.consumer(consumer);
+		}
+		if (options.hasIdle()) {
+			xPendingArgs.idle(options.getIdle());
 		}
 
-		return connection.invoke().from(RedisStreamAsyncCommands::xpending, key, group, range, limit)
+		return connection.invoke().from(RedisStreamAsyncCommands::xpending, key, xPendingArgs)
 				.get(it -> StreamConverters.toPendingMessages(groupName, options.getRange(), it));
 	}
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.core;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -223,10 +224,24 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 	}
 
 	@Override
+	public PendingMessages pending(K key, String group, Range<?> range, long count, Duration idle) {
+
+		byte[] rawKey = rawKey(key);
+		return execute(connection -> connection.xPending(rawKey, group, range, count, idle));
+	}
+
+	@Override
 	public PendingMessages pending(K key, Consumer consumer, Range<?> range, long count) {
 
 		byte[] rawKey = rawKey(key);
 		return execute(connection -> connection.xPending(rawKey, consumer, range, count));
+	}
+
+	@Override
+	public PendingMessages pending(K key, Consumer consumer, Range<?> range, long count, Duration idle) {
+
+		byte[] rawKey = rawKey(key);
+		return execute(connection -> connection.xPending(rawKey, consumer, range, count, idle));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -57,6 +57,7 @@ import org.springframework.util.ClassUtils;
  * @author Marcin Zielinski
  * @author John Blum
  * @author jinkshower
+ * @author Jeonggyu Choi
  * @since 2.2
  */
 class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> implements StreamOperations<K, HK, HV> {

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -55,6 +55,7 @@ import org.springframework.util.Assert;
  * @author Marcin Zielinski
  * @author John Blum
  * @author jinkshower
+ * @author Jeonggyu Choi
  * @since 2.2
  */
 public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> {

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -376,6 +376,8 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 */
 	PendingMessages pending(K key, String group, Range<?> range, long count);
 
+	PendingMessages pending(K key, String group, Range<?> range, long count, Duration idle);
+
 	/**
 	 * Obtain detailed information about pending {@link PendingMessage messages} for a given {@link Range} and
 	 * {@link Consumer} within a {@literal consumer group}.
@@ -389,6 +391,8 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 * @since 2.3
 	 */
 	PendingMessages pending(K key, Consumer consumer, Range<?> range, long count);
+
+	PendingMessages pending(K key, Consumer consumer, Range<?> range, long count, Duration idle);
 
 	/**
 	 * Get the length of a stream.

--- a/src/test/java/org/springframework/data/redis/connection/ReactiveStreamCommandsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/ReactiveStreamCommandsUnitTests.java
@@ -53,4 +53,14 @@ class ReactiveStreamCommandsUnitTests {
 
 		assertThatIllegalArgumentException().isThrownBy(() -> command.range(range, -1L));
 	}
+
+	@Test // GH-2049
+	void pendingRecordsCommandIdleShouldThrowExceptionWhenIdleIsNull() {
+		ByteBuffer key = ByteBuffer.wrap("my-stream".getBytes());
+		String groupName = "my-group";
+
+		PendingRecordsCommand command = PendingRecordsCommand.pending(key, groupName);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> command.idle(null));
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/RedisStreamCommandsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisStreamCommandsUnitTests.java
@@ -46,4 +46,11 @@ class RedisStreamCommandsUnitTests {
 
 		assertThatIllegalArgumentException().isThrownBy(() -> XPendingOptions.range(range, -1L));
 	}
+
+	@Test // GH-2046
+	void xPendingOptionsIdleShouldThrowExceptionWhenIdleIsNull() {
+		XPendingOptions xPendingOptions = XPendingOptions.unbounded();
+
+		assertThatIllegalArgumentException().isThrownBy(() -> xPendingOptions.idle(null));
+	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/jedis/StreamConvertersUnitTest.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/StreamConvertersUnitTest.java
@@ -1,0 +1,30 @@
+package org.springframework.data.redis.connection.jedis;
+
+import static org.assertj.core.api.Assertions.*;
+
+import redis.clients.jedis.params.XPendingParams;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStreamCommands.XPendingOptions;
+
+/**
+ * @author Jeonggyu Choi
+ */
+class StreamConvertersUnitTest {
+
+	@Test // GH-2046
+	void shouldConvertIdle() throws NoSuchFieldException, IllegalAccessException {
+		XPendingOptions options = XPendingOptions.unbounded(5L).idle(Duration.of(1, ChronoUnit.HOURS));
+
+		XPendingParams xPendingParams = StreamConverters.toXPendingParams(options);
+
+		Field idle = XPendingParams.class.getDeclaredField("idle");
+		idle.setAccessible(true);
+		Long idleValue = (Long) idle.get(xPendingParams);
+		assertThat(idleValue).isEqualTo(Duration.of(1, ChronoUnit.HOURS).toMillis());
+	}
+}


### PR DESCRIPTION
## Description

Hello, I'm happy to be here. This is my first time contributing to the Spring Framework.

This pull request resolves #2046 and implements the actual execution.

Below is what I have planned in my mind and my progress so far.

## To do 

### Property test
- [x] `XPendingOptions`
- [x] `PendingRecordsCommand`

### Imperative `pending` command test
```java
// RedisStreamCommands.java
PendingMessages xPending(byte[] key, String groupName, XPendingOptions options);
```
- [ ] JedisClusterStreamCommands.java
- [ ] JedisStreamCommands.java
- [ ] LettuceStreamCommands.java

### Reactive `pending` command test
```java
// ReactiveStreamCommands.java
Flux<CommandResponse<PendingRecordsCommand, PendingMessages>> xPending(Publisher<PendingRecordsCommand> commands);
```
- [ ] LettuceReactiveStreamCommands.java

### Miscellaneous
- [ ] Squash to just one commit
- [ ] Double check commit guideline like commit message format

## Contribution guides
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).