### PR TITLE
Escape backslashes in source string before loading properties

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
@@ -63,6 +63,7 @@ import org.springframework.util.StringUtils;
  * @author John Blum
  * @author Sorokin Evgeniy
  * @author Marcin Grzejszczak
+ * @author JongJun Kim
  */
 public abstract class Converters {
 
@@ -107,7 +108,8 @@ public abstract class Converters {
 
 		Properties info = new Properties();
 
-		try (StringReader stringReader = new StringReader(source)) {
+		String sourceToLoad = source.replace("\\", "\\\\");
+		try (StringReader stringReader = new StringReader(sourceToLoad)) {
 			info.load(stringReader);
 		} catch (Exception ex) {
 			throw new RedisSystemException("Cannot read Redis info", ex);

--- a/src/test/java/org/springframework/data/redis/connection/convert/ConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/convert/ConvertersUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.redis.connection.convert.Converters.ClusterNodes
  * @author Mark Paluch
  * @author Sorokin Evgeniy
  * @author Marcin Grzejszczak
+ * @author JongJun Kim
  */
 class ConvertersUnitTests {
 
@@ -76,6 +77,13 @@ class ConvertersUnitTests {
 	private static final String CLUSTER_NODE_WITH_SINGLE_IPV4_EMPTY_HOSTNAME = "3765733728631672640db35fd2f04743c03119c6 10.180.0.33:11003@16379, master - 0 1708041426947 2 connected 0-5460";
 
 	private static final String CLUSTER_NODE_WITH_SINGLE_IPV4_HOSTNAME = "3765733728631672640db35fd2f04743c03119c6 10.180.0.33:11003@16379,hostname1 master - 0 1708041426947 2 connected 0-5460";
+
+	private static final String WINDOWS_INFO_RESPONSE = "# Server\r\n" //
+			+ "redis_version:3.0.504\r\n" //
+			+ "redis_mode:standalone\r\n" //
+			+ "os:Windows\r\n" //
+			+ "executable:C:\\Program Files\\Redis\\redis-server.exe\r\n" //
+			+ "config_file:C:\\Program Files\\Redis\\redis.windows.conf\r\n";
 
 	@Test // DATAREDIS-315
 	void toSetOfRedis30ClusterNodesShouldConvertSingleStringNodesResponseCorrectly() {
@@ -366,5 +374,12 @@ class ConvertersUnitTests {
 						new AddressPortHostname("2a02:6b8:c67:9c:0:6d8b:33da:5a2c", "6380", "hostname1")));
 
 		return Stream.concat(regular, weird);
+	}
+
+	@Test // GH-3099
+	void toPropertiesShouldParseInfoStringWithWindowsPaths() {
+
+		assertThat(Converters.toProperties(WINDOWS_INFO_RESPONSE)).containsEntry("executable",
+				"C:\\Program Files\\Redis\\redis-server.exe");
 	}
 }


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

**Overview**

This PR resolves an `IllegalArgumentException` that occurs when parsing the Redis `INFO` command response in a Windows environment. This issue is described in [GitHub issue #3099](https://github.com/spring-projects/spring-data-redis/issues/3099) and is also related to the previously closed [issue #1281](https://github.com/spring-projects/spring-data-redis/issues/1281).

**The Problem**

On Windows, the Redis `INFO` command output can contain values with backslashes (`\`), such as the path to the executable (`executable:C:\Users\...`). The `Converters.toProperties(String)` method in `spring-data-redis` uses `java.util.Properties.load()` internally to parse this response.

However, `Properties.load()` treats the backslash as a special escape character. Consequently, it misinterprets sequences like `\u` in a file path as a Unicode escape sequence, leading to an `IllegalArgumentException`. This poses a challenge for developers working in a Windows environment.

**The Solution**

To address this while preserving the existing code structure, I've introduced a minimal change to the `Converters.toProperties(String)` method. Before calling `Properties.load()`, all backslashes (`\`) in the input string are replaced with double backslashes (`\\`).

**Before:**
```java
try (StringReader stringReader = new StringReader(source)) {
    info.load(stringReader);
}
```

**After:**
```java
String sourceToLoad = source.replace("\\", "\\\\");
try (StringReader stringReader = new StringReader(sourceToLoad)) {
    info.load(stringReader);
}
```

This simple change ensures that `Properties.load()` correctly interprets backslashes as literal characters, preventing any parsing errors. The fix is applied to the `Converters` class, which is shared by both `Jedis` and `Lettuce` client implementations, resolving the issue for both drivers.

**Related Issue**

*   Fixes #3099

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
