### PR TITLE
Use default RedisMessageListenerContainer bean name for annotation-driven Redis listeners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.0-GH-3340-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/annotation/EnableRedisListeners.java
+++ b/src/main/java/org/springframework/data/redis/annotation/EnableRedisListeners.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Target;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.config.RedisListenerBootstrapConfiguration;
 import org.springframework.data.redis.config.RedisListenerEndpointRegistry;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.RedisMessageConverters;
 
 /**
@@ -65,8 +66,8 @@ import org.springframework.data.redis.serializer.RedisMessageConverters;
  * </pre>
  * <p>
  * The container to use is identified by the {@link RedisListener#container() container} attribute defining the name of
- * the {@code RedisMessageListenerContainer} bean to use. When none is set a default
- * {@code RedisMessageListenerContainer} bean is assumed to be present.
+ * the {@link RedisMessageListenerContainer} bean to use. When none is set a {@code RedisMessageListenerContainer} bean
+ * named {@code redisMessageListenerContainer} is assumed to be present.
  * <p>
  * The following configuration would ensure that every time a Pub/Sub is received on the topic channel named
  * "myChannel", {@code MyService.process()} is invoked with the content of the message:

--- a/src/main/java/org/springframework/data/redis/annotation/RedisListener.java
+++ b/src/main/java/org/springframework/data/redis/annotation/RedisListener.java
@@ -23,13 +23,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.data.redis.config.RedisListenerConfigUtils;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 
 /**
  * Annotation that marks a method to be the target of a Redis Pub/Sub message listener on the specified {@link #topic}.
  * The {@link #container()} identifies the {@link org.springframework.data.redis.listener.RedisMessageListenerContainer}
- * to subscribe with. If not set, a <em>default</em> container is assumed to be available.
+ * to subscribe with. If not set, a <em>default</em> container is assumed to be available with a bean name of
+ * {@code redisMessageListenerContainer} unless an explicit default has been provided through configuration.
  * <p>
  * Processing of {@code @RedisListener} annotations is performed by registering a
  * {@link RedisListenerAnnotationBeanPostProcessor}. This can be done manually or, more conveniently, through the
@@ -80,9 +82,9 @@ public @interface RedisListener {
 
 	/**
 	 * The bean name of the {@link org.springframework.data.redis.listener.RedisMessageListenerContainer} to subscribe
-	 * with. If empty, the default {@code RedisMessageListenerContainer} bean will be used.
+	 * with.
 	 */
-	String container() default "";
+	String container() default RedisListenerConfigUtils.REDIS_MESSAGE_LISTENER_BEAN_NAME;
 
 	/**
 	 * The destination name for this listener, resolved through a

--- a/src/main/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessor.java
+++ b/src/main/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessor.java
@@ -205,29 +205,38 @@ public class RedisListenerAnnotationBeanPostProcessor
 	 */
 	protected void processRedisListener(RedisListener redisListener, Method method, Object bean) {
 
-		RedisMessageListenerContainer container;
+		RedisMessageListenerContainer container = getRedisMessageListenerContainer(redisListener, method);
+		MethodRedisListenerEndpoint endpoint = createEndpoint(redisListener, method, bean);
+		this.registrar.registerEndpoint(endpoint, container);
+	}
+
+	protected RedisMessageListenerContainer getRedisMessageListenerContainer(RedisListener redisListener, Method method) {
+
 		String containerName = resolve(redisListener.container());
 		Assert.state(this.beanFactory != null, "BeanFactory must be set to obtain container container by bean name");
 
 		if (StringUtils.hasText(containerName)) {
-			try {
-				container = this.beanFactory.getBean(containerName, RedisMessageListenerContainer.class);
-			} catch (NoSuchBeanDefinitionException ex) {
-				throw new BeanInitializationException("Could not register Redis listener endpoint on [" + method + "], no "
-						+ RedisMessageListenerContainer.class.getSimpleName() + " with name '" + containerName
-						+ "' was found in the application context", ex);
-			}
-		} else {
-			try {
-				container = this.beanFactory.getBean(RedisMessageListenerContainer.class);
-			} catch (NoSuchBeanDefinitionException ex) {
-				throw new BeanInitializationException("Could not register Redis listener endpoint on [" + method + "], no "
-						+ RedisMessageListenerContainer.class.getSimpleName() + " was found in the application context", ex);
-			}
+			return getRedisMessageListenerContainer(method, containerName);
 		}
 
-		MethodRedisListenerEndpoint endpoint = createEndpoint(redisListener, method, bean);
-		this.registrar.registerEndpoint(endpoint, container);
+		RedisMessageListenerContainer container = this.beanFactory.getBeanProvider(RedisMessageListenerContainer.class)
+				.getIfUnique();
+
+		if (container == null) {
+			container = getRedisMessageListenerContainer(method, RedisListenerConfigUtils.REDIS_MESSAGE_LISTENER_BEAN_NAME);
+		}
+
+		return container;
+	}
+
+	private RedisMessageListenerContainer getRedisMessageListenerContainer(Method method, String containerName) {
+		try {
+			return this.beanFactory.getBean(containerName, RedisMessageListenerContainer.class);
+		} catch (NoSuchBeanDefinitionException ex) {
+			throw new BeanInitializationException("Could not register Redis listener endpoint on [" + method + "], no "
+					+ RedisMessageListenerContainer.class.getSimpleName() + " with name '" + containerName
+					+ "' was found in the application context", ex);
+		}
 	}
 
 	public MethodRedisListenerEndpoint createEndpoint(RedisListener redisListener, Method method, Object bean) {

--- a/src/main/java/org/springframework/data/redis/config/RedisListenerConfigUtils.java
+++ b/src/main/java/org/springframework/data/redis/config/RedisListenerConfigUtils.java
@@ -33,4 +33,9 @@ public abstract class RedisListenerConfigUtils {
 	 */
 	public static final String REDIS_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME = "org.springframework.data.redis.config.internalRedisListenerEndpointRegistry";
 
+	/**
+	 * The bean name of the default Redis message listener container.
+	 */
+	public static final String REDIS_MESSAGE_LISTENER_BEAN_NAME = "redisMessageListenerContainer";
+
 }

--- a/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
+++ b/src/main/java/org/springframework/data/redis/listener/RedisMessageListenerContainer.java
@@ -71,10 +71,10 @@ import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.FixedBackOff;
 
 /**
- * Container providing asynchronous behaviour for Redis message listeners. Handles the low level details of listening,
+ * Container providing asynchronous behaviour for Redis message listeners. Handles the low-level details of listening,
  * converting and message dispatching.
  * <p>
- * As opposed to the low level Redis (one connection per subscription), the container uses only one connection that is
+ * As opposed to the low-level Redis (one connection per subscription), the container uses only one connection that is
  * 'multiplexed' for all registered listeners, the message dispatch being done through the
  * {@link #setTaskExecutor(Executor) task executor}. It is recommended to configure the task executor (and subscription
  * executor when using a blocking Redis connector) instead of using the default {@link SimpleAsyncTaskExecutor} for

--- a/src/test/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessorIntegrationTests.java
@@ -19,12 +19,18 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
 import org.junit.jupiter.api.Test;
 
-import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.config.RedisListenerConfigUtils;
 import org.springframework.data.redis.config.RedisListenerEndpointRegistry;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.Topic;
@@ -40,22 +46,86 @@ class RedisListenerAnnotationBeanPostProcessorIntegrationTests {
 	@Test // GH-1004
 	void registersListenerWithDefaultContainer() {
 
-		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(Config.class, SimpleService.class);
-		RedisMessageListenerContainer container = context.getBean("redisMessageListenerContainer",
-				RedisMessageListenerContainer.class);
+		AtomicReference<RedisListenerEndpointRegistry> registryRef = new AtomicReference<>();
 
-		verify(container).addMessageListener(any(), any(Topic.class));
+		doWithContext(context -> {
+			RedisMessageListenerContainer container = context.getBean("redisMessageListenerContainer",
+					RedisMessageListenerContainer.class);
 
-		RedisListenerEndpointRegistry registry = context.getBean(RedisListenerEndpointRegistry.class);
-		assertThat(registry.isRunning()).isTrue();
+			verify(container).addMessageListener(any(), any(Topic.class));
 
-		context.close();
-		assertThat(registry.isRunning()).isFalse();
+			RedisListenerEndpointRegistry registry = context.getBean(RedisListenerEndpointRegistry.class);
+			assertThat(registry.isRunning()).isTrue();
+			registryRef.set(registry);
+		}, DefaultConfig.class, SimpleService.class);
+
+		assertThat(registryRef.get().isRunning()).isFalse();
+	}
+
+	@Test // GH-3340
+	void registersListenerWithNamedContainer() {
+
+		doWithContext(context -> {
+			RedisMessageListenerContainer customContainer = context.getBean("customContainer1",
+					RedisMessageListenerContainer.class);
+			RedisMessageListenerContainer defaultContainer = context
+					.getBean(RedisListenerConfigUtils.REDIS_MESSAGE_LISTENER_BEAN_NAME, RedisMessageListenerContainer.class);
+
+			verify(customContainer).addMessageListener(any(), any(Topic.class));
+			verify(defaultContainer, never()).addMessageListener(any(), any(Topic.class));
+		}, DefaultConfig.class, MultiContainerService.class, CustomContainerConfig.class);
+	}
+
+	@Test // GH-3340
+	void registersListenersAcrossMultipleContainers() {
+
+		doWithContext(context -> {
+			RedisMessageListenerContainer containerOne = context.getBean("customContainer1",
+					RedisMessageListenerContainer.class);
+			RedisMessageListenerContainer containerTwo = context.getBean("customContainer2",
+					RedisMessageListenerContainer.class);
+
+			verify(containerOne).addMessageListener(any(), any(Topic.class));
+			verify(containerTwo).addMessageListener(any(), any(Topic.class));
+		}, CustomContainerConfig.class, MultiContainerService.class);
+	}
+
+	@Test // GH-3340
+	void failsWithMissingNamedContainer() {
+
+		assertThatThrownBy(() -> new AnnotationConfigApplicationContext(DefaultConfig.class, NamedContainerService.class))
+				.hasRootCauseInstanceOf(NoSuchBeanDefinitionException.class).hasMessageContaining("customContainer");
+	}
+
+	@Test // GH-3340
+	void registersListenersMultipleContainers() {
+
+		doWithContext(context -> {
+			RedisMessageListenerContainer container = context
+					.getBean(RedisListenerConfigUtils.REDIS_MESSAGE_LISTENER_BEAN_NAME, RedisMessageListenerContainer.class);
+
+			verify(container).addMessageListener(any(), any(Topic.class));
+		}, DefaultConfig.class, CustomContainerConfig.class, UnnamedContainerService.class);
+	}
+
+	@Test // GH-3340
+	void registrationFailsOnUnresolvableContainer() {
+
+		assertThatExceptionOfType(BeanCreationException.class)
+				.isThrownBy(() -> doWithContext(context -> {}, CustomContainerConfig.class, UnnamedContainerService.class));
+	}
+
+	private static void doWithContext(Consumer<ApplicationContext> action, Class<?>... annotatedClasses) {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(annotatedClasses);
+			context.refresh();
+			action.accept(context);
+		}
 	}
 
 	@Configuration
 	@EnableRedisListeners
-	static class Config {
+	static class DefaultConfig {
 
 		@Bean
 		public RedisMessageListenerContainer redisMessageListenerContainer() {
@@ -69,4 +139,43 @@ class RedisListenerAnnotationBeanPostProcessorIntegrationTests {
 		public void handle(String msg) {}
 
 	}
+
+	static class UnnamedContainerService {
+
+		@RedisListener(topic = "test-topic", container = "")
+		public void handle(String msg) {}
+
+	}
+
+	static class NamedContainerService {
+
+		@RedisListener(container = "customContainer", topic = "test-topic")
+		public void handle(String msg) {}
+
+	}
+
+	@Configuration
+	@EnableRedisListeners
+	static class CustomContainerConfig {
+
+		@Bean
+		public RedisMessageListenerContainer customContainer1() {
+			return mock(RedisMessageListenerContainer.class);
+		}
+
+		@Bean
+		public RedisMessageListenerContainer customContainer2() {
+			return mock(RedisMessageListenerContainer.class);
+		}
+
+	}
+
+	static class MultiContainerService {
+
+		@RedisListener(container = "customContainer1", topic = "topic-one")
+		@RedisListener(container = "customContainer2", topic = "topic-two")
+		public void handle(String msg) {}
+
+	}
+
 }

--- a/src/test/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessorUnitTests.java
@@ -31,6 +31,7 @@ import org.mockito.quality.Strictness;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.data.redis.config.MethodRedisListenerEndpoint;
+import org.springframework.data.redis.config.RedisListenerConfigUtils;
 import org.springframework.data.redis.config.RedisListenerEndpointRegistry;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -64,7 +65,8 @@ class RedisListenerAnnotationBeanPostProcessorUnitTests {
 		processor.afterSingletonsInstantiated();
 		processor.setBeanFactory(beanFactory);
 
-		when(beanFactory.getBean(RedisMessageListenerContainer.class)).thenReturn(container);
+		when(beanFactory.getBean(RedisListenerConfigUtils.REDIS_MESSAGE_LISTENER_BEAN_NAME,
+				RedisMessageListenerContainer.class)).thenReturn(container);
 	}
 
 	@Test // GH-1004

--- a/src/test/java/org/springframework/data/redis/annotation/RedisListenerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/annotation/RedisListenerIntegrationTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.redis.annotation;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.Collection;
 import java.util.List;
@@ -27,9 +27,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.config.RedisListenerConfigUtils;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.extension.JedisConnectionFactoryExtension;
@@ -72,7 +74,8 @@ public class RedisListenerIntegrationTests {
 	@Test // GH-1004
 	void shouldListenForMessage() throws InterruptedException {
 
-		context.registerBean("my-container", RedisMessageListenerContainer.class, () -> {
+		context.registerBean(RedisListenerConfigUtils.REDIS_MESSAGE_LISTENER_BEAN_NAME, RedisMessageListenerContainer.class,
+				() -> {
 
 			RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 			container.setRecoveryInterval(100);

--- a/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/listener/ReactiveRedisMessageListenerContainerIntegrationTests.java
@@ -337,7 +337,7 @@ public class ReactiveRedisMessageListenerContainerIntegrationTests {
 
 		c2Subscription.dispose();
 
-		Thread.sleep(200);
+		Thread.sleep(500);
 
 		doPublish(CHANNEL1.getBytes(), MESSAGE.getBytes());
 
@@ -345,6 +345,8 @@ public class ReactiveRedisMessageListenerContainerIntegrationTests {
 		assertThat(c2Collector.poll(100, TimeUnit.MILLISECONDS)).isNull();
 
 		c1Subscription.dispose();
+
+		Thread.sleep(500);
 
 		doPublish(CHANNEL1.getBytes(), MESSAGE.getBytes());
 


### PR DESCRIPTION
We now use a default bean name to ensure that additional `RedisMessageListenerContainer` bean registrations do not break applications by using a default bean name. Also, we align our behavior with other messaging components in the Spring portfolio.

Closes #3340