### PR TITLE
Reuse JsonNode in GenericJackson2JsonRedisSerializer

### DIFF
--- a/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
@@ -52,6 +52,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.databind.node.TreeTraversingParser;
 import com.fasterxml.jackson.databind.ser.SerializerFactory;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -68,6 +69,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  * @author Mao Shuai
  * @author John Blum
  * @author Anne Lee
+ * @author Dongliang Xie
  * @see Jackson2ObjectReader
  * @see Jackson2ObjectWriter
  * @see com.fasterxml.jackson.databind.ObjectMapper
@@ -78,6 +80,8 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 @Deprecated(since = "4.0", forRemoval = true)
 public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Object> {
 
+	private static final Jackson2ObjectReader DEFAULT_READER = Jackson2ObjectReader.create();
+
 	private final Jackson2ObjectReader reader;
 
 	private final Jackson2ObjectWriter writer;
@@ -87,6 +91,8 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	private final ObjectMapper mapper;
 
 	private final TypeResolver typeResolver;
+
+	private final boolean defaultReader;
 
 	/**
 	 * Creates {@link GenericJackson2JsonRedisSerializer} initialized with an {@link ObjectMapper} configured for default
@@ -109,7 +115,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 * @see ObjectMapper#activateDefaultTyping(PolymorphicTypeValidator, DefaultTyping, As)
 	 */
 	public GenericJackson2JsonRedisSerializer(@Nullable String typeHintPropertyName) {
-		this(typeHintPropertyName, Jackson2ObjectReader.create(), Jackson2ObjectWriter.create());
+		this(typeHintPropertyName, DEFAULT_READER, Jackson2ObjectWriter.create());
 	}
 
 	/**
@@ -146,7 +152,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	 * @param mapper must not be {@literal null}.
 	 */
 	public GenericJackson2JsonRedisSerializer(ObjectMapper mapper) {
-		this(mapper, Jackson2ObjectReader.create(), Jackson2ObjectWriter.create());
+		this(mapper, DEFAULT_READER, Jackson2ObjectWriter.create());
 	}
 
 	/**
@@ -174,6 +180,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		this.mapper = mapper;
 		this.reader = reader;
 		this.writer = writer;
+		this.defaultReader = reader == DEFAULT_READER;
 
 		this.defaultTypingEnabled = Lazy.of(() -> mapper.getSerializationConfig().getDefaultTyper(null) != null);
 
@@ -308,10 +315,32 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		}
 
 		try {
-			return (T) reader.read(mapper, source, resolveType(source, type));
+			if (!canReuseResolvedJsonNode()) {
+				return (T) reader.read(mapper, source, resolveType(source, type));
+			}
+
+			ResolvedJavaType resolvedType = resolveTypeAndReadTree(source, type);
+			return (T) read(source, resolvedType);
 		} catch (Exception ex) {
 			throw new SerializationException("Could not read JSON:%s ".formatted(ex.getMessage()), ex);
 		}
+	}
+
+	private Object read(byte[] source, ResolvedJavaType resolvedType) throws IOException {
+
+		JsonNode root = resolvedType.root();
+
+		if (root == null) {
+			return reader.read(mapper, source, resolvedType.javaType());
+		}
+
+		try (JsonParser parser = new TreeTraversingParser(root, mapper)) {
+			return mapper.readValue(parser, resolvedType.javaType());
+		}
+	}
+
+	private boolean canReuseResolvedJsonNode() {
+		return this.defaultReader && getClass() == GenericJackson2JsonRedisSerializer.class;
 	}
 
 	/**
@@ -335,13 +364,19 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 	}
 
 	protected JavaType resolveType(byte[] source, Class<?> type) throws IOException {
+		return resolveTypeAndReadTree(source, type).javaType();
+	}
+
+	private ResolvedJavaType resolveTypeAndReadTree(byte[] source, Class<?> type) throws IOException {
 
 		if (!type.equals(Object.class) || !defaultTypingEnabled.get()) {
-			return typeResolver.constructType(type);
+			return new ResolvedJavaType(typeResolver.constructType(type), null);
 		}
 
 		return typeResolver.resolveType(source, type);
 	}
+
+	private record ResolvedJavaType(JavaType javaType, @Nullable JsonNode root) {}
 
 	/**
 	 * @since 3.0
@@ -363,16 +398,16 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 			return typeFactory.get().constructType(type);
 		}
 
-		protected JavaType resolveType(byte[] source, Class<?> type) throws IOException {
+		protected ResolvedJavaType resolveType(byte[] source, Class<?> type) throws IOException {
 
 			JsonNode root = readTree(source);
 			JsonNode jsonNode = root.get(hintName.get());
 
 			if (jsonNode instanceof TextNode && jsonNode.asText() != null) {
-				return typeFactory.get().constructFromCanonical(jsonNode.asText());
+				return new ResolvedJavaType(typeFactory.get().constructFromCanonical(jsonNode.asText()), root);
 			}
 
-			return constructType(type);
+			return new ResolvedJavaType(constructType(type), root);
 		}
 
 		/**
@@ -466,7 +501,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 
 		private @Nullable String typeHintPropertyName;
 
-		private Jackson2ObjectReader reader = Jackson2ObjectReader.create();
+		private Jackson2ObjectReader reader = DEFAULT_READER;
 
 		private Jackson2ObjectWriter writer = Jackson2ObjectWriter.create();
 

--- a/src/test/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializerUnitTests.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -41,8 +42,10 @@ import org.springframework.cache.support.NullValue;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -63,6 +66,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author John Blum
+ * @author Dongliang Xie
  */
 class GenericJackson2JsonRedisSerializerUnitTests {
 
@@ -503,6 +507,23 @@ class GenericJackson2JsonRedisSerializerUnitTests {
 		assertThat(deserializedValue).isEqualTo(COMPLEX_OBJECT);
 	}
 
+	@Test // GH-3012
+	void defaultReaderReusesJsonNodeParsedForTypeResolution() {
+
+		CountingJsonFactory jsonFactory = new CountingJsonFactory();
+		GenericJackson2JsonRedisSerializer serializer = GenericJackson2JsonRedisSerializer.builder()
+				.objectMapper(new ObjectMapper(jsonFactory).enableDefaultTyping(DefaultTyping.EVERYTHING, As.PROPERTY))
+				.build();
+
+		byte[] serializedValue = serializer.serialize(COMPLEX_OBJECT);
+		jsonFactory.parserCreations.set(0);
+
+		Object deserializedValue = serializer.deserialize(serializedValue, Object.class);
+
+		assertThat(deserializedValue).isEqualTo(COMPLEX_OBJECT);
+		assertThat(jsonFactory.parserCreations).hasValue(1);
+	}
+
 	@Test // GH-2981
 	void defaultSerializeAndDeserializeNullValueWithBuilderClassAndCustomJsonFactory() {
 
@@ -612,6 +633,23 @@ class GenericJackson2JsonRedisSerializerUnitTests {
 		@Override
 		public int hashCode() {
 			return Objects.hash(getLongValue(), getMyArray(), getSimpleObject());
+		}
+	}
+
+	static class CountingJsonFactory extends JsonFactory {
+
+		final AtomicInteger parserCreations = new AtomicInteger();
+
+		@Override
+		public JsonParser createParser(byte[] data) throws IOException {
+			parserCreations.incrementAndGet();
+			return super.createParser(data);
+		}
+
+		@Override
+		public JsonParser createParser(byte[] data, int offset, int len) throws IOException {
+			parserCreations.incrementAndGet();
+			return super.createParser(data, offset, len);
 		}
 	}
 


### PR DESCRIPTION
Closes #3012

This change avoids parsing the same payload twice when `GenericJackson2JsonRedisSerializer` resolves the target type from default typing metadata.

`TypeResolver` now returns the resolved `JavaType` together with the parsed `JsonNode`. For serializer-managed default readers, deserialization can reuse that tree through a `TreeTraversingParser` instead of parsing the original byte array again.

Custom `Jackson2ObjectReader` instances continue to receive the original `byte[]` source, and the existing protected `resolveType(...)` contract remains unchanged.

Tests:
- `./mvnw -s settings.xml -Dtest=GenericJackson2JsonRedisSerializerUnitTests#defaultReaderReusesJsonNodeParsedForTypeResolution test`
- `./mvnw -s settings.xml -Dtest=GenericJackson2JsonRedisSerializerUnitTests,GenericJacksonJsonRedisSerializerUnitTests,Jackson2JsonRedisSerializerTests,JacksonJsonRedisSerializerTests test`
