### PR TITLE
Refactor StringToPropertiesConverter to use Converters.toProperties

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-present the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +15,23 @@
  */
 package org.springframework.data.redis.connection.convert;
 
-import java.io.StringReader;
 import java.util.Properties;
 
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.redis.RedisSystemException;
+import org.springframework.lang.Nullable;
 
 /**
  * Converts Strings to {@link Properties}
  *
  * @author Jennifer Hickey
  * @author Christoph Strobl
+ * @deprecated since 3.4 in favor of {@link Converters#toProperties(String)}.
  */
+@Deprecated(since = "3.4", forRemoval = true)
 public class StringToPropertiesConverter implements Converter<String, Properties> {
 
 	@Override
-	public Properties convert(String source) {
-
-		Properties info = new Properties();
-		try (StringReader stringReader = new StringReader(source)) {
-			info.load(stringReader);
-		} catch (Exception ex) {
-			throw new RedisSystemException("Cannot read Redis info", ex);
-		}
-		return info;
+	public Properties convert(@Nullable String source) {
+		return Converters.toProperties(source);
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverterUnitTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.RedisSystemException;
+
+/**
+ * Unit tests for {@link StringToPropertiesConverter}.
+ */
+class StringToPropertiesConverterUnitTests {
+
+	private final StringToPropertiesConverter converter = new StringToPropertiesConverter();
+
+	@Test
+	void convertShouldParsePropertiesCorrectly() {
+		String source = "key1=value1\nkey2=value2";
+		Properties properties = converter.convert(source);
+
+		assertThat(properties).containsEntry("key1", "value1");
+		assertThat(properties).containsEntry("key2", "value2");
+	}
+
+	@Test
+	void convertShouldHandleEmptyString() {
+		Properties properties = converter.convert("");
+		assertThat(properties).isEmpty();
+	}
+    
+    @Test
+    void convertShouldThrowExceptionForNull() {
+        // Converters.toProperties wraps the NPE in RedisSystemException
+        assertThatExceptionOfType(RedisSystemException.class)
+            .isThrownBy(() -> converter.convert(null));
+    }
+}


### PR DESCRIPTION
Closes #3020
This PR refactors `StringToPropertiesConverter` to delegate logic to `Converters.toProperties` as suggested in the issue.
It also deprecates `StringToPropertiesConverter` in favor of the static method in `Converters`.
- Added unit tests in `StringToPropertiesConverterUnitTests`.