### PR TITLE
Add static factory method for JacksonJsonRedisSerializer.

### DIFF
--- a/src/main/java/org/springframework/data/redis/serializer/JacksonJsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/JacksonJsonRedisSerializer.java
@@ -52,6 +52,20 @@ public class JacksonJsonRedisSerializer<T> implements RedisSerializer<T> {
 
 	/**
 	 * Creates a new {@link JacksonJsonRedisSerializer} for the given target {@link Class}.
+	 * <p>
+	 * This is a convenience factory method equivalent to calling the constructor directly.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @param <T> the target type.
+	 * @return new instance of {@link JacksonJsonRedisSerializer}. Never {@literal null}.
+	 * @since 4.0
+	 */
+	public static <T> JacksonJsonRedisSerializer<T> of(Class<T> type) {
+		return new JacksonJsonRedisSerializer<>(type);
+	}
+
+	/**
+	 * Creates a new {@link JacksonJsonRedisSerializer} for the given target {@link Class}.
 	 *
 	 * @param type must not be {@literal null}.
 	 */

--- a/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisSerializer.java
@@ -66,6 +66,22 @@ public interface RedisSerializer<T> {
 	}
 
 	/**
+	 * Obtain a {@link RedisSerializer} that can read and write JSON using
+	 * <a href="https://github.com/FasterXML/jackson-core">Jackson</a> for a specific type.
+	 * <p>
+	 * Unlike {@link #json()} which uses default typing, this method creates a type-safe serializer
+	 * bound to the given class.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @param <T> the target type.
+	 * @return never {@literal null}.
+	 * @since 4.0
+	 */
+	static <T> RedisSerializer<T> json(Class<T> type) {
+		return new JacksonJsonRedisSerializer<>(type);
+	}
+
+	/**
 	 * Obtain a simple {@link java.lang.String} to {@code byte[]} (and back) serializer using
 	 * {@link java.nio.charset.StandardCharsets#UTF_8 UTF-8} as the default {@link java.nio.charset.Charset}.
 	 *

--- a/src/test/java/org/springframework/data/redis/serializer/JacksonJsonRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/JacksonJsonRedisSerializerUnitTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.serializer;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.redis.Person;
+import org.springframework.data.redis.PersonObjectFactory;
+
+/**
+ * Unit tests for {@link JacksonJsonRedisSerializer}.
+ *
+ * @author Minjun Choi
+ */
+class JacksonJsonRedisSerializerUnitTests {
+
+	@Test // GH-3252
+	void ofShouldCreateSerializerForGivenType() {
+
+		JacksonJsonRedisSerializer<Person> serializer = JacksonJsonRedisSerializer.of(Person.class);
+
+		assertThat(serializer).isNotNull();
+
+		Person person = new PersonObjectFactory().instance();
+		byte[] serialized = serializer.serialize(person);
+		Person deserialized = serializer.deserialize(serialized);
+
+		assertThat(deserialized).isEqualTo(person);
+	}
+
+	@Test // GH-3252
+	void redisSerializerJsonShouldCreateSerializerForGivenType() {
+
+		RedisSerializer<Person> serializer = RedisSerializer.json(Person.class);
+
+		assertThat(serializer).isNotNull();
+		assertThat(serializer).isInstanceOf(JacksonJsonRedisSerializer.class);
+
+		Person person = new PersonObjectFactory().instance();
+		byte[] serialized = serializer.serialize(person);
+		Person deserialized = serializer.deserialize(serialized);
+
+		assertThat(deserialized).isEqualTo(person);
+	}
+
+	@Test // GH-3252
+	void serializeShouldReturnEmptyByteArrayWhenSourceIsNull() {
+
+		JacksonJsonRedisSerializer<Person> serializer = JacksonJsonRedisSerializer.of(Person.class);
+
+		assertThat(serializer.serialize(null)).isEqualTo(SerializationUtils.EMPTY_ARRAY);
+	}
+
+	@Test // GH-3252
+	void deserializeShouldReturnNullWhenSourceIsNull() {
+
+		JacksonJsonRedisSerializer<Person> serializer = JacksonJsonRedisSerializer.of(Person.class);
+
+		assertThat(serializer.deserialize(null)).isNull();
+	}
+
+	@Test // GH-3252
+	void deserializeShouldReturnNullWhenSourceIsEmptyArray() {
+
+		JacksonJsonRedisSerializer<Person> serializer = JacksonJsonRedisSerializer.of(Person.class);
+
+		assertThat(serializer.deserialize(SerializationUtils.EMPTY_ARRAY)).isNull();
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds static factory methods for `JacksonJsonRedisSerializer` to simplify instantiation and improve code readability.

Closes #3252

## Changes

- Added `JacksonJsonRedisSerializer.of(Class<T>)` as a static factory method
- Added `RedisSerializer.json(Class<T>)` as an interface-level helper method (overloading existing `json()` method)
- Added comprehensive unit tests for both factory methods

## Motivation

The current API requires verbose instantiation:
```java
JacksonJsonRedisSerializer<Person> serializer = new JacksonJsonRedisSerializer<>(Person.class);
```

With the new factory methods, code becomes more concise and readable:
```java
// Using static factory method
JacksonJsonRedisSerializer<Person> serializer = JacksonJsonRedisSerializer.of(Person.class);

// Or using interface-level helper
RedisSerializer<Person> serializer = RedisSerializer.json(Person.class);
```

This aligns with modern Java API design conventions (e.g., `Optional.of()`, `List.of()`) and greatly simplifies typical `RedisTemplate` setup code.

## Checklist

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).