### PR TITLE
Jedis: Support of automated background topology refresh in cluster mode

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
@@ -30,6 +30,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Bharat Agarwal
  * @since 2.0
  */
 class DefaultJedisClientConfiguration implements JedisClientConfiguration {
@@ -44,11 +45,13 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	private final Optional<String> clientName;
 	private final Duration readTimeout;
 	private final Duration connectTimeout;
+	private final Optional<Duration> topologyRefreshPeriod;
 
 	DefaultJedisClientConfiguration(@Nullable JedisClientConfigBuilderCustomizer customizer, boolean useSsl,
 			@Nullable SSLSocketFactory sslSocketFactory, @Nullable SSLParameters sslParameters,
 			@Nullable HostnameVerifier hostnameVerifier, boolean usePooling, @Nullable GenericObjectPoolConfig poolConfig,
-			@Nullable String clientName, Duration readTimeout, Duration connectTimeout) {
+			@Nullable String clientName, Duration readTimeout, Duration connectTimeout, 
+			@Nullable Duration topologyRefreshPeriod) {
 
 		this.customizer = Optional.ofNullable(customizer);
 		this.useSsl = useSsl;
@@ -60,6 +63,7 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 		this.clientName = Optional.ofNullable(clientName);
 		this.readTimeout = readTimeout;
 		this.connectTimeout = connectTimeout;
+		this.topologyRefreshPeriod = Optional.ofNullable(topologyRefreshPeriod);
 	}
 
 	@Override
@@ -110,5 +114,9 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	@Override
 	public Duration getConnectTimeout() {
 		return connectTimeout;
+	}
+	@Override
+	public Optional<Duration> getTopologyRefreshPeriod() {
+		return topologyRefreshPeriod;
 	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -93,6 +93,7 @@ import org.springframework.util.ObjectUtils;
  * @author Mark Paluch
  * @author Fu Jian
  * @author Ajith Kumar
+ * @author Bharat Agarwal
  * @see JedisClientConfiguration
  * @see Jedis
  */
@@ -846,7 +847,11 @@ public class JedisConnectionFactory
 
 		int redirects = clusterConfig.getMaxRedirects() != null ? clusterConfig.getMaxRedirects() : 5;
 
-		return new JedisCluster(hostAndPort, this.clientConfig, redirects, poolConfig);
+		// When maxTotalRetriesDuration passed, Jedis use this method to calcuate, to use topologyRefreshPeriod, Jedis constructor expect maxTotalRetriesDuration. 
+		Duration maxTotalRetriesDuration = Duration.ofMillis((long)this.clientConfig.getSocketTimeoutMillis() * (long)redirects);
+		Duration topologyRefreshPeriod = this.clientConfiguration.getTopologyRefreshPeriod().orElse(null);
+
+		return new JedisCluster(hostAndPort, this.clientConfig, poolConfig, topologyRefreshPeriod, redirects, maxTotalRetriesDuration);
 	}
 
 	@Override
@@ -1093,6 +1098,7 @@ public class JedisConnectionFactory
 		private @Nullable String clientName;
 		private Duration readTimeout = Duration.ofMillis(Protocol.DEFAULT_TIMEOUT);
 		private Duration connectTimeout = Duration.ofMillis(Protocol.DEFAULT_TIMEOUT);
+		private @Nullable Duration topologyRefreshPeriod = null;
 
 		public static JedisClientConfiguration create(GenericObjectPoolConfig jedisPoolConfig) {
 
@@ -1185,6 +1191,11 @@ public class JedisConnectionFactory
 
 		public void setConnectTimeout(Duration connectTimeout) {
 			this.connectTimeout = connectTimeout;
+		}
+
+		@Override
+		public Optional<Duration> getTopologyRefreshPeriod() {
+			return Optional.empty();
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
@@ -49,6 +49,7 @@ class JedisClientConfigurationUnitTests {
 		assertThat(configuration.getPoolConfig()).isPresent();
 		assertThat(configuration.getSslParameters()).isEmpty();
 		assertThat(configuration.getSslSocketFactory()).isEmpty();
+		assertThat(configuration.getTopologyRefreshPeriod()).isEmpty();
 	}
 
 	@Test // DATAREDIS-574
@@ -64,6 +65,7 @@ class JedisClientConfigurationUnitTests {
 				.sslParameters(sslParameters) //
 				.sslSocketFactory(socketFactory).and() //
 				.clientName("my-client") //
+				.topologyRefreshPeriod(Duration.ofMillis(100)) // adding topologyRefreshPeriod
 				.connectTimeout(Duration.ofMinutes(10)) //
 				.readTimeout(Duration.ofHours(5)) //
 				.usePooling().poolConfig(poolConfig) //
@@ -79,6 +81,8 @@ class JedisClientConfigurationUnitTests {
 		assertThat(configuration.getReadTimeout()).isEqualTo(Duration.ofHours(5));
 
 		assertThat(configuration.getPoolConfig()).contains(poolConfig);
+
+		assertThat(configuration.getTopologyRefreshPeriod()).isEqualTo(Duration.ofMillis(100));
 	}
 
 	enum MyHostnameVerifier implements HostnameVerifier {


### PR DESCRIPTION
### Issue
Currently, when using `JedisConnectionFactory` from spring-data-redis, there is no support for configuring an automatic, periodic topology refresh for the Jedis client.

This functionality was initially added only for Lettuce. At that time, Jedis did not provide a feature and interface to enable background, periodic topology refresh.
Issue: https://github.com/spring-projects/spring-boot/issues/15630

Jedis has added support for automated background topology refresh, allowing users to configure a period at which Jedis refreshes the cluster node topology.

This was done from jedis [v5.1.0](https://github.com/redis/jedis/releases/tag/v5.1.0):  
Implementation details in pull request: https://github.com/redis/jedis/pull/3596

### Fix
Added support for configuring the topology refresh period duration in the `JedisClientConfiguration` builder. 
By default, this value is set to null.

- When no value is set for `topologyRefreshPeriod` in the configuration, `null` is passed to the Jedis constructor (the default Jedis behavior). In this case, Jedis does not create or perform automatic background topology refresh.
- When a Duration value is provided, it is passed to the Jedis constructor, and Jedis starts performing periodic topology refresh in the background.

*Example Code*: Enabling Automated Topology Refresh with a Configured Period
```java 
    JedisClientConfiguration clientConfig = JedisClientConfiguration.builder()
            .connectTimeout(Duration.ofMillis(connectTimeout))
            .topologyRefreshPeriod(Duration.ofSeconds(topologyRefreshInterval)) // setting period to refresh topology
            .readTimeout(Duration.ofMillis(readTimeout))
            .usePooling()
            .poolConfig(poolConfig)
            .build();
    RedisClusterConfiguration redisClusterConfig = new RedisClusterConfiguration(redisNodes);
    JedisConnectionFactory connectionFactory = new JedisConnectionFactory(redisClusterConfig, clientConfig);
```


*Example Code*: Disabling Automated Topology Refresh (Default/Existing Behavior)
```java
    JedisClientConfiguration clientConfig = JedisClientConfiguration.builder()
            .connectTimeout(Duration.ofMillis(connectTimeout))
            .readTimeout(Duration.ofMillis(readTimeout))
            .usePooling()
            .poolConfig(poolConfig)
            .build();
    RedisClusterConfiguration redisClusterConfig = new RedisClusterConfiguration(redisNodes);
    JedisConnectionFactory connectionFactory = new JedisConnectionFactory(redisClusterConfig, clientConfig);
```

---
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
