### PR TITLE
Remove unused generic from RedisKeyExpiredEvent #2106

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
@@ -30,7 +30,7 @@ import org.springframework.data.redis.core.convert.MappingRedisConverter.BinaryK
  * @author Mark Paluch
  * @since 1.7
  */
-public class RedisKeyExpiredEvent<T> extends RedisKeyspaceEvent {
+public class RedisKeyExpiredEvent extends RedisKeyspaceEvent {
 
 	/**
 	 * Use {@literal UTF-8} as default charset.

--- a/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyValueAdapter.java
@@ -856,7 +856,7 @@ public class RedisKeyValueAdapter extends AbstractKeyValueAdapter
 					? converter.getConversionService().convert(channelAsBytes, String.class)
 					: null;
 
-			RedisKeyExpiredEvent<?> event = new RedisKeyExpiredEvent<>(channel, key, value);
+			RedisKeyExpiredEvent event = new RedisKeyExpiredEvent(channel, key, value);
 
 			ops.execute((RedisCallback<Void>) connection -> {
 

--- a/src/test/java/org/springframework/data/redis/core/RedisKeyExpiredEventUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisKeyExpiredEventUnitTests.java
@@ -29,16 +29,16 @@ class RedisKeyExpiredEventUnitTests {
 	@Test // DATAREDIS-744
 	void shouldReturnKeyspace() {
 
-		assertThat(new RedisKeyExpiredEvent<>("foo".getBytes(), "").getKeyspace()).isNull();
-		assertThat(new RedisKeyExpiredEvent<>("foo:bar".getBytes(), "").getKeyspace()).isEqualTo("foo");
-		assertThat(new RedisKeyExpiredEvent<>("foo:bar:baz".getBytes(), "").getKeyspace()).isEqualTo("foo");
+		assertThat(new RedisKeyExpiredEvent("foo".getBytes(), "").getKeyspace()).isNull();
+		assertThat(new RedisKeyExpiredEvent("foo:bar".getBytes(), "").getKeyspace()).isEqualTo("foo");
+		assertThat(new RedisKeyExpiredEvent("foo:bar:baz".getBytes(), "").getKeyspace()).isEqualTo("foo");
 	}
 
 	@Test // DATAREDIS-744
 	void shouldReturnId() {
 
-		assertThat(new RedisKeyExpiredEvent<>("foo".getBytes(), "").getId()).isEqualTo("foo".getBytes());
-		assertThat(new RedisKeyExpiredEvent<>("foo:bar".getBytes(), "").getId()).isEqualTo("bar".getBytes());
-		assertThat(new RedisKeyExpiredEvent<>("foo:bar:baz".getBytes(), "").getId()).isEqualTo("bar:baz".getBytes());
+		assertThat(new RedisKeyExpiredEvent("foo".getBytes(), "").getId()).isEqualTo("foo".getBytes());
+		assertThat(new RedisKeyExpiredEvent("foo:bar".getBytes(), "").getId()).isEqualTo("bar".getBytes());
+		assertThat(new RedisKeyExpiredEvent("foo:bar:baz".getBytes(), "").getId()).isEqualTo("bar:baz".getBytes());
 	}
 }


### PR DESCRIPTION
Closes #2106

### Motivation

`RedisKeyExpiredEvent<T>` declares a generic type parameter that is not used anywhere in the current API.
The presence of `<T>` suggests type safety that the event does not actually provide, which can be confusing for users.

### Changes

- Removed the unused generic type parameter from `RedisKeyExpiredEvent`
- Kept the existing runtime behavior unchanged (`getValue()` continues to return `Object`)

### Rationale

The original issue outlines two possible directions.
This PR intentionally takes the minimal approach by removing the unused generic parameter.

Implementing a typed `getValue(): T` would require additional design decisions around
value deserialization and type resolution, which felt out of scope for a small cleanup.
Removing the unused generic improves API clarity without introducing new semantics.

### Compatibility

This is a source-level incompatible change for code explicitly using `RedisKeyExpiredEvent<T>`.
However, since the generic parameter was unused and did not provide actual type safety,
the migration impact is minimal and runtime behavior remains unchanged.

### Tests

- Existing unit tests pass