### PR TITLE
RedisKeyExpiredEvent: fix 'occured' -> 'occurred' in Javadoc

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java
@@ -80,7 +80,7 @@ public class RedisKeyExpiredEvent<T> extends RedisKeyspaceEvent {
 	}
 
 	/**
-	 * Gets the keyspace in which the expiration occured.
+	 * Gets the keyspace in which the expiration occurred.
 	 *
 	 * @return {@literal null} if it could not be determined.
 	 */


### PR DESCRIPTION
Javadoc in `src/main/java/org/springframework/data/redis/core/RedisKeyExpiredEvent.java` line 83 reads `expiration occured`. Fixed to `occurred`. Comment-only change.