### PR TITLE
Add Range and Limit support to ZSetOperations.rangeByScoreWithScores

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  * @author Andrey Shlykov
  * @author Shyngys Sapraliyev
  * @author John Blum
+ * @author Kim Sumin
  */
 class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZSetOperations<K, V> {
 
@@ -636,6 +637,48 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 		Cursor<Tuple> cursor = template.executeWithStickyConnection(connection -> connection.zScan(rawKey, options));
 
 		return new ConvertingCursor<>(cursor, this::deserializeTuple);
+	}
+
+	@Override
+	public Set<TypedTuple<V>> rangeByScoreWithScores(K key, Range<Double> range, Limit limit) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(range, "Range must not be null!");
+
+		byte[] rawKey = rawKey(key);
+
+		return execute(connection -> {
+			Set<Tuple> result;
+
+			if (limit.isUnlimited()) {
+				result = connection.zRangeByScoreWithScores(rawKey, range);
+			} else {
+				result = connection.zRangeByScoreWithScores(rawKey, range, limit);
+			}
+
+			return deserializeTupleValues(result);
+		});
+	}
+
+	@Override
+	public Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range, Limit limit) {
+
+		Assert.notNull(key, "Key must not be null!");
+		Assert.notNull(range, "Range must not be null!");
+
+		byte[] rawKey = rawKey(key);
+
+		return execute(connection -> {
+			Set<Tuple> result;
+
+			if (limit.isUnlimited()) {
+				result = connection.zRevRangeByScoreWithScores(rawKey, range);
+			} else {
+				result = connection.zRevRangeByScoreWithScores(rawKey, range, limit);
+			}
+
+			return deserializeTupleValues(result);
+		});
 	}
 
 	public Set<byte[]> rangeByScore(K key, String min, String max) {

--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  * @author Wongoo (望哥)
  * @author Andrey Shlykov
  * @author Shyngys Sapraliyev
+ * @author Kim Sumin
  */
 public interface ZSetOperations<K, V> {
 
@@ -1271,4 +1272,63 @@ public interface ZSetOperations<K, V> {
 	 * @return never {@literal null}.
 	 */
 	RedisOperations<K, V> getOperations();
+
+
+	/**
+	 * Get set of {@link TypedTuple}s where score is between the values defined by the
+	 * {@link Range} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @since 3.5 (or next version number)
+	 */
+	@Nullable
+	default Set<TypedTuple<V>> rangeByScoreWithScores(K key, Range<Double> range) {
+		return rangeByScoreWithScores(key, range, Limit.unlimited());
+	}
+
+	/**
+	 * Get set of {@link TypedTuple}s where score is between the values defined by the
+	 * {@link Range} and limited by the {@link Limit} from sorted set.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @param limit can be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/zrangebyscore">Redis Documentation: ZRANGEBYSCORE</a>
+	 * @since 3.5 (or next version number)
+	 */
+	@Nullable
+	Set<TypedTuple<V>> rangeByScoreWithScores(K key, Range<Double> range, Limit limit);
+
+	/**
+	 * Get set of {@link TypedTuple}s where score is between the values defined by the
+	 * {@link Range} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @since 3.5 (or next version number)
+	 */
+	@Nullable
+	default Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range) {
+		return reverseRangeByScoreWithScores(key, range, Limit.unlimited());
+	}
+
+	/**
+	 * Get set of {@link TypedTuple}s where score is between the values defined by the
+	 * {@link Range} and limited by the {@link Limit} from sorted set ordered from high to low.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param range must not be {@literal null}.
+	 * @param limit can be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/zrevrangebyscore">Redis Documentation: ZREVRANGEBYSCORE</a>
+	 * @since 3.5 (or next version number)
+	 */
+	@Nullable
+	Set<TypedTuple<V>> reverseRangeByScoreWithScores(K key, Range<Double> range, Limit limit);
 }

--- a/src/test/java/org/springframework/data/redis/core/DefaultZSetOperationsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultZSetOperationsUnitTests.java
@@ -31,6 +31,7 @@ import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
  * Unit tests for {@link DefaultZSetOperations}.
  *
  * @author Christoph Strobl
+ * @author Kim Sumin
  */
 class DefaultZSetOperationsUnitTests {
 
@@ -68,5 +69,43 @@ class DefaultZSetOperationsUnitTests {
 		zSetOperations.addIfAbsent("key", Collections.singleton(TypedTuple.of("value", 1D)));
 
 		template.verify().zAdd(eq(template.serializeKey("key")), any(Set.class), eq(ZAddArgs.ifNotExists()));
+	}
+
+	@Test // GH-3139
+	void delegatesRangeByScoreWithScoresWithRange() {
+
+		Range<Double> range = Range.closed(1.0, 3.0);
+		zSetOperations.rangeByScoreWithScores("key", range);
+
+		template.verify().zRangeByScoreWithScores(eq(template.serializeKey("key")), eq(range));
+	}
+
+	@Test // GH-3139
+	void delegatesRangeByScoreWithScoresWithRangeAndLimit() {
+
+		Range<Double> range = Range.closed(1.0, 3.0);
+		org.springframework.data.redis.connection.Limit limit = org.springframework.data.redis.connection.Limit.limit().offset(1).count(2);
+		zSetOperations.rangeByScoreWithScores("key", range, limit);
+
+		template.verify().zRangeByScoreWithScores(eq(template.serializeKey("key")), eq(range), eq(limit));
+	}
+
+	@Test // GH-3139
+	void delegatesReverseRangeByScoreWithScoresWithRange() {
+
+		Range<Double> range = Range.closed(1.0, 3.0);
+		zSetOperations.reverseRangeByScoreWithScores("key", range);
+
+		template.verify().zRevRangeByScoreWithScores(eq(template.serializeKey("key")), eq(range));
+	}
+
+	@Test // GH-3139
+	void delegatesReverseRangeByScoreWithScoresWithRangeAndLimit() {
+
+		Range<Double> range = Range.closed(1.0, 3.0);
+		org.springframework.data.redis.connection.Limit limit = org.springframework.data.redis.connection.Limit.limit().offset(1).count(2);
+		zSetOperations.reverseRangeByScoreWithScores("key", range, limit);
+
+		template.verify().zRevRangeByScoreWithScores(eq(template.serializeKey("key")), eq(range), eq(limit));
 	}
 }


### PR DESCRIPTION
## Overview
This PR adds support for the Range and Limit parameters to the rangeByScoreWithScores and reverseRangeByScoreWithScores methods in the ZSetOperations interface, enhancing flexibility and consistency with other methods in the API.

## Description
The PR implements four new methods in the ZSetOperations interface:
- `rangeByScoreWithScores(K key, Range<Double> range)`
- `rangeByScoreWithScores(K key, Range<Double> range, Limit limit)`
- `reverseRangeByScoreWithScores(K key, Range<Double> range)`
- `reverseRangeByScoreWithScores(K key, Range<Double> range, Limit limit)`

This allows users to:
- Use Range objects to define score boundaries with inclusion/exclusion control
- Apply Limit to control result pagination
- Create more expressive and flexible queries

## Motivation
Currently, rangeByScoreWithScores methods only accept double parameters for min/max scores, which limits flexibility for boundary conditions and special values like infinity. Using Range and Limit objects provides a more powerful and consistent API.

This enhancement was requested in issue #3139 and relates to older issues #796 and #938, where @mp911de indicated these methods should be added.

## Testing
Added both unit tests in DefaultZSetOperationsUnitTests and integration tests in DefaultZSetOperationsIntegrationTests to verify correct functionality.

The tests validate:
- Range parameter handling with various boundary conditions
- Limit parameter for pagination
- Correct ordering of results for reverse operations


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
