### PR TITLE
Extract start helper in JedisConnectionFactory integration tests

### DIFF
--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactoryIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.test.condition.EnabledOnRedisClusterAvailable;
 import org.springframework.data.redis.test.condition.EnabledOnRedisVersion;
 import org.springframework.data.redis.util.RedisClientLibraryInfo;
+import org.springframework.util.Assert;
 
 /**
  * Integration tests for {@link JedisConnectionFactory}.
@@ -56,8 +57,7 @@ class JedisConnectionFactoryIntegrationTests {
 		factory = new JedisConnectionFactory(
 				new RedisStandaloneConfiguration(SettingsUtils.getHost(), SettingsUtils.getPort()),
 				JedisClientConfiguration.defaultConfiguration());
-		factory.afterPropertiesSet();
-		factory.start();
+		startFactory();
 
 		try (RedisConnection connection = factory.getConnection()) {
 			assertThat(connection.ping()).isEqualTo("PONG");
@@ -70,8 +70,7 @@ class JedisConnectionFactoryIntegrationTests {
 		factory = new JedisConnectionFactory(
 				new RedisStandaloneConfiguration(SettingsUtils.getHost(), SettingsUtils.getPort()),
 				JedisClientConfiguration.builder().clientName("clientName").build());
-		factory.afterPropertiesSet();
-		factory.start();
+		startFactory();
 
 		RedisConnection connection = factory.getConnection();
 
@@ -85,8 +84,7 @@ class JedisConnectionFactoryIntegrationTests {
 		factory = new JedisConnectionFactory(
 				new RedisStandaloneConfiguration(SettingsUtils.getHost(), SettingsUtils.getPort()),
 				JedisClientConfiguration.builder().clientName("clientNameLibName").build());
-		factory.afterPropertiesSet();
-		factory.start();
+		startFactory();
 
 		try (RedisConnection connection = factory.getConnection()) {
 
@@ -110,9 +108,7 @@ class JedisConnectionFactoryIntegrationTests {
 		factory = new JedisConnectionFactory(
 				new RedisStandaloneConfiguration(SettingsUtils.getHost(), SettingsUtils.getPort()),
 				JedisClientConfiguration.defaultConfiguration());
-		factory.afterPropertiesSet();
-
-		factory.start();
+		startFactory();
 		assertThat(factory.isRunning()).isTrue();
 
 		factory.stop();
@@ -142,5 +138,12 @@ class JedisConnectionFactoryIntegrationTests {
 		assertThat(clusterCommandExecutor).extracting("executor").isEqualTo(mockTaskExecutor);
 
 		factory.destroy();
+	}
+
+	private void startFactory() {
+
+		Assert.state(factory != null, "Factory must not be null");
+		factory.afterPropertiesSet();
+		factory.start();
 	}
 }


### PR DESCRIPTION
## Motivation

`JedisConnectionFactoryIntegrationTests` repeats `afterPropertiesSet()` and `start()` across multiple test cases.
Extracting this lifecycle setup into a helper reduces duplication and keeps the tests focused on behavior.

## Changes

- Introduced `startFactory()` helper to centralize factory initialization
- Replaced repeated lifecycle setup calls with `startFactory()`

## How to test

- Run: `./mvnw test`
- (Optional) Run only this test: `./mvnw -Dtest=JedisConnectionFactoryIntegrationTests test`