### PR TITLE
fix: duplicated conditional TTL evaluation

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/DefaultRedisCacheWriter.java
@@ -270,10 +270,11 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 		Assert.notNull(key, "Key must not be null");
 
 		boolean withTtl = shouldExpireWithin(ttl);
+		Duration ttlForGet = (timeToIdleEnabled && withTtl ? ttl : null);
 
 		// double-checked locking optimization
 		if (isLockingCacheWriter()) {
-			byte[] bytes = get(name, key, timeToIdleEnabled && withTtl ? ttl : null);
+			byte[] bytes = get(name, key, ttlForGet);
 			if (bytes != null) {
 				return bytes;
 			}
@@ -287,7 +288,7 @@ class DefaultRedisCacheWriter implements RedisCacheWriter {
 
 			try {
 
-				byte[] result = doGet(connection, name, key, timeToIdleEnabled && withTtl ? ttl : null);
+				byte[] result = doGet(connection, name, key, ttlForGet);
 
 				if (result != null) {
 					return result;


### PR DESCRIPTION
#### Summary

This PR refactors duplicated TTL computation logic inside DefaultRedisCacheWriter's get method

following expression was previously evaluated twice

```java
  timeToIdleEnabled && withTtl ? ttl : null
```

#### What Changed

A new local variable ttlForGet is introduced to compute the TTL once

Closes: https://github.com/spring-projects/spring-data-redis/issues/3266