### PR TITLE
Refactor: use String.replace instead of replaceAll

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/convert/PathIndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/PathIndexResolver.java
@@ -264,10 +264,10 @@ public class PathIndexResolver implements IndexResolver {
 		}
 
 		if (property.isMap()) {
-			return path.replace("\\[", "").replace("\\]", "");
+			return path.replace("[", "").replace("]", "");
 		}
 		if (property.isCollectionLike()) {
-			return path.replaceAll("\\[(\\p{Digit})*\\]", "").replace("\\.\\.", ".");
+			return path.replaceAll("\\[(\\p{Digit})*\\]", "").replace("..", ".");
 		}
 
 		return path;

--- a/src/main/java/org/springframework/data/redis/core/convert/PathIndexResolver.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/PathIndexResolver.java
@@ -264,10 +264,10 @@ public class PathIndexResolver implements IndexResolver {
 		}
 
 		if (property.isMap()) {
-			return path.replaceAll("\\[", "").replaceAll("\\]", "");
+			return path.replace("\\[", "").replace("\\]", "");
 		}
 		if (property.isCollectionLike()) {
-			return path.replaceAll("\\[(\\p{Digit})*\\]", "").replaceAll("\\.\\.", ".");
+			return path.replaceAll("\\[(\\p{Digit})*\\]", "").replace("\\.\\.", ".");
 		}
 
 		return path;


### PR DESCRIPTION
## Summary
Use String#replace instead of String#replaceAll for simple, non-regex replacements in PathIndexResolver to avoid unnecessary regex overhead and clarify the intent.

## Details
- For map properties, replace
    path.replaceAll("\\[", "").replaceAll("\\]", "")
  with
    path.replace("[", "").replace("]", "").
- For collection-like properties, keep the regex-based index removal but replace the non-regex ".." handling:
    path.replaceAll("\\[(\\p{Digit})*\\]", "").replaceAll("\\.\\.", ".")
  becomes
    path.replaceAll("\\[(\\p{Digit})*\\]", "").replace("..", ".").

This change is intended to be behavior-preserving while simplifying the implementation and avoiding regex processing where it is not required.

## Testing
- Existing tests continue to pass.