### PR TITLE
Deprecate StringToPropertiesConverter

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
@@ -15,29 +15,22 @@
  */
 package org.springframework.data.redis.connection.convert;
 
-import java.io.StringReader;
 import java.util.Properties;
 
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.redis.RedisSystemException;
 
 /**
  * Converts Strings to {@link Properties}
  *
  * @author Jennifer Hickey
  * @author Christoph Strobl
+ * @deprecated since 4.1 in favor of {@link Converters#stringToProps()}.
  */
+@Deprecated(since = "4.1")
 public class StringToPropertiesConverter implements Converter<String, Properties> {
 
 	@Override
 	public Properties convert(String source) {
-
-		Properties info = new Properties();
-		try (StringReader stringReader = new StringReader(source)) {
-			info.load(stringReader);
-		} catch (Exception ex) {
-			throw new RedisSystemException("Cannot read Redis info", ex);
-		}
-		return info;
+		return Converters.toProperties(source);
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/convert/ConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/convert/ConvertersUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.convert;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Iterator;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -76,6 +77,15 @@ class ConvertersUnitTests {
 	private static final String CLUSTER_NODE_WITH_SINGLE_IPV4_EMPTY_HOSTNAME = "3765733728631672640db35fd2f04743c03119c6 10.180.0.33:11003@16379, master - 0 1708041426947 2 connected 0-5460";
 
 	private static final String CLUSTER_NODE_WITH_SINGLE_IPV4_HOSTNAME = "3765733728631672640db35fd2f04743c03119c6 10.180.0.33:11003@16379,hostname1 master - 0 1708041426947 2 connected 0-5460";
+
+	@Test // GH-3020
+	@SuppressWarnings("deprecation")
+	void stringToPropertiesConverterShouldDelegateToConverters() {
+
+		Properties properties = new StringToPropertiesConverter().convert("redis_version:7.2.4\nconnected_clients:1");
+
+		assertThat(properties).containsEntry("redis_version", "7.2.4").containsEntry("connected_clients", "1");
+	}
 
 	@Test // DATAREDIS-315
 	void toSetOfRedis30ClusterNodesShouldConvertSingleStringNodesResponseCorrectly() {


### PR DESCRIPTION
Closes #3020.

`StringToPropertiesConverter` duplicates `Converters.toProperties(String)`. This change deprecates the standalone converter and delegates to the shared converter implementation so Redis INFO string parsing is kept in one place.

Tests: `./mvnw -Dtest=ConvertersUnitTests test`