### PR TITLE
Deprecate `TimeUnit`-based Template API in favor of `Duration` and `Expiration` types

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/BoundKeyOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundKeyOperations.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.redis.connection.DataType;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.util.Assert;
 
 /**
@@ -82,8 +83,18 @@ public interface BoundKeyOperations<K> {
 
 		Assert.notNull(timeout, "Timeout must not be null");
 
-		return expire(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		return expire(Expiration.from(timeout));
 	}
+
+	/**
+	 * Sets the key time-to-live/expiration.
+	 *
+	 * @param expiration must not be {@literal null}.
+	 * @return {@literal true} if expiration was set, {@literal false} otherwise. {@literal null} when used in pipeline /
+	 *         transaction.
+	 * @since 4.2
+	 */
+	@Nullable Boolean expire(Expiration expiration);
 
 	/**
 	 * Sets the key time-to-live/expiration.
@@ -91,7 +102,9 @@ public interface BoundKeyOperations<K> {
 	 * @param timeout expiration value
 	 * @param unit expiration unit
 	 * @return true if expiration was set, false otherwise. {@literal null} when used in pipeline / transaction.
+	 * @deprecated in favor of {@link #expire(Expiration)}
 	 */
+	@Deprecated(since = "4.2", forRemoval = true)
 	@Nullable
 	Boolean expire(long timeout, TimeUnit unit);
 

--- a/src/main/java/org/springframework/data/redis/core/BoundOperationsProxyFactory.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundOperationsProxyFactory.java
@@ -30,6 +30,7 @@ import org.springframework.data.projection.DefaultMethodInvokingMethodIntercepto
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.util.ReflectionUtils;
 
 /**
@@ -220,6 +221,11 @@ class BoundOperationsProxyFactory {
 		@Override
 		public Long getExpire() {
 			return ops.getExpire(key);
+		}
+
+		@Override
+		public Boolean expire(Expiration expiration) {
+			return ops.expire(key, expiration);
 		}
 
 		@Override

--- a/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
@@ -247,6 +247,16 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	V getAndDelete();
 
 	/**
+	 * Return the value at the bound key and expire the key by applying {@code expiration}.
+	 *
+	 * @param expiration must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 4.2
+	 */
+	V getAndExpire(@NonNull Expiration expiration);
+
+	/**
 	 * Return the value at the bound key and expire the key by applying {@code timeout}.
 	 *
 	 * @param timeout
@@ -254,7 +264,9 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
 	 * @since 2.6
+	 * @deprecated in favor of {@link #getAndExpire(Expiration)}
 	 */
+	@Deprecated(since = "4.2", forRemoval = true)
 	V getAndExpire(long timeout, @NonNull TimeUnit unit);
 
 	/**

--- a/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultValueOperations.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
 import org.springframework.data.redis.connection.DefaultedRedisConnection;
@@ -58,6 +59,12 @@ class DefaultValueOperations<K, V> extends AbstractOperations<K, V> implements V
 	}
 
 	@Override
+	public @Nullable V getAndExpire(@NonNull K key, @NonNull Expiration expiration) {
+		return execute(valueCallbackFor(key, (connection, rawKey) -> connection.getEx(rawKey, expiration)));
+	}
+
+	@Override
+	@Deprecated(since = "4.2", forRemoval = true)
 	public @Nullable V getAndExpire(K key, long timeout, TimeUnit unit) {
 		return execute(
 				valueCallbackFor(key, (connection, rawKey) -> connection.getEx(rawKey, Expiration.from(timeout, unit))));

--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -319,10 +319,22 @@ public interface RedisOperations<K, V> {
 	 * Set time to live for given {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
+	 * @param expiration must not be {@literal null}.
+	 * @return changes to the expiry. {@literal null} when used in pipeline / transaction.
+	 * @since 4.2
+	 */
+	Boolean expire(@NonNull K key, @NonNull Expiration expiration);
+
+	/**
+	 * Set time to live for given {@code key}.
+	 *
+	 * @param key must not be {@literal null}.
 	 * @param timeout
 	 * @param unit must not be {@literal null}.
 	 * @return {@literal null} when used in pipeline / transaction.
+	 * @deprecated in favor of {@link #expire(Object, Expiration)}
 	 */
+	@Deprecated(since = "4.2", forRemoval = true)
 	Boolean expire(@NonNull K key, long timeout, @NonNull TimeUnit unit);
 
 	/**
@@ -338,8 +350,7 @@ public interface RedisOperations<K, V> {
 
 		Assert.notNull(timeout, "Timeout must not be null");
 
-		return TimeoutUtils.hasMillis(timeout) ? expire(key, timeout.toMillis(), TimeUnit.MILLISECONDS)
-				: expire(key, timeout.getSeconds(), TimeUnit.SECONDS);
+		return expire(key, Expiration.from(timeout));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -688,6 +688,15 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	}
 
 	@Override
+	public Boolean expire(@NonNull K key, @NonNull Expiration expiration) {
+
+		byte[] rawKey = rawKey(key);
+		long rawTimeout = expiration.getExpirationTimeInMilliseconds();
+		return doWithKeys(connection -> connection.pExpire(rawKey, rawTimeout));
+	}
+
+	@Override
+	@Deprecated(since = "4.2", forRemoval = true)
 	public Boolean expire(K key, final long timeout, final TimeUnit unit) {
 
 		byte[] rawKey = rawKey(key);

--- a/src/main/java/org/springframework/data/redis/core/ValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ValueOperations.java
@@ -293,6 +293,17 @@ public interface ValueOperations<K, V> {
 	V getAndDelete(@NonNull K key);
 
 	/**
+	 * Return the value at {@code key} and expire the key by applying {@code expiration}.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param expiration must not be {@literal null}.
+	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
+	 * @since 4.2
+	 */
+	V getAndExpire(@NonNull K key, @NonNull Expiration expiration);
+
+	/**
 	 * Return the value at {@code key} and expire the key by applying {@code timeout}.
 	 *
 	 * @param key must not be {@literal null}.
@@ -301,8 +312,10 @@ public interface ValueOperations<K, V> {
 	 * @return {@literal null} when key does not exist or used in pipeline / transaction.
 	 * @see <a href="https://redis.io/commands/getex">Redis Documentation: GETEX</a>
 	 * @since 2.6
+	 * @deprecated in favor of {@link #getAndExpire(Object, Expiration)}
 	 */
 	@Nullable
+	@Deprecated(since = "4.2", forRemoval = true)
 	V getAndExpire(@NonNull K key, long timeout, @NonNull TimeUnit unit);
 
 	/**

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicDouble.java
@@ -30,6 +30,7 @@ import org.springframework.data.redis.core.BoundKeyOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.util.Assert;
@@ -377,6 +378,12 @@ public class RedisAtomicDouble extends Number implements Serializable, BoundKeyO
 	}
 
 	@Override
+	public Boolean expire(Expiration expiration) {
+		return generalOps.expire(key, expiration);
+	}
+
+	@Override
+	@Deprecated(since = "4.2", forRemoval = true)
 	public Boolean expire(long timeout, TimeUnit unit) {
 		return generalOps.expire(key, timeout, unit);
 	}

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicInteger.java
@@ -30,6 +30,7 @@ import org.springframework.data.redis.core.BoundKeyOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.util.Assert;
@@ -374,6 +375,11 @@ public class RedisAtomicInteger extends Number implements Serializable, BoundKey
 	@Override
 	public Long getExpire() {
 		return generalOps.getExpire(key);
+	}
+
+	@Override
+	public Boolean expire(Expiration expiration) {
+		return generalOps.expire(key, expiration);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
+++ b/src/main/java/org/springframework/data/redis/support/atomic/RedisAtomicLong.java
@@ -30,6 +30,7 @@ import org.springframework.data.redis.core.BoundKeyOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -371,6 +372,11 @@ public class RedisAtomicLong extends Number implements Serializable, BoundKeyOpe
 	@Override
 	public Long getExpire() {
 		return generalOps.getExpire(key);
+	}
+
+	@Override
+	public Boolean expire(Expiration expiration) {
+		return generalOps.expire(key, expiration);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/support/collections/AbstractRedisCollection.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/AbstractRedisCollection.java
@@ -20,8 +20,10 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.util.Assert;
 
 /**
@@ -104,6 +106,11 @@ public abstract class AbstractRedisCollection<E> extends AbstractCollection<E> i
 	@Override
 	public Boolean expire(long timeout, TimeUnit unit) {
 		return operations.expire(key, timeout, unit);
+	}
+
+	@Override
+	public Boolean expire(@NonNull Expiration expiration) {
+		return operations.expire(key, expiration);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisMap.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/DefaultRedisMap.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.core.BoundHashFieldExpirationOperations;
@@ -30,6 +31,7 @@ import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.data.redis.core.types.Expiration;
 
 /**
  * Default implementation for {@link RedisMap}. Note that the current implementation doesn't provide the same locking
@@ -292,6 +294,11 @@ public class DefaultRedisMap<K, V> implements RedisMap<K, V> {
 	@Override
 	public Long getExpire() {
 		return hashOps.getExpire();
+	}
+
+	@Override
+	public Boolean expire(@NonNull Expiration expiration) {
+		return hashOps.expire(expiration);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/support/collections/RedisProperties.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/RedisProperties.java
@@ -29,11 +29,13 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.core.BoundHashFieldExpirationOperations;
 import org.springframework.data.redis.core.BoundHashOperations;
 import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.types.Expiration;
 
 /**
  * {@link Properties} extension for a Redis back-store. Useful for reading (and storing) properties inside a Redis hash.
@@ -250,6 +252,11 @@ public class RedisProperties extends Properties implements RedisMap<Object, Obje
 	@Override
 	public Long getExpire() {
 		return hashOps.getExpire();
+	}
+
+	@Override
+	public Boolean expire(@NonNull Expiration expiration) {
+		return hashOps.expire(expiration);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/support/collections/ReversedRedisListView.java
+++ b/src/main/java/org/springframework/data/redis/support/collections/ReversedRedisListView.java
@@ -24,10 +24,12 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.RedisListCommands.Direction;
 import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.types.Expiration;
 
 /**
  * Implementation and view of an existing {@link RedisList} where the elements in the list (deque) are returned in
@@ -57,6 +59,11 @@ class ReversedRedisListView<E> implements RedisList<E> {
 	@Override
 	public Long getExpire() {
 		return this.base.getExpire();
+	}
+
+	@Override
+	public Boolean expire(@NonNull Expiration expiration) {
+		return this.base.expire(expiration);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/core/DefaultValueOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultValueOperationsIntegrationTests.java
@@ -236,9 +236,25 @@ public class DefaultValueOperationsIntegrationTests<K, V> {
 		assertThat(valueOps.get(noSuchKey)).isNull();
 	}
 
+	@Test
+	@EnabledOnCommand("GETEX")
+	void testGetAndExpireWithExpiration() {
+
+		K key = keyFactory.instance();
+		V value = valueFactory.instance();
+
+		valueOps.set(key, value);
+
+		assertThat(valueOps.getAndExpire(key, Expiration.seconds(10))).isEqualTo(value);
+		assertThat(redisTemplate.getExpire(key)).isGreaterThan(1);
+
+		K noSuchKey = keyFactory.instance();
+		assertThat(valueOps.getAndExpire(noSuchKey, Expiration.seconds(10))).isNull();
+	}
+
 	@Test // GH-2050
 	@EnabledOnCommand("GETEX")
-	void testGetAndExpire() {
+	void testGetAndExpireWithDuration() {
 
 		K key = keyFactory.instance();
 		V value1 = valueFactory.instance();

--- a/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/support/atomic/RedisAtomicDoubleIntegrationTests.java
@@ -34,6 +34,7 @@ import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -45,6 +46,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Graham MacMaster
+ * @author Yordan Tsintsov
  */
 @ParameterizedClass
 @MethodSource("testParams")
@@ -144,6 +146,13 @@ public class RedisAtomicDoubleIntegrationTests {
 		assertThat(doubleCounter.get()).isEqualTo(1.2);
 	}
 
+	@Test
+	void testExpireWithExpiration() {
+
+		assertThat(doubleCounter.expire(Expiration.seconds(1))).isTrue();
+		assertThat(doubleCounter.getExpire()).isGreaterThan(0);
+	}
+
 	@Test // DATAREDIS-198
 	void testExpire() {
 
@@ -204,7 +213,7 @@ public class RedisAtomicDoubleIntegrationTests {
 
 		template.delete("test");
 
-		assertThatExceptionOfType(DataRetrievalFailureException.class).isThrownBy(() -> test.get())
+		assertThatExceptionOfType(DataRetrievalFailureException.class).isThrownBy(test::get)
 				.withMessageContaining("'test' seems to no longer exist");
 	}
 


### PR DESCRIPTION
Introduces new methods accepting `Expiration` (instead of `Duration`/`TimeUnit`) for `getAndExpire` and `expire` operations across `ValueOperations`, `BoundValueOperations`, `BoundKeyOperations`, and `RedisOperations`.

Deprecates existing `TimeUnit`-based methods in favor of the new
`Expiration`-based variants:
- ValueOperations#getAndExpire(K, long, TimeUnit)
- BoundValueOperations#getAndExpire(long, TimeUnit)
- BoundKeyOperations#expire(long, TimeUnit)
- RedisOperations#expire(K, long, TimeUnit)

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
