### PR TITLE
Add support for HGETGEL, HGETEX and HSETEX commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION?=7.4.0
+VERSION?=8.0.0
 PROJECT?=redis
 GH_ORG?=redis
 SPRING_PROFILE?=ci

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -1615,6 +1615,11 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
         return convertAndReturn(delegate.hGetDel(serialize(key), serializeMulti(fields)), byteListToStringList);
     }
 
+    @Override
+    public List<String> hGetEx(String key, Expiration expiration, String... fields) {
+        return convertAndReturn(delegate.hGetEx(serialize(key), expiration, serializeMulti(fields)), byteListToStringList);
+    }
+
 	@Override
 	public Long incr(String key) {
 		return incr(serialize(key));
@@ -2591,6 +2596,11 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
     @Override
     public List<byte[]> hGetDel(@NotNull byte[] key, @NotNull byte[]... fields) {
         return convertAndReturn(delegate.hGetDel(key, fields), Converters.identityConverter());
+    }
+
+    @Override
+    public List<byte[]> hGetEx(@NotNull byte[] key, Expiration expiration, @NotNull byte[]... fields) {
+        return convertAndReturn(delegate.hGetEx(key, expiration, fields), Converters.identityConverter());
     }
 
 	public @Nullable List<Long> applyExpiration(String key,

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -23,6 +23,7 @@ import java.util.function.IntFunction;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.convert.converter.Converter;
@@ -1609,6 +1610,11 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 		return convertAndReturn(delegate.hVals(serialize(key)), byteListToStringList);
 	}
 
+    @Override
+    public List<String> hGetDel(String key, String... fields) {
+        return convertAndReturn(delegate.hGetDel(serialize(key), serializeMulti(fields)), byteListToStringList);
+    }
+
 	@Override
 	public Long incr(String key) {
 		return incr(serialize(key));
@@ -2581,6 +2587,11 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	public List<Long> hTtl(byte[] key, TimeUnit timeUnit, byte[]... fields) {
 		return this.delegate.hTtl(key, timeUnit, fields);
 	}
+
+    @Override
+    public List<byte[]> hGetDel(@NotNull byte[] key, @NotNull byte[]... fields) {
+        return convertAndReturn(delegate.hGetDel(key, fields), Converters.identityConverter());
+    }
 
 	public @Nullable List<Long> applyExpiration(String key,
 			org.springframework.data.redis.core.types.Expiration expiration,

--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -24,6 +24,7 @@ import java.util.function.IntFunction;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.convert.converter.Converter;
@@ -1620,6 +1621,11 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
         return convertAndReturn(delegate.hGetEx(serialize(key), expiration, serializeMulti(fields)), byteListToStringList);
     }
 
+    @Override
+    public Boolean hSetEx(@NonNull String key, @NonNull Map<@NonNull String, String> hashes, HashFieldSetOption condition, Expiration expiration) {
+        return convertAndReturn(delegate.hSetEx(serialize(key), serialize(hashes), condition, expiration), Converters.identityConverter());
+    }
+
 	@Override
 	public Long incr(String key) {
 		return incr(serialize(key));
@@ -2601,6 +2607,11 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
     @Override
     public List<byte[]> hGetEx(@NotNull byte[] key, Expiration expiration, @NotNull byte[]... fields) {
         return convertAndReturn(delegate.hGetEx(key, expiration, fields), Converters.identityConverter());
+    }
+
+    @Override
+    public Boolean hSetEx(@NotNull byte[] key, @NonNull Map<byte[], byte[]> hashes, HashFieldSetOption condition, Expiration expiration) {
+        return convertAndReturn(delegate.hSetEx(key, hashes, condition, expiration), Converters.identityConverter());
     }
 
 	public @Nullable List<Long> applyExpiration(String key,

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -1608,6 +1608,13 @@ public interface DefaultedRedisConnection extends RedisCommands, RedisCommandsPr
         return hashCommands().hGetEx(key, expiration, fields);
     }
 
+    /** @deprecated in favor of {@link RedisConnection#hashCommands()}}. */
+    @Override
+    @Deprecated
+    default Boolean hSetEx(byte[] key, Map<byte[], byte[]> hashes, HashFieldSetOption condition, Expiration expiration) {
+        return hashCommands().hSetEx(key, hashes, condition, expiration);
+    }
+
 	/** @deprecated in favor of {@link RedisConnection#hashCommands()}}. */
 	@Override
 	@Deprecated

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -1594,6 +1594,13 @@ public interface DefaultedRedisConnection extends RedisCommands, RedisCommandsPr
 		return hashCommands().hpTtl(key, fields);
 	}
 
+    /** @deprecated in favor of {@link RedisConnection#hashCommands()}}. */
+    @Override
+    @Deprecated
+    default List<byte[]> hGetDel(byte[] key, byte[]... fields) {
+        return hashCommands().hGetDel(key, fields);
+    }
+
 	/** @deprecated in favor of {@link RedisConnection#hashCommands()}}. */
 	@Override
 	@Deprecated

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -1601,6 +1601,13 @@ public interface DefaultedRedisConnection extends RedisCommands, RedisCommandsPr
         return hashCommands().hGetDel(key, fields);
     }
 
+    /** @deprecated in favor of {@link RedisConnection#hashCommands()}}. */
+    @Override
+    @Deprecated
+    default List<byte[]> hGetEx(byte[] key, Expiration expiration, byte[]... fields) {
+        return hashCommands().hGetEx(key, expiration, fields);
+    }
+
 	/** @deprecated in favor of {@link RedisConnection#hashCommands()}}. */
 	@Override
 	@Deprecated

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -58,6 +58,7 @@ public interface ReactiveHashCommands {
 	 *
 	 * @author Christoph Strobl
 	 * @author Tihomir Mateev
+     * @author Viktoriya Kutsarova
 	 */
 	class HashFieldsCommand extends KeyCommand {
 
@@ -1255,4 +1256,86 @@ public interface ReactiveHashCommands {
 	 */
 	Flux<NumericResponse<HashFieldsCommand, Long>> hpTtl(Publisher<HashFieldsCommand> commands);
 
+
+    /**
+     * {@literal HGETDEL} {@link Command}.
+     *
+     * @author Viktoriya Kutsarova
+     * @see <a href="https://redis.io/commands/hgetdel">Redis Documentation: HGETDEL</a>
+     */
+    class HGetDelCommand extends HashFieldsCommand {
+
+        private HGetDelCommand(@Nullable ByteBuffer key, List<ByteBuffer> fields) {
+            super(key, fields);
+        }
+
+        /**
+         * Creates a new {@link HGetDelCommand} given a {@link ByteBuffer field name}.
+         *
+         * @param field must not be {@literal null}.
+         * @return a new {@link HGetDelCommand} for a {@link ByteBuffer field name}.
+         */
+        public static HGetDelCommand field(ByteBuffer field) {
+
+            Assert.notNull(field, "Field must not be null");
+
+            return new HGetDelCommand(null, Collections.singletonList(field));
+        }
+
+        /**
+         * Creates a new {@link HGetDelCommand} given a {@link Collection} of field names.
+         *
+         * @param fields must not be {@literal null}.
+         * @return a new {@link HGetDelCommand} for a {@link Collection} of field names.
+         */
+        public static HGetDelCommand fields(Collection<ByteBuffer> fields) {
+
+            Assert.notNull(fields, "Fields must not be null");
+
+            return new HGetDelCommand(null, new ArrayList<>(fields));
+        }
+
+        /**
+         * Applies the hash {@literal key}. Constructs a new command instance with all previously configured properties.
+         *
+         * @param key must not be {@literal null}.
+         * @return a new {@link HGetDelCommand} with {@literal key} applied.
+         */
+        public HGetDelCommand from(ByteBuffer key) {
+
+            Assert.notNull(key, "Key must not be null");
+
+            return new HGetDelCommand(key, getFields());
+        }
+    }
+
+
+    /**
+     * Get and delete the value of one or more {@literal fields} from hash at {@literal key}. Values are returned in the
+     * order of the requested keys. Absent field values are represented using {@literal null} in the resulting {@link List}.
+     * When the last field is deleted, the key will also be deleted.
+     *
+     * @param key must not be {@literal null}.
+     * @param fields must not be {@literal null}.
+     * @return never {@literal null}.
+     * @see <a href="https://redis.io/commands/hgetdel">Redis Documentation: HGETDEL</a>
+     */
+    default Mono<List<ByteBuffer>> hGetDel(ByteBuffer key, Collection<ByteBuffer> fields) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(fields, "Fields must not be null");
+
+        return hGetDel(Mono.just(HGetDelCommand.fields(fields).from(key))).next().map(MultiValueResponse::getOutput);
+    }
+
+    /**
+     * Get and delete the value of one or more {@literal fields} from hash at {@literal key}. Values are returned in the
+     * order of the requested keys. Absent field values are represented using {@literal null} in the resulting {@link List}.
+     * When the last field is deleted, the key will also be deleted.
+     *
+     * @param commands must not be {@literal null}.
+     * @return never {@literal null}.
+     * @see <a href="https://redis.io/commands/hgetdel">Redis Documentation: HGETDEL</a>
+     */
+    Flux<MultiValueResponse<HGetDelCommand, ByteBuffer>> hGetDel(Publisher<HGetDelCommand> commands);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
@@ -34,6 +34,7 @@ import org.springframework.util.ObjectUtils;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Tihomir Mateev
+ * @author Viktoriya Kutsarova
  * @see RedisCommands
  */
 @NullUnmarked
@@ -541,4 +542,16 @@ public interface RedisHashCommands {
 	 * @since 3.5
 	 */
 	List<@NonNull Long> hpTtl(byte @NonNull [] key, byte @NonNull [] @NonNull... fields);
+
+    /**
+     * Get and delete the value of one or more {@code fields} from hash at {@code key}. Values are returned in the order of
+     * the requested keys. Absent field values are represented using {@literal null} in the resulting {@link List}.
+     * When the last field is deleted, the key will also be deleted.
+     *
+     * @param key must not be {@literal null}.
+     * @param fields must not be {@literal null}.
+     * @return empty {@link List} if key does not exist. {@literal null} when used in pipeline / transaction.
+     * @see <a href="https://redis.io/commands/hgetdel">Redis Documentation: HGETDEL</a>
+     */
+    List<byte[]> hGetDel(byte @NonNull [] key, byte @NonNull [] @NonNull... fields);
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullUnmarked;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -554,4 +555,17 @@ public interface RedisHashCommands {
      * @see <a href="https://redis.io/commands/hgetdel">Redis Documentation: HGETDEL</a>
      */
     List<byte[]> hGetDel(byte @NonNull [] key, byte @NonNull [] @NonNull... fields);
+
+    /**
+     * Get the value of one or more {@code fields} from hash at {@code key} and optionally set expiration time or
+     * time-to-live (TTL) for given {@code fields}.
+     *
+     * @param key must not be {@literal null}.
+     * @param fields must not be {@literal null}.
+     * @return empty {@link List} if key does not exist. {@literal null} when used in pipeline / transaction.
+     * @see <a href="https://redis.io/commands/hgetex">Redis Documentation: HGETEX</a>
+     */
+    List<byte[]> hGetEx(byte @NonNull [] key, Expiration expiration,
+                                byte @NonNull [] @NonNull... fields);
+
 }

--- a/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
@@ -568,4 +568,60 @@ public interface RedisHashCommands {
     List<byte[]> hGetEx(byte @NonNull [] key, Expiration expiration,
                                 byte @NonNull [] @NonNull... fields);
 
+    /**
+     * Set field-value pairs in hash at {@literal key} with optional condition and expiration.
+     *
+     * @param key must not be {@literal null}.
+     * @param hashes the field-value pairs to set; must not be {@literal null}.
+     * @param hashFieldSetOption the optional condition for setting fields.
+     * @param expiration the optional expiration to apply.
+     * @return never {@literal null}.
+     * @see <a href="https://redis.io/commands/hsetex">Redis Documentation: HSETEX</a>
+     */
+    Boolean hSetEx(byte @NonNull [] key, @NonNull Map<byte[], byte[]> hashes, HashFieldSetOption hashFieldSetOption,
+                   Expiration expiration);
+
+    /**
+     * {@code HSETEX} command arguments for {@code FNX}, {@code FXX}.
+     *
+     * @author Viktoriya Kutsarova
+     */
+    enum HashFieldSetOption {
+
+        /**
+         * Do not set any additional command argument.
+         */
+        UPSERT,
+
+        /**
+         * {@code FNX}
+         */
+        IF_NONE_EXIST,
+
+        /**
+         * {@code FXX}
+         */
+        IF_ALL_EXIST;
+
+        /**
+         * Do not set any additional command argument.
+         */
+        public static HashFieldSetOption upsert() {
+            return UPSERT;
+        }
+
+        /**
+         * {@code FNX}
+         */
+        public static HashFieldSetOption ifNoneExist() {
+            return IF_NONE_EXIST;
+        }
+
+        /**
+         * {@code FXX}
+         */
+        public static HashFieldSetOption ifAllExist() {
+            return IF_ALL_EXIST;
+        }
+    }
 }

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -2576,6 +2576,20 @@ public interface StringRedisConnection extends RedisConnection {
      */
     List<String> hGetEx(@NonNull String key, Expiration expiration, @NonNull String @NonNull... fields);
 
+    /**
+     * Set field-value pairs in hash at {@literal key} with optional condition and expiration.
+     *
+     * @param key must not be {@literal null}.
+     * @param hashes the field-value pairs to set; must not be {@literal null}.
+     * @param condition the optional condition for setting fields.
+     * @param expiration the optional expiration to apply.
+     * @return never {@literal null}.
+     * @see <a href="https://redis.io/commands/hsetex">Redis Documentation: HSETEX</a>
+     * @see RedisHashCommands#hSetEx(byte[], Map, HashFieldSetOption, Expiration)
+     */
+    Boolean hSetEx(@NonNull String key, @NonNull Map<@NonNull String, String> hashes, HashFieldSetOption condition,
+                   Expiration expiration);
+
 	// -------------------------------------------------------------------------
 	// Methods dealing with HyperLogLog
 	// -------------------------------------------------------------------------

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -2552,6 +2552,18 @@ public interface StringRedisConnection extends RedisConnection {
 	 */
 	List<Long> hpTtl(@NonNull String key, @NonNull String @NonNull... fields);
 
+    /**
+     * Get and delete the value of one or more {@code fields} from hash at {@code key}. When the last field is deleted,
+     * the key will also be deleted.
+     *
+     * @param key must not be {@literal null}.
+     * @param fields must not be {@literal null}.
+     * @return empty {@link List} if key does not exist. {@literal null} when used in pipeline / transaction.
+     * @see <a href="https://redis.io/commands/hmget">Redis Documentation: HMGET</a>
+     * @see RedisHashCommands#hMGet(byte[], byte[]...)
+     */
+    List<String> hGetDel(@NonNull String key, @NonNull String @NonNull... fields);
+
 	// -------------------------------------------------------------------------
 	// Methods dealing with HyperLogLog
 	// -------------------------------------------------------------------------

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -2564,6 +2564,18 @@ public interface StringRedisConnection extends RedisConnection {
      */
     List<String> hGetDel(@NonNull String key, @NonNull String @NonNull... fields);
 
+    /**
+     * Get the value of one or more {@code fields} from hash at {@code key} and optionally set expiration time or
+     * time-to-live (TTL) for given {@code fields}.
+     *
+     * @param key must not be {@literal null}.
+     * @param fields must not be {@literal null}.
+     * @return empty {@link List} if key does not exist. {@literal null} when used in pipeline / transaction.
+     * @see <a href="https://redis.io/commands/hgetex">Redis Documentation: HGETEX</a>
+     * @see RedisHashCommands#hGetEx(byte[], Expiration, byte[]...)
+     */
+    List<String> hGetEx(@NonNull String key, Expiration expiration, @NonNull String @NonNull... fields);
+
 	// -------------------------------------------------------------------------
 	// Methods dealing with HyperLogLog
 	// -------------------------------------------------------------------------

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
@@ -414,6 +414,20 @@ class JedisClusterHashCommands implements RedisHashCommands {
 		}
 	}
 
+    @Override
+    public List<byte[]> hGetDel(byte[] key, byte[]... fields) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(fields, "Fields must not be null");
+
+        try {
+            return connection.getCluster().hgetdel(key, fields);
+        } catch (Exception ex) {
+            throw convertJedisAccessException(ex);
+        }
+
+    }
+
 	@Nullable
 	@Override
 	public Long hStrLen(byte[] key, byte[] field) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import org.springframework.data.redis.core.types.Expiration;
 import redis.clients.jedis.args.ExpiryOption;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
@@ -425,7 +426,19 @@ class JedisClusterHashCommands implements RedisHashCommands {
         } catch (Exception ex) {
             throw convertJedisAccessException(ex);
         }
+    }
 
+    @Override
+    public List<byte[]> hGetEx(byte[] key, Expiration expiration, byte[]... fields) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(fields, "Fields must not be null");
+
+        try {
+            return connection.getCluster().hgetex(key, JedisConverters.toHGetExParams(expiration), fields);
+        } catch (Exception ex) {
+            throw convertJedisAccessException(ex);
+        }
     }
 
 	@Nullable

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterHashCommands.java
@@ -441,6 +441,19 @@ class JedisClusterHashCommands implements RedisHashCommands {
         }
     }
 
+    @Override
+    public Boolean hSetEx(byte[] key, Map<byte[], byte[]> hashes, HashFieldSetOption condition, Expiration expiration) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(hashes, "Fields must not be null");
+
+        try {
+            return JedisConverters.toBoolean(connection.getCluster().hsetex(key, JedisConverters.toHSetExParams(condition, expiration), hashes));
+        } catch (Exception ex) {
+            throw convertJedisAccessException(ex);
+        }
+    }
+
 	@Nullable
 	@Override
 	public Long hStrLen(byte[] key, byte[] field) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import org.springframework.data.redis.core.types.Expiration;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.args.ExpiryOption;
 import redis.clients.jedis.commands.PipelineBinaryCommands;
@@ -339,6 +340,15 @@ class JedisHashCommands implements RedisHashCommands {
         Assert.notNull(fields, "Fields must not be null");
 
         return connection.invoke().just(Jedis::hgetdel, PipelineBinaryCommands::hgetdel, key, fields);
+    }
+
+    @Override
+    public List<byte[]> hGetEx(byte @NonNull [] key, Expiration expiration, byte @NonNull [] @NonNull... fields) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(fields, "Fields must not be null");
+
+        return connection.invoke().just(Jedis::hgetex, PipelineBinaryCommands::hgetex, key, JedisConverters.toHGetExParams(expiration), fields);
     }
 
 	@Nullable

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
@@ -332,6 +332,15 @@ class JedisHashCommands implements RedisHashCommands {
 		return connection.invoke().just(Jedis::hpttl, PipelineBinaryCommands::hpttl, key, fields);
 	}
 
+    @Override
+    public List<byte[]> hGetDel(byte @NonNull [] key, byte @NonNull [] @NonNull... fields) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(fields, "Fields must not be null");
+
+        return connection.invoke().just(Jedis::hgetdel, PipelineBinaryCommands::hgetdel, key, fields);
+    }
+
 	@Nullable
 	@Override
 	public Long hStrLen(byte[] key, byte[] field) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisHashCommands.java
@@ -351,6 +351,18 @@ class JedisHashCommands implements RedisHashCommands {
         return connection.invoke().just(Jedis::hgetex, PipelineBinaryCommands::hgetex, key, JedisConverters.toHGetExParams(expiration), fields);
     }
 
+    @Override
+    public Boolean hSetEx(byte @NonNull [] key, @NonNull Map<byte[], byte[]> hashes, HashFieldSetOption condition,
+                          Expiration expiration) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(hashes, "Hashes must not be null");
+
+        return connection.invoke().from(Jedis::hsetex, PipelineBinaryCommands::hsetex, key,
+                JedisConverters.toHSetExParams(condition, expiration), hashes)
+                .get(Converters::toBoolean);
+    }
+
 	@Nullable
 	@Override
 	public Long hStrLen(byte[] key, byte[] field) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -1243,6 +1243,7 @@ public class LettuceConnection extends AbstractRedisConnection {
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZRANGEBYSCORE, ValueListOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZREVRANGE, ValueListOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZREVRANGEBYSCORE, ValueListOutput.class);
+            COMMAND_OUTPUT_TYPE_MAPPING.put(HGETDEL, ValueListOutput.class);
 
 			// BOOLEAN
 			COMMAND_OUTPUT_TYPE_MAPPING.put(EXISTS, BooleanOutput.class);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -1244,8 +1244,9 @@ public class LettuceConnection extends AbstractRedisConnection {
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZREVRANGE, ValueListOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(ZREVRANGEBYSCORE, ValueListOutput.class);
             COMMAND_OUTPUT_TYPE_MAPPING.put(HGETDEL, ValueListOutput.class);
+            COMMAND_OUTPUT_TYPE_MAPPING.put(HGETEX, ValueListOutput.class);
 
-			// BOOLEAN
+            // BOOLEAN
 			COMMAND_OUTPUT_TYPE_MAPPING.put(EXISTS, BooleanOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(EXPIRE, BooleanOutput.class);
 			COMMAND_OUTPUT_TYPE_MAPPING.put(EXPIREAT, BooleanOutput.class);

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConverters.java
@@ -23,6 +23,8 @@ import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode.NodeFlag;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -619,6 +621,35 @@ public abstract class LettuceConverters extends Converters {
 		return expiration.isUnixTimestamp() ? args.exAt(expiration.getConverted(TimeUnit.SECONDS))
 				: args.ex(expiration.getConverted(TimeUnit.SECONDS));
 	}
+
+    /**
+     * Convert {@link Expiration} to {@link HGetExArgs}.
+     *
+     * @param expiration can be {@literal null}.
+     * @since 4.0
+     */
+    static HGetExArgs toHGetExArgs(@Nullable Expiration expiration) {
+
+        HGetExArgs args = new HGetExArgs();
+
+        if (expiration == null) {
+            return args;
+        }
+
+        if (expiration.isPersistent()) {
+            return args.persist();
+        }
+
+        if (expiration.getTimeUnit() == TimeUnit.MILLISECONDS) {
+            if (expiration.isUnixTimestamp()) {
+                return args.pxAt(Instant.ofEpochSecond(expiration.getExpirationTime()));
+            }
+            return args.px(Duration.ofMillis(expiration.getExpirationTime()));
+        }
+
+        return expiration.isUnixTimestamp() ? args.exAt(Instant.ofEpochSecond(expiration.getConverted(TimeUnit.SECONDS)))
+                : args.ex(Duration.ofSeconds(expiration.getConverted(TimeUnit.SECONDS)));
+    }
 
 	@SuppressWarnings("NullAway")
 	static Converter<List<byte[]>, Long> toTimeConverter(TimeUnit timeUnit) {

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
@@ -40,6 +40,7 @@ import org.springframework.data.redis.core.Cursor.CursorId;
 import org.springframework.data.redis.core.KeyBoundCursor;
 import org.springframework.data.redis.core.ScanIteration;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
@@ -272,6 +273,17 @@ class LettuceHashCommands implements RedisHashCommands {
         Assert.notNull(fields, "Fields must not be null");
 
         return connection.invoke().fromMany(RedisHashAsyncCommands::hgetdel, key, fields)
+                .toList(source -> source.getValueOrElse(null));
+    }
+
+    @Override
+    public List<byte[]> hGetEx(byte @NonNull [] key, Expiration expiration, byte @NonNull []... fields) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(fields, "Fields must not be null");
+
+        return connection.invoke().fromMany(RedisHashAsyncCommands::hgetex, key,
+                LettuceConverters.toHGetExArgs(expiration), fields)
                 .toList(source -> source.getValueOrElse(null));
     }
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
@@ -265,6 +265,16 @@ class LettuceHashCommands implements RedisHashCommands {
 		return connection.invoke().fromMany(RedisHashAsyncCommands::hpttl, key, fields).toList();
 	}
 
+    @Override
+    public List<byte[]> hGetDel(byte @NonNull [] key, byte @NonNull []... fields) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(fields, "Fields must not be null");
+
+        return connection.invoke().fromMany(RedisHashAsyncCommands::hgetdel, key, fields)
+                .toList(source -> source.getValueOrElse(null));
+    }
+
 	/**
 	 * @param key
 	 * @param cursorId

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceHashCommands.java
@@ -287,6 +287,17 @@ class LettuceHashCommands implements RedisHashCommands {
                 .toList(source -> source.getValueOrElse(null));
     }
 
+    public Boolean hSetEx(byte @NonNull [] key, @NonNull Map<byte[], byte[]> hashes, HashFieldSetOption condition,
+                          Expiration expiration) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(hashes, "Hashes must not be null");
+
+        return connection.invoke().from(RedisHashAsyncCommands::hsetex, key,
+                LettuceConverters.toHSetExArgs(condition, expiration), hashes)
+                .get(LettuceConverters.longToBooleanConverter());
+    }
+
 	/**
 	 * @param key
 	 * @param cursorId

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveHashCommands.java
@@ -356,6 +356,20 @@ class LettuceReactiveHashCommands implements ReactiveHashCommands {
 		}));
 	}
 
+    @Override
+    public Flux<MultiValueResponse<HGetDelCommand, ByteBuffer>> hGetDel(Publisher<HGetDelCommand> commands) {
+
+        return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
+
+            Assert.notNull(command.getKey(), "Key must not be null");
+            Assert.notNull(command.getFields(), "Fields must not be null");
+
+            return cmd.hgetdel(command.getKey(), command.getFields().toArray(ByteBuffer[]::new)).collectList()
+                    .map(value -> new MultiValueResponse<>(command, value.stream().map(v -> v.getValueOrElse(null))
+                            .collect(Collectors.toList())));
+        }));
+    }
+
 	private static Map.Entry<ByteBuffer, ByteBuffer> toEntry(KeyValue<ByteBuffer, ByteBuffer> kv) {
 
 		return new Entry<ByteBuffer, ByteBuffer>() {

--- a/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullUnmarked;
+import org.springframework.data.redis.core.types.Expiration;
 
 /**
  * Hash operations bound to a certain key.
@@ -255,4 +256,15 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 	 * @since 3.1
 	 */
     List<HV> getAndDelete(@NonNull Collection<@NonNull HK> hashFields);
+
+    /**
+     * Get and optionally expire the value for given {@code hashFields} from the hash at the bound key. Values are in the order of the
+     * requested hash fields. Absent field values are represented using {@literal null} in the resulting {@link List}.
+     *
+     * @param expiration is optional.
+     * @param hashFields must not be {@literal null}.
+     * @return never {@literal null}.
+     * @since 4.0
+     */
+    List<HV> getAndExpire(Expiration expiration, @NonNull Collection<@NonNull HK> hashFields);
 }

--- a/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
@@ -246,4 +246,13 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
 	@NonNull
 	RedisOperations<H, ?> getOperations();
 
+	/**
+	 * Get and remove the value for given {@code hashFields} from the hash at the bound key. Values are in the order of the
+	 * requested hash fields. Absent field values are represented using {@literal null} in the resulting {@link List}.
+	 *
+	 * @param hashFields must not be {@literal null}.
+	 * @return {@literal null} when used in pipeline / transaction.
+	 * @since 3.1
+	 */
+    List<HV> getAndDelete(@NonNull Collection<@NonNull HK> hashFields);
 }

--- a/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundHashOperations.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullUnmarked;
+import org.springframework.data.redis.connection.RedisHashCommands;
 import org.springframework.data.redis.core.types.Expiration;
 
 /**
@@ -267,4 +268,17 @@ public interface BoundHashOperations<H, HK, HV> extends BoundKeyOperations<H> {
      * @since 4.0
      */
     List<HV> getAndExpire(Expiration expiration, @NonNull Collection<@NonNull HK> hashFields);
+
+    /**
+     * Set the value of one or more fields using data provided in {@code m} at the bound key, and optionally set their
+     * expiration time or time-to-live (TTL). The {@code condition} determines whether the fields are set.
+     *
+     * @param m must not be {@literal null}.
+     * @param condition is optional. Use {@link RedisHashCommands.HashFieldSetOption#IF_NONE_EXIST} (FNX) to only set the fields if
+     *                  none of them already exist, {@link RedisHashCommands.HashFieldSetOption#IF_ALL_EXIST} (FXX) to only set the
+     *                  fields if all of them already exist, or {@link RedisHashCommands.HashFieldSetOption#UPSERT} to set the fields
+     *                  unconditionally.
+     * @param expiration is optional.
+     */
+    void putAndExpire(Map<? extends @NonNull HK, ? extends HV> m, RedisHashCommands.HashFieldSetOption condition, Expiration expiration);
 }

--- a/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
@@ -214,6 +214,26 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 		return deserializeHashValues(rawValues);
 	}
 
+    @Override
+    public List<HV> getAndExpire(@NonNull K key, @NonNull Expiration expiration,
+			@NonNull Collection<@NonNull HK> fields) {
+
+		if (fields.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		byte[] rawKey = rawKey(key);
+		byte[][] rawHashKeys = new byte[fields.size()][];
+		int counter = 0;
+		for (@NonNull
+		HK hashKey : fields) {
+			rawHashKeys[counter++] = rawHashKey(hashKey);
+		}
+		List<byte[]> rawValues = execute(connection -> connection.hashCommands().hGetEx(rawKey, expiration, rawHashKeys));
+
+		return deserializeHashValues(rawValues);
+	}
+
 	@Override
 	public void put(@NonNull K key, @NonNull HK hashKey, HV value) {
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
@@ -195,6 +195,25 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 		return deserializeHashValues(rawValues);
 	}
 
+    @Override
+    public List<HV> getAndDelete(@NonNull K key, @NonNull Collection<@NonNull HK> fields) {
+
+		if (fields.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		byte[] rawKey = rawKey(key);
+		byte[][] rawHashKeys = new byte[fields.size()][];
+        int counter = 0;
+		for (@NonNull
+		HK hashKey : fields) {
+			rawHashKeys[counter++] = rawHashKey(hashKey);
+		}
+        List<byte[]> rawValues = execute(connection -> connection.hashCommands().hGetDel(rawKey, rawHashKeys));
+
+		return deserializeHashValues(rawValues);
+	}
+
 	@Override
 	public void put(@NonNull K key, @NonNull HK hashKey, HV value) {
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
@@ -31,6 +31,7 @@ import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.redis.connection.ExpirationOptions;
+import org.springframework.data.redis.connection.RedisHashCommands;
 import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.Expirations;
@@ -233,6 +234,24 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 
 		return deserializeHashValues(rawValues);
 	}
+
+    @Override
+    public Boolean putAndExpire(@NonNull K key, @NonNull Map<? extends @NonNull HK, ? extends HV> m,
+                                RedisHashCommands.HashFieldSetOption condition, Expiration expiration) {
+        if (m.isEmpty()) {
+            return false;
+        }
+
+        byte[] rawKey = rawKey(key);
+
+        Map<byte[], byte[]> hashes = new LinkedHashMap<>(m.size());
+
+        for (Map.Entry<? extends HK, ? extends HV> entry : m.entrySet()) {
+            hashes.put(rawHashKey(entry.getKey()), rawHashValue(entry.getValue()));
+        }
+
+        return execute(connection -> connection.hashCommands().hSetEx(rawKey, hashes, condition, expiration));
+    }
 
 	@Override
 	public void put(@NonNull K key, @NonNull HK hashKey, HV value) {

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
@@ -123,6 +123,19 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
                 .flatMap(hks -> hashCommands.hGetDel(rawKey(key), hks)).map(this::deserializeHashValues));
     }
 
+    @Override
+    public Mono<List<HV>> getAndExpire(H key, Expiration expiration, Collection<HK> hashKeys) {
+
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(hashKeys, "Hash keys must not be null");
+        Assert.notEmpty(hashKeys, "Hash keys must not be empty");
+
+        return createMono(hashCommands -> Flux.fromIterable(hashKeys) //
+                .map(this::rawHashKey) //
+                .collectList() //
+                .flatMap(hks -> hashCommands.hGetEx(rawKey(key), expiration, hks)).map(this::deserializeHashValues));
+    }
+
 	@Override
 	public Mono<Long> increment(H key, HK hashKey, long delta) {
 

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
@@ -111,6 +111,18 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 				.flatMap(hks -> hashCommands.hMGet(rawKey(key), hks)).map(this::deserializeHashValues));
 	}
 
+    @Override
+    public Mono<List<HV>> getAndDelete(H key, Collection<HK> hashKeys) {
+        Assert.notNull(key, "Key must not be null");
+        Assert.notNull(hashKeys, "Hash keys must not be null");
+        Assert.notEmpty(hashKeys, "Hash keys must not be empty");
+
+        return createMono(hashCommands -> Flux.fromIterable(hashKeys) //
+                .map(this::rawHashKey) //
+                .collectList() //
+                .flatMap(hks -> hashCommands.hGetDel(rawKey(key), hks)).map(this::deserializeHashValues));
+    }
+
 	@Override
 	public Mono<Long> increment(H key, HK hashKey, long delta) {
 

--- a/src/main/java/org/springframework/data/redis/core/HashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/HashOperations.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.redis.connection.ExpirationOptions;
+import org.springframework.data.redis.connection.RedisHashCommands;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.Expirations;
 
@@ -102,6 +103,19 @@ public interface HashOperations<H, HK, HV> {
      * @since 4.0
      */
     List<HV> getAndExpire(@NonNull H key, Expiration expiration, @NonNull Collection<@NonNull HK> hashKeys);
+
+    /**
+     * Set multiple hash fields to multiple values using data provided in {@code m} with optional condition and expiration.
+     *
+     * @param key must not be {@literal null}.
+     * @param m must not be {@literal null}.
+     * @param condition is optional.
+     * @param expiration is optional.
+     * @return {@literal null} when used in pipeline / transaction.
+     * @since 4.0
+     */
+    Boolean putAndExpire(@NonNull H key, @NonNull Map<? extends @NonNull HK, ? extends HV> m,
+                         RedisHashCommands.HashFieldSetOption condition, Expiration expiration);
 
 	/**
 	 * Increment {@code value} of a hash {@code hashKey} by the given {@code delta}.

--- a/src/main/java/org/springframework/data/redis/core/HashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/HashOperations.java
@@ -38,6 +38,7 @@ import org.springframework.data.redis.core.types.Expirations;
  * @author Christoph Strobl
  * @author Ninad Divadkar
  * @author Tihomir Mateev
+ * @author Viktoriya Kutsarova
  */
 @NullUnmarked
 public interface HashOperations<H, HK, HV> {
@@ -78,6 +79,17 @@ public interface HashOperations<H, HK, HV> {
 	 * @return {@literal null} when used in pipeline / transaction.
 	 */
 	List<HV> multiGet(@NonNull H key, @NonNull Collection<@NonNull HK> hashKeys);
+
+    /**
+     * Get and remove the value for given {@code hashKeys} from hash at {@code key}. Values are in the order of the
+     * requested keys. Absent field values are represented using {@literal null} in the resulting {@link List}.
+     *
+     * @param key must not be {@literal null}.
+     * @param hashKeys must not be {@literal null}.
+     * @return {@literal null} when used in pipeline / transaction.
+     * @since 4.0
+     */
+    List<HV> getAndDelete(@NonNull H key, @NonNull Collection<@NonNull HK> hashKeys);
 
 	/**
 	 * Increment {@code value} of a hash {@code hashKey} by the given {@code delta}.

--- a/src/main/java/org/springframework/data/redis/core/HashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/HashOperations.java
@@ -91,6 +91,18 @@ public interface HashOperations<H, HK, HV> {
      */
     List<HV> getAndDelete(@NonNull H key, @NonNull Collection<@NonNull HK> hashKeys);
 
+    /**
+     * Get and optionally expire the value for given {@code hashKeys} from hash at {@code key}. Values are in the order of
+     * the requested keys. Absent field values are represented using {@literal null} in the resulting {@link List}.
+     *
+     * @param key must not be {@literal null}.
+     * @param expiration is optional.
+     * @param hashKeys must not be {@literal null}.
+     * @return {@literal null} when used in pipeline / transaction.
+     * @since 4.0
+     */
+    List<HV> getAndExpire(@NonNull H key, Expiration expiration, @NonNull Collection<@NonNull HK> hashKeys);
+
 	/**
 	 * Increment {@code value} of a hash {@code hashKey} by the given {@code delta}.
 	 *
@@ -362,6 +374,8 @@ public interface HashOperations<H, HK, HV> {
 			@NonNull Collection<@NonNull HK> hashFields) {
 		return new DefaultBoundHashFieldExpirationOperations<>(this, key, () -> hashFields);
 	}
+
+
 
 	/**
 	 * @return the underlying {@link RedisOperations} used to execute commands.

--- a/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
@@ -95,6 +95,18 @@ public interface ReactiveHashOperations<H, HK, HV> {
      */
     Mono<List<HV>> getAndDelete(H key, Collection<HK> hashKeys);
 
+    /**
+     * Get and optionally expire the value for given {@code hashKeys} from hash at {@code key}. Values are in the order of the
+     * requested keys. Absent field values are represented using {@literal null} in the resulting {@link List}.
+     *
+     * @param key must not be {@literal null}.
+     * @param expiration is optional.
+     * @param hashKeys must not be {@literal null}.
+     * @return never {@literal null}.
+     * @since 4.0
+     */
+    Mono<List<HV>> getAndExpire(H key, Expiration expiration, Collection<HK> hashKeys);
+
 	/**
 	 * Increment {@code value} of a hash {@code hashKey} by the given {@code delta}.
 	 *

--- a/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.core;
 
+import org.springframework.data.redis.connection.RedisHashCommands;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -94,6 +95,19 @@ public interface ReactiveHashOperations<H, HK, HV> {
      * @since 4.0
      */
     Mono<List<HV>> getAndDelete(H key, Collection<HK> hashKeys);
+
+    /**
+     * Set multiple hash fields to multiple values using data provided in {@code m} with optional condition and expiration.
+     *
+     * @param key must not be {@literal null}.
+     * @param map must not be {@literal null}.
+     * @param condition is optional.
+     * @param expiration is optional.
+     * @return never {@literal null}.
+     * @since 4.0
+     */
+    Mono<Boolean> putAndExpire(H key, Map<? extends HK, ? extends HV> map, RedisHashCommands.HashFieldSetOption condition,
+                               Expiration expiration);
 
     /**
      * Get and optionally expire the value for given {@code hashKeys} from hash at {@code key}. Values are in the order of the

--- a/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
@@ -41,6 +41,7 @@ import org.springframework.data.redis.core.types.Expirations;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Viktoriya Kutsarova
  * @since 2.0
  */
 public interface ReactiveHashOperations<H, HK, HV> {
@@ -81,6 +82,18 @@ public interface ReactiveHashOperations<H, HK, HV> {
 	 * @return
 	 */
 	Mono<List<HV>> multiGet(H key, Collection<HK> hashKeys);
+    
+    /**
+     * Get and remove the value for given {@code hashKeys} from hash at {@code key}. Values are in the order of the
+     * requested keys. Absent field values are represented using {@literal null} in the resulting {@link List}.
+     * When the last field is deleted, the key will also be deleted.
+     *
+     * @param key must not be {@literal null}.
+     * @param hashKeys must not be {@literal null}.
+     * @return never {@literal null}.
+     * @since 4.0
+     */
+    Mono<List<HV>> getAndDelete(H key, Collection<HK> hashKeys);
 
 	/**
 	 * Increment {@code value} of a hash {@code hashKey} by the given {@code delta}.

--- a/src/main/java/org/springframework/data/redis/core/RedisCommand.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisCommand.java
@@ -147,6 +147,7 @@ public enum RedisCommand {
 	HMSET("w", 3), //
 	HPOP("rw", 3),
 	HSET("w", 3, 3), //
+    HSETEX("w", 3), //
 	HSETNX("w", 3, 3), //
 	HVALS("r", 1, 1), //
 	HEXPIRE("w", 5), //

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -3725,6 +3725,83 @@ public abstract class AbstractConnectionIntegrationTests {
 		verifyResults(Arrays.asList(new Object[] { List.of(-2L), List.of(-2L) }));
 	}
 
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelReturnsValueAndDeletesField() {
+
+		actual.add(connection.hSet("hash-hgetdel", "field-1", "value-1"));
+		actual.add(connection.hSet("hash-hgetdel", "field-2", "value-2"));
+		actual.add(connection.hGetDel("hash-hgetdel", "field-1"));
+		actual.add(connection.hExists("hash-hgetdel", "field-1"));
+		actual.add(connection.hExists("hash-hgetdel", "field-2"));
+
+		verifyResults(Arrays.asList(Boolean.TRUE, Boolean.TRUE, List.of("value-1"), Boolean.FALSE, Boolean.TRUE));
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelReturnsNullWhenFieldDoesNotExist() {
+
+		actual.add(connection.hSet("hash-hgetdel", "field-1", "value-1"));
+		actual.add(connection.hGetDel("hash-hgetdel", "missing-field"));
+		actual.add(connection.hExists("hash-hgetdel", "field-1"));
+
+		verifyResults(Arrays.asList(Boolean.TRUE, Arrays.asList((Object) null), Boolean.TRUE));
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelReturnsNullWhenKeyDoesNotExist() {
+
+		actual.add(connection.hGetDel("missing-hash", "field-1"));
+
+		verifyResults(Arrays.asList(Arrays.asList((Object) null)));
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelMultipleFieldsReturnsValuesAndDeletesFields() {
+
+		actual.add(connection.hSet("hash-hgetdel", "field-1", "value-1"));
+		actual.add(connection.hSet("hash-hgetdel", "field-2", "value-2"));
+		actual.add(connection.hSet("hash-hgetdel", "field-3", "value-3"));
+		actual.add(connection.hGetDel("hash-hgetdel", "field-1", "field-2"));
+		actual.add(connection.hExists("hash-hgetdel", "field-1"));
+		actual.add(connection.hExists("hash-hgetdel", "field-2"));
+		actual.add(connection.hExists("hash-hgetdel", "field-3"));
+
+		verifyResults(Arrays.asList(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE,
+			Arrays.asList("value-1", "value-2"),
+			Boolean.FALSE, Boolean.FALSE, Boolean.TRUE));
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelMultipleFieldsWithNonExistentFields() {
+
+		actual.add(connection.hSet("hash-hgetdel", "field-1", "value-1"));
+		actual.add(connection.hGetDel("hash-hgetdel", "field-1", "missing-field"));
+		actual.add(connection.hExists("hash-hgetdel", "field-1"));
+
+		verifyResults(Arrays.asList(Boolean.TRUE,
+			Arrays.asList("value-1", null),
+			Boolean.FALSE));
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelDeletesKeyWhenAllFieldsRemoved() {
+
+		actual.add(connection.hSet("hash-hgetdel", "field-1", "value-1"));
+		actual.add(connection.hSet("hash-hgetdel", "field-2", "value-2"));
+		actual.add(connection.hGetDel("hash-hgetdel", "field-1", "field-2"));
+		actual.add(connection.exists("hash-hgetdel"));
+
+		verifyResults(Arrays.asList(Boolean.TRUE, Boolean.TRUE,
+			Arrays.asList("value-1", "value-2"),
+			Boolean.FALSE));
+	}
+
 	@Test // DATAREDIS-694
 	void touchReturnsNrOfKeysTouched() {
 

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -3802,6 +3802,69 @@ public abstract class AbstractConnectionIntegrationTests {
 			Boolean.FALSE));
 	}
 
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExReturnsValueAndSetsExpiration() {
+
+		actual.add(connection.hSet("hash-hgetex", "field-1", "value-1"));
+		actual.add(connection.hSet("hash-hgetex", "field-2", "value-2"));
+		actual.add(connection.hGetEx("hash-hgetex", Expiration.seconds(60), "field-1"));
+		actual.add(connection.hExists("hash-hgetex", "field-1"));
+		actual.add(connection.hExists("hash-hgetex", "field-2"));
+
+		verifyResults(Arrays.asList(Boolean.TRUE, Boolean.TRUE, List.of("value-1"), Boolean.TRUE, Boolean.TRUE));
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExReturnsNullWhenFieldDoesNotExist() {
+
+		actual.add(connection.hSet("hash-hgetex", "field-1", "value-1"));
+		actual.add(connection.hGetEx("hash-hgetex", Expiration.seconds(60), "missing-field"));
+		actual.add(connection.hExists("hash-hgetex", "field-1"));
+
+		verifyResults(Arrays.asList(Boolean.TRUE, Arrays.asList((Object) null), Boolean.TRUE));
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExReturnsNullWhenKeyDoesNotExist() {
+
+		actual.add(connection.hGetEx("missing-hash", Expiration.seconds(60), "field-1"));
+
+		verifyResults(Arrays.asList(Arrays.asList((Object) null)));
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExMultipleFieldsReturnsValuesAndSetsExpiration() {
+
+		actual.add(connection.hSet("hash-hgetex", "field-1", "value-1"));
+		actual.add(connection.hSet("hash-hgetex", "field-2", "value-2"));
+		actual.add(connection.hSet("hash-hgetex", "field-3", "value-3"));
+		actual.add(connection.hGetEx("hash-hgetex", Expiration.seconds(120), "field-1", "field-2"));
+		actual.add(connection.hExists("hash-hgetex", "field-1"));
+		actual.add(connection.hExists("hash-hgetex", "field-2"));
+		actual.add(connection.hExists("hash-hgetex", "field-3"));
+
+		verifyResults(Arrays.asList(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE,
+			Arrays.asList("value-1", "value-2"),
+			Boolean.TRUE, Boolean.TRUE, Boolean.TRUE));
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExMultipleFieldsWithNonExistentFields() {
+
+		actual.add(connection.hSet("hash-hgetex", "field-1", "value-1"));
+		actual.add(connection.hGetEx("hash-hgetex", Expiration.seconds(60), "field-1", "missing-field"));
+		actual.add(connection.hExists("hash-hgetex", "field-1"));
+
+		verifyResults(Arrays.asList(Boolean.TRUE,
+			Arrays.asList("value-1", null),
+			Boolean.TRUE));
+	}
+
 	@Test // DATAREDIS-694
 	void touchReturnsNrOfKeysTouched() {
 

--- a/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
@@ -445,6 +445,10 @@ class RedisConnectionUnitTests {
 			return delegate.hMGet(key, fields);
 		}
 
+        public List<byte[]> hGetDel(byte[] key, byte[]... fields) {
+            return delegate.hGetDel(key, fields);
+        }
+
 		public Long zRem(byte[] key, byte[]... values) {
 			return delegate.zRem(key, values);
 		}

--- a/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
@@ -453,6 +453,10 @@ class RedisConnectionUnitTests {
             return delegate.hGetEx(key, expiration, fields);
         }
 
+        public Boolean hSetEx(byte[] key, Map<byte[], byte[]> hashes, HashFieldSetOption condition, Expiration expiration) {
+            return delegate.hSetEx(key, hashes, condition, expiration);
+        }
+
 		public Long zRem(byte[] key, byte[]... values) {
 			return delegate.zRem(key, values);
 		}

--- a/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisConnectionUnitTests.java
@@ -449,6 +449,10 @@ class RedisConnectionUnitTests {
             return delegate.hGetDel(key, fields);
         }
 
+        public List<byte[]> hGetEx(byte[] key, Expiration expiration, byte[]... fields) {
+            return delegate.hGetEx(key, expiration, fields);
+        }
+
 		public Long zRem(byte[] key, byte[]... values) {
 			return delegate.zRem(key, values);
 		}

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -1324,6 +1324,73 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hashCommands().hExists(KEY_1_BYTES, KEY_3_BYTES)).isFalse();
 	}
 
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExReturnsValueAndSetsExpiration() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+		nativeConnection.hset(KEY_1, KEY_3, VALUE_2);
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetEx(KEY_1_BYTES, Expiration.seconds(60), KEY_2_BYTES);
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isEqualTo(VALUE_1_BYTES);
+		assertThat(clusterConnection.hashCommands().hExists(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
+		assertThat(clusterConnection.hashCommands().hExists(KEY_1_BYTES, KEY_3_BYTES)).isTrue();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExReturnsNullWhenFieldDoesNotExist() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetEx(KEY_1_BYTES, Expiration.seconds(60), KEY_3_BYTES);
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isNull();
+		assertThat(clusterConnection.hashCommands().hExists(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExReturnsNullWhenKeyDoesNotExist() {
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetEx(KEY_1_BYTES, Expiration.seconds(60), KEY_2_BYTES);
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isNull();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExMultipleFieldsReturnsValuesAndSetsExpiration() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+		nativeConnection.hset(KEY_1, KEY_3, VALUE_2);
+		nativeConnection.hset(KEY_1, "field3", "value3");
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetEx(KEY_1_BYTES, Expiration.seconds(120), KEY_2_BYTES, KEY_3_BYTES);
+
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0)).isEqualTo(VALUE_1_BYTES);
+		assertThat(result.get(1)).isEqualTo(VALUE_2_BYTES);
+		assertThat(clusterConnection.hashCommands().hExists(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
+		assertThat(clusterConnection.hashCommands().hExists(KEY_1_BYTES, KEY_3_BYTES)).isTrue();
+		assertThat(clusterConnection.hashCommands().hExists(KEY_1_BYTES, "field3".getBytes())).isTrue();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETEX")
+	public void hGetExMultipleFieldsWithNonExistentFields() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetEx(KEY_1_BYTES, Expiration.seconds(60), KEY_2_BYTES, KEY_3_BYTES);
+
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0)).isEqualTo(VALUE_1_BYTES);
+		assertThat(result.get(1)).isNull();
+		assertThat(clusterConnection.hashCommands().hExists(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
+	}
+
 	@Test // DATAREDIS-315
 	public void hValsShouldRetrieveValuesCorrectly() {
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -16,7 +16,6 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.data.Offset.*;
 import static org.assertj.core.data.Offset.offset;
 import static org.springframework.data.redis.connection.BitFieldSubCommands.*;
 import static org.springframework.data.redis.connection.BitFieldSubCommands.BitFieldIncrBy.Overflow.*;
@@ -1302,6 +1301,91 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 
 		assertThat(clusterConnection.hashCommands().hTtl(KEY_1_BYTES, KEY_1_BYTES)).contains(-2L);
 		assertThat(clusterConnection.hashCommands().hTtl(KEY_3_BYTES, KEY_2_BYTES)).contains(-2L);
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelReturnsValueAndDeletesField() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+		nativeConnection.hset(KEY_1, KEY_3, VALUE_2);
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetDel(KEY_1_BYTES, KEY_2_BYTES);
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isEqualTo(VALUE_1_BYTES);
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_2_BYTES)).isFalse();
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_3_BYTES)).isTrue();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelReturnsNullWhenFieldDoesNotExist() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetDel(KEY_1_BYTES, KEY_3_BYTES);
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isNull();
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelReturnsNullWhenKeyDoesNotExist() {
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetDel(KEY_1_BYTES, KEY_2_BYTES);
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isNull();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelMultipleFieldsReturnsValuesAndDeletesFields() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+		nativeConnection.hset(KEY_1, KEY_3, VALUE_2);
+		nativeConnection.hset(KEY_1, "field3", "value3");
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetDel(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES);
+
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0)).isEqualTo(VALUE_1_BYTES);
+		assertThat(result.get(1)).isEqualTo(VALUE_2_BYTES);
+
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_2_BYTES)).isFalse();
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_3_BYTES)).isFalse();
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, "field3".getBytes())).isTrue();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelMultipleFieldsWithNonExistentFields() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetDel(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES);
+
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0)).isEqualTo(VALUE_1_BYTES);
+		assertThat(result.get(1)).isNull();
+
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_2_BYTES)).isFalse();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	public void hGetDelDeletesKeyWhenAllFieldsRemoved() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+		nativeConnection.hset(KEY_1, KEY_3, VALUE_2);
+
+		List<byte[]> result = clusterConnection.hashCommands().hGetDel(KEY_1_BYTES, KEY_2_BYTES, KEY_3_BYTES);
+
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0)).isEqualTo(VALUE_1_BYTES);
+		assertThat(result.get(1)).isEqualTo(VALUE_2_BYTES);
+
+		assertThat(clusterConnection.exists(KEY_1_BYTES)).isFalse();
 	}
 
 	@Test // DATAREDIS-315

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -1455,6 +1455,77 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
 	}
 
+	@Test // GH-3211
+	@EnabledOnCommand("HSETEX")
+	public void hSetExUpsertConditionSetsFieldsWithExpiration() {
+
+		Map<byte[], byte[]> fieldMap = Map.of(KEY_2_BYTES, VALUE_1_BYTES, KEY_3_BYTES, VALUE_2_BYTES);
+		Boolean result = clusterConnection.hashCommands().hSetEx(KEY_1_BYTES, fieldMap, RedisHashCommands.HashFieldSetOption.upsert(), Expiration.seconds(60));
+
+		assertThat(result).isTrue();
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_3_BYTES)).isTrue();
+		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES);
+		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_3_BYTES)).isEqualTo(VALUE_2_BYTES);
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HSETEX")
+	public void hSetExIfNoneExistConditionSucceedsWhenNoFieldsExist() {
+
+		Map<byte[], byte[]> fieldMap = Map.of(KEY_2_BYTES, VALUE_1_BYTES, KEY_3_BYTES, VALUE_2_BYTES);
+		Boolean result = clusterConnection.hashCommands().hSetEx(KEY_1_BYTES, fieldMap, RedisHashCommands.HashFieldSetOption.ifNoneExist(), Expiration.seconds(60));
+
+		assertThat(result).isTrue();
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_2_BYTES)).isTrue();
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_3_BYTES)).isTrue();
+		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES);
+		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_3_BYTES)).isEqualTo(VALUE_2_BYTES);
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HSETEX")
+	public void hSetExIfNoneExistConditionFailsWhenSomeFieldsExist() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+
+		Map<byte[], byte[]> fieldMap = Map.of(KEY_2_BYTES, VALUE_2_BYTES, KEY_3_BYTES, VALUE_2_BYTES);
+		Boolean result = clusterConnection.hashCommands().hSetEx(KEY_1_BYTES, fieldMap, RedisHashCommands.HashFieldSetOption.ifNoneExist(), Expiration.seconds(60));
+
+		assertThat(result).isFalse();
+		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES); // unchanged
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_3_BYTES)).isFalse(); // not set
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HSETEX")
+	public void hSetExIfAllExistConditionSucceedsWhenAllFieldsExist() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+		nativeConnection.hset(KEY_1, KEY_3, VALUE_2);
+
+		Map<byte[], byte[]> fieldMap = Map.of(KEY_2_BYTES, "new-value-1".getBytes(), KEY_3_BYTES, "new-value-2".getBytes());
+		Boolean result = clusterConnection.hashCommands().hSetEx(KEY_1_BYTES, fieldMap, RedisHashCommands.HashFieldSetOption.ifAllExist(), Expiration.seconds(60));
+
+		assertThat(result).isTrue();
+		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_2_BYTES)).isEqualTo("new-value-1".getBytes()); // updated
+		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_3_BYTES)).isEqualTo("new-value-2".getBytes()); // updated
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HSETEX")
+	public void hSetExIfAllExistConditionFailsWhenSomeFieldsMissing() {
+
+		nativeConnection.hset(KEY_1, KEY_2, VALUE_1);
+
+		Map<byte[], byte[]> fieldMap = Map.of(KEY_2_BYTES, VALUE_2_BYTES, KEY_3_BYTES, VALUE_2_BYTES);
+		Boolean result = clusterConnection.hashCommands().hSetEx(KEY_1_BYTES, fieldMap, RedisHashCommands.HashFieldSetOption.ifAllExist(), Expiration.seconds(60));
+
+		assertThat(result).isFalse();
+		assertThat(clusterConnection.hGet(KEY_1_BYTES, KEY_2_BYTES)).isEqualTo(VALUE_1_BYTES); // unchanged
+		assertThat(clusterConnection.hExists(KEY_1_BYTES, KEY_3_BYTES)).isFalse(); // not set
+	}
+
 	@Test // DATAREDIS-315
 	public void hValsShouldRetrieveValuesCorrectly() {
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assumptions.*;
 import static org.junit.jupiter.api.condition.OS.*;
 
+import org.springframework.data.redis.connection.RedisHashCommands;
 import org.springframework.data.redis.core.types.Expiration;
 import reactor.test.StepVerifier;
 
@@ -907,6 +908,227 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 				.consumeNextWith(actual -> {
 					assertThat(actual).hasSize(1).containsExactly((HV) null);
 				})
+				.verifyComplete();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HSETEX")
+	void putAndExpireUpsert() {
+
+		assumeThat(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory)
+				.isTrue();
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+
+		Map<HK, HV> fieldMap = Map.of(hashkey1, hashvalue1, hashkey2, hashvalue2);
+
+		hashOperations.putAndExpire(key, fieldMap, RedisHashCommands.HashFieldSetOption.upsert(), Expiration.seconds(60))
+				.as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		// Verify fields were set
+		hashOperations.hasKey(key, hashkey1).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey2).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.get(key, hashkey1).as(StepVerifier::create)
+				.expectNext(hashvalue1)
+				.verifyComplete();
+
+		hashOperations.get(key, hashkey2).as(StepVerifier::create)
+				.expectNext(hashvalue2)
+				.verifyComplete();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HSETEX")
+	void putAndExpireIfNoneExist() {
+
+		assumeThat(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory)
+				.isTrue();
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+		HK hashkey3 = hashKeyFactory.instance();
+		HV hashvalue3 = hashValueFactory.instance();
+
+		// Set up existing field
+		hashOperations.put(key, hashkey1, hashvalue1).as(StepVerifier::create).expectNext(true).verifyComplete();
+
+		// Try to set fields where one already exists - should fail
+		Map<HK, HV> fieldMap = Map.of(hashkey1, hashvalue2, hashkey2, hashvalue2);
+
+		hashOperations.putAndExpire(key, fieldMap, RedisHashCommands.HashFieldSetOption.ifNoneExist(), Expiration.seconds(60))
+				.as(StepVerifier::create)
+				.expectNext(false)
+				.verifyComplete();
+
+		// Verify original value unchanged and new field not set
+		hashOperations.get(key, hashkey1).as(StepVerifier::create)
+				.expectNext(hashvalue1)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey2).as(StepVerifier::create)
+				.expectNext(false)
+				.verifyComplete();
+
+		// Try with all new fields - should succeed
+		Map<HK, HV> newFieldMap = Map.of(hashkey2, hashvalue2, hashkey3, hashvalue3);
+
+		hashOperations.putAndExpire(key, newFieldMap, RedisHashCommands.HashFieldSetOption.ifNoneExist(), Expiration.seconds(120))
+				.as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		// Verify new fields were set
+		hashOperations.hasKey(key, hashkey2).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey3).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HSETEX")
+	void putAndExpireIfAllExist() {
+
+		assumeThat(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory)
+				.isTrue();
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+		HK hashkey3 = hashKeyFactory.instance();
+		HV hashvalue3 = hashValueFactory.instance();
+
+		// Set up existing fields
+		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
+
+		// Try to update existing fields - should succeed
+		Map<HK, HV> fieldMap = Map.of(hashkey1, hashvalue3, hashkey2, hashvalue3);
+
+		hashOperations.putAndExpire(key, fieldMap, RedisHashCommands.HashFieldSetOption.ifAllExist(), Expiration.seconds(60))
+				.as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		// Verify values were updated
+		hashOperations.get(key, hashkey1).as(StepVerifier::create)
+				.expectNext(hashvalue3)
+				.verifyComplete();
+
+		hashOperations.get(key, hashkey2).as(StepVerifier::create)
+				.expectNext(hashvalue3)
+				.verifyComplete();
+
+		// Try with non-existent field - should fail
+		Map<HK, HV> mixedFieldMap = Map.of(hashkey1, hashvalue1, hashkey3, hashvalue1);
+
+		hashOperations.putAndExpire(key, mixedFieldMap, RedisHashCommands.HashFieldSetOption.ifAllExist(), Expiration.seconds(120))
+				.as(StepVerifier::create)
+				.expectNext(false)
+				.verifyComplete();
+
+		// Verify values unchanged
+		hashOperations.get(key, hashkey1).as(StepVerifier::create)
+				.expectNext(hashvalue3)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey3).as(StepVerifier::create)
+				.expectNext(false)
+				.verifyComplete();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HSETEX")
+	void putAndExpireWithDifferentExpirationPolicies() {
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+		HK hashkey3 = hashKeyFactory.instance();
+		HV hashvalue3 = hashValueFactory.instance();
+		HK hashkey4 = hashKeyFactory.instance();
+		HV hashvalue4 = hashValueFactory.instance();
+		HK hashkey5 = hashKeyFactory.instance();
+		HV hashvalue5 = hashValueFactory.instance();
+
+		// Test with seconds expiration
+		Map<HK, HV> fieldMap1 = Map.of(hashkey1, hashvalue1);
+		hashOperations.putAndExpire(key, fieldMap1, RedisHashCommands.HashFieldSetOption.upsert(), Expiration.seconds(60))
+				.as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey1).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		// Test with milliseconds expiration
+		Map<HK, HV> fieldMap2 = Map.of(hashkey2, hashvalue2);
+		hashOperations.putAndExpire(key, fieldMap2, RedisHashCommands.HashFieldSetOption.upsert(), Expiration.milliseconds(120000))
+				.as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey2).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		// Test with Duration expiration
+		Map<HK, HV> fieldMap3 = Map.of(hashkey3, hashvalue3);
+		hashOperations.putAndExpire(key, fieldMap3, RedisHashCommands.HashFieldSetOption.upsert(), Expiration.from(Duration.ofMinutes(3)))
+				.as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey3).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		// Test with unix timestamp expiration (5 minutes from now)
+		long futureTimestamp = System.currentTimeMillis() / 1000 + 300; // 5 minutes from now
+		Map<HK, HV> fieldMap4 = Map.of(hashkey4, hashvalue4);
+		hashOperations.putAndExpire(key, fieldMap4, RedisHashCommands.HashFieldSetOption.upsert(), Expiration.unixTimestamp(futureTimestamp, TimeUnit.SECONDS))
+				.as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey4).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		// Test with keepTtl expiration
+		// First set a field with TTL, then update it with keepTtl
+		hashOperations.put(key, hashkey5, hashvalue5).as(StepVerifier::create).expectNext(true).verifyComplete();
+		hashOperations.expire(key, Duration.ofMinutes(4), Arrays.asList(hashkey5)).as(StepVerifier::create).expectNextCount(1).verifyComplete();
+
+		Map<HK, HV> fieldMap5 = Map.of(hashkey5, hashvalue5);
+		hashOperations.putAndExpire(key, fieldMap5, RedisHashCommands.HashFieldSetOption.upsert(), Expiration.keepTtl())
+				.as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey5).as(StepVerifier::create)
+				.expectNext(true)
 				.verifyComplete();
 	}
 }

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
@@ -685,4 +685,150 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 				.expectNext(true) //
 				.verifyComplete();
 	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	void getAndDeleteSingleKey() {
+
+		assumeThat(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory)
+				.isTrue();
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+
+		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
+
+		hashOperations.getAndDelete(key, Arrays.asList(hashkey1)).as(StepVerifier::create)
+				.consumeNextWith(actual -> {
+					assertThat(actual).hasSize(1).containsExactly(hashvalue1);
+				})
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey1).as(StepVerifier::create)
+				.expectNext(false)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey2).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	void getAndDeletePartialKeys() {
+
+		assumeThat(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory)
+				.isTrue();
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+
+		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
+
+		hashOperations.getAndDelete(key, Arrays.asList(hashkey1)).as(StepVerifier::create)
+				.consumeNextWith(actual -> {
+					assertThat(actual).hasSize(1).containsExactly(hashvalue1);
+				})
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey1).as(StepVerifier::create)
+				.expectNext(false)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey2).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.get(key, hashkey2).as(StepVerifier::create)
+				.expectNext(hashvalue2)
+				.verifyComplete();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	void getAndDeleteNonExistentKeys() {
+
+		assumeThat(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory)
+				.isTrue();
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+		HK nonExistentKey = hashKeyFactory.instance();
+
+		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
+
+		hashOperations.getAndDelete(key, Arrays.asList(nonExistentKey)).as(StepVerifier::create)
+				.consumeNextWith(actual -> {
+					assertThat(actual).hasSize(1).containsExactly((HV) null);
+				})
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey1).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.hasKey(key, hashkey2).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	void getAndDeleteKeyDeletionBehavior() {
+
+		assumeThat(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory)
+				.isTrue();
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+
+		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
+
+		redisTemplate.hasKey(key).as(StepVerifier::create)
+				.expectNext(true)
+				.verifyComplete();
+
+		hashOperations.getAndDelete(key, Arrays.asList(hashkey1, hashkey2)).as(StepVerifier::create)
+				.consumeNextWith(actual -> {
+					assertThat(actual).hasSize(2).containsSequence(hashvalue1, hashvalue2);
+				})
+				.verifyComplete();
+
+		hashOperations.size(key).as(StepVerifier::create)
+				.expectNext(0L)
+				.verifyComplete();
+
+        redisTemplate.hasKey(key).as(StepVerifier::create)
+				.expectNext(false)
+				.verifyComplete();
+	}
+
+	@Test // GH-3211
+	@EnabledOnCommand("HGETDEL")
+	void getAndDeleteFromNonExistentHash() {
+
+		assumeThat(hashKeyFactory instanceof StringObjectFactory && hashValueFactory instanceof StringObjectFactory)
+				.isTrue();
+
+		K nonExistentKey = keyFactory.instance();
+		HK hashkey = hashKeyFactory.instance();
+
+		hashOperations.getAndDelete(nonExistentKey, Arrays.asList(hashkey)).as(StepVerifier::create)
+				.consumeNextWith(actual -> {
+					assertThat(actual).hasSize(1).containsExactly((HV) null);
+				})
+				.verifyComplete();
+	}
 }


### PR DESCRIPTION
This change introduces the [Add HGETDEL, HGETEX and HSETEX hash commands](https://github.com/redis/redis/pull/13798) feature as part of the features provided by the spring-data-redis project. Closes spring-projects/spring-data-redis#3211.

As part of the change the following commands would be made available:

- [x] HGETDEL - get and delete the value of one or more fields of a given hash key. When the last field is deleted, the key will also be deleted
 - [x] HGETEX - get the value of one or more fields of a given hash key and optionally set their expiration time or time-to-live (TTL)
 - [x] HSETEX - set the value of one or more fields of a given hash key, and optionally set their expiration time or time-to-live (TTL)

The new commands are available as part of the following interfaces:
(based on similar PR [#3054](https://github.com/spring-projects/spring-data-redis/pull/3054))

- RedisHashCommands / ReactiveHashCommands
- HashOperations / ReactiveHashOperations / BoundHashOperations
- StringRedisConnection
- New enum HashFieldSetOption inside RedisHashCommands similar to SetOption in RedisStringCommands

This feature is available starting from [Redis OSS version 8.0.x](https://redis.io/docs/latest/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes/) and later

---
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
---
