### PR TITLE
Add SslOptions support to JedisClientConfiguration

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.SslOptions;
+
 import java.time.Duration;
 import java.util.Optional;
 
@@ -30,6 +32,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Geonhyeon Kim
  * @since 2.0
  */
 class DefaultJedisClientConfiguration implements JedisClientConfiguration {
@@ -40,6 +43,7 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	private final Optional<SSLSocketFactory> sslSocketFactory;
 	private final Optional<SSLParameters> sslParameters;
 	private final Optional<HostnameVerifier> hostnameVerifier;
+	private final Optional<SslOptions> sslOptions;
 	private final boolean usePooling;
 	private final Optional<GenericObjectPoolConfig<?>> poolConfig;
 	private final Optional<String> clientName;
@@ -49,8 +53,9 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	DefaultJedisClientConfiguration(@Nullable JedisClientConfigBuilderCustomizer clientConfigCustomizer,
 			@Nullable JedisClientBuilderCustomizer clientCustomizer, boolean useSsl,
 			@Nullable SSLSocketFactory sslSocketFactory, @Nullable SSLParameters sslParameters,
-			@Nullable HostnameVerifier hostnameVerifier, boolean usePooling, @Nullable GenericObjectPoolConfig<?> poolConfig,
-			@Nullable String clientName, Duration readTimeout, Duration connectTimeout) {
+			@Nullable HostnameVerifier hostnameVerifier, @Nullable SslOptions sslOptions, boolean usePooling,
+			@Nullable GenericObjectPoolConfig<?> poolConfig, @Nullable String clientName, Duration readTimeout,
+			Duration connectTimeout) {
 
 		this.clientConfigCustomizer = Optional.ofNullable(clientConfigCustomizer);
 		this.clientCustomizer = Optional.ofNullable(clientCustomizer);
@@ -58,6 +63,7 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 		this.sslSocketFactory = Optional.ofNullable(sslSocketFactory);
 		this.sslParameters = Optional.ofNullable(sslParameters);
 		this.hostnameVerifier = Optional.ofNullable(hostnameVerifier);
+		this.sslOptions = Optional.ofNullable(sslOptions);
 		this.usePooling = usePooling;
 		this.poolConfig = Optional.ofNullable(poolConfig);
 		this.clientName = Optional.ofNullable(clientName);
@@ -93,6 +99,11 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	@Override
 	public Optional<HostnameVerifier> getHostnameVerifier() {
 		return hostnameVerifier;
+	}
+
+	@Override
+	public Optional<SslOptions> getSslOptions() {
+		return sslOptions;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.connection.jedis;
 
 import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.SslOptions;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -32,6 +33,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Geonhyeon Kim
  * @since 2.0
  */
 class DefaultJedisClientConfiguration implements JedisClientConfiguration {
@@ -42,6 +44,7 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	private final Optional<SSLSocketFactory> sslSocketFactory;
 	private final Optional<SSLParameters> sslParameters;
 	private final Optional<HostnameVerifier> hostnameVerifier;
+	private final Optional<SslOptions> sslOptions;
 	private final boolean usePooling;
 	private final Optional<GenericObjectPoolConfig<?>> poolConfig;
 	private final Optional<String> clientName;
@@ -52,8 +55,9 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	DefaultJedisClientConfiguration(@Nullable JedisClientConfigBuilderCustomizer clientConfigCustomizer,
 			@Nullable JedisClientBuilderCustomizer clientCustomizer, boolean useSsl,
 			@Nullable SSLSocketFactory sslSocketFactory, @Nullable SSLParameters sslParameters,
-			@Nullable HostnameVerifier hostnameVerifier, boolean usePooling, @Nullable GenericObjectPoolConfig<?> poolConfig,
-			@Nullable String clientName, Duration connectTimeout, Duration readTimeout, RedisProtocol protocol) {
+			@Nullable HostnameVerifier hostnameVerifier, @Nullable SslOptions sslOptions, boolean usePooling,
+			@Nullable GenericObjectPoolConfig<?> poolConfig, @Nullable String clientName, Duration connectTimeout,
+			Duration readTimeout, RedisProtocol protocol) {
 
 		this.clientConfigCustomizer = Optional.ofNullable(clientConfigCustomizer);
 		this.clientCustomizer = Optional.ofNullable(clientCustomizer);
@@ -61,6 +65,7 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 		this.sslSocketFactory = Optional.ofNullable(sslSocketFactory);
 		this.sslParameters = Optional.ofNullable(sslParameters);
 		this.hostnameVerifier = Optional.ofNullable(hostnameVerifier);
+		this.sslOptions = Optional.ofNullable(sslOptions);
 		this.usePooling = usePooling;
 		this.poolConfig = Optional.ofNullable(poolConfig);
 		this.clientName = Optional.ofNullable(clientName);
@@ -97,6 +102,11 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 	@Override
 	public Optional<HostnameVerifier> getHostnameVerifier() {
 		return hostnameVerifier;
+	}
+
+	@Override
+	public Optional<SslOptions> getSslOptions() {
+		return sslOptions;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/DefaultJedisClientConfiguration.java
@@ -89,11 +89,13 @@ class DefaultJedisClientConfiguration implements JedisClientConfiguration {
 		return useSsl;
 	}
 
+	@Deprecated
 	@Override
 	public Optional<SSLSocketFactory> getSslSocketFactory() {
 		return sslSocketFactory;
 	}
 
+	@Deprecated
 	@Override
 	public Optional<SSLParameters> getSslParameters() {
 		return sslParameters;

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.connection.jedis;
 
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.SslOptions;
 
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -41,6 +42,7 @@ import org.springframework.util.Assert;
  * <li>Optional {@link SSLSocketFactory}</li>
  * <li>Optional {@link SSLParameters}</li>
  * <li>Optional {@link HostnameVerifier}</li>
+ * <li>Optional {@link SslOptions}</li>
  * <li>Whether to use connection-pooling</li>
  * <li>Optional {@link GenericObjectPoolConfig}</li>
  * <li>Optional client name</li>
@@ -51,6 +53,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Chao Chang
+ * @author Geonhyeon Kim
  * @since 2.0
  * @see redis.clients.jedis.Jedis
  * @see org.springframework.data.redis.connection.RedisStandaloneConfiguration
@@ -99,6 +102,12 @@ public interface JedisClientConfiguration {
 	 * @return the optional {@link HostnameVerifier}.
 	 */
 	Optional<HostnameVerifier> getHostnameVerifier();
+
+	/**
+	 * @return the optional {@link SslOptions}.
+	 * @since 4.1
+	 */
+	Optional<SslOptions> getSslOptions();
 
 	/**
 	 * @return {@literal true} to use connection-pooling. Applies only to single node Redis. Sentinel and Cluster modes
@@ -303,6 +312,14 @@ public interface JedisClientConfiguration {
 		JedisSslClientConfigurationBuilder hostnameVerifier(HostnameVerifier hostnameVerifier);
 
 		/**
+		 * @param sslOptions must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 * @throws IllegalArgumentException if sslOptions is {@literal null}.
+		 * @since 4.1
+		 */
+		JedisSslClientConfigurationBuilder sslOptions(SslOptions sslOptions);
+
+		/**
 		 * Return to {@link JedisClientConfigurationBuilder}.
 		 *
 		 * @return {@link JedisClientConfigurationBuilder}.
@@ -330,6 +347,7 @@ public interface JedisClientConfiguration {
 		private @Nullable SSLSocketFactory sslSocketFactory;
 		private @Nullable SSLParameters sslParameters;
 		private @Nullable HostnameVerifier hostnameVerifier;
+		private @Nullable SslOptions sslOptions;
 		private boolean usePooling;
 		private GenericObjectPoolConfig<?> poolConfig = new JedisPoolConfig();
 		private @Nullable String clientName;
@@ -388,6 +406,15 @@ public interface JedisClientConfiguration {
 		}
 
 		@Override
+		public JedisSslClientConfigurationBuilder sslOptions(SslOptions sslOptions) {
+
+			Assert.notNull(sslOptions, "SslOptions must not be null");
+
+			this.sslOptions = sslOptions;
+			return this;
+		}
+
+		@Override
 		public JedisPoolingClientConfigurationBuilder usePooling() {
 
 			this.usePooling = true;
@@ -439,7 +466,7 @@ public interface JedisClientConfiguration {
 		public JedisClientConfiguration build() {
 
 			return new DefaultJedisClientConfiguration(clientConfigCustomizer, clientCustomizer, useSsl, sslSocketFactory,
-					sslParameters, hostnameVerifier,
+					sslParameters, hostnameVerifier, sslOptions,
 					usePooling, poolConfig, clientName, readTimeout, connectTimeout);
 		}
 	}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.jedis;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.SslOptions;
 
 import java.net.SocketAddress;
 import java.time.Duration;
@@ -42,6 +43,7 @@ import org.springframework.util.Assert;
  * <li>Optional {@link SSLSocketFactory}</li>
  * <li>Optional {@link SSLParameters}</li>
  * <li>Optional {@link HostnameVerifier}</li>
+ * <li>Optional {@link SslOptions}</li>
  * <li>Whether to use connection-pooling</li>
  * <li>Optional {@link GenericObjectPoolConfig}</li>
  * <li>Optional client name</li>
@@ -52,6 +54,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Chao Chang
+ * @author Geonhyeon Kim
  * @since 2.0
  * @see redis.clients.jedis.Jedis
  * @see org.springframework.data.redis.connection.RedisStandaloneConfiguration
@@ -100,6 +103,12 @@ public interface JedisClientConfiguration {
 	 * @return the optional {@link HostnameVerifier}.
 	 */
 	Optional<HostnameVerifier> getHostnameVerifier();
+
+	/**
+	 * @return the optional {@link SslOptions}.
+	 * @since 4.2
+	 */
+	Optional<SslOptions> getSslOptions();
 
 	/**
 	 * @return {@literal true} to use connection-pooling. Applies only to single node Redis. Sentinel and Cluster modes
@@ -323,6 +332,14 @@ public interface JedisClientConfiguration {
 		JedisSslClientConfigurationBuilder hostnameVerifier(HostnameVerifier hostnameVerifier);
 
 		/**
+		 * @param sslOptions must not be {@literal null}.
+		 * @return {@literal this} builder.
+		 * @throws IllegalArgumentException if sslOptions is {@literal null}.
+		 * @since 4.2
+		 */
+		JedisSslClientConfigurationBuilder sslOptions(SslOptions sslOptions);
+
+		/**
 		 * Return to {@link JedisClientConfigurationBuilder}.
 		 *
 		 * @return {@link JedisClientConfigurationBuilder}.
@@ -350,6 +367,7 @@ public interface JedisClientConfiguration {
 		private @Nullable SSLSocketFactory sslSocketFactory;
 		private @Nullable SSLParameters sslParameters;
 		private @Nullable HostnameVerifier hostnameVerifier;
+		private @Nullable SslOptions sslOptions;
 		private boolean usePooling;
 		private GenericObjectPoolConfig<?> poolConfig = new JedisPoolConfig();
 		private @Nullable String clientName;
@@ -405,6 +423,15 @@ public interface JedisClientConfiguration {
 			Assert.notNull(hostnameVerifier, "HostnameVerifier must not be null");
 
 			this.hostnameVerifier = hostnameVerifier;
+			return this;
+		}
+
+		@Override
+		public JedisSslClientConfigurationBuilder sslOptions(SslOptions sslOptions) {
+
+			Assert.notNull(sslOptions, "SslOptions must not be null");
+
+			this.sslOptions = sslOptions;
 			return this;
 		}
 
@@ -469,7 +496,8 @@ public interface JedisClientConfiguration {
 		public JedisClientConfiguration build() {
 
 			return new DefaultJedisClientConfiguration(clientConfigCustomizer, clientCustomizer, useSsl, sslSocketFactory,
-					sslParameters, hostnameVerifier, usePooling, poolConfig, clientName, connectTimeout, readTimeout, protocol);
+					sslParameters, hostnameVerifier, sslOptions, usePooling, poolConfig, clientName, connectTimeout, readTimeout,
+					protocol);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClientConfiguration.java
@@ -91,12 +91,18 @@ public interface JedisClientConfiguration {
 
 	/**
 	 * @return the optional {@link SSLSocketFactory}.
+	 * @deprecated since 4.2, use {@link #getSslOptions()} instead following the deprecation of the corresponding Jedis
+	 *             configuration.
 	 */
+	@Deprecated(since = "4.2")
 	Optional<SSLSocketFactory> getSslSocketFactory();
 
 	/**
 	 * @return the optional {@link SSLParameters}.
+	 * @deprecated since 4.2, use {@link #getSslOptions()} instead following the deprecation of the corresponding Jedis
+	 *             configuration.
 	 */
+	@Deprecated(since = "4.2")
 	Optional<SSLParameters> getSslParameters();
 
 	/**
@@ -314,14 +320,20 @@ public interface JedisClientConfiguration {
 		 * @param sslSocketFactory must not be {@literal null}.
 		 * @return {@literal this} builder.
 		 * @throws IllegalArgumentException if sslSocketFactory is {@literal null}.
+		 * @deprecated since 4.2, use {@link #sslOptions(SslOptions)} instead following the deprecation of the corresponding
+		 *             Jedis configuration.
 		 */
+		@Deprecated(since = "4.2")
 		JedisSslClientConfigurationBuilder sslSocketFactory(SSLSocketFactory sslSocketFactory);
 
 		/**
 		 * @param sslParameters must not be {@literal null}.
 		 * @return {@literal this} builder.
 		 * @throws IllegalArgumentException if sslParameters is {@literal null}.
+		 * @deprecated since 4.2, use {@link #sslOptions(SslOptions)} instead following the deprecation of the corresponding
+		 *             Jedis configuration.
 		 */
+		@Deprecated(since = "4.2")
 		JedisSslClientConfigurationBuilder sslParameters(SSLParameters sslParameters);
 
 		/**
@@ -399,6 +411,7 @@ public interface JedisClientConfiguration {
 			return this;
 		}
 
+		@Deprecated
 		@Override
 		public JedisSslClientConfigurationBuilder sslSocketFactory(SSLSocketFactory sslSocketFactory) {
 
@@ -408,6 +421,7 @@ public interface JedisClientConfiguration {
 			return this;
 		}
 
+		@Deprecated
 		@Override
 		public JedisSslClientConfigurationBuilder sslParameters(SSLParameters sslParameters) {
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -94,6 +94,7 @@ import org.springframework.util.ObjectUtils;
  * @author Fu Jian
  * @author Ajith Kumar
  * @author Tihomir Mateev
+ * @author Geonhyeon Kim
  * @see JedisClientConfiguration
  * @see Jedis
  */
@@ -753,6 +754,7 @@ public class JedisConnectionFactory
 			this.clientConfiguration.getSslSocketFactory().ifPresent(builder::sslSocketFactory);
 			this.clientConfiguration.getHostnameVerifier().ifPresent(builder::hostnameVerifier);
 			this.clientConfiguration.getSslParameters().ifPresent(builder::sslParameters);
+			this.clientConfiguration.getSslOptions().ifPresent(builder::sslOptions);
 		}
 
 		this.clientConfiguration.getClientConfigCustomizer().ifPresent(customizer -> customizer.customize(builder));

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -1288,9 +1288,6 @@ public class JedisConnectionFactory
 	static class MutableJedisClientConfiguration implements JedisClientConfiguration {
 
 		private boolean useSsl;
-		private @Nullable SSLSocketFactory sslSocketFactory;
-		private @Nullable SSLParameters sslParameters;
-		private @Nullable HostnameVerifier hostnameVerifier;
 		private boolean usePooling = true;
 		private GenericObjectPoolConfig<?> poolConfig = new JedisPoolConfig();
 		private @Nullable String clientName;
@@ -1325,29 +1322,22 @@ public class JedisConnectionFactory
 
 		@Override
 		public Optional<SSLSocketFactory> getSslSocketFactory() {
-			return Optional.ofNullable(sslSocketFactory);
-		}
-
-		public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
-			this.sslSocketFactory = sslSocketFactory;
+			return Optional.empty();
 		}
 
 		@Override
 		public Optional<SSLParameters> getSslParameters() {
-			return Optional.ofNullable(sslParameters);
-		}
-
-		public void setSslParameters(SSLParameters sslParameters) {
-			this.sslParameters = sslParameters;
+			return Optional.empty();
 		}
 
 		@Override
 		public Optional<HostnameVerifier> getHostnameVerifier() {
-			return Optional.ofNullable(hostnameVerifier);
+			return Optional.empty();
 		}
 
-		public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
-			this.hostnameVerifier = hostnameVerifier;
+		@Override
+		public Optional<SslOptions> getSslOptions() {
+			return Optional.empty();
 		}
 
 		@Override

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -1292,9 +1292,6 @@ public class JedisConnectionFactory
 	static class MutableJedisClientConfiguration implements JedisClientConfiguration {
 
 		private boolean useSsl;
-		private @Nullable SSLSocketFactory sslSocketFactory;
-		private @Nullable SSLParameters sslParameters;
-		private @Nullable HostnameVerifier hostnameVerifier;
 		private boolean usePooling = true;
 		private GenericObjectPoolConfig<?> poolConfig = new JedisPoolConfig();
 		private @Nullable String clientName;
@@ -1330,29 +1327,22 @@ public class JedisConnectionFactory
 
 		@Override
 		public Optional<SSLSocketFactory> getSslSocketFactory() {
-			return Optional.ofNullable(sslSocketFactory);
-		}
-
-		public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
-			this.sslSocketFactory = sslSocketFactory;
+			return Optional.empty();
 		}
 
 		@Override
 		public Optional<SSLParameters> getSslParameters() {
-			return Optional.ofNullable(sslParameters);
-		}
-
-		public void setSslParameters(SSLParameters sslParameters) {
-			this.sslParameters = sslParameters;
+			return Optional.empty();
 		}
 
 		@Override
 		public Optional<HostnameVerifier> getHostnameVerifier() {
-			return Optional.ofNullable(hostnameVerifier);
+			return Optional.empty();
 		}
 
-		public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
-			this.hostnameVerifier = hostnameVerifier;
+		@Override
+		public Optional<SslOptions> getSslOptions() {
+			return Optional.empty();
 		}
 
 		@Override

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -94,6 +94,7 @@ import org.springframework.util.ObjectUtils;
  * @author Fu Jian
  * @author Ajith Kumar
  * @author Tihomir Mateev
+ * @author Geonhyeon Kim
  * @see JedisClientConfiguration
  * @see Jedis
  */
@@ -754,6 +755,7 @@ public class JedisConnectionFactory
 			this.clientConfiguration.getSslSocketFactory().ifPresent(builder::sslSocketFactory);
 			this.clientConfiguration.getHostnameVerifier().ifPresent(builder::hostnameVerifier);
 			this.clientConfiguration.getSslParameters().ifPresent(builder::sslParameters);
+			this.clientConfiguration.getSslOptions().ifPresent(builder::sslOptions);
 		}
 
 		this.clientConfiguration.getClientConfigCustomizer().ifPresent(customizer -> customizer.customize(builder));

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnectionFactory.java
@@ -729,6 +729,7 @@ public class JedisConnectionFactory
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	private JedisClientConfig createClientConfig(int database, @Nullable String username, RedisPassword password) {
 
 		DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder();

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisClientConfigurationUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.jedis;
 import static org.assertj.core.api.Assertions.*;
 
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.SslOptions;
 
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link JedisClientConfiguration}.
  *
  * @author Mark Paluch
+ * @author Geonhyeon Kim
  */
 class JedisClientConfigurationUnitTests {
 
@@ -49,6 +51,7 @@ class JedisClientConfigurationUnitTests {
 		assertThat(configuration.getPoolConfig()).isPresent();
 		assertThat(configuration.getSslParameters()).isEmpty();
 		assertThat(configuration.getSslSocketFactory()).isEmpty();
+		assertThat(configuration.getSslOptions()).isEmpty();
 	}
 
 	@Test // DATAREDIS-574
@@ -57,12 +60,14 @@ class JedisClientConfigurationUnitTests {
 		SSLParameters sslParameters = new SSLParameters();
 		SSLContext context = SSLContext.getDefault();
 		SSLSocketFactory socketFactory = context.getSocketFactory();
+		SslOptions sslOptions = SslOptions.builder().build();
 		JedisPoolConfig poolConfig = new JedisPoolConfig();
 
 		JedisClientConfiguration configuration = JedisClientConfiguration.builder().useSsl() //
 				.hostnameVerifier(MyHostnameVerifier.INSTANCE) //
 				.sslParameters(sslParameters) //
-				.sslSocketFactory(socketFactory).and() //
+				.sslSocketFactory(socketFactory) //
+				.sslOptions(sslOptions).and() //
 				.clientName("my-client") //
 				.connectTimeout(Duration.ofMinutes(10)) //
 				.readTimeout(Duration.ofHours(5)) //
@@ -73,6 +78,7 @@ class JedisClientConfigurationUnitTests {
 		assertThat(configuration.getHostnameVerifier()).contains(MyHostnameVerifier.INSTANCE);
 		assertThat(configuration.getSslParameters()).contains(sslParameters);
 		assertThat(configuration.getSslSocketFactory()).contains(socketFactory);
+		assertThat(configuration.getSslOptions()).contains(sslOptions);
 
 		assertThat(configuration.getClientName()).contains("my-client");
 		assertThat(configuration.getConnectTimeout()).isEqualTo(Duration.ofMinutes(10));


### PR DESCRIPTION
## Description

Adds `SslOptions` support to `JedisClientConfiguration` for consistency with the existing `SSLSocketFactory`, `SSLParameters`, and `HostnameVerifier` options, as discussed in #3355.

```java
JedisClientConfiguration.builder()
    .useSsl()
    .sslOptions(SslOptions.builder()
        .truststore("truststore.p12", "secret")
        .sslProtocol("TLSv1.3")
        .build())
    .build();
```

The Mutable cleanup follows your direction: the `sslSocketFactory`, `sslParameters`, and `hostnameVerifier` fields/setters had no invocations, so they are removed; the corresponding getters now return `Optional.empty()`.

## Open question

Javadoc uses `@since 4.2` to match the current 4.2.0-SNAPSHOT main. Happy to retarget if you prefer a different release line.

Closes #3355

---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).