### PR TITLE
Fix `RedisPipelineException` double-wrapping in `LettuceConnection.closePipeline()`

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceConnection.java
@@ -103,6 +103,7 @@ import org.springframework.util.ObjectUtils;
  * @author Tamil Selvan
  * @author ihaohong
  * @author John Blum
+ * @author Jaeik Jeong
  */
 @NullUnmarked
 public class LettuceConnection extends AbstractRedisConnection {
@@ -651,6 +652,8 @@ public class LettuceConnection extends AbstractRedisConnection {
 			}
 
 			throw new RedisPipelineException(new QueryTimeoutException("Redis command timed out"));
+		} catch (RedisPipelineException ex) {
+			throw ex;
 		} catch (Exception ex) {
 			throw new RedisPipelineException(ex);
 		}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConnectionUnitTests.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -48,8 +49,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
+import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.redis.connection.AbstractConnectionUnitTestBase;
+import org.springframework.data.redis.connection.RedisPipelineException;
 import org.springframework.data.redis.connection.RedisServerCommands.ShutdownOption;
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
@@ -426,6 +430,47 @@ class LettuceConnectionUnitTests {
 			assertThat(captor.getAllValues()).map(ScanCursor::getCursor).containsExactly("0", cursorId);
 		}
 
+	}
+
+	@Nested
+	class ClosePipelineUnitTests {
+
+		@Test // GH-3346
+		void closePipelineShouldNotDoubleWrapTimeoutException() {
+
+			connection.openPipeline();
+			connection.set("foo".getBytes(), "bar".getBytes());
+
+			try (MockedStatic<LettuceFutures> lf = Mockito.mockStatic(LettuceFutures.class)) {
+				lf.when(() -> LettuceFutures.awaitAll(anyLong(), any(TimeUnit.class), any())).thenReturn(false);
+
+				assertThatThrownBy(() -> connection.closePipeline())
+						.isInstanceOf(RedisPipelineException.class)
+						.hasCauseInstanceOf(QueryTimeoutException.class);
+			}
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Test // GH-3346
+		void closePipelineShouldNotDoubleWrapCommandException() {
+
+			Command<?, ?, ?> cmd = new Command<>(CommandType.SET, new StatusOutput<>(ByteArrayCodec.INSTANCE));
+			AsyncCommand<?, ?, ?> future = new AsyncCommand<>(cmd);
+			future.completeExceptionally(new RuntimeException("ERR some error"));
+
+			when(asyncCommandsMock.set(any(byte[].class), any(byte[].class))).thenReturn((RedisFuture) future);
+
+			connection.openPipeline();
+			connection.set("foo".getBytes(), "bar".getBytes());
+
+			try (MockedStatic<LettuceFutures> lf = Mockito.mockStatic(LettuceFutures.class)) {
+				lf.when(() -> LettuceFutures.awaitAll(anyLong(), any(TimeUnit.class), any())).thenReturn(true);
+
+				assertThatThrownBy(() -> connection.closePipeline())
+						.isInstanceOf(RedisPipelineException.class)
+						.hasCauseInstanceOf(InvalidDataAccessApiUsageException.class);
+			}
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
## Bug Description

  `LettuceConnection.closePipeline()` wraps all exceptions in a generic `RedisPipelineException` with the misleading message  **"Pipeline contained one or more invalid commands"**, even when the actual  cause is a timeout or a failed Redis command.

  ## Root Cause

  The `try-catch` block in `closePipeline()` is too broad. Both intentional  `RedisPipelineException` throws (lines 646 and 653) are caught by the same
  `catch (Exception ex)` block, causing them to be wrapped again in a new  `RedisPipelineException`.

  ```java
  // Both of these throws are caught below...
  throw new RedisPipelineException(problem, results);                          // line 646
  throw new RedisPipelineException(new QueryTimeoutException("...timed out")); // line 653

  } catch (Exception ex) {
      // ...and re-wrapped here with a misleading message
      throw new RedisPipelineException(ex);
  }
```
  Impact

  - A timeout (awaitAll returns false) surfaces as:
RedisPipelineException("Pipeline contained one or more invalid commands",  cause=RedisPipelineException(cause=QueryTimeoutException)) instead of:  RedisPipelineException(cause=QueryTimeoutException)
 
- A failed command surfaces with the same misleading message and an  extra layer of wrapping, making it impossible to distinguish a timeout from an actual invalid command via getCause().

  Expected Behavior

  RedisPipelineException thrown intentionally inside closePipeline()  should propagate directly without re-wrapping.

  Fix

  } catch (RedisPipelineException ex) {
      throw ex;
  } catch (Exception ex) {
      throw new RedisPipelineException(ex);
  }

 ## Addendum

The default message `"Pipeline contained one or more invalid commands"` is  hardcoded in the `RedisPipelineException(Exception cause)` constructor.

This message is misleading when the actual cause is a timeout rather than  an invalid command. Whether this message should also be improved is left for further discussion.

Closes #3346 

