### PR TITLE
Fixed nondetermistic tests in MappingRedisConverterUnitTests.

### DIFF
--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -100,6 +100,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Mark Paluch
  * @author Golam Mazid Sajib
  * @author John Blum
+ * @author Edwin Ing
  */
 @ExtendWith(MockitoExtension.class)
 class MappingRedisConverterUnitTests {
@@ -1080,7 +1081,15 @@ class MappingRedisConverterUnitTests {
 		address.city = "unknown";
 		rand.address = address;
 
-		assertThat(write(rand)).containsEntry("address", "{\"city\":\"unknown\",\"country\":\"Tel'aran'rhiod\"}");
+		ObjectMapper mapper = new ObjectMapper();
+		assertThat(write(rand))
+				.hasEntrySatisfying("address", addr -> {
+					try {
+						assertThat(mapper.readTree(addr)).isEqualTo(mapper.readTree("{\"city\":\"unknown\",\"country\":\"Tel'aran'rhiod\"}"));
+					} catch (Exception e) {
+						throw new AssertionError("Error during JSON comparison: " + e.getMessage(), e);
+					}
+				});
 	}
 
 	@Test // DATAREDIS-425
@@ -1775,7 +1784,15 @@ class MappingRedisConverterUnitTests {
 
 		PartialUpdate<Person> update = new PartialUpdate<>("123", Person.class).set("address", address);
 
-		assertThat(write(update)).containsEntry("address", "{\"city\":\"unknown\",\"country\":\"Tel'aran'rhiod\"}");
+        ObjectMapper mapper = new ObjectMapper();
+        assertThat(write(update))
+                .hasEntrySatisfying("address", addr -> {
+                    try {
+                        assertThat(mapper.readTree(addr)).isEqualTo(mapper.readTree("{\"city\":\"unknown\",\"country\":\"Tel'aran'rhiod\"}"));
+                    } catch (Exception e) {
+                        throw new AssertionError("Error during JSON comparison: " + e.getMessage(), e);
+                    }
+                });
 	}
 
 	@Test // DATAREDIS-471


### PR DESCRIPTION
Fixes #3241 
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

### Summary

For the tests: 
- [`org.springframework.data.redis.core.convert.MappingRedisConverterUnitTests.writeShouldWritePartialUpdatePathWithRegisteredCustomConversionCorrectly`](https://github.com/spring-projects/spring-data-redis/blob/cbc02c0138b160679b68d1ed8a4cdcae7c3d9ef2/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java#L1765)
- [`org.springframework.data.redis.core.convert.MappingRedisConverterUnitTests.writeShouldHonorCustomConversionOnNestedType`](https://github.com/spring-projects/spring-data-redis/blob/cbc02c0138b160679b68d1ed8a4cdcae7c3d9ef2/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java#L1066)

An `ObjectMapper` was used to parse the JSON string and expected JSON string, enabling the assertion to test for equality while being insensitive to property ordering.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
