### PR TITLE
Make removeMessageListener listener parameter non-nullable

### DIFF
--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -104,6 +104,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * @author John Blum
  * @author Seongjun Lee
  * @author Su Ko
+ * @author Mingi Lee
  * @see MessageListener
  * @see SubscriptionListener
  */
@@ -591,7 +592,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 	 * @param listener message listener.
 	 * @param topics message listener topics.
 	 */
-	public void removeMessageListener(@Nullable MessageListener listener, Collection<? extends Topic> topics) {
+	public void removeMessageListener(MessageListener listener, Collection<? extends Topic> topics) {
 		removeListener(listener, topics);
 	}
 
@@ -605,7 +606,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 	 * @param listener message listener.
 	 * @param topic message topic.
 	 */
-	public void removeMessageListener(@Nullable MessageListener listener, Topic topic) {
+	public void removeMessageListener(MessageListener listener, Topic topic) {
 		removeMessageListener(listener, Collections.singleton(topic));
 	}
 
@@ -744,11 +745,12 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 		return mapping.computeIfAbsent(topic, k -> new CopyOnWriteArraySet<>());
 	}
 
-	private void removeListener(@Nullable MessageListener listener, Collection<? extends Topic> topics) {
+	private void removeListener(MessageListener listener, Collection<? extends Topic> topics) {
 
+		Assert.notNull(listener, "MessageListener must not be null");
 		Assert.notNull(topics, "Topics must not be null");
 
-		if (listener != null && listenerTopics.get(listener) == null) {
+		if (listenerTopics.get(listener) == null) {
 			// Listener not subscribed
 			return;
 		}


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->
## Overview
Changed the `listener` parameter of `removeMessageListener` methods in `RedisMessageListenerContainer` to be non-nullable. (issue #3016)

## Changes
- Removed `@Nullable` annotation from `listener` parameter in `removeMessageListener(MessageListener, Collection<Topic>)` method
- Removed `@Nullable` annotation from `listener` parameter in `removeMessageListener(MessageListener, Topic)` method
- Removed `@Nullable` annotation from `listener` parameter in internal `removeListener` method
- Added `Assert.notNull(listener, "MessageListener must not be null")` validation in `removeListener` method
- Simplified listener null check logic (removed unnecessary `if (listener != null && ...)` condition)

-----
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
