### PR TITLE
Indicate spin-wait in `RedisMessageListenerContainer` retries

### DIFF
--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -409,6 +409,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 		while (!doSubscribe(backOffExecution)) {
 			// busy-loop, allow for synchronization against doUnsubscribe therefore we want to retry.
+			Thread.onSpinWait();
 			containerListenFuture = this.listenFuture;
 		}
 
@@ -500,6 +501,7 @@ public class RedisMessageListenerContainer implements InitializingBean, Disposab
 
 		while (!doUnsubscribe()) {
 			// busy-loop, allow for synchronization against doSubscribe therefore we want to retry.
+			Thread.onSpinWait();
 		}
 	}
 


### PR DESCRIPTION
## Motivation

`RedisMessageListenerContainer` retries subscription/unsubscription in a tight loop as part of synchronization.
Adding `Thread.onSpinWait()` preserves the existing behavior while reducing CPU overhead during the spin.

## Changes

- Added `Thread.onSpinWait()` to the retry loops in `lazyListen(…)` and `stopListening()`

## How to test

- Run: `./mvnw test`