### PR TITLE
fixed a javaDoc typo error on org.springframework.data.redis.stream.StreamMessageListenerContainer.batchSize()

### DIFF
--- a/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
@@ -107,6 +107,8 @@ import org.springframework.util.ErrorHandler;
  * @author Christoph Strobl
  * @author Christian Rest
  * @author DongCheol Kim
+ * @author Wilson Chuks
+ *
  * @param <K> Stream key and Stream field type.
  * @param <V> Stream value type.
  * @since 2.2
@@ -635,12 +637,12 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 		/**
 		 * Configure a batch size for the {@code COUNT} option during reading.
 		 *
-		 * @param messagesPerPoll must not be greater zero.
+		 * @param messagesPerPoll must be greater than zero.
 		 * @return {@code this} {@link StreamMessageListenerContainerOptionsBuilder}.
 		 */
 		public StreamMessageListenerContainerOptionsBuilder<K, V> batchSize(int messagesPerPoll) {
 
-			Assert.isTrue(messagesPerPoll > 0, "Batch size must be greater zero");
+			Assert.isTrue(messagesPerPoll > 0, "Batch size must be greater than zero");
 
 			this.batchSize = messagesPerPoll;
 			return this;


### PR DESCRIPTION

This pull request includes minor updates to the `StreamMessageListenerContainer` class in the Spring Data Redis project. The changes include a correction to a parameter description and assertion message, as well as an update to the class's author list.

Documentation and code quality improvements:

* [`src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java`](diffhunk://#diff-a28f723d1948c8dd932aaa09259bc118201c4bf460e7555def734ca75859c0b2R110-R111): Added "Wilson Chuks" to the list of authors in the class documentation.
* [`src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java`](diffhunk://#diff-a28f723d1948c8dd932aaa09259bc118201c4bf460e7555def734ca75859c0b2L638-R645): Fixed a typo in the parameter description and assertion message for the `batchSize` method, changing "greater zero" to "greater than zero."

- [ Yes] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [Yes ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [No] You submit test cases (unit or integration tests) that back your changes.
- [Yes ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
