### PR TITLE
Make auto-startup configurable in DefaultStreamMessageListenerContainer.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/redis/redis-streams.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/redis-streams.adoc
@@ -128,6 +128,8 @@ StreamMessageListenerContainer<String, MapRecord<String, String, String>> contai
 Subscription subscription = container.receive(StreamOffset.fromStart("my-stream"), streamListener);
 ----
 
+The default value for `autoStartup` is `true`.
+
 Please refer to the Javadoc of the various message listener containers for a full description of the features supported by each implementation.
 
 [[reactive-streamreceiver]]

--- a/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
@@ -69,7 +69,7 @@ class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implement
 	private boolean running = false;
 
 	private int phase = Integer.MAX_VALUE;
-	private boolean autoStartup;
+	private boolean autoStartup = true;
 
 	/**
 	 * Create a new {@link DefaultStreamMessageListenerContainer}.
@@ -190,6 +190,10 @@ class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implement
 	@Override
 	public boolean isAutoStartup() {
 		return this.autoStartup;
+	}
+
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
@@ -402,12 +402,13 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		assertThat(container.getPhase()).isEqualTo(3208);
 	}
 
-	@Test // GH-3208
-	void defaultAutoStartupShouldBeFalse() {
+	@Test // GH-3208, GH-2568
+	void defaultAutoStartupShouldBeTrue() {
+
 		StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
 				.create(connectionFactory, containerOptions);
 
-		assertThat(container.isAutoStartup()).isEqualTo(false);
+		assertThat(container.isAutoStartup()).isTrue();
 	}
 
 	@Test // GH-3208

--- a/src/test/java/org/springframework/data/redis/stream/LettuceStreamMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/LettuceStreamMessageListenerContainerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,11 +15,15 @@
  */
 package org.springframework.data.redis.stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.extension.LettuceConnectionFactoryExtension;
+import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.test.condition.EnabledOnCommand;
 
 /**
@@ -34,8 +38,38 @@ import org.springframework.data.redis.test.condition.EnabledOnCommand;
 public class LettuceStreamMessageListenerContainerIntegrationTests
 		extends AbstractStreamMessageListenerContainerIntegrationTests {
 
+	private final RedisConnectionFactory connectionFactory;
+
 	public LettuceStreamMessageListenerContainerIntegrationTests(RedisConnectionFactory connectionFactory) {
 		super(connectionFactory);
+		this.connectionFactory = connectionFactory;
 	}
 
+	@Test // GH-2568
+	void shouldHaveAutoStartupEnabledByDefault() {
+
+		StreamMessageListenerContainer.StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
+				StreamMessageListenerContainer.StreamMessageListenerContainerOptions.builder().build();
+
+		StreamMessageListenerContainer<String, MapRecord<String, String, String>> container =
+				StreamMessageListenerContainer.create(connectionFactory, options);
+
+		assertThat(container.isAutoStartup()).isTrue();
+	}
+
+	@Test // GH-2568
+	void shouldAllowConfiguringAutoStartup() {
+
+		StreamMessageListenerContainer.StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
+				StreamMessageListenerContainer.StreamMessageListenerContainerOptions.builder().build();
+
+		DefaultStreamMessageListenerContainer<String, MapRecord<String, String, String>> container =
+				new DefaultStreamMessageListenerContainer<>(connectionFactory, options);
+
+		container.setAutoStartup(false);
+		assertThat(container.isAutoStartup()).isFalse();
+
+		container.setAutoStartup(true);
+		assertThat(container.isAutoStartup()).isTrue();
+	}
 }


### PR DESCRIPTION
The auto-startup flag is now configurable via a setter and defaults to true to align with the SmartLifecycle contract.

This change ensures that the container starts automatically by default, reducing boilerplate code for users who expect standard Spring behavior. Integration tests have been updated to verify the default behavior and the ability to disable auto-startup explicitly.

Closes #2568

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
