### PR TITLE
GH-2298 - Read empty collections as empty values

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/MappingRedisConverter.java
@@ -101,6 +101,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Paluch
  * @author Golam Mazid Sajib
  * @author Leehyoungwoo
+ * @author Hyeonseop Won
  * @since 1.7
  */
 public class MappingRedisConverter implements RedisConverter, InitializingBean {
@@ -852,7 +853,7 @@ public class MappingRedisConverter implements RedisConverter, InitializingBean {
 			}
 		}
 
-		return isArray ? toArray(target, collectionType, valueType) : (target.isEmpty() ? null : target);
+		return isArray ? toArray(target, collectionType, valueType) : target;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/ConversionTestEntities.java
@@ -45,6 +45,7 @@ import org.springframework.data.redis.core.index.Indexed;
  * @author Mark Paluch
  * @author Golam Mazid Sajib
  * @author John Blum
+ * @author Hyeonseop Won
  */
 public class ConversionTestEntities {
 
@@ -61,6 +62,7 @@ public class ConversionTestEntities {
 		Gender gender;
 
 		List<String> nicknames;
+		Set<String> aliases;
 		List<Person> coworkers;
 		List<Integer> positions;
 		Integer age;

--- a/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/MappingRedisConverterUnitTests.java
@@ -64,6 +64,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Mark Paluch
  * @author Golam Mazid Sajib
  * @author John Blum
+ * @author Hyeonseop Won
  */
 @ExtendWith(MockitoExtension.class)
 class MappingRedisConverterUnitTests {
@@ -284,6 +285,22 @@ class MappingRedisConverterUnitTests {
 		RedisData rdo = new RedisData(Bucket.newBucketFromStringMap(map));
 
 		assertThat(converter.read(Person.class, rdo).nicknames).containsExactly("dragon reborn", "lews therin");
+	}
+
+	@Test // GH-2298
+	void readConvertsEmptyListToEmptyCollection() {
+
+		RedisData rdo = new RedisData(Bucket.newBucketFromStringMap(Collections.emptyMap()));
+
+		assertThat(converter.read(Person.class, rdo).nicknames).isEmpty();
+	}
+
+	@Test // GH-2298
+	void readConvertsEmptySetToEmptyCollection() {
+
+		RedisData rdo = new RedisData(Bucket.newBucketFromStringMap(Collections.emptyMap()));
+
+		assertThat(converter.read(Person.class, rdo).aliases).isEmpty();
 	}
 
 	@Test // DATAREDIS-425
@@ -1880,7 +1897,7 @@ class MappingRedisConverterUnitTests {
 
 		Outer outer = read(Outer.class, source);
 
-		assertThat(outer.values).isNull();
+		assertThat(outer.values).isEmpty();
 		assertThat(outer.inners.get(0).values).isEqualTo(Arrays.asList("i-1", "i-2"));
 	}
 


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

This change makes `MappingRedisConverter` return empty collection instances instead of `null` when reading collection properties that have no mapped elements. This covers empty `List` and `Set` properties and keeps array handling unchanged.

Closes #2298

Tested with:

```
./mvnw -Dtest=MappingRedisConverterUnitTests test
```