### PR TITLE
Add support for Redis SINTERCARD command

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -82,6 +82,7 @@ import org.springframework.util.ObjectUtils;
  * @author Dennis Neufeld
  * @author Shyngys Sapraliyev
  * @author Jeonggyu Choi
+ * @author Mingi Lee
  */
 @NullUnmarked
 @SuppressWarnings({ "ConstantConditions", "deprecation" })
@@ -830,6 +831,11 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	@Override
 	public Long sInterStore(byte[] destKey, byte[]... keys) {
 		return convertAndReturn(delegate.sInterStore(destKey, keys), Converters.identityConverter());
+	}
+
+	@Override
+	public Long sInterCard(byte[]... keys) {
+		return convertAndReturn(delegate.sInterCard(keys), Converters.identityConverter());
 	}
 
 	@Override
@@ -1822,6 +1828,11 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	@Override
 	public Long sInterStore(String destKey, String... keys) {
 		return sInterStore(serialize(destKey), serializeMulti(keys));
+	}
+
+	@Override
+	public Long sInterCard(String... keys) {
+		return sInterCard(serializeMulti(keys));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -67,6 +67,7 @@ import org.springframework.data.redis.domain.geo.GeoShape;
  * @author Dennis Neufeld
  * @author Shyngys Sapraliyev
  * @author Tihomir Mateev
+ * @author Mingi Lee
  * @since 2.0
  */
 @Deprecated
@@ -888,6 +889,13 @@ public interface DefaultedRedisConnection extends RedisCommands, RedisCommandsPr
 	@Deprecated
 	default Long sInterStore(byte[] destKey, byte[]... keys) {
 		return setCommands().sInterStore(destKey, keys);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#setCommands()}}. */
+	@Override
+	@Deprecated
+	default Long sInterCard(byte[]... keys) {
+		return setCommands().sInterCard(keys);
 	}
 
 	/** @deprecated in favor of {@link RedisConnection#setCommands()}}. */

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveSetCommands.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Mingi Lee
  * @since 2.0
  */
 public interface ReactiveSetCommands {
@@ -774,6 +775,73 @@ public interface ReactiveSetCommands {
 	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	Flux<NumericResponse<SInterStoreCommand, Long>> sInterStore(Publisher<SInterStoreCommand> commands);
+
+	/**
+	 * {@code SINTERCARD} command parameters.
+	 *
+	 * @author Mingi Lee
+	 * @since 4.0
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 */
+	class SInterCardCommand implements Command {
+
+		private final List<ByteBuffer> keys;
+
+		private SInterCardCommand(List<ByteBuffer> keys) {
+			this.keys = keys;
+		}
+
+		/**
+		 * Creates a new {@link SInterCardCommand} given a {@link Collection} of keys.
+		 *
+		 * @param keys must not be {@literal null}.
+		 * @return a new {@link SInterCardCommand} for a {@link Collection} of keys.
+		 */
+		public static SInterCardCommand keys(Collection<ByteBuffer> keys) {
+
+			Assert.notNull(keys, "Keys must not be null");
+
+			return new SInterCardCommand(new ArrayList<>(keys));
+		}
+
+		@Override
+		public @Nullable ByteBuffer getKey() {
+			return null;
+		}
+
+		/**
+		 * @return never {@literal null}.
+		 */
+		public List<ByteBuffer> getKeys() {
+			return keys;
+		}
+	}
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of all given sets at {@literal keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 4.0
+	 */
+	default Mono<Long> sInterCard(Collection<ByteBuffer> keys) {
+
+		Assert.notNull(keys, "Keys must not be null");
+
+		return sInterCard(Mono.just(SInterCardCommand.keys(keys))).next().map(NumericResponse::getOutput);
+	}
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of all given sets at
+	 * {@link SInterCardCommand#getKeys()}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 4.0
+	 */
+	Flux<NumericResponse<SInterCardCommand, Long>> sInterCard(Publisher<SInterCardCommand> commands);
 
 	/**
 	 * {@code SUNION} command parameters.

--- a/src/main/java/org/springframework/data/redis/connection/RedisSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSetCommands.java
@@ -160,7 +160,7 @@ public interface RedisSetCommands {
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
-	 * @since 3.4
+	 * @since 4.0
 	 */
 	Long sInterCard(byte @NonNull [] @NonNull... keys);
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisSetCommands.java
@@ -29,6 +29,7 @@ import org.springframework.data.redis.core.ScanOptions;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Mingi Lee
  * @see RedisCommands
  */
 @NullUnmarked
@@ -152,6 +153,16 @@ public interface RedisSetCommands {
 	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	Long sInterStore(byte @NonNull [] destKey, byte @NonNull [] @NonNull... keys);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of all the given sets.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 3.4
+	 */
+	Long sInterCard(byte @NonNull [] @NonNull... keys);
 
 	/**
 	 * Union all sets at given {@code keys}.

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -1177,7 +1177,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @return
 	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
 	 * @see RedisSetCommands#sInterCard(byte[]...)
-	 * @since 3.4
+	 * @since 4.0
 	 */
 	Long sInterCard(@NonNull String @NonNull... keys);
 

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -74,6 +74,7 @@ import org.springframework.util.CollectionUtils;
  * @author ihaohong
  * @author Shyngys Sapraliyev
  * @author Jeonggyu Choi
+ * @author Mingi Lee
  * @see RedisCallback
  * @see RedisSerializer
  * @see StringRedisTemplate
@@ -1168,6 +1169,17 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @see RedisSetCommands#sInterStore(byte[], byte[]...)
 	 */
 	Long sInterStore(@NonNull String destKey, @NonNull String @NonNull... keys);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of all the given sets.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @see RedisSetCommands#sInterCard(byte[]...)
+	 * @since 3.4
+	 */
+	Long sInterCard(@NonNull String @NonNull... keys);
 
 	/**
 	 * Union all sets at given {@code keys}.

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisSetCommands.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Mingi Lee
  * @since 2.0
  */
 @NullUnmarked
@@ -103,6 +104,15 @@ class JedisSetCommands implements RedisSetCommands {
 		Assert.noNullElements(keys, "Source keys must not contain null elements");
 
 		return connection.invoke().just(Jedis::sinterstore, PipelineBinaryCommands::sinterstore, destKey, keys);
+	}
+
+	@Override
+	public Long sInterCard(byte @NonNull [] @NonNull... keys) {
+
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		return connection.invoke().just(Jedis::sintercard, PipelineBinaryCommands::sintercard, keys);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceClusterSetCommands.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Mingi Lee
  * @since 2.0
  */
 class LettuceClusterSetCommands extends LettuceSetCommands {
@@ -116,6 +117,21 @@ class LettuceClusterSetCommands extends LettuceSetCommands {
 			return 0L;
 		}
 		return sAdd(destKey, result.toArray(new byte[result.size()][]));
+	}
+
+	@Override
+	public Long sInterCard(byte[]... keys) {
+
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		if (ClusterSlotHashUtil.isSameSlotForAllKeys(keys)) {
+			return super.sInterCard(keys);
+		}
+
+		// For multi-slot clusters, calculate intersection cardinality by performing intersection
+		Set<byte[]> result = sInter(keys);
+		return (long) result.size();
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveSetCommands.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Mingi Lee
  * @since 2.0
  */
 class LettuceReactiveSetCommands implements ReactiveSetCommands {
@@ -171,6 +172,18 @@ class LettuceReactiveSetCommands implements ReactiveSetCommands {
 			Assert.notNull(command.getKey(), "Destination key must not be null");
 
 			return cmd.sinterstore(command.getKey(), command.getKeys().toArray(new ByteBuffer[0]))
+					.map(value -> new NumericResponse<>(command, value));
+		}));
+	}
+
+	@Override
+	public Flux<NumericResponse<SInterCardCommand, Long>> sInterCard(Publisher<SInterCardCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
+
+			Assert.notNull(command.getKeys(), "Keys must not be null");
+
+			return cmd.sintercard(command.getKeys().toArray(new ByteBuffer[0]))
 					.map(value -> new NumericResponse<>(command, value));
 		}));
 	}

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSetCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceSetCommands.java
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Mingi Lee
  * @since 2.0
  */
 @NullUnmarked
@@ -104,6 +105,15 @@ class LettuceSetCommands implements RedisSetCommands {
 		Assert.noNullElements(keys, "Source keys must not contain null elements");
 
 		return connection.invoke().just(RedisSetAsyncCommands::sinterstore, destKey, keys);
+	}
+
+	@Override
+	public Long sInterCard(byte @NonNull [] @NonNull... keys) {
+
+		Assert.notNull(keys, "Keys must not be null");
+		Assert.noNullElements(keys, "Keys must not contain null elements");
+
+		return connection.invoke().just(RedisSetAsyncCommands::sintercard, keys);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/BoundSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundSetOperations.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.NullUnmarked;
  *
  * @author Costin Leau
  * @author Mark Paluch
+ * @author Mingi Lee
  */
 @NullUnmarked
 public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
@@ -130,6 +131,26 @@ public interface BoundSetOperations<K, V> extends BoundKeyOperations<K> {
 	 * @see <a href="https://redis.io/commands/sinterstore">Redis Documentation: SINTERSTORE</a>
 	 */
 	void intersectAndStore(@NonNull Collection<@NonNull K> keys, @NonNull K destKey);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of the bound key and {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 4.0
+	 */
+	Long intersectSize(@NonNull K key);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of the bound key and {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 4.0
+	 */
+	Long intersectSize(@NonNull Collection<@NonNull K> keys);
 
 	/**
 	 * Union all sets at given {@code key} and {@code key}.

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveSetOperations.java
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Roman Bezpalko
  * @author John Blum
+ * @author Mingi Lee
  * @since 2.0
  */
 class DefaultReactiveSetOperations<K, V> implements ReactiveSetOperations<K, V> {
@@ -211,6 +212,35 @@ class DefaultReactiveSetOperations<K, V> implements ReactiveSetOperations<K, V> 
 				.map(this::rawKey) //
 				.collectList() //
 				.flatMap(rawKeys -> setCommands.sInterStore(rawKey(destKey), rawKeys)));
+	}
+
+	@Override
+	public Mono<Long> intersectSize(K key, K otherKey) {
+
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(otherKey, "Other key must not be null");
+
+		return intersectSize(key, Collections.singleton(otherKey));
+	}
+
+	@Override
+	public Mono<Long> intersectSize(K key, Collection<K> otherKeys) {
+
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(otherKeys, "Other keys must not be null");
+
+		return intersectSize(getKeys(key, otherKeys));
+	}
+
+	@Override
+	public Mono<Long> intersectSize(Collection<K> keys) {
+
+		Assert.notNull(keys, "Keys must not be null");
+
+		return createMono(setCommands -> Flux.fromIterable(keys) //
+				.map(this::rawKey) //
+				.collectList() //
+				.flatMap(setCommands::sInterCard));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultSetOperations.java
@@ -141,6 +141,25 @@ class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements Set
 	}
 
 	@Override
+	public Long intersectSize(K key, K otherKey) {
+		return intersectSize(Arrays.asList(key, otherKey));
+	}
+
+	@Override
+	public Long intersectSize(K key, Collection<K> otherKeys) {
+
+		byte[][] rawKeys = rawKeys(key, otherKeys);
+		return execute(connection -> connection.sInterCard(rawKeys));
+	}
+
+	@Override
+	public Long intersectSize(Collection<K> keys) {
+
+		byte[][] rawKeys = rawKeys(keys);
+		return execute(connection -> connection.sInterCard(rawKeys));
+	}
+
+	@Override
 	public Boolean isMember(K key, Object o) {
 
 		byte[] rawKey = rawKey(key);

--- a/src/main/java/org/springframework/data/redis/core/DefaultSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultSetOperations.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Roman Bezpalko
+ * @author Mingi Lee
  */
 class DefaultSetOperations<K, V> extends AbstractOperations<K, V> implements SetOperations<K, V> {
 

--- a/src/main/java/org/springframework/data/redis/core/ReactiveSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveSetOperations.java
@@ -33,6 +33,7 @@ import java.util.Map;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Roman Bezpalko
+ * @author Mingi Lee
  * @see <a href="https://redis.io/commands#set">Redis Documentation: Set Commands</a>
  * @since 2.0
  */
@@ -180,6 +181,38 @@ public interface ReactiveSetOperations<K, V> {
 	 * @since 2.2
 	 */
 	Mono<Long> intersectAndStore(Collection<K> keys, K destKey);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of {@code key} and {@code otherKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @return
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 4.0
+	 */
+	Mono<Long> intersectSize(K key, K otherKey);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of {@code key} and {@code otherKeys}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @return
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 4.0
+	 */
+	Mono<Long> intersectSize(K key, Collection<K> otherKeys);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of all given sets at {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 4.0
+	 */
+	Mono<Long> intersectSize(Collection<K> keys);
 
 	/**
 	 * Union all sets at given {@code keys} and {@code otherKey}.

--- a/src/main/java/org/springframework/data/redis/core/SetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/SetOperations.java
@@ -186,7 +186,7 @@ public interface SetOperations<K, V> {
 	 * @param otherKey must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
-	 * @since 3.4
+	 * @since 4.0
 	 */
 	Long intersectSize(@NonNull K key, @NonNull K otherKey);
 
@@ -197,7 +197,7 @@ public interface SetOperations<K, V> {
 	 * @param otherKeys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
-	 * @since 3.4
+	 * @since 4.0
 	 */
 	Long intersectSize(@NonNull K key, @NonNull Collection<@NonNull K> otherKeys);
 
@@ -207,7 +207,7 @@ public interface SetOperations<K, V> {
 	 * @param keys must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
-	 * @since 3.4
+	 * @since 4.0
 	 */
 	Long intersectSize(@NonNull Collection<@NonNull K> keys);
 

--- a/src/main/java/org/springframework/data/redis/core/SetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/SetOperations.java
@@ -30,6 +30,7 @@ import org.jspecify.annotations.NullUnmarked;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Roman Bezpalko
+ * @author Mingi Lee
  */
 @NullUnmarked
 public interface SetOperations<K, V> {
@@ -177,6 +178,38 @@ public interface SetOperations<K, V> {
 	 * @since 2.2
 	 */
 	Long intersectAndStore(@NonNull Collection<@NonNull K> keys, @NonNull K destKey);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of {@code key} and {@code otherKey}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKey must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 3.4
+	 */
+	Long intersectSize(@NonNull K key, @NonNull K otherKey);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of {@code key} and {@code otherKeys}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param otherKeys must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 3.4
+	 */
+	Long intersectSize(@NonNull K key, @NonNull Collection<@NonNull K> otherKeys);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of all given sets at {@code keys}.
+	 *
+	 * @param keys must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 3.4
+	 */
+	Long intersectSize(@NonNull Collection<@NonNull K> keys);
 
 	/**
 	 * Union all sets at given {@code keys} and {@code otherKey}.

--- a/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisSet.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisSet.java
@@ -33,6 +33,7 @@ import org.springframework.data.redis.core.ScanOptions;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Mingi Lee
  */
 public class DefaultRedisSet<E> extends AbstractRedisCollection<E> implements RedisSet<E> {
 
@@ -115,6 +116,16 @@ public class DefaultRedisSet<E> extends AbstractRedisCollection<E> implements Re
 	public RedisSet<E> intersectAndStore(Collection<? extends RedisSet<?>> sets, String destKey) {
 		boundSetOps.intersectAndStore(CollectionUtils.extractKeys(sets), destKey);
 		return new DefaultRedisSet<>(boundSetOps.getOperations().boundSetOps(destKey));
+	}
+
+	@Override
+	public Long intersectSize(RedisSet<?> set) {
+		return boundSetOps.intersectSize(set.getKey());
+	}
+
+	@Override
+	public Long intersectSize(Collection<? extends RedisSet<?>> sets) {
+		return boundSetOps.intersectSize(CollectionUtils.extractKeys(sets));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/support/collections/RedisSet.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/RedisSet.java
@@ -28,6 +28,7 @@ import org.springframework.data.redis.core.RedisOperations;
  * @author Costin Leau
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Mingi Lee
  */
 public interface RedisSet<E> extends RedisCollection<E>, Set<E> {
 
@@ -121,6 +122,28 @@ public interface RedisSet<E> extends RedisCollection<E>, Set<E> {
 	 * @since 1.0
 	 */
 	RedisSet<E> intersectAndStore(Collection<? extends RedisSet<?>> sets, String destKey);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of this set and another
+	 * {@link RedisSet}.
+	 *
+	 * @param set must not be {@literal null}.
+	 * @return the cardinality of the intersection.
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 4.0
+	 */
+	Long intersectSize(RedisSet<?> set);
+
+	/**
+	 * Returns the cardinality of the set which would result from the intersection of this set and other
+	 * {@link RedisSet}s.
+	 *
+	 * @param sets must not be {@literal null}.
+	 * @return the cardinality of the intersection.
+	 * @see <a href="https://redis.io/commands/sintercard">Redis Documentation: SINTERCARD</a>
+	 * @since 4.0
+	 */
+	Long intersectSize(Collection<? extends RedisSet<?>> sets);
 
 	/**
 	 * Get random element from the set.

--- a/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultSetOperationsIntegrationTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.redis.test.condition.EnabledOnCommand;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Mingi Lee
  */
 @ParameterizedClass
 @MethodSource("testParams")
@@ -327,6 +328,38 @@ public class DefaultSetOperationsIntegrationTests<K, V> {
 
 		assertThat(setOps.intersectAndStore(sourceKey1, sourceKey2, destinationKey)).isEqualTo(2L);
 		assertThat(setOps.intersectAndStore(Arrays.asList(sourceKey1, sourceKey2), destinationKey)).isEqualTo(2L);
+	}
+
+	@Test // GH-2906
+	@EnabledOnCommand("SINTERCARD")
+	void intersectSizeShouldReturnIntersectionCardinality() {
+
+		K sourceKey1 = keyFactory.instance();
+		K sourceKey2 = keyFactory.instance();
+		K sourceKey3 = keyFactory.instance();
+
+		V v1 = valueFactory.instance();
+		V v2 = valueFactory.instance();
+		V v3 = valueFactory.instance();
+		V v4 = valueFactory.instance();
+		V v5 = valueFactory.instance();
+
+		setOps.add(sourceKey1, v1, v2, v3);
+		setOps.add(sourceKey2, v2, v3, v4);
+		setOps.add(sourceKey3, v3, v4, v5);
+
+		// Test two keys intersection
+		assertThat(setOps.intersectSize(sourceKey1, sourceKey2)).isEqualTo(2L);
+
+		// Test key and collection intersection
+		assertThat(setOps.intersectSize(sourceKey1, Arrays.asList(sourceKey2, sourceKey3))).isEqualTo(1L);
+
+		// Test collection intersection
+		assertThat(setOps.intersectSize(Arrays.asList(sourceKey1, sourceKey2, sourceKey3))).isEqualTo(1L);
+
+		// Test empty intersection
+		K emptyKey = keyFactory.instance();
+		assertThat(setOps.intersectSize(sourceKey1, emptyKey)).isEqualTo(0L);
 	}
 
 	@Test // GH-2037


### PR DESCRIPTION
## Summary

Implements support for Redis 7.0+ SINTERCARD command in Spring Data Redis.

Fixes #2906

## Changes

### Core Implementation
- Add `sInterCard` method to `RedisSetCommands` interface
- Implement `sInterCard` in `JedisSetCommands` using Jedis client
- Implement `sInterCard` in `LettuceSetCommands` using Lettuce client

### Cluster Support  
- Add cluster-aware `sInterCard` in `JedisClusterSetCommands`
- Add cluster-aware `sInterCard` in `LettuceClusterSetCommands`
- Same-slot optimization with native cluster commands
- Cross-slot fallback using intersection calculation

### Connection Wrappers
- Add `sInterCard` delegation in `DefaultedRedisConnection`
- Add `sInterCard` support in `StringRedisConnection`
- Implement serialization handling in `DefaultStringRedisConnection`

### High-Level API
- Add user-friendly `intersectSize` methods to `SetOperations`
- Implement `intersectSize` in `DefaultSetOperations`
- Support multiple method overloads for different key patterns

### Testing
- Comprehensive integration tests with `@EnabledOnCommand("SINTERCARD")`
- Test coverage for all connection types (Jedis, Lettuce, Cluster)
- Various intersection scenarios (empty, partial, full)

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
