### PR TITLE
Add configurable deletion strategy for Redis repository operations #2294

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -103,6 +104,7 @@ import org.springframework.util.ObjectUtils;
  * @author Mark Paluch
  * @author Andrey Muchnik
  * @author John Blum
+ * @author Kim Sumin
  * @since 1.7
  */
 public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
@@ -126,12 +128,50 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 	private EnableKeyspaceEvents enableKeyspaceEvents = EnableKeyspaceEvents.OFF;
 	private @Nullable String keyspaceNotificationsConfigParameter = null;
 	private ShadowCopy shadowCopy = ShadowCopy.DEFAULT;
+	private DeletionStrategy deletionStrategy = DeletionStrategy.DEL;
 
 	/**
 	 * Lifecycle state of this factory.
 	 */
 	enum State {
 		CREATED, STARTING, STARTED, STOPPING, STOPPED, DESTROYED;
+	}
+
+	/**
+	 * Strategy for deleting Redis keys in Repository operations.
+	 * <p>
+	 * Allows configuration of whether to use synchronous {@literal DEL} or asynchronous {@literal UNLINK} commands for
+	 * key deletion operations.
+	 *
+	 * @author [Your Name]
+	 * @since 3.6
+	 * @see <a href="https://redis.io/commands/del">Redis DEL</a>
+	 * @see <a href="https://redis.io/commands/unlink">Redis UNLINK</a>
+	 */
+	public enum DeletionStrategy {
+
+		/**
+		 * Use Redis {@literal DEL} command for key deletion.
+		 * <p>
+		 * 기key from memory. The command blocks until the key is completely removed, which can cause performance issues when
+		 * deleting large data structures under high load.
+		 * <p>
+		 * This is the default strategy for backward compatibility.
+		 */
+		DEL,
+
+		/**
+		 * Use Redis {@literal UNLINK} command for key deletion.
+		 * <p>
+		 * This is a non-blocking operation that asynchronously removes the key. The key is immediately removed from the
+		 * keyspace, but the actual memory reclamation happens in the background, providing better performance for
+		 * applications with frequent updates on existing keys.
+		 * <p>
+		 * Requires Redis 4.0 or later.
+		 *
+		 * @since Redis 4.0
+		 */
+		UNLINK
 	}
 
 	/**
@@ -228,7 +268,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 			byte[] key = toBytes(rdo.getId());
 			byte[] objectKey = createKey(rdo.getKeyspace(), rdo.getId());
 
-			boolean isNew = connection.del(objectKey) == 0;
+			boolean isNew = applyDeletionStrategy(connection, objectKey) == 0;
 
 			connection.hMSet(objectKey, rdo.getBucket().rawMap());
 
@@ -245,11 +285,11 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 				byte[] phantomKey = ByteUtils.concat(objectKey, BinaryKeyspaceIdentifier.PHANTOM_SUFFIX);
 
 				if (expires(rdo)) {
-					connection.del(phantomKey);
+					applyDeletionStrategy(connection, phantomKey);
 					connection.hMSet(phantomKey, rdo.getBucket().rawMap());
 					connection.expire(phantomKey, rdo.getTimeToLive() + PHANTOM_KEY_TTL);
 				} else if (!isNew) {
-					connection.del(phantomKey);
+					applyDeletionStrategy(connection, phantomKey);
 				}
 			}
 
@@ -323,7 +363,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 
 			redisOps.execute((RedisCallback<Void>) connection -> {
 
-				connection.del(keyToDelete);
+				applyDeletionStrategy(connection, keyToDelete);
 				connection.sRem(binKeyspace, binId);
 				new IndexWriter(connection, converter).removeKeyFromIndexes(keyspace, binId);
 
@@ -335,7 +375,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 
 						byte[] phantomKey = ByteUtils.concat(keyToDelete, BinaryKeyspaceIdentifier.PHANTOM_SUFFIX);
 
-						connection.del(phantomKey);
+						applyDeletionStrategy(connection, phantomKey);
 					}
 				}
 				return null;
@@ -485,7 +525,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 					connection.persist(redisKey);
 
 					if (keepShadowCopy()) {
-						connection.del(ByteUtils.concat(redisKey, BinaryKeyspaceIdentifier.PHANTOM_SUFFIX));
+						applyDeletionStrategy(connection, ByteUtils.concat(redisKey, BinaryKeyspaceIdentifier.PHANTOM_SUFFIX));
 					}
 				}
 			}
@@ -493,6 +533,18 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 			new IndexWriter(connection, converter).updateIndexes(toBytes(id), rdo.getIndexedData());
 			return null;
 		});
+	}
+
+	/**
+	 * Apply the configured deletion strategy to delete the given key.
+	 *
+	 * @param connection the Redis connection
+	 * @param key the key to delete
+	 * @return the number of keys that were removed
+	 */
+	private Long applyDeletionStrategy(RedisConnection connection, byte[] key) {
+		return Objects
+				.requireNonNull(deletionStrategy == DeletionStrategy.UNLINK ? connection.unlink(key) : connection.del(key));
 	}
 
 	private RedisUpdateObject fetchDeletePathsFromHashAndUpdateIndex(RedisUpdateObject redisUpdateObject, String path,
@@ -705,6 +757,30 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 	}
 
 	/**
+	 * Configure the deletion strategy for Redis keys.
+	 * <p>
+	 * {@link DeletionStrategy#DEL DEL} performs synchronous key deletion, while {@link DeletionStrategy#UNLINK UNLINK}
+	 * performs asynchronous deletion which can improve performance under high load scenarios.
+	 *
+	 * @param deletionStrategy the strategy to use for key deletion operations
+	 * @since 3.6
+	 */
+	public void setDeletionStrategy(DeletionStrategy deletionStrategy) {
+		Assert.notNull(deletionStrategy, "DeletionStrategy must not be null");
+		this.deletionStrategy = deletionStrategy;
+	}
+
+	/**
+	 * Get the current deletion strategy.
+	 *
+	 * @return the current deletion strategy
+	 * @since 3.6
+	 */
+	public DeletionStrategy getDeletionStrategy() {
+		return this.deletionStrategy;
+	}
+
+	/**
 	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
 	 * @since 1.8
 	 */
@@ -792,7 +868,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 
 		if (this.expirationListener.get() == null) {
 			MappingExpirationListener listener = new MappingExpirationListener(messageListenerContainer, this.redisOps,
-					this.converter, this.shadowCopy);
+					this.converter, this.shadowCopy, this.deletionStrategy);
 
 			listener.setKeyspaceNotificationsConfigParameter(keyspaceNotificationsConfigParameter);
 
@@ -819,17 +895,19 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 		private final RedisOperations<?, ?> ops;
 		private final RedisConverter converter;
 		private final ShadowCopy shadowCopy;
+		private final DeletionStrategy deletionStrategy;
 
 		/**
 		 * Creates new {@link MappingExpirationListener}.
 		 */
 		MappingExpirationListener(RedisMessageListenerContainer listenerContainer, RedisOperations<?, ?> ops,
-				RedisConverter converter, ShadowCopy shadowCopy) {
+				RedisConverter converter, ShadowCopy shadowCopy, DeletionStrategy deletionStrategy) {
 
 			super(listenerContainer);
 			this.ops = ops;
 			this.converter = converter;
 			this.shadowCopy = shadowCopy;
+			this.deletionStrategy = deletionStrategy;
 		}
 
 		@Override
@@ -883,7 +961,11 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 				Map<byte[], byte[]> phantomValue = connection.hGetAll(phantomKey);
 
 				if (!CollectionUtils.isEmpty(phantomValue)) {
-					connection.del(phantomKey);
+					if (deletionStrategy == DeletionStrategy.UNLINK) {
+						connection.unlink(phantomKey);
+					} else {
+						connection.del(phantomKey);
+					}
 				}
 
 				return phantomValue;

--- a/src/main/java/org/springframework/data/redis/repository/configuration/EnableRedisRepositories.java
+++ b/src/main/java/org/springframework/data/redis/repository/configuration/EnableRedisRepositories.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.keyvalue.core.KeyValueOperations;
 import org.springframework.data.keyvalue.repository.config.QueryCreatorType;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.DeletionStrategy;
 import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
 import org.springframework.data.redis.core.RedisKeyValueAdapter.ShadowCopy;
 import org.springframework.data.redis.core.RedisOperations;
@@ -47,6 +48,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy.Key;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Kim Sumin
  * @since 1.7
  */
 @Target(ElementType.TYPE)
@@ -129,7 +131,9 @@ public @interface EnableRedisRepositories {
 
 	/**
 	 * Configure a specific {@link BeanNameGenerator} to be used when creating the repositoy beans.
-	 * @return the {@link BeanNameGenerator} to be used or the base {@link BeanNameGenerator} interface to indicate context default.
+	 * 
+	 * @return the {@link BeanNameGenerator} to be used or the base {@link BeanNameGenerator} interface to indicate
+	 *         context default.
 	 * @since 3.4
 	 */
 	Class<? extends BeanNameGenerator> nameGenerator() default BeanNameGenerator.class;
@@ -204,4 +208,20 @@ public @interface EnableRedisRepositories {
 	 */
 	String keyspaceNotificationsConfigParameter() default "Ex";
 
+	/**
+	 * Configure the deletion strategy for Redis keys during repository operations.
+	 * <p>
+	 * {@link DeletionStrategy#DEL DEL} uses synchronous deletion (blocking), while {@link DeletionStrategy#UNLINK UNLINK}
+	 * uses asynchronous deletion (non-blocking).
+	 * <p>
+	 * {@literal UNLINK} can provide better performance for applications with frequent updates on existing keys,
+	 * especially when dealing with large data structures under high load.
+	 * <p>
+	 * Requires Redis 4.0 or later when using {@link DeletionStrategy#UNLINK}.
+	 *
+	 * @return the deletion strategy to use
+	 * @since 3.6
+	 * @see DeletionStrategy
+	 */
+	DeletionStrategy deletionStrategy() default DeletionStrategy.DEL;
 }

--- a/src/main/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtension.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.data.keyvalue.repository.config.KeyValueRepositoryConfigurationExtension;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.DeletionStrategy;
 import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
 import org.springframework.data.redis.core.RedisKeyValueAdapter.ShadowCopy;
 import org.springframework.data.redis.core.RedisKeyValueTemplate;
@@ -44,6 +45,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Kim Sumin
  * @since 1.7
  */
 public class RedisRepositoryConfigurationExtension extends KeyValueRepositoryConfigurationExtension {
@@ -145,7 +147,9 @@ public class RedisRepositoryConfigurationExtension extends KeyValueRepositoryCon
 						configuration.getRequiredAttribute("enableKeyspaceEvents", EnableKeyspaceEvents.class)) //
 				.addPropertyValue("keyspaceNotificationsConfigParameter",
 						configuration.getAttribute("keyspaceNotificationsConfigParameter", String.class).orElse("")) //
-				.addPropertyValue("shadowCopy", configuration.getRequiredAttribute("shadowCopy", ShadowCopy.class));
+				.addPropertyValue("shadowCopy", configuration.getRequiredAttribute("shadowCopy", ShadowCopy.class))
+				.addPropertyValue("deletionStrategy",
+						configuration.getRequiredAttribute("deletionStrategy", DeletionStrategy.class));
 
 		configuration.getAttribute("messageListenerContainerRef")
 				.ifPresent(it -> builder.addPropertyReference("messageListenerContainer", it));

--- a/src/test/java/org/springframework/data/redis/core/MappingExpirationListenerTest.java
+++ b/src/test/java/org/springframework/data/redis/core/MappingExpirationListenerTest.java
@@ -40,6 +40,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 /**
  * @author Lucian Torje
  * @author Christoph Strobl
+ * @author Kim Sumin
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -58,7 +59,7 @@ class MappingExpirationListenerTest {
 		byte[] key = "testKey".getBytes();
 		when(message.getBody()).thenReturn(key);
 		listener = new RedisKeyValueAdapter.MappingExpirationListener(listenerContainer, redisOperations, redisConverter,
-				RedisKeyValueAdapter.ShadowCopy.ON);
+				RedisKeyValueAdapter.ShadowCopy.ON, RedisKeyValueAdapter.DeletionStrategy.DEL);
 
 		listener.onMessage(message, null);
 
@@ -74,7 +75,7 @@ class MappingExpirationListenerTest {
 		when(message.getBody()).thenReturn(key);
 
 		listener = new RedisKeyValueAdapter.MappingExpirationListener(listenerContainer, redisOperations, redisConverter,
-				RedisKeyValueAdapter.ShadowCopy.OFF);
+				RedisKeyValueAdapter.ShadowCopy.OFF, RedisKeyValueAdapter.DeletionStrategy.DEL);
 		listener.setApplicationEventPublisher(eventList::add);
 		listener.onMessage(message, null);
 
@@ -97,7 +98,7 @@ class MappingExpirationListenerTest {
 		when(conversionService.convert(any(), eq(byte[].class))).thenReturn("foo".getBytes());
 
 		listener = new RedisKeyValueAdapter.MappingExpirationListener(listenerContainer, redisOperations, redisConverter,
-				RedisKeyValueAdapter.ShadowCopy.ON);
+				RedisKeyValueAdapter.ShadowCopy.ON, RedisKeyValueAdapter.DeletionStrategy.DEL);
 		listener.setApplicationEventPublisher(eventList::add);
 		listener.onMessage(message, null);
 

--- a/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/repository/configuration/RedisRepositoryConfigurationExtensionUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.repository.configuration;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +33,7 @@ import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.keyvalue.repository.KeyValueRepository;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.DeletionStrategy;
 import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource;
@@ -43,6 +45,7 @@ import org.springframework.data.repository.config.RepositoryConfigurationSource;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Kim Sumin
  */
 class RedisRepositoryConfigurationExtensionUnitTests {
 
@@ -117,6 +120,22 @@ class RedisRepositoryConfigurationExtensionUnitTests {
 		assertThat(getKeyspaceNotificationsConfigParameter(beanDefintionRegistry)).isEqualTo("");
 	}
 
+	@Test // GH-2294
+	void picksUpDeletionStrategyDefaultCorrectly() {
+		metadata = new StandardAnnotationMetadata(ConfigWithDefaultDeletionStrategy.class, true);
+		BeanDefinitionRegistry beanDefinitionRegistry = getBeanDefinitionRegistry();
+
+		assertThat(getDeletionStrategy(beanDefinitionRegistry)).isEqualTo(DeletionStrategy.DEL);
+	}
+
+	@Test // GH-2294
+	void picksUpDeletionStrategyUnlinkCorrectly() {
+		metadata = new StandardAnnotationMetadata(ConfigWithUnlinkDeletionStrategy.class, true);
+		BeanDefinitionRegistry beanDefinitionRegistry = getBeanDefinitionRegistry();
+
+		assertThat(getDeletionStrategy(beanDefinitionRegistry)).isEqualTo(DeletionStrategy.UNLINK);
+	}
+
 	private static void assertDoesNotHaveRepo(Class<?> repositoryInterface,
 			Collection<RepositoryConfiguration<RepositoryConfigurationSource>> configs) {
 
@@ -166,6 +185,11 @@ class RedisRepositoryConfigurationExtensionUnitTests {
 				.getPropertyValue("keyspaceNotificationsConfigParameter").getValue();
 	}
 
+	private Object getDeletionStrategy(BeanDefinitionRegistry beanDefinitionRegistry) {
+		return Objects.requireNonNull(beanDefinitionRegistry.getBeanDefinition("redisKeyValueAdapter").getPropertyValues()
+				.getPropertyValue("deletionStrategy").getValue());
+	}
+
 	@EnableRedisRepositories(considerNestedRepositories = true, enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP)
 	private static class Config {
 
@@ -187,6 +211,12 @@ class RedisRepositoryConfigurationExtensionUnitTests {
 	private static class ConfigWithEmptyConfigParameter {
 
 	}
+
+	@EnableRedisRepositories(considerNestedRepositories = true)
+	private static class ConfigWithDefaultDeletionStrategy {}
+
+	@EnableRedisRepositories(considerNestedRepositories = true, deletionStrategy = DeletionStrategy.UNLINK)
+	private static class ConfigWithUnlinkDeletionStrategy {}
 
 	@RedisHash
 	static class Sample {


### PR DESCRIPTION
## Summary

This PR implements configurable deletion strategy for Redis repository operations, allowing applications to choose between synchronous `DEL` and asynchronous `UNLINK` commands for better performance optimization.

## Background

Currently, Spring Data Redis repositories always use the blocking `DEL` command when updating existing keys, which can cause performance issues in update-intensive applications, especially when dealing with large data structures. Redis 4.0+ introduced the non-blocking `UNLINK` command as an alternative.

## Changes

### Core Implementation
- **`DeletionStrategy` enum**: Defines `DEL` (default) and `UNLINK` options
- **`RedisKeyValueAdapter`**: 
  - Added `setDeletionStrategy()` and `getDeletionStrategy()` methods
  - Updated `put()`, `delete()`, and expiration handling to use configured strategy
  - Added `applyDeletionStrategy()` utility method
- **`@EnableRedisRepositories`**: Extended with `deletionStrategy` attribute
- **`RedisRepositoryConfigurationExtension`**: Updated to propagate configuration

### Test Coverage
- **`RedisKeyValueAdapterTests`**: Basic functionality and configuration tests
- **`RedisRepositoryConfigurationExtensionUnitTests`**: Annotation configuration tests

Closes #2294

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
