### PR TITLE
Added a mention of the PatternTopic class to the pubsub.adoc document

### DIFF
--- a/src/main/antora/modules/ROOT/pages/redis/pubsub.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/pubsub.adoc
@@ -162,7 +162,7 @@ XML::
 ----
 ======
 
-NOTE: The listener topic can be either a channel (for example, `topic="chatroom"`) or a pattern (for example, `topic="*room"`)
+NOTE: The listener topic can be either a channel (for example, `topic="chatroom"`) or a pattern (for example, `topic="*room"`). For channels, you should use the `ChannelTopic` class, and for patterns, use the `PatternTopic` class.
 
 The preceding example uses the Redis namespace to declare the message listener container and automatically register the POJOs as listeners. The full-blown beans definition follows:
 


### PR DESCRIPTION
related doc: https://docs.spring.io/spring-data/redis/reference/redis/pubsub.html

Previously, the document explained that listener topics can be set using a pattern but did not mention the `PatternTopic` class, so this information has been added.

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
