### PR TITLE
Add incrementScore to RedisZSet

### DIFF
--- a/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisZSet.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisZSet.java
@@ -39,6 +39,7 @@ import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Andrey Shlykov
+ * @author Vinoth Selvaraj
  */
 public class DefaultRedisZSet<E> extends AbstractRedisCollection<E> implements RedisZSet<E> {
 
@@ -453,6 +454,11 @@ public class DefaultRedisZSet<E> extends AbstractRedisCollection<E> implements R
 	@Override
 	public Double score(Object o) {
 		return boundZSetOps.score(o);
+	}
+
+	@Override
+	public Double incrementScore(E e, double increment) {
+		return boundZSetOps.incrementScore(e, increment);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/support/collections/RedisZSet.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/RedisZSet.java
@@ -41,6 +41,7 @@ import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Andrey Shlykov
+ * @author Vinoth Selvaraj
  */
 public interface RedisZSet<E> extends RedisCollection<E>, Set<E> {
 
@@ -563,6 +564,18 @@ public interface RedisZSet<E> extends RedisCollection<E>, Set<E> {
 	 * @return the score associated with the given object
 	 */
 	Double score(Object o);
+
+	/**
+	 * Increments the score of the given element by the specified {@code increment}.
+	 * <p>
+	 * If the element does not exist in the sorted set, it will be added with the specified increment as its initial score.
+	 *
+	 * @param e the element whose score to increment, must not be {@literal null}.
+	 * @param increment the value by which the score should be increased.
+	 * @return the new score after incrementing
+	 * @see <a href="https://redis.io/commands/zincrby">Redis Documentation: ZINCRBY</a>
+	 */
+	Double incrementScore(E e, double increment);
 
 	/**
 	 * Returns the rank (position) of the given element in the set, in ascending order. Returns null if the element is not

--- a/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisZSetTestIntegration.java
+++ b/src/test/java/org/springframework/data/redis/support/collections/AbstractRedisZSetTestIntegration.java
@@ -54,6 +54,7 @@ import org.springframework.data.redis.test.condition.EnabledOnCommand;
  * @author Mark Paluch
  * @author Andrey Shlykov
  * @author Christoph Strobl
+ * @author Vinoth Selvaraj
  */
 public abstract class AbstractRedisZSetTestIntegration<T> extends AbstractRedisCollectionIntegrationTests<T> {
 
@@ -295,6 +296,29 @@ public abstract class AbstractRedisZSetTestIntegration<T> extends AbstractRedisC
 		assertThat(zSet.score(t1)).isEqualTo(Double.valueOf(3));
 		assertThat(zSet.score(t2)).isEqualTo(Double.valueOf(4));
 		assertThat(zSet.score(t3)).isEqualTo(Double.valueOf(5));
+	}
+
+	@Test // DATAREDIS-3256
+	void testIncrementScore() {
+		RedisZSet<T> set = createZSetFor("test:zset:increment");
+		T t1 = getT();
+		T t2 = getT();
+		T t3 = getT(); // new member for creation test
+
+		set.add(t1, 3);
+		set.add(t2, 4);
+
+		// existing members
+		set.incrementScore(t1, 5);
+		set.incrementScore(t2, -2);
+
+		assertThat(set.score(t1)).isEqualTo(Double.valueOf(8));
+		assertThat(set.score(t2)).isEqualTo(Double.valueOf(2));
+
+		// new member (absent before)
+		Double newScore = set.incrementScore(t3, 7);
+		assertThat(newScore).isEqualTo(Double.valueOf(7));
+		assertThat(set.score(t3)).isEqualTo(Double.valueOf(7));
 	}
 
 	@Test


### PR DESCRIPTION
Adds a method to increment the score of an element in a Redis sorted set.
Implements the Redis `ZINCRBY` command through Spring Data’s RedisZSet.
Includes a test verifying score updates for existing and new members.

Closes #3256

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
