### PR TITLE
Support FLUSHDB ASYNC for resetCaches()

### DIFF
--- a/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
+++ b/src/main/java/org/springframework/data/redis/cache/RedisCacheWriter.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisServerCommands.FlushOption;
 import org.springframework.util.Assert;
 
 /**
@@ -341,6 +342,18 @@ public interface RedisCacheWriter extends CacheStatisticsProvider {
 	 * @since 2.4
 	 */
 	void clearStatistics(String name);
+
+	/**
+	 * Flush the entire database using the given {@link FlushOption}.
+	 * <p>
+	 * <strong>Warning:</strong> This operation removes ALL keys from the current database,
+	 * not just cache entries. Only use when Redis is dedicated solely for caching.
+	 *
+	 * @param option flush option (SYNC or ASYNC). Must not be {@literal null}.
+	 * @since 4.1
+	 * @see FlushOption
+	 */
+	void flushDb(FlushOption option);
 
 	/**
 	 * Obtain a {@link RedisCacheWriter} using the given {@link CacheStatisticsCollector} to collect metrics.


### PR DESCRIPTION
## Summary

- Add `flushDbOnResetCaches()` builder option to `RedisCacheManager` that enables using `FLUSHDB ASYNC` command when `resetCaches()` is called
- This is more efficient when Redis is dedicated solely for caching purposes
- Opt-in only - default behavior remains unchanged

## Changes

- Add `flushDb(FlushOption)` method to `RedisCacheWriter` interface
- Implement `flushDb()` in `DefaultRedisCacheWriter` (sync and async)
- Override `resetCaches()` in `RedisCacheManager`
- Add `flushDbOnResetCaches()` to `RedisCacheManagerBuilder`

## Usage

```java
RedisCacheManager cacheManager = RedisCacheManager.builder(connectionFactory)
    .flushDbOnResetCaches()  // Enable FLUSHDB ASYNC
    .build();

cacheManager.resetCaches();  // Uses FLUSHDB ASYNC
```

## Test plan

- [x] Unit tests for `resetCachesWithFlushDbOptionCallsFlushDb()`
- [x] Unit tests for `resetCachesWithoutFlushDbOptionClearsEachCache()`
- [x] Unit tests for builder option verification
- [x] All existing cache tests pass (1,263 tests)

Closes #3290