### PR TITLE
Refine `ZSetOperations` method argument names

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultZSetOperations.java
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Andrey Shlykov
  * @author Shyngys Sapraliyev
  * @author John Blum
+ * @author Gunha Hwang
  */
 @NullUnmarked
 class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZSetOperations<K, V> {
@@ -349,10 +350,10 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	}
 
 	@Override
-	public Long rank(@NonNull K key, @NonNull Object o) {
+	public Long rank(@NonNull K key, @NonNull Object value) {
 
 		byte[] rawKey = rawKey(key);
-		byte[] rawValue = rawValue(o);
+		byte[] rawValue = rawValue(value);
 
 		return execute(connection -> {
 			Long zRank = connection.zRank(rawKey, rawValue);
@@ -361,10 +362,10 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	}
 
 	@Override
-	public Long reverseRank(@NonNull K key, @NonNull Object o) {
+	public Long reverseRank(@NonNull K key, @NonNull Object value) {
 
 		byte[] rawKey = rawKey(key);
-		byte[] rawValue = rawValue(o);
+		byte[] rawValue = rawValue(value);
 
 		return execute(connection -> {
 			Long zRank = connection.zRevRank(rawKey, rawValue);
@@ -406,10 +407,10 @@ class DefaultZSetOperations<K, V> extends AbstractOperations<K, V> implements ZS
 	}
 
 	@Override
-	public Double score(@NonNull K key, Object o) {
+	public Double score(@NonNull K key, Object value) {
 
 		byte[] rawKey = rawKey(key);
-		byte[] rawValue = rawValue(o);
+		byte[] rawValue = rawValue(value);
 
 		return execute(connection -> connection.zScore(rawKey, rawValue));
 	}

--- a/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ZSetOperations.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  * @author Wongoo (望哥)
  * @author Andrey Shlykov
  * @author Shyngys Sapraliyev
+ * @author Gunha Hwang
  */
 @NullUnmarked
 public interface ZSetOperations<K, V> {
@@ -210,21 +211,21 @@ public interface ZSetOperations<K, V> {
 	 * Determine the index of element with {@code value} in a sorted set.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param o the value.
+	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/zrank">Redis Documentation: ZRANK</a>
 	 */
-	Long rank(@NonNull K key, @NonNull Object o);
+	Long rank(@NonNull K key, @NonNull Object value);
 
 	/**
 	 * Determine the index of element with {@code value} in a sorted set when scored high to low.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param o the value.
+	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/zrevrank">Redis Documentation: ZREVRANK</a>
 	 */
-	Long reverseRank(@NonNull K key, @NonNull Object o);
+	Long reverseRank(@NonNull K key, @NonNull Object value);
 
 	/**
 	 * Get elements between {@code start} and {@code end} from sorted set.
@@ -525,11 +526,11 @@ public interface ZSetOperations<K, V> {
 	 * Get the score of element with {@code value} from sorted set with key {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param o the value.
+	 * @param value the value.
 	 * @return {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/zscore">Redis Documentation: ZSCORE</a>
 	 */
-	Double score(@NonNull K key, Object o);
+	Double score(@NonNull K key, Object value);
 
 	/**
 	 * Get the scores of elements with {@code values} from sorted set with key {@code key}.


### PR DESCRIPTION
I think the parameter name `o` in ZSetOperations was ambiguous and did not clearly represent its purpose.
This PR renames it to `value` to improve readability and make its role more explicit.