### PR TITLE
Fix 'occured' -> 'occurred' typo in RedisKeyExpiredEvent#getKeyspace javadoc

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
@@ -80,7 +80,7 @@ public class RedisKeyExpiredEvent<T> extends RedisKeyspaceEvent {
 	}
 
 	/**
-	 * Gets the keyspace in which the expiration occured.
+	 * Gets the keyspace in which the expiration occurred.
 	 *
 	 * @return {@literal null} if it could not be determined.
 	 */


### PR DESCRIPTION
Javadoc on `RedisKeyExpiredEvent.getKeyspace` in `src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java:83` read `Gets the keyspace in which the expiration occured`. Doc-only Java change inside a `/** */` block.