### PR TITLE
Add performance warning to RedisTemplate#keys() and RedisOperations#keys() Javadoc

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -262,11 +262,14 @@ public interface RedisOperations<K, V> {
 	DataType type(K key);
 
 	/**
-	 * Find all keys matching the given {@code pattern}.
+	 * Retrieve keys matching the given pattern via {@code KEYS} command.
+	 * <p>
+	 * Note: This command scans the entire keyspace and may cause performance issues
+	 * in production environments. Prefer using {@link #scan(ScanOptions)} for large datasets.
 	 *
-	 * @param pattern must not be {@literal null}.
-	 * @return {@literal null} when used in pipeline / transaction.
-	 * @see <a href="https://redis.io/commands/keys">Redis Documentation: KEYS</a>
+	 * @param pattern key pattern
+	 * @return set of matching keys, or {@literal null} when used in pipeline / transaction
+	 * @see <a href="https://redis.io/commands/keys">Redis KEYS command</a>
 	 */
 	@Nullable
 	Set<K> keys(K pattern);

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -637,6 +637,16 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 		return doWithKeys(connection -> connection.type(rawKey));
 	}
 
+	/**
+	 * Retrieve keys matching the given pattern via {@code KEYS} command.
+	 * <p>
+	 * Note: This command scans the entire keyspace and may cause performance issues
+	 * in production environments. Prefer using {@link #scan(ScanOptions)} for large datasets.
+	 *
+	 * @param pattern key pattern
+	 * @return set of matching keys
+	 * @see <a href="https://redis.io/commands/keys">Redis KEYS command</a>
+	 */
 	@Override
 	@SuppressWarnings("unchecked")
 	public Set<K> keys(K pattern) {


### PR DESCRIPTION
## Description

This pull request updates the Javadoc of both `RedisTemplate#keys()` and `RedisOperations#keys()` methods to include a performance warning regarding the use of the `KEYS` command.

The `KEYS` command performs a full scan of the Redis keyspace, which can severely impact performance in production environments.  
To avoid misuse, the updated Javadocs include a warning and recommend using `scan(ScanOptions)` as a safer alternative for large datasets.

- The warning has been added to:
  - `RedisTemplate#keys()` implementation method.
  - `RedisOperations#keys()` interface method.

Note: `ReactiveRedisOperations#keys()` already contains a similar warning and did not require changes.

---

## Checklist

- [x] I have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] I used the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and did not include any formatting-only changes.
- [x] No test cases were needed as this change is limited to documentation (Javadoc only).
- [x] No author header update was required since only a Javadoc comment was changed and no logic was modified.

---

## References

- [Redis KEYS command](https://redis.io/commands/keys)
- [`scan(ScanOptions)` alternative](https://docs.spring.io/spring-data/data-redis/docs/current/api/org/springframework/data/redis/core/RedisTemplate.html#scan-org.springframework.data.redis.core.ScanOptions-)
