### PR TITLE
Fix sort direction ignored in GeoSearchStoreCommandArgs.sort().

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisGeoCommands.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Ninad Divadkar
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Yeonsu Kim
  * @since 1.8
  * @see RedisCommands
  */
@@ -497,13 +498,14 @@ public interface RedisGeoCommands {
 		/**
 		 * Apply a sort direction.
 		 *
+		 * @param direction the sort direction; must not be {@literal null}.
 		 * @return never {@literal null}.
 		 */
 		public GeoSearchStoreCommandArgs sort(Direction direction) {
 
 			Assert.notNull(direction, "Sort direction must not be null");
 
-			sortDirection = Direction.ASC;
+			sortDirection = direction;
 			return this;
 		}
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultGeoOperationsIntegrationTests.java
@@ -53,6 +53,7 @@ import org.springframework.data.redis.test.condition.EnabledOnCommand;
  * @author Ninad Divadkar
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Yeonsu Kim
  */
 @ParameterizedClass
 @MethodSource("testParams")
@@ -605,5 +606,29 @@ public class DefaultGeoOperationsIntegrationTests<K, M> {
 
 		assertThat(result).isEqualTo(2);
 		assertThat(redisTemplate.boundZSetOps(destKey).size()).isEqualTo(2);
+	}
+
+	@Test // GH-3342
+	@EnabledOnCommand("GEOSEARCHSTORE")
+	void geoSearchAndStoreShouldRespectSortDirection() {
+
+		assumeThat(redisTemplate.getRequiredConnectionFactory()).isInstanceOf(LettuceConnectionFactory.class);
+
+		K key = keyFactory.instance();
+		K destKey = keyFactory.instance();
+		M member1 = valueFactory.instance();
+		M member2 = valueFactory.instance();
+		M member3 = valueFactory.instance();
+
+		geoOperations.add(key, POINT_PALERMO, member1);
+		geoOperations.add(key, POINT_CATANIA, member2);
+		geoOperations.add(key, POINT_ARIGENTO, member3);
+
+		Long result = geoOperations.searchAndStore(key, destKey, GeoReference.fromCoordinate(POINT_PALERMO),
+				new Distance(300, KILOMETERS),
+				RedisGeoCommands.GeoSearchStoreCommandArgs.newGeoSearchStoreArgs().sortDescending().limit(1));
+
+		assertThat(result).isEqualTo(1);
+		assertThat(redisTemplate.boundZSetOps(destKey).range(0, -1)).containsExactly(member2);
 	}
 }


### PR DESCRIPTION
## Problem

`GeoSearchStoreCommandArgs.sort(Direction)` always assigned `Direction.ASC`
regardless of the provided argument:

```java
public GeoSearchStoreCommandArgs sort(Direction direction) {
    Assert.notNull(direction, "Sort direction must not be null");
    sortDirection = Direction.ASC; // direction parameter ignored
    return this;
}
```

This caused `sortDescending()` to have no effect, and the SORT DESC flag
was never passed to the underlying Redis GEOSEARCHSTORE command in either
Lettuce or Jedis drivers.

The equivalent method in `GeoSearchCommandArgs` is implemented correctly and
served as a reference.

## Fix

Assign the provided direction argument directly:

```java
sortDirection = direction;
```

## Testing

Added integration test `geoSearchAndStoreShouldRespectSortDirection` that:

- Adds three members at different distances from a reference point (Palermo, Agrigento, Catania)
- Calls `searchAndStore` with `sortDescending().limit(1)`
- Verifies that only the farthest member (Catania) is stored in the destination key

Closes #3342

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
