### PR TITLE
Fix typo in redis cache example code

### DIFF
--- a/src/main/antora/modules/ROOT/pages/redis/redis-cache.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/redis-cache.adoc
@@ -181,7 +181,7 @@ If all cache entries should expire after a set duration of time, then simply con
 [source,java]
 ----
 RedisCacheConfiguration fiveMinuteTtlExpirationDefaults =
-    RedisCacheConfiguration.defaultCacheConfig().enableTtl(Duration.ofMinutes(5));
+    RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(5));
 ----
 
 However, if the TTL expiration timeout should vary by cache entry, then you must provide a custom implementation of the `RedisCacheWriter.TtlFunction` interface:


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

Fixed minor typo on example code
`RedisCacheConfiguration.defaultCacheConfig().enableTtl(Duration.class)` to `RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.class)`
[Related Docs](https://docs.spring.io/spring-data/redis/reference/redis/redis-cache.html#redis:support:cache-abstraction:expiration:tti)

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
