### PR TITLE
Expand bitwise operations with DIFF, DIFF1, ANDOR, ONE.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStringCommands.java
@@ -1289,7 +1289,7 @@ public interface ReactiveStringCommands {
 	}
 
 	/**
-	 * Emmit the the position of the first bit set to given {@code bit} in a string. Get the length of the value stored at
+	 * Emit the position of the first bit set to given {@code bit} in a string. Get the length of the value stored at
 	 * {@literal key}.
 	 *
 	 * @param commands must not be {@literal null}.

--- a/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStringCommands.java
@@ -38,7 +38,7 @@ import org.springframework.data.redis.core.types.Expiration;
 public interface RedisStringCommands {
 
 	enum BitOperation {
-		AND, OR, XOR, NOT;
+		AND, OR, XOR, NOT, DIFF, DIFF1, ANDOR, ONE;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConverters.java
@@ -285,6 +285,10 @@ abstract class JedisConverters extends Converters {
 			case OR -> BitOP.OR;
 			case NOT -> BitOP.NOT;
 			case XOR -> BitOP.XOR;
+			case DIFF -> BitOP.DIFF;
+			case DIFF1 ->  BitOP.DIFF1;
+			case ANDOR -> BitOP.ANDOR;
+			case ONE -> BitOP.ONE;
 		};
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommands.java
@@ -22,6 +22,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -368,7 +369,10 @@ class LettuceReactiveStringCommands implements ReactiveStringCommands {
 					Assert.isTrue(sourceKeys.length == 1, "BITOP NOT does not allow more than 1 source key.");
 					yield reactiveCommands.bitopNot(destinationKey, sourceKeys[0]);
 				}
-				default -> throw new IllegalArgumentException("Unknown BITOP '%s'".formatted(command.getBitOp()));
+				case DIFF -> reactiveCommands.bitopDiff(destinationKey, sourceKeys[0], Arrays.copyOfRange(sourceKeys, 1, sourceKeys.length));
+				case DIFF1 -> reactiveCommands.bitopDiff1(destinationKey, sourceKeys[0], Arrays.copyOfRange(sourceKeys, 1, sourceKeys.length));
+				case ANDOR -> reactiveCommands.bitopAndor(destinationKey, sourceKeys[0], Arrays.copyOfRange(sourceKeys, 1, sourceKeys.length));
+				case ONE -> reactiveCommands.bitopOne(destinationKey, sourceKeys);
 			};
 
 			return result.map(value -> new NumericResponse<>(command, value));

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStringCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStringCommands.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.api.async.RedisStringAsyncCommands;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -307,6 +308,10 @@ class LettuceStringCommands implements RedisStringCommands {
 				}
 				yield it.bitopNot(destination, keys[0]);
 			}
+			case DIFF -> it.bitopDiff(destination, keys[0], Arrays.copyOfRange(keys, 1, keys.length));
+			case DIFF1 -> it.bitopDiff1(destination, keys[0], Arrays.copyOfRange(keys, 1, keys.length));
+			case ANDOR -> it.bitopAndor(destination, keys[0], Arrays.copyOfRange(keys, 1, keys.length));
+			case ONE -> it.bitopOne(destination, keys);
 		});
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -572,6 +572,42 @@ public abstract class AbstractConnectionIntegrationTests {
 	}
 
 	@Test
+	void testBitOpDiff() {
+
+		actual.add(connection.set("key1", "foobar"));
+		actual.add(connection.set("key2", "abcdef"));
+		actual.add(connection.bitOp(BitOperation.DIFF, "key3", "key1", "key2"));
+		verifyResults(Arrays.asList(Boolean.TRUE, Boolean.TRUE, 6L));
+	}
+
+	@Test
+	void testBitOpDiff1() {
+
+		actual.add(connection.set("key1", "foobar"));
+		actual.add(connection.set("key2", "abcdef"));
+		actual.add(connection.bitOp(BitOperation.DIFF1, "key3", "key1", "key2"));
+		verifyResults(Arrays.asList(Boolean.TRUE, Boolean.TRUE, 6L));
+	}
+
+	@Test
+	void testBitOpAndor() {
+
+		actual.add(connection.set("key1", "foo"));
+		actual.add(connection.set("key2", "bar"));
+		actual.add(connection.bitOp(BitOperation.ANDOR, "key3", "key1", "key2"));
+		verifyResults(Arrays.asList(Boolean.TRUE, Boolean.TRUE, 3L));
+	}
+
+	@Test
+	void testBitOpOne() {
+
+		actual.add(connection.set("key1", "foo"));
+		actual.add(connection.set("key2", "bar"));
+		actual.add(connection.bitOp(BitOperation.ONE, "key3", "key1", "key2"));
+		verifyResults(Arrays.asList(Boolean.TRUE, Boolean.TRUE, 3L));
+	}
+
+	@Test
 	@EnabledOnCommand("COPY")
 	void testCopy() {
 

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionPipelineTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionPipelineTests.java
@@ -1011,6 +1011,90 @@ public class DefaultStringRedisConnectionPipelineTests extends DefaultStringRedi
 	}
 
 	@Test
+	public void testBitOpOrBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpOrBytes();
+	}
+
+	@Test
+	public void testBitOpOr() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpOr();
+	}
+
+	@Test
+	public void testBitOpXorBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpXorBytes();
+	}
+
+	@Test
+	public void testBitOpXor() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpXor();
+	}
+
+	@Test
+	public void testBitOpNotBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpNotBytes();
+	}
+
+	@Test
+	public void testBitOpNot() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpNot();
+	}
+
+	@Test
+	public void testBitOpDiffBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpDiffBytes();
+	}
+
+	@Test
+	public void testBitOpDiff() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpDiff();
+	}
+
+	@Test
+	public void testBitOpDiff1Bytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpDiff1Bytes();
+	}
+
+	@Test
+	public void testBitOpDiff1() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpDiff1();
+	}
+
+	@Test
+	public void testBitOpAndorBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpAndorBytes();
+	}
+
+	@Test
+	public void testBitOpAndor() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpAndor();
+	}
+
+	@Test
+	public void testBitOpOneBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpOneBytes();
+	}
+
+	@Test
+	public void testBitOpOne() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).closePipeline();
+		super.testBitOpOne();
+	}
+
+	@Test
 	public void testSUnionBytes() {
 		doReturn(Collections.singletonList(bytesSet)).when(nativeConnection).closePipeline();
 		super.testSUnionBytes();

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionPipelineTxTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionPipelineTxTests.java
@@ -1026,6 +1026,90 @@ public class DefaultStringRedisConnectionPipelineTxTests extends DefaultStringRe
 	}
 
 	@Test
+	public void testBitOpOrBytes() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpOrBytes();
+	}
+
+	@Test
+	public void testBitOpOr() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpOr();
+	}
+
+	@Test
+	public void testBitOpXorBytes() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpXorBytes();
+	}
+
+	@Test
+	public void testBitOpXor() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpXor();
+	}
+
+	@Test
+	public void testBitOpNotBytes() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpNotBytes();
+	}
+
+	@Test
+	public void testBitOpNot() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpNot();
+	}
+
+	@Test
+	public void testBitOpDiffBytes() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpDiffBytes();
+	}
+
+	@Test
+	public void testBitOpDiff() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpDiff();
+	}
+
+	@Test
+	public void testBitOpDiff1Bytes() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpDiff1Bytes();
+	}
+
+	@Test
+	public void testBitOpDiff1() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpDiff1();
+	}
+
+	@Test
+	public void testBitOpAndorBytes() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpAndorBytes();
+	}
+
+	@Test
+	public void testBitOpAndor() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpAndor();
+	}
+
+	@Test
+	public void testBitOpOneBytes() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpOneBytes();
+	}
+
+	@Test
+	public void testBitOpOne() {
+		doReturn(Collections.singletonList(Collections.singletonList(5L))).when(nativeConnection).closePipeline();
+		super.testBitOpOne();
+	}
+
+	@Test
 	public void testSUnionBytes() {
 		doReturn(Collections.singletonList(Collections.singletonList(bytesSet))).when(nativeConnection).closePipeline();
 		super.testSUnionBytes();

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTests.java
@@ -1267,6 +1267,104 @@ public class DefaultStringRedisConnectionTests {
 	}
 
 	@Test
+	public void testBitOpOrBytes() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.OR, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.OR, fooBytes, barBytes));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpOr() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.OR, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.OR, foo, bar));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpXorBytes() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.XOR, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.XOR, fooBytes, barBytes));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpXor() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.XOR, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.XOR, foo, bar));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpNotBytes() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.NOT, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.NOT, fooBytes, barBytes));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpNot() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.NOT, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.NOT, foo, bar));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpDiffBytes() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.DIFF, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.DIFF, fooBytes, barBytes));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpDiff() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.DIFF, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.DIFF, foo, bar));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpDiff1Bytes() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.DIFF1, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.DIFF1, fooBytes, barBytes));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpDiff1() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.DIFF1, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.DIFF1, foo, bar));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpAndorBytes() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.ANDOR, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.ANDOR, fooBytes, barBytes));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpAndor() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.ANDOR, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.ANDOR, foo, bar));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpOneBytes() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.ONE, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.ONE, fooBytes, barBytes));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
+	public void testBitOpOne() {
+		doReturn(5L).when(nativeConnection).bitOp(BitOperation.ONE, fooBytes, barBytes);
+		actual.add(connection.bitOp(BitOperation.ONE, foo, bar));
+		verifyResults(Collections.singletonList(5L));
+	}
+
+	@Test
 	public void testSUnionBytes() {
 		doReturn(bytesSet).when(nativeConnection).sUnion(fooBytes, barBytes);
 		actual.add(connection.sUnion(fooBytes, barBytes));

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTxTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTxTests.java
@@ -996,6 +996,90 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 	}
 
 	@Test
+	public void testBitOpOrBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpOrBytes();
+	}
+
+	@Test
+	public void testBitOpOr() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpOr();
+	}
+
+	@Test
+	public void testBitOpXorBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpXorBytes();
+	}
+
+	@Test
+	public void testBitOpXor() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpXor();
+	}
+
+	@Test
+	public void testBitOpNotBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpNotBytes();
+	}
+
+	@Test
+	public void testBitOpNot() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpNot();
+	}
+
+	@Test
+	public void testBitOpDiffBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpDiffBytes();
+	}
+
+	@Test
+	public void testBitOpDiff() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpDiff();
+	}
+
+	@Test
+	public void testBitOpDiff1Bytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpDiff1Bytes();
+	}
+
+	@Test
+	public void testBitOpDiff1() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpDiff1();
+	}
+
+	@Test
+	public void testBitOpAndorBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpAndorBytes();
+	}
+
+	@Test
+	public void testBitOpAndor() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpAndor();
+	}
+
+	@Test
+	public void testBitOpOneBytes() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpOneBytes();
+	}
+
+	@Test
+	public void testBitOpOne() {
+		doReturn(Collections.singletonList(5L)).when(nativeConnection).exec();
+		super.testBitOpOne();
+	}
+
+	@Test
 	public void testSUnionBytes() {
 		doReturn(Collections.singletonList(bytesSet)).when(nativeConnection).exec();
 		super.testSUnionBytes();

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClusterConnectionTests.java
@@ -78,6 +78,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @author Pavel Khokhlov
  * @author Dennis Neufeld
  * @author Tihomir Mateev
+ * @author Viktoriya Kutsarova
  */
 @EnabledOnRedisClusterAvailable
 @ExtendWith(JedisExtension.class)
@@ -189,6 +190,82 @@ public class JedisClusterConnectionTests implements ClusterConnectionTests {
 		clusterConnection.bitOp(BitOperation.AND, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isEqualTo("bab");
+	}
+
+	@Test
+	void bitOpOrShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
+		nativeConnection.set(SAME_SLOT_KEY_2, "ugh");
+
+		clusterConnection.bitOp(BitOperation.OR, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isEqualTo("woo");
+	}
+
+	@Test
+	void bitOpXorShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "aaa");
+		nativeConnection.set(SAME_SLOT_KEY_2, "___");
+
+		clusterConnection.bitOp(BitOperation.XOR, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isEqualTo(">>>");
+	}
+
+	@Test
+	void bitOpNotShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
+
+		clusterConnection.bitOp(BitOperation.NOT, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpDiffShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foobar");
+		nativeConnection.set(SAME_SLOT_KEY_2, "abcdef");
+
+		clusterConnection.bitOp(BitOperation.DIFF, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpDiff1ShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foobar");
+		nativeConnection.set(SAME_SLOT_KEY_2, "abcdef");
+
+		clusterConnection.bitOp(BitOperation.DIFF1, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpAndorShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
+		nativeConnection.set(SAME_SLOT_KEY_2, "bar");
+
+		clusterConnection.bitOp(BitOperation.ANDOR, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpOneShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
+		nativeConnection.set(SAME_SLOT_KEY_2, "bar");
+
+		clusterConnection.bitOp(BitOperation.ONE, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
 	}
 
 	@Test // DATAREDIS-315

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceClusterConnectionTests.java
@@ -76,6 +76,7 @@ import org.springframework.data.redis.util.ConnectionVerifier;
  * @author Mark Paluch
  * @author Dennis Neufeld
  * @author Tihomir Mateev
+ * @author Viktoriya Kutsarova
  */
 @SuppressWarnings("deprecation")
 @EnabledOnRedisClusterAvailable
@@ -277,6 +278,82 @@ public class LettuceClusterConnectionTests implements ClusterConnectionTests {
 		clusterConnection.bitOp(BitOperation.AND, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
 
 		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isEqualTo("bab");
+	}
+
+	@Test
+	void bitOpOrShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
+		nativeConnection.set(SAME_SLOT_KEY_2, "ugh");
+
+		clusterConnection.bitOp(BitOperation.OR, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isEqualTo("woo");
+	}
+
+	@Test
+	void bitOpXorShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "aaa");
+		nativeConnection.set(SAME_SLOT_KEY_2, "___");
+
+		clusterConnection.bitOp(BitOperation.XOR, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isEqualTo(">>>");
+	}
+
+	@Test
+	void bitOpNotShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
+
+		clusterConnection.bitOp(BitOperation.NOT, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpDiffShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foobar");
+		nativeConnection.set(SAME_SLOT_KEY_2, "abcdef");
+
+		clusterConnection.bitOp(BitOperation.DIFF, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpDiff1ShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foobar");
+		nativeConnection.set(SAME_SLOT_KEY_2, "abcdef");
+
+		clusterConnection.bitOp(BitOperation.DIFF1, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpAndorShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
+		nativeConnection.set(SAME_SLOT_KEY_2, "bar");
+
+		clusterConnection.bitOp(BitOperation.ANDOR, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpOneShouldWorkCorrectly() {
+
+		nativeConnection.set(SAME_SLOT_KEY_1, "foo");
+		nativeConnection.set(SAME_SLOT_KEY_2, "bar");
+
+		clusterConnection.bitOp(BitOperation.ONE, SAME_SLOT_KEY_3_BYTES, SAME_SLOT_KEY_1_BYTES, SAME_SLOT_KEY_2_BYTES);
+
+		assertThat(nativeConnection.get(SAME_SLOT_KEY_3)).isNotNull();
 	}
 
 	@Test // DATAREDIS-315

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommandsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveClusterStringCommandsIntegrationTests.java
@@ -83,11 +83,76 @@ class LettuceReactiveClusterStringCommandsIntegrationTests extends LettuceReacti
 		assertThat(nativeCommands.get(SAME_SLOT_KEY_3)).isEqualTo(VALUE_3);
 	}
 
+	@Test
+	void bitOpXorShouldWorkAsExpectedWhenKeysMapToSameSlot() {
+
+		nativeCommands.set(SAME_SLOT_KEY_1, VALUE_1);
+		nativeCommands.set(SAME_SLOT_KEY_2, VALUE_2);
+
+		assertThat(connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER),
+				RedisStringCommands.BitOperation.XOR, SAME_SLOT_KEY_3_BBUFFER).block()).isEqualTo(7L);
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpNotShouldWorkAsExpectedWhenKeysMapToSameSlot() {
+
+		nativeCommands.set(SAME_SLOT_KEY_1, VALUE_1);
+
+		assertThat(connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER),
+				RedisStringCommands.BitOperation.NOT, SAME_SLOT_KEY_3_BBUFFER).block()).isEqualTo(7L);
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
 	@Test // DATAREDIS-525
 	void bitNotShouldThrowExceptionWhenMoreThanOnSourceKeyAndKeysMapToSameSlot() {
 		assertThatIllegalArgumentException().isThrownBy(
 				() -> connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER),
 						RedisStringCommands.BitOperation.NOT, SAME_SLOT_KEY_3_BBUFFER).block());
+	}
+
+	@Test
+	void bitOpDiffShouldWorkAsExpectedWhenKeysMapToSameSlot() {
+
+		nativeCommands.set(SAME_SLOT_KEY_1, "foobar");
+		nativeCommands.set(SAME_SLOT_KEY_2, "abcdef");
+
+		assertThat(connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER),
+				RedisStringCommands.BitOperation.DIFF, SAME_SLOT_KEY_3_BBUFFER).block()).isEqualTo(6L);
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpDiff1ShouldWorkAsExpectedWhenKeysMapToSameSlot() {
+
+		nativeCommands.set(SAME_SLOT_KEY_1, "foobar");
+		nativeCommands.set(SAME_SLOT_KEY_2, "abcdef");
+
+		assertThat(connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER),
+				RedisStringCommands.BitOperation.DIFF1, SAME_SLOT_KEY_3_BBUFFER).block()).isEqualTo(6L);
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpAndorShouldWorkAsExpectedWhenKeysMapToSameSlot() {
+
+		nativeCommands.set(SAME_SLOT_KEY_1, VALUE_1);
+		nativeCommands.set(SAME_SLOT_KEY_2, VALUE_2);
+
+		assertThat(connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER),
+				RedisStringCommands.BitOperation.ANDOR, SAME_SLOT_KEY_3_BBUFFER).block()).isEqualTo(7L);
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpOneShouldWorkAsExpectedWhenKeysMapToSameSlot() {
+
+		nativeCommands.set(SAME_SLOT_KEY_1, VALUE_1);
+		nativeCommands.set(SAME_SLOT_KEY_2, VALUE_2);
+
+		assertThat(connection.stringCommands().bitOp(Arrays.asList(SAME_SLOT_KEY_1_BBUFFER, SAME_SLOT_KEY_2_BBUFFER),
+				RedisStringCommands.BitOperation.ONE, SAME_SLOT_KEY_3_BBUFFER).block()).isEqualTo(7L);
+		assertThat(nativeCommands.get(SAME_SLOT_KEY_3)).isNotNull();
 	}
 
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStringCommandsIntegrationTests.java
@@ -61,6 +61,7 @@ import org.springframework.data.redis.util.ByteUtils;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Michele Mancioppi
+ * @author Viktoriya Kutsarova
  */
 @ParameterizedClass
 public class LettuceReactiveStringCommandsIntegrationTests extends LettuceReactiveCommandsTestSupport {
@@ -506,6 +507,70 @@ public class LettuceReactiveStringCommandsIntegrationTests extends LettuceReacti
 				.as(StepVerifier::create) //
 				.expectError(IllegalArgumentException.class) //
 				.verify();
+	}
+
+	@Test
+	void bitOpDiffShouldWorkAsExpected() {
+
+		assumeTrue(connectionProvider instanceof StandaloneConnectionProvider);
+
+		nativeCommands.set(KEY_1, "foobar");
+		nativeCommands.set(KEY_2, "abcdef");
+
+		connection.stringCommands().bitOp(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), BitOperation.DIFF, KEY_3_BBUFFER)
+				.as(StepVerifier::create) //
+				.expectNext(6L) //
+				.verifyComplete();
+
+		assertThat(nativeCommands.get(KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpDiff1ShouldWorkAsExpected() {
+
+		assumeTrue(connectionProvider instanceof StandaloneConnectionProvider);
+
+		nativeCommands.set(KEY_1, "foobar");
+		nativeCommands.set(KEY_2, "abcdef");
+
+		connection.stringCommands().bitOp(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), BitOperation.DIFF1, KEY_3_BBUFFER)
+				.as(StepVerifier::create) //
+				.expectNext(6L) //
+				.verifyComplete();
+
+		assertThat(nativeCommands.get(KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpAndorShouldWorkAsExpected() {
+
+		assumeTrue(connectionProvider instanceof StandaloneConnectionProvider);
+
+		nativeCommands.set(KEY_1, "foo");
+		nativeCommands.set(KEY_2, "bar");
+
+		connection.stringCommands().bitOp(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), BitOperation.ANDOR, KEY_3_BBUFFER)
+				.as(StepVerifier::create) //
+				.expectNext(3L) //
+				.verifyComplete();
+
+		assertThat(nativeCommands.get(KEY_3)).isNotNull();
+	}
+
+	@Test
+	void bitOpOneShouldWorkAsExpected() {
+
+		assumeTrue(connectionProvider instanceof StandaloneConnectionProvider);
+
+		nativeCommands.set(KEY_1, VALUE_1);
+		nativeCommands.set(KEY_2, VALUE_2);
+
+		connection.stringCommands().bitOp(Arrays.asList(KEY_1_BBUFFER, KEY_2_BBUFFER), BitOperation.ONE, KEY_3_BBUFFER)
+				.as(StepVerifier::create) //
+				.expectNext(7L) //
+				.verifyComplete();
+
+		assertThat(nativeCommands.get(KEY_3)).isNotNull();
 	}
 
 	@Test // DATAREDIS-525


### PR DESCRIPTION
This change introduces the support for expanded bitwise operations as BITOP DIFF, DIFF1, ANDOR, ONE as part of the features provided by the spring-data-redis project.

As part of the change the following expanded operations would be made available:

- [x] [BITOP DIFF destkey X [Y1 Y2 ...]](https://redis.io/docs/latest/commands/bitop/) [1](https://redis.io/docs/latest/commands/bitop/#list-note-1): A bit in destkey is set if it is set in X, but not in any of Y1, Y2, ... .
- [x] [BITOP DIFF1 destkey X [Y1 Y2 ...]](https://redis.io/docs/latest/commands/bitop/) [1](https://redis.io/docs/latest/commands/bitop/#list-note-1): A bit in destkey is set if it is set in one or more of Y1, Y2, ..., but not in X.
- [x] [BITOP ANDOR destkey X [Y1 Y2 ...]](https://redis.io/docs/latest/commands/bitop/) [1](https://redis.io/docs/latest/commands/bitop/#list-note-1): A bit in destkey is set if it is set in X and also in one or more of Y1, Y2, .... 
- [x] [BITOP ONE destkey X1 [X2 X3 ...]](https://redis.io/docs/latest/commands/bitop/) [1](https://redis.io/docs/latest/commands/bitop/#list-note-1): A bit in destkey is set if it is set in exactly one of X1, X2, ....

The expanded operations are available as part of the following interfaces:

- RedisStringCommands#BitOperation
- LettuceReactiveStringCommands / LettuceStringCommands

This feature is available starting from [Redis OSS version 8.2.x](https://redis.io/docs/latest/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes/) and later

---
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
---
