### PR TITLE
Make StreamListener read batch messages at once

### DIFF
--- a/src/main/java/org/springframework/data/redis/stream/StreamListener.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamListener.java
@@ -17,6 +17,8 @@ package org.springframework.data.redis.stream;
 
 import org.springframework.data.redis.connection.stream.Record;
 
+import java.util.List;
+
 /**
  * Listener interface to receive delivery of {@link Record messages}.
  *
@@ -33,5 +35,5 @@ public interface StreamListener<K, V extends Record<K, ?>> {
 	 *
 	 * @param message never {@literal null}.
 	 */
-	void onMessage(V message);
+	void onMessage(List<V> message);
 }

--- a/src/main/java/org/springframework/data/redis/stream/StreamListener.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamListener.java
@@ -23,6 +23,7 @@ import java.util.List;
  * Listener interface to receive delivery of {@link Record messages}.
  *
  * @author Mark Paluch
+ * @author Yongha Kwon
  * @param <K> Stream key and Stream field type.
  * @param <V> Stream value type.
  * @since 2.2

--- a/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.stream;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.OptionalInt;
 import java.util.concurrent.Executor;
 import java.util.function.Predicate;
@@ -82,10 +83,10 @@ import org.springframework.util.ErrorHandler;
  * <p>
  * {@link StreamMessageListenerContainer} requires a {@link Executor} to fork long-running polling tasks on a different
  * {@link Thread}. This thread is used as event loop to poll for stream messages and invoke the
- * {@link StreamListener#onMessage(Record) listener callback}.
+ * {@link StreamListener#onMessage(List)}  listener callback}.
  * <p>
  * {@link StreamMessageListenerContainer} tasks propagate errors during stream reads and
- * {@link StreamListener#onMessage(Record) listener notification} to a configurable {@link ErrorHandler}. Errors stop a
+ * {@link StreamListener#onMessage(List)}  listener notification} to a configurable {@link ErrorHandler}. Errors stop a
  * {@link Subscription} by default. Configuring a {@link Predicate} for a {@link StreamReadRequest} allows conditional
  * subscription cancelling or continuing on all errors.
  * <p>

--- a/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
@@ -91,7 +91,7 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		BlockingQueue<MapRecord<String, String, String>> queue = new LinkedBlockingQueue<>();
 
 		container.start();
-		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::add);
+		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::addAll);
 
 		subscription.await(DEFAULT_TIMEOUT);
 
@@ -119,7 +119,7 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		BlockingQueue<ObjectRecord<String, String>> queue = new LinkedBlockingQueue<>();
 
 		container.start();
-		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::add);
+		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::addAll);
 
 		subscription.await(DEFAULT_TIMEOUT);
 
@@ -143,7 +143,7 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		BlockingQueue<ObjectRecord<String, LoginEvent>> queue = new LinkedBlockingQueue<>();
 
 		container.start();
-		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::add);
+		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::addAll);
 
 		subscription.await(DEFAULT_TIMEOUT);
 
@@ -168,7 +168,7 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 
 		container.start();
 		Subscription subscription = container.receive(Consumer.from("my-group", "my-consumer"),
-				StreamOffset.create("my-stream", ReadOffset.lastConsumed()), queue::add);
+				StreamOffset.create("my-stream", ReadOffset.lastConsumed()), queue::addAll);
 
 		subscription.await(DEFAULT_TIMEOUT);
 
@@ -194,7 +194,7 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 
 		container.start();
 		Subscription subscription = container.receiveAutoAck(Consumer.from("my-group", "my-consumer"),
-				StreamOffset.create("my-stream", ReadOffset.lastConsumed()), queue::add);
+				StreamOffset.create("my-stream", ReadOffset.lastConsumed()), queue::addAll);
 
 		subscription.await(DEFAULT_TIMEOUT);
 
@@ -316,7 +316,7 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("payload", "3"));
 
 		container.start();
-		Subscription subscription = container.register(readRequest, records::add);
+		Subscription subscription = container.register(readRequest, records::addAll);
 
 		subscription.await(DEFAULT_TIMEOUT);
 
@@ -347,7 +347,7 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		BlockingQueue<MapRecord<String, String, String>> queue = new LinkedBlockingQueue<>();
 
 		container.start();
-		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::add);
+		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::addAll);
 
 		subscription.await(DEFAULT_TIMEOUT);
 		cancelAwait(subscription);
@@ -365,7 +365,7 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		BlockingQueue<MapRecord<String, String, String>> queue = new LinkedBlockingQueue<>();
 
 		container.start();
-		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::add);
+		Subscription subscription = container.receive(StreamOffset.create("my-stream", ReadOffset.from("0-0")), queue::addAll);
 
 		subscription.await(DEFAULT_TIMEOUT);
 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).


Resolves [spring-projects/spring-data-redis#3078](https://github.com/spring-projects/spring-data-redis/issues/3078)

This pull request implements support for batch message consumption in StreamListener,
allowing it to receive and process multiple messages at once.
