### PR TITLE
Allow configuring phase in `RedisMessageListenerContainer`

### DIFF
--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -633,6 +633,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
      * The default is {@code Integer.MAX_VALUE}.
      *
      * @see SmartLifecycle#getPhase()
+     * @since 4.0
      */
     public void setPhase(int phase) {
         this.phase = phase;
@@ -649,6 +650,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
      * The default is {@code true}.
      *
      * @see SmartLifecycle#isAutoStartup()
+     * @since 4.0
      */
     public void setAutoStartup(boolean autoStartup) {
         this.autoStartup = autoStartup;

--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -103,6 +103,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * @author Mark Paluch
  * @author John Blum
  * @author Seongjun Lee
+ * @author Su Ko
  * @see MessageListener
  * @see SubscriptionListener
  */
@@ -167,6 +168,8 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 	private @Nullable String beanName;
 
 	private @Nullable Subscriber subscriber;
+
+    private int phase = Integer.MAX_VALUE;
 
 	/**
 	 * Set an ErrorHandler to be invoked in case of any uncaught exceptions thrown while processing a Message. By default,
@@ -617,6 +620,22 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 		removeMessageListener(listener, Collections.emptySet());
 	}
+
+    @Override
+    public int getPhase() {
+        return this.phase;
+    }
+
+    /**
+     * Specify the lifecycle phase for this container.
+     * Lower values start earlier and stop later.
+     * The default is {@code Integer.MAX_VALUE}.
+     *
+     * @see SmartLifecycle#getPhase()
+     */
+    public void setPhase(int phase) {
+        this.phase = phase;
+    }
 
 	private void initMapping(Map<? extends MessageListener, Collection<? extends Topic>> listeners) {
 

--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -170,6 +170,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 	private @Nullable Subscriber subscriber;
 
     private int phase = Integer.MAX_VALUE;
+    private boolean autoStartup = true;
 
 	/**
 	 * Set an ErrorHandler to be invoked in case of any uncaught exceptions thrown while processing a Message. By default,
@@ -635,6 +636,22 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
      */
     public void setPhase(int phase) {
         this.phase = phase;
+    }
+
+    @Override
+    public boolean isAutoStartup() {
+        return this.autoStartup;
+    }
+
+    /**
+     * Configure if this Lifecycle connection factory should get started automatically by the container at the time that
+     * the containing ApplicationContext gets refreshed.
+     * The default is {@code true}.
+     *
+     * @see SmartLifecycle#isAutoStartup()
+     */
+    public void setAutoStartup(boolean autoStartup) {
+        this.autoStartup = autoStartup;
     }
 
 	private void initMapping(Map<? extends MessageListener, Collection<? extends Topic>> listeners) {

--- a/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
@@ -94,6 +94,14 @@ class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implement
 		} else {
 			this.streamOperations = this.template.opsForStream();
 		}
+
+        if(containerOptions.isAutoStartup().isPresent()){
+            this.autoStartup = containerOptions.isAutoStartup().get();
+        }
+
+        if(containerOptions.getPhase().isPresent()){
+            this.phase = containerOptions.getPhase().getAsInt();
+        }
 	}
 
 	private static StreamReadOptions getStreamReadOptions(StreamMessageListenerContainerOptions<?, ?> options) {

--- a/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
@@ -50,6 +50,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Su Ko
  * @since 2.2
  */
 class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implements StreamMessageListenerContainer<K, V> {
@@ -66,6 +67,9 @@ class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implement
 	private final List<Subscription> subscriptions = new ArrayList<>();
 
 	private boolean running = false;
+
+    private int phase = Integer.MAX_VALUE;
+    private boolean autoStartup = false;
 
 	/**
 	 * Create a new {@link DefaultStreamMessageListenerContainer}.
@@ -123,8 +127,20 @@ class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implement
 
 	@Override
 	public boolean isAutoStartup() {
-		return false;
+		return this.autoStartup;
 	}
+
+    /**
+     * Configure if this Lifecycle connection factory should get started automatically by the container at the time that
+     * the containing ApplicationContext gets refreshed.
+     * The default is {@code false}.
+     *
+     * @see org.springframework.context.SmartLifecycle#isAutoStartup()
+     * @since 4.0
+     */
+    public void setAutoStartup(boolean autoStartup) {
+        this.autoStartup = autoStartup;
+    }
 
 	@Override
 	public void stop(Runnable callback) {
@@ -177,8 +193,20 @@ class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implement
 
 	@Override
 	public int getPhase() {
-		return Integer.MAX_VALUE;
+		return this.phase;
 	}
+
+    /**
+     * Specify the lifecycle phase for this container.
+     * Lower values start earlier and stop later.
+     * The default is {@code Integer.MAX_VALUE}.
+     *
+     * @see org.springframework.context.SmartLifecycle#getPhase()
+     * @since 4.0
+     */
+    public void setPhase(int phase) {
+        this.phase = phase;
+    }
 
 	@Override
 	public Subscription register(StreamReadRequest<K> streamRequest, StreamListener<K, V> listener) {

--- a/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.stream;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.Executor;
 import java.util.function.Predicate;
@@ -107,6 +108,7 @@ import org.springframework.util.ErrorHandler;
  * @author Christoph Strobl
  * @author Christian Rest
  * @author DongCheol Kim
+ * @author Su Ko
  * @param <K> Stream key and Stream field type.
  * @param <V> Stream value type.
  * @since 2.2
@@ -503,12 +505,14 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 		private final @Nullable HashMapper<Object, Object, Object> hashMapper;
 		private final ErrorHandler errorHandler;
 		private final Executor executor;
+        private final @Nullable Integer phase;
+        private final @Nullable Boolean autoStartup;
 
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		private StreamMessageListenerContainerOptions(Duration pollTimeout, @Nullable Integer batchSize,
 				RedisSerializer<K> keySerializer, RedisSerializer<Object> hashKeySerializer,
 				RedisSerializer<Object> hashValueSerializer, @Nullable Class<?> targetType,
-				@Nullable HashMapper<V, ?, ?> hashMapper, ErrorHandler errorHandler, Executor executor) {
+				@Nullable HashMapper<V, ?, ?> hashMapper, ErrorHandler errorHandler, Executor executor,@Nullable Integer phase, @Nullable Boolean autoStartup) {
 			this.pollTimeout = pollTimeout;
 			this.batchSize = batchSize;
 			this.keySerializer = keySerializer;
@@ -518,6 +522,8 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 			this.hashMapper = (HashMapper) hashMapper;
 			this.errorHandler = errorHandler;
 			this.executor = executor;
+            this.phase = phase;
+            this.autoStartup = autoStartup;
 		}
 
 		/**
@@ -598,6 +604,21 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 			return executor;
 		}
 
+        /**
+         * @return the phase.
+         * @since 4.0
+         */
+        public OptionalInt getPhase() {
+            return phase != null ? OptionalInt.of(phase) : OptionalInt.empty();
+        }
+
+        /**
+         * @return the autoStartup.
+         * @since 4.0
+         */
+        public Optional<Boolean> isAutoStartup() {
+            return autoStartup != null ? Optional.of(autoStartup) : Optional.empty();
+        }
 	}
 
 	/**
@@ -618,6 +639,8 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 		private @Nullable Class<?> targetType;
 		private ErrorHandler errorHandler = LoggingErrorHandler.INSTANCE;
 		private Executor executor = new SimpleAsyncTaskExecutor();
+        private @Nullable Integer phase;
+        private @Nullable Boolean autoStartup;
 
 		@SuppressWarnings("NullAway")
 		private StreamMessageListenerContainerOptionsBuilder() {}
@@ -678,6 +701,28 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 			this.errorHandler = errorHandler;
 			return this;
 		}
+
+        /**
+         * Configure a phase for the {@link SmartLifecycle}
+         *
+         * @return {@code this} {@link StreamMessageListenerContainerOptionsBuilder}.
+         * @since 4.0
+         */
+        public StreamMessageListenerContainerOptionsBuilder<K, V> phase(int phase) {
+            this.phase = phase;
+            return this;
+        }
+
+        /**
+         * Configure a autoStartup for the {@link SmartLifecycle}
+         *
+         * @return {@code this} {@link StreamMessageListenerContainerOptionsBuilder}.
+         * @since 4.0
+         */
+        public StreamMessageListenerContainerOptionsBuilder<K, V> autoStartup(boolean autoStartup) {
+            this.autoStartup = autoStartup;
+            return this;
+        }
 
 		/**
 		 * Configure a key, hash key and hash value serializer.
@@ -796,7 +841,7 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 			Assert.notNull(hashValueSerializer, "Hash Value Serializer must not be null");
 
 			return new StreamMessageListenerContainerOptions<>(pollTimeout, batchSize, keySerializer, hashKeySerializer,
-					hashValueSerializer, targetType, hashMapper, errorHandler, executor);
+					hashValueSerializer, targetType, hashMapper, errorHandler, executor,phase,autoStartup);
 		}
 
 	}

--- a/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerUnitTests.java
@@ -250,4 +250,16 @@ class RedisMessageListenerContainerUnitTests {
         container.setPhase(3208);
         assertThat(container.getPhase()).isEqualTo(3208);
     }
+
+    @Test // GH-3208
+    void defaultAutoStartupShouldBeMaxValue() {
+        assertThat(container.isAutoStartup()).isEqualTo(true);
+    }
+
+    @Test // GH-3208
+    void shouldApplyConfiguredAutoStartup() {
+        container.setAutoStartup(false);
+        assertThat(container.isAutoStartup()).isEqualTo(false);
+    }
+
 }

--- a/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerUnitTests.java
@@ -252,7 +252,7 @@ class RedisMessageListenerContainerUnitTests {
     }
 
     @Test // GH-3208
-    void defaultAutoStartupShouldBeMaxValue() {
+    void defaultAutoStartupShouldBeTrue() {
         assertThat(container.isAutoStartup()).isEqualTo(true);
     }
 

--- a/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/RedisMessageListenerContainerUnitTests.java
@@ -239,4 +239,15 @@ class RedisMessageListenerContainerUnitTests {
 
 		assertThatNoException().isThrownBy(() -> container.removeMessageListener(null, Collections.singletonList(topic)));
 	}
+
+    @Test // GH-3208
+    void defaultPhaseShouldBeMaxValue() {
+        assertThat(container.getPhase()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test // GH-3208
+    void shouldApplyConfiguredPhase() {
+        container.setPhase(3208);
+        assertThat(container.getPhase()).isEqualTo(3208);
+    }
 }

--- a/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
@@ -384,6 +384,44 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		cancelAwait(subscription);
 	}
 
+    @Test // GH-3208
+    void defaultPhaseShouldBeMaxValue() {
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
+                .create(connectionFactory, containerOptions);
+
+        assertThat(container.getPhase()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test // GH-3208
+    void shouldApplyConfiguredPhase() {
+        StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options = StreamMessageListenerContainerOptions.builder()
+                .phase(3208)
+                .build();
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
+                .create(connectionFactory, options);
+
+        assertThat(container.getPhase()).isEqualTo(3208);
+    }
+
+    @Test // GH-3208
+    void defaultAutoStartupShouldBeFalse() {
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
+                .create(connectionFactory, containerOptions);
+
+        assertThat(container.isAutoStartup()).isEqualTo(false);
+    }
+
+    @Test // GH-3208
+    void shouldApplyConfiguredAutoStartup() {
+        StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options = StreamMessageListenerContainerOptions.builder()
+                .autoStartup(true)
+                .build();
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
+                .create(connectionFactory, options);
+
+        assertThat(container.isAutoStartup()).isEqualTo(true);
+    }
+
 	private static void cancelAwait(Subscription subscription) {
 
 		subscription.cancel();


### PR DESCRIPTION
This PR introduces a configurable `phase` property in `RedisMessageListenerContainer`.  
Previously, the container always used `Integer.MAX_VALUE` as its SmartLifecycle phase, making it difficult to align startup/shutdown ordering with other SmartLifecycle beans.
#3208 


<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
