### PR TITLE
Fix HGETDEL, HGETEX and HSETEX pipeline and transaction integration tests.

### DIFF
--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -3774,7 +3774,7 @@ public abstract class AbstractConnectionIntegrationTests {
 
 		Map<String, String> fieldMap = Map.of("field-1", "value-1", "field-2", "value-2");
 		actual.add(connection.hSetEx("hash-hsetex", fieldMap, RedisHashCommands.HashFieldSetOption.upsert(),
-				Expiration.seconds(2)));
+				Expiration.seconds(30)));
 		actual.add(connection.hGet("hash-hsetex", "field-1"));
 		actual.add(connection.hGet("hash-hsetex", "field-2"));
 


### PR DESCRIPTION
This change fixes the pipeline and transaction tests for the **HGETDEL**, **HGETEX** and **HSETEX**.

---
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
---
