### PR TITLE
Remove precision API fallback from RedisTemplate.

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -92,6 +92,7 @@ import org.springframework.util.CollectionUtils;
  * @author ihaohong
  * @author Chen Li
  * @author Vedran Pavic
+ * @author Chris Bono
  * @param <K> the Redis key type against which the template works (usually a String)
  * @param <V> the Redis value type against which the template works
  * @see StringRedisTemplate
@@ -691,29 +692,14 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 
 		byte[] rawKey = rawKey(key);
 		long rawTimeout = TimeoutUtils.toMillis(timeout, unit);
-
-		return doWithKeys(connection -> {
-			try {
-				return connection.pExpire(rawKey, rawTimeout);
-			} catch (Exception ignore) {
-				// Driver may not support pExpire or we may be running on Redis 2.4
-				return connection.expire(rawKey, TimeoutUtils.toSeconds(timeout, unit));
-			}
-		});
+		return doWithKeys(connection -> connection.pExpire(rawKey, rawTimeout));
 	}
 
 	@Override
 	public Boolean expireAt(K key, final Date date) {
 
 		byte[] rawKey = rawKey(key);
-
-		return doWithKeys(connection -> {
-			try {
-				return connection.pExpireAt(rawKey, date.getTime());
-			} catch (Exception ignore) {
-				return connection.expireAt(rawKey, date.getTime() / 1000);
-			}
-		});
+		return doWithKeys(connection -> connection.pExpireAt(rawKey, date.getTime()));
 	}
 
 	@Override
@@ -743,14 +729,7 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	public Long getExpire(K key, TimeUnit timeUnit) {
 
 		byte[] rawKey = rawKey(key);
-		return doWithKeys(connection -> {
-			try {
-				return connection.pTtl(rawKey, timeUnit);
-			} catch (Exception ignore) {
-				// Driver may not support pTtl or we may be running on Redis 2.4
-				return connection.ttl(rawKey, timeUnit);
-			}
-		});
+		return doWithKeys(connection -> connection.pTtl(rawKey, timeUnit));
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/core/RedisTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisTemplateIntegrationTests.java
@@ -42,7 +42,6 @@ import org.springframework.data.redis.connection.ExpirationOptions;
 import org.springframework.data.redis.connection.RedisClusterConnection;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.StringRedisConnection;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.data.redis.core.query.SortQueryBuilder;
@@ -52,7 +51,6 @@ import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.data.redis.test.condition.EnabledIfLongRunningTest;
 import org.springframework.data.redis.test.condition.EnabledOnCommand;
 import org.springframework.data.redis.test.extension.LettuceTestClientResources;
 import org.springframework.data.redis.test.util.CollectionAwareComparator;
@@ -710,24 +708,6 @@ public class RedisTemplateIntegrationTests<K, V> {
 		redisTemplate.boundValueOps(key1).set(value1);
 		redisTemplate.expireAt(key1, Instant.now().plus(5, ChronoUnit.MILLIS));
 		await().until(() -> !redisTemplate.hasKey(key1));
-	}
-
-	@Test
-	@EnabledIfLongRunningTest
-	void testExpireAtMillisNotSupported() {
-
-		assumeThat(redisTemplate.getConnectionFactory() instanceof JedisConnectionFactory).isTrue();
-
-		K key1 = keyFactory.instance();
-		V value1 = valueFactory.instance();
-
-		assumeThat(key1 instanceof String && value1 instanceof String).isTrue();
-
-		StringRedisTemplate template2 = new StringRedisTemplate(redisTemplate.getConnectionFactory());
-		template2.boundValueOps((String) key1).set((String) value1);
-		template2.expireAt((String) key1, new Date(System.currentTimeMillis() + 5L));
-		// Just ensure this works as expected, pExpireAt just adds some precision over expireAt
-		await().until(() -> !template2.hasKey((String) key1));
 	}
 
 	@Test


### PR DESCRIPTION
In Redis 2.4 (and below) several precision commands which use millis granularity rather than secs were not available (e.g.`pExpireAt` and `expireAt`). There was a fallback in RedisTemplate that would try the precise variant and if that failed it would fallback to the non-precise variant. This removes these fallbacks from RedisTemplate.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
