### PR TITLE
Deprecate duplicate String properties converter

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
@@ -15,29 +15,22 @@
  */
 package org.springframework.data.redis.connection.convert;
 
-import java.io.StringReader;
 import java.util.Properties;
 
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.redis.RedisSystemException;
 
 /**
  * Converts Strings to {@link Properties}
  *
  * @author Jennifer Hickey
  * @author Christoph Strobl
+ * @deprecated since 4.1, use {@link Converters#stringToProps()} or {@link Converters#toProperties(String)} instead.
  */
+@Deprecated(since = "4.1")
 public class StringToPropertiesConverter implements Converter<String, Properties> {
 
 	@Override
 	public Properties convert(String source) {
-
-		Properties info = new Properties();
-		try (StringReader stringReader = new StringReader(source)) {
-			info.load(stringReader);
-		} catch (Exception ex) {
-			throw new RedisSystemException("Cannot read Redis info", ex);
-		}
-		return info;
+		return Converters.toProperties(source);
 	}
 }

--- a/src/test/java/org/springframework/data/redis/connection/convert/ConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/convert/ConvertersUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.redis.connection.convert;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Iterator;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -76,6 +77,19 @@ class ConvertersUnitTests {
 	private static final String CLUSTER_NODE_WITH_SINGLE_IPV4_EMPTY_HOSTNAME = "3765733728631672640db35fd2f04743c03119c6 10.180.0.33:11003@16379, master - 0 1708041426947 2 connected 0-5460";
 
 	private static final String CLUSTER_NODE_WITH_SINGLE_IPV4_HOSTNAME = "3765733728631672640db35fd2f04743c03119c6 10.180.0.33:11003@16379,hostname1 master - 0 1708041426947 2 connected 0-5460";
+
+	@Test // GH-3020
+	void stringToPropsShouldConvertRedisInfoToProperties() {
+
+		Properties properties = Converters.stringToProps().convert("""
+				# Server
+				redis_version:7.4.1
+				connected_clients:2
+				""");
+
+		assertThat(properties).containsEntry("redis_version", "7.4.1") //
+				.containsEntry("connected_clients", "2");
+	}
 
 	@Test // DATAREDIS-315
 	void toSetOfRedis30ClusterNodesShouldConvertSingleStringNodesResponseCorrectly() {


### PR DESCRIPTION
Deprecates `StringToPropertiesConverter` and delegates its conversion logic to the shared `Converters.toProperties(String)` implementation.

This removes the duplicate String-to-Properties parsing path while preserving the existing converter type for compatibility. A focused converter test was added to cover Redis INFO-style property conversion through the shared converter API.

Closes gh-3020.

Tests:
- `./mvnw -Dtest=ConvertersUnitTests test`
- `./mvnw -DskipTests verify`

Note: `./mvnw verify` was also attempted, but local integration tests require Redis on localhost:6379 and failed because Redis was not available.