### PR TITLE
Add batch listener support for Redis StreamMessageListenerContainer.

### DIFF
--- a/src/main/java/org/springframework/data/redis/stream/BatchStreamListener.java
+++ b/src/main/java/org/springframework/data/redis/stream/BatchStreamListener.java
@@ -15,26 +15,26 @@
  */
 package org.springframework.data.redis.stream;
 
+import java.util.List;
+
 import org.springframework.data.redis.connection.stream.Record;
 
 /**
- * Listener interface to receive delivery of {@link Record messages}.
+ * Listener interface to receive delivery of {@link Record records}.
  *
- * @author Mark Paluch
  * @author Taewan Kim
  * @param <K> Stream key and Stream field type.
  * @param <V> Stream value type.
- * @since 2.2
  */
 @FunctionalInterface
-public interface StreamListener<K, V extends Record<K, ?>> extends GenericStreamListener<V> {
+public interface BatchStreamListener<K, V extends Record<K, ?>> extends GenericStreamListener<List<V>> {
 
-	/**
-	 * Callback invoked on receiving a {@link Record}.
-	 *
-	 * @param message never {@literal null}.
-	 */
+    /**
+     * Callback invoked on receiving {@link Record records}.
+     *
+     * @param messages never {@literal null}.
+     */
     @Override
-	void onMessage(V message);
+    void onMessage(List<V> messages);
 
 }

--- a/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/DefaultStreamMessageListenerContainer.java
@@ -52,6 +52,7 @@ import org.springframework.util.ObjectUtils;
  * @author Christoph Strobl
  * @author Su Ko
  * @author Yumin Jung
+ * @author Taewan Kim
  * @since 2.2
  */
 class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implements StreamMessageListenerContainer<K, V> {
@@ -213,8 +214,17 @@ class DefaultStreamMessageListenerContainer<K, V extends Record<K, ?>> implement
 		return doRegister(getReadTask(streamRequest, listener));
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private StreamPollTask<K, V> getReadTask(StreamReadRequest<K> streamRequest, StreamListener<K, V> listener) {
+    @Override
+    public Subscription registerBatch(StreamReadRequest<K> streamRequest, BatchStreamListener<K, V> listener) {
+
+        Assert.notNull(streamRequest, "StreamReadRequest must not be null");
+        Assert.notNull(listener, "BatchStreamListener must not be null");
+
+        return doRegister(getReadTask(streamRequest, listener));
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+	private StreamPollTask<K, V> getReadTask(StreamReadRequest<K> streamRequest, GenericStreamListener<?> listener) {
 
 		Function<ReadOffset, List<ByteRecord>> readFunction = getReadFunction(streamRequest);
 		Function<ByteRecord, V> deserializerToUse = getDeserializer();

--- a/src/main/java/org/springframework/data/redis/stream/GenericStreamListener.java
+++ b/src/main/java/org/springframework/data/redis/stream/GenericStreamListener.java
@@ -15,26 +15,15 @@
  */
 package org.springframework.data.redis.stream;
 
-import org.springframework.data.redis.connection.stream.Record;
-
 /**
- * Listener interface to receive delivery of {@link Record messages}.
+ * Common listener contract for stream message callbacks.
  *
- * @author Mark Paluch
  * @author Taewan Kim
- * @param <K> Stream key and Stream field type.
- * @param <V> Stream value type.
- * @since 2.2
+ * @param <T> message type.
  */
 @FunctionalInterface
-public interface StreamListener<K, V extends Record<K, ?>> extends GenericStreamListener<V> {
+public interface GenericStreamListener<T> {
 
-	/**
-	 * Callback invoked on receiving a {@link Record}.
-	 *
-	 * @param message never {@literal null}.
-	 */
-    @Override
-	void onMessage(V message);
+    void onMessage(T message);
 
 }

--- a/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamMessageListenerContainer.java
@@ -109,6 +109,7 @@ import org.springframework.util.ErrorHandler;
  * @author Christian Rest
  * @author DongCheol Kim
  * @author Su Ko
+ * @author Taewan Kim
  * @param <K> Stream key and Stream field type.
  * @param <V> Stream value type.
  * @since 2.2
@@ -228,7 +229,45 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 		return register(StreamReadRequest.builder(streamOffset).consumer(consumer).autoAcknowledge(true).build(), listener);
 	}
 
-	/**
+    /**
+     * Register a batch listener for a Redis Stream.
+     *
+     * @param streamOffset the stream and its offset.
+     * @param listener the message listener.
+     * @return the subscription handle.
+     */
+    default Subscription receiveBatch(StreamOffset<K> streamOffset, BatchStreamListener<K, V> listener) {
+        return registerBatch(StreamReadRequest.builder(streamOffset).build(), listener);
+    }
+
+    /**
+     * Register a batch listener using a consumer group with external acknowledge.
+     *
+     * @param consumer consumer group and identity.
+     * @param streamOffset the stream and its offset.
+     * @param listener the message listener.
+     * @return the subscription handle.
+     */
+    default Subscription receiveBatch(Consumer consumer, StreamOffset<K> streamOffset, BatchStreamListener<K, V> listener) {
+        return registerBatch(StreamReadRequest.builder(streamOffset).consumer(consumer).autoAcknowledge(false).build(),
+                listener);
+    }
+
+    /**
+     * Register a batch listener with auto acknowledge.
+     *
+     * @param consumer consumer group and identity.
+     * @param streamOffset the stream and its offset.
+     * @param listener the message listener.
+     * @return the subscription handle.
+     */
+    default Subscription receiveBatchAutoAck(Consumer consumer, StreamOffset<K> streamOffset, BatchStreamListener<K, V> listener) {
+        return registerBatch(StreamReadRequest.builder(streamOffset).consumer(consumer).autoAcknowledge(true).build(),
+                listener);
+    }
+
+
+    /**
 	 * Register a new subscription for a Redis Stream. If the container is already
 	 * {@link StreamMessageListenerContainer#isRunning() running} the {@link Subscription} will be added and started
 	 * immediately, otherwise it'll be scheduled and started once the container is actually
@@ -250,7 +289,16 @@ public interface StreamMessageListenerContainer<K, V extends Record<K, ?>> exten
 	 */
 	Subscription register(StreamReadRequest<K> streamRequest, StreamListener<K, V> listener);
 
-	/**
+    /**
+     * Register a batch listener subscription.
+     *
+     * @param streamRequest must not be {@literal null}.
+     * @param listener must not be {@literal null}.
+     * @return the subscription handle.
+     */
+    Subscription registerBatch(StreamReadRequest<K> streamRequest, BatchStreamListener<K, V> listener);
+
+    /**
 	 * Unregister a given {@link Subscription} from the container. This prevents the {@link Subscription} to be restarted
 	 * in a potential {@link SmartLifecycle#stop() stop}/{@link SmartLifecycle#start() start} scenario. An
 	 * {@link Subscription#isActive() active} {@link Subscription subcription} is {@link Subscription#cancel() cancelled}

--- a/src/main/java/org/springframework/data/redis/stream/StreamPollTask.java
+++ b/src/main/java/org/springframework/data/redis/stream/StreamPollTask.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.stream;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -42,11 +43,12 @@ import org.springframework.util.ErrorHandler;
  * {@link Task} that invokes a {@link BiFunction read function} to poll on a Redis Stream.
  *
  * @author Mark Paluch
+ * @author Taewan Kim
  * @see 2.2
  */
 class StreamPollTask<K, V extends Record<K, ?>> implements Task {
 
-	private final StreamListener<K, V> listener;
+    private final GenericStreamListener<?> listener;
 	private final ErrorHandler errorHandler;
 	private final Predicate<Throwable> cancelSubscriptionOnError;
 	private final Function<ReadOffset, List<ByteRecord>> readFunction;
@@ -57,7 +59,7 @@ class StreamPollTask<K, V extends Record<K, ?>> implements Task {
 
 	private volatile boolean isInEventLoop = false;
 
-	StreamPollTask(StreamReadRequest<K> streamRequest, StreamListener<K, V> listener, ErrorHandler errorHandler,
+	StreamPollTask(StreamReadRequest<K> streamRequest, GenericStreamListener<?> listener, ErrorHandler errorHandler,
 			TypeDescriptor targetType, Function<ReadOffset, List<ByteRecord>> readFunction,
 			Function<ByteRecord, V> deserializer) {
 
@@ -147,27 +149,75 @@ class StreamPollTask<K, V extends Record<K, ?>> implements Task {
 		return readFunction.apply(pollState.getCurrentReadOffset());
 	}
 
-	private void deserializeAndEmitRecords(List<ByteRecord> records) {
+	 private void deserializeAndEmitRecords(List<ByteRecord> records) {
+
+        if (listener instanceof StreamListener<?, ?>) {
+            emitIndividually(records);
+            return;
+        }
+
+        if (listener instanceof BatchStreamListener<?, ?>) {
+            emitBatch(records);
+            return;
+        }
+
+        throw new IllegalStateException("Unsupported listener type %s".formatted(listener.getClass().getName()));
+    }
+
+	@SuppressWarnings("unchecked")
+	private void emitIndividually(List<ByteRecord> records) {
+
+		StreamListener<K, V> streamListener = (StreamListener<K, V>) listener;
 
 		for (ByteRecord raw : records) {
-
 			try {
-
 				pollState.updateReadOffset(raw.getId().getValue());
 				V record = convertRecord(raw);
-				listener.onMessage(record);
+				streamListener.onMessage(record);
+
 			} catch (RuntimeException ex) {
 
 				if (cancelSubscriptionOnError.test(ex)) {
-
 					cancel();
 					errorHandler.handleError(ex);
-
 					return;
 				}
 
 				errorHandler.handleError(ex);
 			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private void emitBatch(List<ByteRecord> records) {
+
+		if (records.isEmpty()) {
+			return;
+		}
+
+		BatchStreamListener<K, V> batchStreamListener = (BatchStreamListener<K, V>) listener;
+
+		try {
+			List<V> converted = new ArrayList<>(records.size());
+
+			for (ByteRecord raw : records) {
+				converted.add(convertRecord(raw));
+			}
+
+			batchStreamListener.onMessage(converted);
+
+			ByteRecord last = records.get(records.size() - 1);
+			pollState.updateReadOffset(last.getId().getValue());
+
+		} catch (RuntimeException ex) {
+
+			if (cancelSubscriptionOnError.test(ex)) {
+				cancel();
+				errorHandler.handleError(ex);
+				return;
+			}
+
+			errorHandler.handleError(ex);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/stream/AbstractStreamMessageListenerContainerIntegrationTests.java
@@ -21,12 +21,15 @@ import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.output.NestedMultiOutput;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +60,7 @@ import org.springframework.util.NumberUtils;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author John Blum
+ * @author Taewan Kim
  */
 @EnabledOnCommand("XREAD")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -108,7 +112,36 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		assertThat(subscription.isActive()).isFalse();
 	}
 
-	@Test // DATAREDIS-864
+    @Test // GH-3190
+    void shouldReceiveBatchMapMessages() throws InterruptedException {
+
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
+                .create(connectionFactory, containerOptions);
+        BlockingQueue<List<MapRecord<String, String, String>>> batches = new LinkedBlockingQueue<>();
+
+        container.start();
+        Subscription subscription = container.receiveBatch(StreamOffset.create("my-stream", ReadOffset.from("0-0")),
+                batches::add);
+
+        subscription.await(DEFAULT_TIMEOUT);
+
+        redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value1"));
+        redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value2"));
+        redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value3"));
+
+        Awaitility.await().atMost(DEFAULT_TIMEOUT).untilAsserted(() -> {
+            List<List<MapRecord<String, String, String>>> drained = new ArrayList<>();
+            batches.drainTo(drained);
+
+            assertThat(drained).isNotEmpty();
+            assertThat(drained.stream().flatMap(List::stream).map(it -> it.getValue().get("key")))
+                    .contains("value1", "value2", "value3");
+        });
+
+        cancelAwait(subscription);
+    }
+
+    @Test // DATAREDIS-864
 	void shouldReceiveSimpleObjectHashRecords() throws InterruptedException {
 
 		StreamMessageListenerContainerOptions<String, ObjectRecord<String, String>> containerOptions = StreamMessageListenerContainerOptions
@@ -183,6 +216,33 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		cancelAwait(subscription);
 	}
 
+    @Test // GH-3190
+    void shouldReceiveBatchMessagesInConsumerGroup() throws InterruptedException {
+
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
+                .create(connectionFactory, containerOptions);
+        BlockingQueue<List<MapRecord<String, String, String>>> batches = new LinkedBlockingQueue<>();
+        RecordId messageId = redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value1"));
+        redisTemplate.opsForStream().createGroup("my-stream", ReadOffset.from(messageId), "my-group");
+
+        container.start();
+        Subscription subscription = container.receiveBatch(Consumer.from("my-group", "my-consumer"),
+                StreamOffset.create("my-stream", ReadOffset.lastConsumed()), batches::add);
+
+        subscription.await(DEFAULT_TIMEOUT);
+
+        redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value2"));
+
+        List<MapRecord<String, String, String>> messageBatch = batches.poll(1, TimeUnit.SECONDS);
+        assertThat(messageBatch).isNotNull();
+        assertThat(messageBatch).isNotEmpty();
+        assertThat(messageBatch.stream().map(it -> it.getValue().get("key"))).contains("value2");
+
+        assertThat(getNumberOfPending("my-stream", "my-group")).isOne();
+
+        cancelAwait(subscription);
+    }
+
 	@Test // DATAREDIS-1079
 	void shouldReceiveAndAckMessagesInConsumerGroup() throws InterruptedException {
 
@@ -208,6 +268,33 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 
 		cancelAwait(subscription);
 	}
+
+    @Test // GH-3190
+    void shouldReceiveAndAutoAckBatchMessagesInConsumerGroup() throws InterruptedException {
+
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
+                .create(connectionFactory, containerOptions);
+        BlockingQueue<List<MapRecord<String, String, String>>> batches = new LinkedBlockingQueue<>();
+        RecordId messageId = redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value1"));
+        redisTemplate.opsForStream().createGroup("my-stream", ReadOffset.from(messageId), "my-group");
+
+        container.start();
+        Subscription subscription = container.receiveBatchAutoAck(Consumer.from("my-group", "my-consumer"),
+                StreamOffset.create("my-stream", ReadOffset.lastConsumed()), batches::add);
+
+        subscription.await(DEFAULT_TIMEOUT);
+
+        redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value2"));
+
+        List<MapRecord<String, String, String>> messageBatch = batches.poll(1, TimeUnit.SECONDS);
+        assertThat(messageBatch).isNotNull();
+        assertThat(messageBatch).isNotEmpty();
+        assertThat(messageBatch.stream().map(it -> it.getValue().get("key"))).contains("value2");
+
+        assertThat(getNumberOfPending("my-stream", "my-group")).isZero();
+
+        cancelAwait(subscription);
+    }
 
 	@Test // DATAREDIS-864
 	void shouldUseCustomErrorHandler() throws InterruptedException {
@@ -339,7 +426,82 @@ abstract class AbstractStreamMessageListenerContainerIntegrationTests {
 		cancelAwait(subscription);
 	}
 
-	@Test // DATAREDIS-864
+    @Test // GH-3190
+    void emptyBatchPollShouldNotFailOrInvokeListener() throws InterruptedException {
+
+        BlockingQueue<Throwable> failures = new LinkedBlockingQueue<>();
+        AtomicInteger callbackInvocations = new AtomicInteger();
+
+        StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options = StreamMessageListenerContainerOptions
+                .builder().errorHandler(failures::add).pollTimeout(Duration.ofMillis(100)).build();
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
+                .create(connectionFactory, options);
+
+        container.start();
+        Subscription subscription = container.receiveBatch(StreamOffset.create("my-stream", ReadOffset.from("0-0")),
+                messages -> callbackInvocations.incrementAndGet());
+
+        subscription.await(DEFAULT_TIMEOUT);
+
+        Thread.sleep(250);
+
+        assertThat(callbackInvocations).hasValue(0);
+        assertThat(failures).isEmpty();
+        assertThat(subscription.isActive()).isTrue();
+
+        cancelAwait(subscription);
+    }
+
+    @Test // GH-3190
+    void batchListenerFailureShouldNotAdvanceOffsetWhenContinuingOnError() throws InterruptedException {
+
+        BlockingQueue<Throwable> failures = new LinkedBlockingQueue<>();
+        BlockingQueue<List<MapRecord<String, String, String>>> received = new LinkedBlockingQueue<>();
+        AtomicBoolean failOnce = new AtomicBoolean(true);
+        AtomicInteger callbackInvocations = new AtomicInteger();
+
+        StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options = StreamMessageListenerContainerOptions
+                .builder().batchSize(3).pollTimeout(Duration.ofMillis(100)).build();
+        StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer
+                .create(connectionFactory, options);
+
+        StreamReadRequest<String> readRequest = StreamReadRequest
+                .builder(StreamOffset.create("my-stream", ReadOffset.from("0-0"))) //
+                .errorHandler(failures::add) //
+                .cancelOnError(it -> false) //
+                .build();
+
+        redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value1"));
+        redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value2"));
+        redisTemplate.opsForStream().add("my-stream", Collections.singletonMap("key", "value3"));
+
+        container.start();
+        Subscription subscription = container.registerBatch(readRequest, messages -> {
+
+            callbackInvocations.incrementAndGet();
+
+            if (failOnce.compareAndSet(true, false)) {
+                throw new RuntimeException("boom");
+            }
+
+            received.add(messages);
+        });
+
+        subscription.await(DEFAULT_TIMEOUT);
+
+        List<MapRecord<String, String, String>> delivered = received.poll(2, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered).hasSize(3);
+        assertThat(delivered.stream().map(it -> it.getValue().get("key")))
+                .containsExactly("value1", "value2", "value3");
+        assertThat(callbackInvocations.get()).isGreaterThanOrEqualTo(2);
+        assertThat(failures).isNotEmpty();
+        assertThat(subscription.isActive()).isTrue();
+
+        cancelAwait(subscription);
+    }
+
+    @Test // DATAREDIS-864
 	void cancelledStreamShouldNotReceiveMessages() throws InterruptedException {
 
 		StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer


### PR DESCRIPTION
This PR introduces batch listener support for Redis StreamMessageListenerContainer.

Currently, records are delivered individually through StreamListener even when multiple records are returned from Redis using COUNT. This PR adds a BatchStreamListener abstraction to allow processing multiple records in a single callback.

New APIs (registerBatch, receiveBatch) are introduced to support batch consumption while keeping the existing StreamListener API unchanged for backward compatibility.

Batch processing advances the read offset only after successful listener invocation. In case of failures, records may be redelivered, avoiding message loss.

Closes #3190 

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
