### PR TITLE
Update observability note to reflect MicrometerTracing usage

### DIFF
--- a/src/main/antora/modules/ROOT/pages/observability.adoc
+++ b/src/main/antora/modules/ROOT/pages/observability.adoc
@@ -31,9 +31,7 @@ class ObservabilityConfiguration {
 }
 ----
 
-NOTE: When using Spring Boot, `LettuceMetricsAutoConfiguration` configures Lettuce's `MicrometerCommandLatencyRecorder`.
-Depending on whether you want only Metrics or Metrics and Tracing, you might want to exclude this auto-configuration class in your application.
-
+NOTE: NOTE: When using Spring Boot, Redis auto-configuration configures Lettuce's `MicrometerTracing` to integrate with Micrometer's Observation API, providing both metrics and tracing spans for Redis commands.
 See also for further reference:
 * https://redis.github.io/lettuce/advanced-usage/#micrometer[Lettuce Tracing]
 * https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/database/#redis[OpenTelemetry Semantic Conventions] .


### PR DESCRIPTION
The observability documentation currently refers to `LettuceMetricsAutoConfiguration` configuring `MicrometerCommandLatencyRecorder` when using Spring Boot.

Recent Spring Boot versions integrate Lettuce observability through `MicrometerTracing` using the Micrometer Observation API.

This PR updates the NOTE section in the observability documentation to reflect the current behavior and removes the outdated reference.

Closes #3313

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
