### PR TITLE
Add read-only script execution

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -85,6 +85,7 @@ import org.springframework.util.ObjectUtils;
  * @author Jeonggyu Choi
  * @author Mingi Lee
  * @author Yordan Tsintsov
+ * @author won-seoop
  */
 @NullUnmarked
 @SuppressWarnings({ "ConstantConditions", "deprecation" })
@@ -1359,14 +1360,32 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	}
 
 	@Override
+	public <T> T evalReadOnly(byte[] script, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
+		return convertAndReturn(delegate.evalReadOnly(script, returnType, numKeys, keysAndArgs),
+				Converters.identityConverter());
+	}
+
+	@Override
 	public <T> T evalSha(String scriptSha1, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
 		return convertAndReturn(delegate.evalSha(scriptSha1, returnType, numKeys, keysAndArgs),
 				Converters.identityConverter());
 	}
 
 	@Override
+	public <T> T evalShaReadOnly(String scriptSha1, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
+		return convertAndReturn(delegate.evalShaReadOnly(scriptSha1, returnType, numKeys, keysAndArgs),
+				Converters.identityConverter());
+	}
+
+	@Override
 	public <T> T evalSha(byte[] scriptSha1, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
 		return convertAndReturn(delegate.evalSha(scriptSha1, returnType, numKeys, keysAndArgs),
+				Converters.identityConverter());
+	}
+
+	@Override
+	public <T> T evalShaReadOnly(byte[] scriptSha1, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
+		return convertAndReturn(delegate.evalShaReadOnly(scriptSha1, returnType, numKeys, keysAndArgs),
 				Converters.identityConverter());
 	}
 
@@ -2550,8 +2569,24 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	 * NOTE: This method will not deserialize Strings returned by Lua scripts, as they may not be encoded with the same
 	 * serializer used here. They will be returned as byte[]s
 	 */
+	public <T> T evalReadOnly(String script, ReturnType returnType, int numKeys, String... keysAndArgs) {
+		return evalReadOnly(serialize(script), returnType, numKeys, serializeMulti(keysAndArgs));
+	}
+
+	/**
+	 * NOTE: This method will not deserialize Strings returned by Lua scripts, as they may not be encoded with the same
+	 * serializer used here. They will be returned as byte[]s
+	 */
 	public <T> T evalSha(String scriptSha1, ReturnType returnType, int numKeys, String... keysAndArgs) {
 		return evalSha(scriptSha1, returnType, numKeys, serializeMulti(keysAndArgs));
+	}
+
+	/**
+	 * NOTE: This method will not deserialize Strings returned by Lua scripts, as they may not be encoded with the same
+	 * serializer used here. They will be returned as byte[]s
+	 */
+	public <T> T evalShaReadOnly(String scriptSha1, ReturnType returnType, int numKeys, String... keysAndArgs) {
+		return evalShaReadOnly(scriptSha1, returnType, numKeys, serializeMulti(keysAndArgs));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -70,6 +70,7 @@ import org.springframework.data.redis.domain.geo.GeoShape;
  * @author Tihomir Mateev
  * @author Mingi Lee
  * @author Yordan Tsintsov
+ * @author won-seoop
  * @since 2.0
  */
 @Deprecated
@@ -2026,6 +2027,13 @@ public interface DefaultedRedisConnection extends RedisCommands, RedisCommandsPr
 	/** @deprecated in favor of {@link RedisConnection#scriptingCommands()}. */
 	@Override
 	@Deprecated
+	default <T> T evalReadOnly(byte[] script, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
+		return scriptingCommands().evalReadOnly(script, returnType, numKeys, keysAndArgs);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#scriptingCommands()}. */
+	@Override
+	@Deprecated
 	default <T> T evalSha(String scriptSha, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
 		return scriptingCommands().evalSha(scriptSha, returnType, numKeys, keysAndArgs);
 	}
@@ -2033,8 +2041,22 @@ public interface DefaultedRedisConnection extends RedisCommands, RedisCommandsPr
 	/** @deprecated in favor of {@link RedisConnection#scriptingCommands()}. */
 	@Override
 	@Deprecated
+	default <T> T evalShaReadOnly(String scriptSha, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
+		return scriptingCommands().evalShaReadOnly(scriptSha, returnType, numKeys, keysAndArgs);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#scriptingCommands()}. */
+	@Override
+	@Deprecated
 	default <T> T evalSha(byte[] scriptSha, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
 		return scriptingCommands().evalSha(scriptSha, returnType, numKeys, keysAndArgs);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#scriptingCommands()}. */
+	@Override
+	@Deprecated
+	default <T> T evalShaReadOnly(byte[] scriptSha, ReturnType returnType, int numKeys, byte[]... keysAndArgs) {
+		return scriptingCommands().evalShaReadOnly(scriptSha, returnType, numKeys, keysAndArgs);
 	}
 
 	/** @deprecated in favor of {@link RedisConnection#zSetCommands()}}. */

--- a/src/main/java/org/springframework/data/redis/connection/RedisScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisScriptingCommands.java
@@ -27,6 +27,7 @@ import org.jspecify.annotations.NullUnmarked;
  * @author Christoph Strobl
  * @author David Liu
  * @author Mark Paluch
+ * @author won-seoop
  * @see RedisCommands
  */
 @NullUnmarked
@@ -80,6 +81,22 @@ public interface RedisScriptingCommands {
 			byte @NonNull [] @NonNull... keysAndArgs);
 
 	/**
+	 * Evaluate given read-only {@code script}.
+	 *
+	 * @param script must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
+	 * @param numKeys
+	 * @param keysAndArgs must not be {@literal null}.
+	 * @return script result. {@literal null} when used in pipeline / transaction.
+	 * @since 4.1
+	 * @see <a href="https://redis.io/commands/eval_ro">Redis Documentation: EVAL_RO</a>
+	 */
+	default <T> T evalReadOnly(byte @NonNull [] script, @NonNull ReturnType returnType, int numKeys,
+			byte @NonNull [] @NonNull... keysAndArgs) {
+		throw new UnsupportedOperationException("EVAL_RO is not supported");
+	}
+
+	/**
 	 * Evaluate given {@code scriptSha}.
 	 *
 	 * @param scriptSha must not be {@literal null}.
@@ -91,6 +108,22 @@ public interface RedisScriptingCommands {
 	 */
 	<T> T evalSha(@NonNull String scriptSha, @NonNull ReturnType returnType, int numKeys,
 			byte @NonNull [] @NonNull... keysAndArgs);
+
+	/**
+	 * Evaluate given read-only {@code scriptSha}.
+	 *
+	 * @param scriptSha must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
+	 * @param numKeys
+	 * @param keysAndArgs must not be {@literal null}.
+	 * @return script result. {@literal null} when used in pipeline / transaction.
+	 * @since 4.1
+	 * @see <a href="https://redis.io/commands/evalsha_ro">Redis Documentation: EVALSHA_RO</a>
+	 */
+	default <T> T evalShaReadOnly(@NonNull String scriptSha, @NonNull ReturnType returnType, int numKeys,
+			byte @NonNull [] @NonNull... keysAndArgs) {
+		throw new UnsupportedOperationException("EVALSHA_RO is not supported");
+	}
 
 	/**
 	 * Evaluate given {@code scriptSha}.
@@ -105,4 +138,20 @@ public interface RedisScriptingCommands {
 	 */
 	<T> T evalSha(byte @NonNull [] scriptSha, @NonNull ReturnType returnType, int numKeys,
 			byte @NonNull [] @NonNull... keysAndArgs);
+
+	/**
+	 * Evaluate given read-only {@code scriptSha}.
+	 *
+	 * @param scriptSha must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
+	 * @param numKeys
+	 * @param keysAndArgs must not be {@literal null}.
+	 * @return script result. {@literal null} when used in pipeline / transaction.
+	 * @since 4.1
+	 * @see <a href="https://redis.io/commands/evalsha_ro">Redis Documentation: EVALSHA_RO</a>
+	 */
+	default <T> T evalShaReadOnly(byte @NonNull [] scriptSha, @NonNull ReturnType returnType, int numKeys,
+			byte @NonNull [] @NonNull... keysAndArgs) {
+		throw new UnsupportedOperationException("EVALSHA_RO is not supported");
+	}
 }

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -76,6 +76,7 @@ import org.springframework.util.CollectionUtils;
  * @author Jeonggyu Choi
  * @author Mingi Lee
  * @author Yordan Tsintsov
+ * @author won-seoop
  * @see RedisCallback
  * @see RedisSerializer
  * @see StringRedisTemplate
@@ -2984,6 +2985,23 @@ public interface StringRedisConnection extends RedisConnection {
 			@NonNull String @NonNull... keysAndArgs);
 
 	/**
+	 * Evaluate given read-only {@code script}.
+	 *
+	 * @param script must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
+	 * @param numKeys
+	 * @param keysAndArgs must not be {@literal null}.
+	 * @return
+	 * @since 4.1
+	 * @see <a href="https://redis.io/commands/eval_ro">Redis Documentation: EVAL_RO</a>
+	 * @see RedisScriptingCommands#evalReadOnly(byte[], ReturnType, int, byte[]...)
+	 */
+	default <T> T evalReadOnly(@NonNull String script, @NonNull ReturnType returnType, int numKeys,
+			@NonNull String @NonNull... keysAndArgs) {
+		throw new UnsupportedOperationException("EVAL_RO is not supported");
+	}
+
+	/**
 	 * Evaluate given {@code scriptSha}.
 	 *
 	 * @param scriptSha must not be {@literal null}.
@@ -2996,6 +3014,23 @@ public interface StringRedisConnection extends RedisConnection {
 	 */
 	<T> T evalSha(@NonNull String scriptSha, @NonNull ReturnType returnType, int numKeys,
 			@NonNull String @NonNull... keysAndArgs);
+
+	/**
+	 * Evaluate given read-only {@code scriptSha}.
+	 *
+	 * @param scriptSha must not be {@literal null}.
+	 * @param returnType must not be {@literal null}.
+	 * @param numKeys
+	 * @param keysAndArgs must not be {@literal null}.
+	 * @return
+	 * @since 4.1
+	 * @see <a href="https://redis.io/commands/evalsha_ro">Redis Documentation: EVALSHA_RO</a>
+	 * @see RedisScriptingCommands#evalShaReadOnly(String, ReturnType, int, byte[]...)
+	 */
+	default <T> T evalShaReadOnly(@NonNull String scriptSha, @NonNull ReturnType returnType, int numKeys,
+			@NonNull String @NonNull... keysAndArgs) {
+		throw new UnsupportedOperationException("EVALSHA_RO is not supported");
+	}
 
 	/**
 	 * Assign given name to current connection.

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisScriptingCommands.java
@@ -19,6 +19,7 @@ import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.commands.JedisBinaryCommands;
 import redis.clients.jedis.commands.ScriptingKeyPipelineBinaryCommands;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.jspecify.annotations.NonNull;
@@ -31,6 +32,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Ivan Kripakov
  * @author Tihomir Mateev
+ * @author won-seoop
  * @since 2.0
  */
 @NullUnmarked
@@ -98,9 +100,32 @@ class JedisScriptingCommands implements RedisScriptingCommands {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T evalReadOnly(byte @NonNull [] script, @NonNull ReturnType returnType, int numKeys,
+			byte @NonNull [] @NonNull... keysAndArgs) {
+
+		Assert.notNull(script, "Script must not be null");
+
+		byte[][] keys = extractScriptKeys(numKeys, keysAndArgs);
+		byte[][] args = extractScriptArgs(numKeys, keysAndArgs);
+
+		JedisScriptReturnConverter converter = new JedisScriptReturnConverter(returnType);
+		return (T) connection.invoke()
+				.from(j -> j.evalReadonly(script, Arrays.asList(keys), Arrays.asList(args)),
+						p -> p.evalReadonly(script, Arrays.asList(keys), Arrays.asList(args)))
+				.getOrElse(converter, () -> converter.convert(null));
+	}
+
+	@Override
 	public <T> T evalSha(@NonNull String scriptSha1, @NonNull ReturnType returnType, int numKeys,
 			byte @NonNull [] @NonNull... keysAndArgs) {
 		return evalSha(JedisConverters.toBytes(scriptSha1), returnType, numKeys, keysAndArgs);
+	}
+
+	@Override
+	public <T> T evalShaReadOnly(@NonNull String scriptSha1, @NonNull ReturnType returnType, int numKeys,
+			byte @NonNull [] @NonNull... keysAndArgs) {
+		return evalShaReadOnly(JedisConverters.toBytes(scriptSha1), returnType, numKeys, keysAndArgs);
 	}
 
 	@Override
@@ -114,6 +139,32 @@ class JedisScriptingCommands implements RedisScriptingCommands {
 		return (T) connection.invoke()
 				.from(JedisBinaryCommands::evalsha, ScriptingKeyPipelineBinaryCommands::evalsha, scriptSha, numKeys, keysAndArgs)
 				.getOrElse(converter, () -> converter.convert(null));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T evalShaReadOnly(byte @NonNull [] scriptSha, @NonNull ReturnType returnType, int numKeys,
+			byte @NonNull [] @NonNull... keysAndArgs) {
+
+		Assert.notNull(scriptSha, "Script digest must not be null");
+
+		byte[][] keys = extractScriptKeys(numKeys, keysAndArgs);
+		byte[][] args = extractScriptArgs(numKeys, keysAndArgs);
+
+		JedisScriptReturnConverter converter = new JedisScriptReturnConverter(returnType);
+		return (T) connection.invoke()
+				.from(j -> j.evalshaReadonly(scriptSha, Arrays.asList(keys), Arrays.asList(args)),
+						p -> p.evalshaReadonly(scriptSha, Arrays.asList(keys), Arrays.asList(args)))
+				.getOrElse(converter, () -> converter.convert(null));
+	}
+
+	private static byte[][] extractScriptKeys(int numKeys, byte[]... keysAndArgs) {
+		return numKeys > 0 ? Arrays.copyOfRange(keysAndArgs, 0, numKeys) : new byte[0][0];
+	}
+
+	private static byte[][] extractScriptArgs(int numKeys, byte[]... keysAndArgs) {
+		return keysAndArgs.length > numKeys ? Arrays.copyOfRange(keysAndArgs, numKeys, keysAndArgs.length)
+				: new byte[0][0];
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceScriptingCommands.java
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Mark Paluch
+ * @author won-seoop
  * @since 2.0
  */
 @NullUnmarked
@@ -90,6 +91,22 @@ class LettuceScriptingCommands implements RedisScriptingCommands {
 	}
 
 	@Override
+	public <T> T evalReadOnly(byte @NonNull [] script, @NonNull ReturnType returnType, int numKeys,
+			byte @NonNull [] @NonNull... keysAndArgs) {
+
+		Assert.notNull(script, "Script must not be null");
+
+		byte[][] keys = extractScriptKeys(numKeys, keysAndArgs);
+		byte[][] args = extractScriptArgs(numKeys, keysAndArgs);
+		String convertedScript = LettuceConverters.toString(script);
+
+		return connection
+				.invoke().from(RedisScriptingAsyncCommands::evalReadOnly, convertedScript,
+						LettuceConverters.toScriptOutputType(returnType), keys, args)
+				.get(new LettuceEvalResultsConverter<T>(returnType));
+	}
+
+	@Override
 	public <T> T evalSha(@NonNull String scriptSha1, @NonNull ReturnType returnType, int numKeys,
 			byte @NonNull [] @NonNull... keysAndArgs) {
 
@@ -105,12 +122,36 @@ class LettuceScriptingCommands implements RedisScriptingCommands {
 	}
 
 	@Override
+	public <T> T evalShaReadOnly(@NonNull String scriptSha1, @NonNull ReturnType returnType, int numKeys,
+			byte @NonNull [] @NonNull... keysAndArgs) {
+
+		Assert.notNull(scriptSha1, "Script digest must not be null");
+
+		byte[][] keys = extractScriptKeys(numKeys, keysAndArgs);
+		byte[][] args = extractScriptArgs(numKeys, keysAndArgs);
+
+		return connection
+				.invoke().from(RedisScriptingAsyncCommands::evalshaReadOnly, scriptSha1,
+						LettuceConverters.toScriptOutputType(returnType), keys, args)
+				.get(new LettuceEvalResultsConverter<T>(returnType));
+	}
+
+	@Override
 	public <T> T evalSha(byte @NonNull [] scriptSha1, @NonNull ReturnType returnType, int numKeys,
 			byte @NonNull [] @NonNull... keysAndArgs) {
 
 		Assert.notNull(scriptSha1, "Script digest must not be null");
 
 		return evalSha(LettuceConverters.toString(scriptSha1), returnType, numKeys, keysAndArgs);
+	}
+
+	@Override
+	public <T> T evalShaReadOnly(byte @NonNull [] scriptSha1, @NonNull ReturnType returnType, int numKeys,
+			byte @NonNull [] @NonNull... keysAndArgs) {
+
+		Assert.notNull(scriptSha1, "Script digest must not be null");
+
+		return evalShaReadOnly(LettuceConverters.toString(scriptSha1), returnType, numKeys, keysAndArgs);
 	}
 
 	private static byte[][] extractScriptKeys(int numKeys, byte[]... keysAndArgs) {

--- a/src/main/java/org/springframework/data/redis/core/RedisCommand.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisCommand.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author John Blum
  * @author LeeHyungGeol
  * @author Yordan Tsintsov
+ * @author won-seoop
  * @since 1.3
  * @link <a href=
  *       "https://github.com/antirez/redis/blob/843de8b786562d8d77c78d83a971060adc61f77a/src/server.c#L180">Redis
@@ -96,9 +97,9 @@ public enum RedisCommand {
 	// -- E
 	ECHO("r", 1, 1), //
 	EVAL("rw", 2), //
-	EVAL_RO("r", 2), //
+	EVAL_RO("r", 2, -1, "evalreadonly"), //
 	EVALSHA("rw", 2), //
-	EVALSHA_RO("r", 2), //
+	EVALSHA_RO("r", 2, -1, "evalshareadonly"), //
 	EXEC("rw", 0, 0), //
 	EXISTS("r", 1, 1), //
 	EXPIRE("rw", 2), //

--- a/src/main/java/org/springframework/data/redis/core/RedisOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisOperations.java
@@ -61,6 +61,7 @@ import org.springframework.util.Assert;
  * @author Vedran Pavic
  * @author Marcin Grzejszczak
  * @author Yordan Tsintsov
+ * @author won-seoop
  */
 @NullUnmarked
 public interface RedisOperations<K, V> {
@@ -156,6 +157,21 @@ public interface RedisOperations<K, V> {
 			@NonNull Object @NonNull... args);
 
 	/**
+	 * Executes the given read-only {@link RedisScript}.
+	 *
+	 * @param script The script to execute
+	 * @param keys Any keys that need to be passed to the script
+	 * @param args Any args that need to be passed to the script
+	 * @return The return value of the script or null if {@link RedisScript#getResultType()} is null, likely indicating a
+	 *         throw-away status reply (i.e. "OK")
+	 * @since 4.1
+	 */
+	default <T extends @Nullable Object> T executeReadOnly(@NonNull RedisScript<T> script,
+			@NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args) {
+		throw new UnsupportedOperationException("Read-only script execution is not supported");
+	}
+
+	/**
 	 * Executes the given {@link RedisScript}, using the provided {@link RedisSerializer}s to serialize the script
 	 * arguments and result.
 	 *
@@ -169,6 +185,25 @@ public interface RedisOperations<K, V> {
 	 */
 	<T extends @Nullable Object> T execute(@NonNull RedisScript<T> script, @NonNull RedisSerializer<?> argsSerializer,
 			@NonNull RedisSerializer<T> resultSerializer, @NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args);
+
+	/**
+	 * Executes the given read-only {@link RedisScript}, using the provided {@link RedisSerializer}s to serialize the script
+	 * arguments and result.
+	 *
+	 * @param script The script to execute
+	 * @param argsSerializer The {@link RedisSerializer} to use for serializing args
+	 * @param resultSerializer The {@link RedisSerializer} to use for serializing the script return value
+	 * @param keys Any keys that need to be passed to the script
+	 * @param args Any args that need to be passed to the script
+	 * @return The return value of the script or null if {@link RedisScript#getResultType()} is null, likely indicating a
+	 *         throw-away status reply (i.e. "OK")
+	 * @since 4.1
+	 */
+	default <T extends @Nullable Object> T executeReadOnly(@NonNull RedisScript<T> script,
+			@NonNull RedisSerializer<?> argsSerializer, @NonNull RedisSerializer<T> resultSerializer,
+			@NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args) {
+		throw new UnsupportedOperationException("Read-only script execution is not supported");
+	}
 
 	/**
 	 * Allocates and binds a new {@link RedisConnection} to the actual return type of the method. It is up to the caller

--- a/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
+++ b/src/main/java/org/springframework/data/redis/core/RedisTemplate.java
@@ -96,6 +96,7 @@ import org.springframework.util.CollectionUtils;
  * @author Vedran Pavic
  * @author Chris Bono
  * @author Yordan Tsintsov
+ * @author won-seoop
  * @param <K> the Redis key type against which the template works (usually a String)
  * @param <V> the Redis value type against which the template works
  * @see StringRedisTemplate
@@ -518,10 +519,23 @@ public class RedisTemplate<K, V> extends RedisAccessor implements RedisOperation
 	}
 
 	@Override
+	public <T extends @Nullable Object> T executeReadOnly(@NonNull RedisScript<T> script,
+			@NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args) {
+		return scriptExecutor.executeReadOnly(script, keys, args);
+	}
+
+	@Override
 	public <T extends @Nullable Object> T execute(@NonNull RedisScript<T> script,
 			@NonNull RedisSerializer<?> argsSerializer, @NonNull RedisSerializer<T> resultSerializer,
 			@NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args) {
 		return scriptExecutor.execute(script, argsSerializer, resultSerializer, keys, args);
+	}
+
+	@Override
+	public <T extends @Nullable Object> T executeReadOnly(@NonNull RedisScript<T> script,
+			@NonNull RedisSerializer<?> argsSerializer, @NonNull RedisSerializer<T> resultSerializer,
+			@NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args) {
+		return scriptExecutor.executeReadOnly(script, argsSerializer, resultSerializer, keys, args);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/script/DefaultScriptExecutor.java
+++ b/src/main/java/org/springframework/data/redis/core/script/DefaultScriptExecutor.java
@@ -37,6 +37,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author won-seoop
  * @param <K> The type of keys that may be passed during script execution
  */
 @NullUnmarked
@@ -62,6 +63,28 @@ public class DefaultScriptExecutor<K> implements ScriptExecutor<K> {
 	public <T extends @Nullable Object> T execute(@NonNull RedisScript<T> script,
 			@NonNull RedisSerializer<?> argsSerializer, @NonNull RedisSerializer<T> resultSerializer,
 			@NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args) {
+		return execute(script, argsSerializer, resultSerializer, keys, false, args);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends @Nullable Object> T executeReadOnly(@NonNull RedisScript<T> script,
+			@NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args) {
+		// use the Template's value serializer for args and result
+		return executeReadOnly(script, template.getValueSerializer(), (RedisSerializer<T>) template.getValueSerializer(),
+				keys, args);
+	}
+
+	@Override
+	public <T extends @Nullable Object> T executeReadOnly(@NonNull RedisScript<T> script,
+			@NonNull RedisSerializer<?> argsSerializer, @NonNull RedisSerializer<T> resultSerializer,
+			@NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args) {
+		return execute(script, argsSerializer, resultSerializer, keys, true, args);
+	}
+
+	private <T extends @Nullable Object> T execute(@NonNull RedisScript<T> script,
+			@NonNull RedisSerializer<?> argsSerializer, @NonNull RedisSerializer<T> resultSerializer,
+			@NonNull List<@NonNull K> keys, boolean readOnly, @NonNull Object @NonNull... args) {
 		return template.execute((RedisCallback<T>) connection -> {
 			final ReturnType returnType = ReturnType.fromJavaType(script.getResultType());
 			final byte[][] keysAndArgs = keysAndArgs(argsSerializer, keys, args);
@@ -69,10 +92,15 @@ public class DefaultScriptExecutor<K> implements ScriptExecutor<K> {
 			if (connection.isPipelined() || connection.isQueueing()) {
 				// We could script load first and then do evalsha to ensure sha is present,
 				// but this adds a sha1 to exec/closePipeline results. Instead, just eval
-				connection.eval(scriptBytes(script), returnType, keySize, keysAndArgs);
+				if (readOnly) {
+					connection.evalReadOnly(scriptBytes(script), returnType, keySize, keysAndArgs);
+				} else {
+					connection.eval(scriptBytes(script), returnType, keySize, keysAndArgs);
+				}
 				return null;
 			}
-			return eval(connection, script, returnType, keySize, keysAndArgs, resultSerializer);
+			return readOnly ? evalReadOnly(connection, script, returnType, keySize, keysAndArgs, resultSerializer)
+					: eval(connection, script, returnType, keySize, keysAndArgs, resultSerializer);
 		});
 	}
 
@@ -90,6 +118,29 @@ public class DefaultScriptExecutor<K> implements ScriptExecutor<K> {
 			}
 
 			result = connection.eval(scriptBytes(script), returnType, numKeys, keysAndArgs);
+		}
+
+		if (script.getResultType() == null) {
+			return null;
+		}
+
+		return deserializeResult(resultSerializer, result);
+	}
+
+	protected <T> T evalReadOnly(RedisConnection connection, RedisScript<T> script, ReturnType returnType, int numKeys,
+			byte[][] keysAndArgs, RedisSerializer<T> resultSerializer) {
+
+		Object result;
+		try {
+			result = connection.evalShaReadOnly(script.getSha1(), returnType, numKeys, keysAndArgs);
+		} catch (Exception ex) {
+
+			if (!ScriptUtils.exceptionContainsNoScriptError(ex)) {
+				throw ex instanceof RuntimeException runtimeException ? runtimeException
+						: new RedisSystemException(ex.getMessage(), ex);
+			}
+
+			result = connection.evalReadOnly(scriptBytes(script), returnType, numKeys, keysAndArgs);
 		}
 
 		if (script.getResultType() == null) {

--- a/src/main/java/org/springframework/data/redis/core/script/ScriptExecutor.java
+++ b/src/main/java/org/springframework/data/redis/core/script/ScriptExecutor.java
@@ -27,6 +27,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
  * Executes {@link RedisScript}s
  *
  * @author Jennifer Hickey
+ * @author won-seoop
  * @param <K> The type of keys that may be passed during script execution
  */
 @NullUnmarked
@@ -45,6 +46,21 @@ public interface ScriptExecutor<K> {
 			@NonNull Object @NonNull... args);
 
 	/**
+	 * Executes the given read-only {@link RedisScript}.
+	 *
+	 * @param script the script to execute.
+	 * @param keys any keys that need to be passed to the script.
+	 * @param args any args that need to be passed to the script.
+	 * @return The return value of the script or {@literal null} if {@link RedisScript#getResultType()} is
+	 *         {@literal null}, likely indicating a throw-away status reply (i.e. "OK")
+	 * @since 4.1
+	 */
+	default <T extends @Nullable Object> T executeReadOnly(@NonNull RedisScript<T> script,
+			@NonNull List<@NonNull K> keys, @NonNull Object @NonNull... args) {
+		throw new UnsupportedOperationException("Read-only script execution is not supported");
+	}
+
+	/**
 	 * Executes the given {@link RedisScript}, using the provided {@link RedisSerializer}s to serialize the script
 	 * arguments and result.
 	 *
@@ -58,5 +74,24 @@ public interface ScriptExecutor<K> {
 	 */
 	<T extends @Nullable Object> T execute(@NonNull RedisScript<T> script, @NonNull RedisSerializer<?> argsSerializer,
 			@NonNull RedisSerializer<T> resultSerializer, @NonNull List<@NonNull K> keys, @NonNull Object... args);
+
+	/**
+	 * Executes the given read-only {@link RedisScript}, using the provided {@link RedisSerializer}s to serialize the script
+	 * arguments and result.
+	 *
+	 * @param script the script to execute.
+	 * @param argsSerializer The {@link RedisSerializer} to use for serializing args.
+	 * @param resultSerializer The {@link RedisSerializer} to use for serializing the script return value.
+	 * @param keys any keys that need to be passed to the script.
+	 * @param args any args that need to be passed to the script.
+	 * @return The return value of the script or {@literal null} if {@link RedisScript#getResultType()} is
+	 *         {@literal null}, likely indicating a throw-away status reply (i.e. "OK")
+	 * @since 4.1
+	 */
+	default <T extends @Nullable Object> T executeReadOnly(@NonNull RedisScript<T> script,
+			@NonNull RedisSerializer<?> argsSerializer, @NonNull RedisSerializer<T> resultSerializer,
+			@NonNull List<@NonNull K> keys, @NonNull Object... args) {
+		throw new UnsupportedOperationException("Read-only script execution is not supported");
+	}
 
 }

--- a/src/test/java/org/springframework/data/redis/core/RedisCommandUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisCommandUnitTests.java
@@ -31,6 +31,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @author Mark Paluch
  * @author Oscar Cai
  * @author John Blum
+ * @author won-seoop
  */
 class RedisCommandUnitTests {
 
@@ -52,6 +53,13 @@ class RedisCommandUnitTests {
 	@Test // DATAREDIS-73
 	void shouldIdentifyAliasCorrectlyViaLookup() {
 		assertThat(RedisCommand.failsafeCommandLookup("setconfig")).isEqualTo(RedisCommand.CONFIG_SET);
+	}
+
+	@Test // GH-2617
+	void shouldIdentifyReadOnlyScriptAliasesCorrectlyViaLookup() {
+
+		assertThat(RedisCommand.failsafeCommandLookup("evalReadOnly")).isEqualTo(RedisCommand.EVAL_RO);
+		assertThat(RedisCommand.failsafeCommandLookup("evalShaReadOnly")).isEqualTo(RedisCommand.EVALSHA_RO);
 	}
 
 	@Test // DATAREDIS-73

--- a/src/test/java/org/springframework/data/redis/core/RedisConnectionUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/RedisConnectionUtilsUnitTests.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisKeyCommands;
+import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
@@ -36,6 +37,7 @@ import org.springframework.transaction.support.TransactionTemplate;
  * Unit tests for {@link RedisConnectionUtils}.
  *
  * @author Mark Paluch
+ * @author won-seoop
  */
 class RedisConnectionUtilsUnitTests {
 
@@ -216,6 +218,27 @@ class RedisConnectionUtilsUnitTests {
 
 			assertThat(connection.exists(anyBytes)).isEqualTo(true);
 		});
+	}
+
+	@Test // GH-2617
+	void connectionProxyShouldInvokeReadOnlyScriptMethods() {
+
+		TransactionTemplate template = new TransactionTemplate(new DummyTransactionManager());
+
+		byte[] script = new byte[] { 1, 2, 3 };
+		byte[] result = new byte[] { 4, 5, 6 };
+
+		when(connectionMock2.evalReadOnly(script, ReturnType.VALUE, 0)).thenReturn(result);
+
+		template.executeWithoutResult(status -> {
+
+			RedisConnection connection = RedisConnectionUtils.getConnection(factoryMock, true);
+
+			assertThat((Object) connection.evalReadOnly(script, ReturnType.VALUE, 0)).isSameAs(result);
+		});
+
+		verify(connectionMock2).evalReadOnly(script, ReturnType.VALUE, 0);
+		verify(connectionMock1, never()).evalReadOnly(script, ReturnType.VALUE, 0);
 	}
 
 	@Test // GH-2886

--- a/src/test/java/org/springframework/data/redis/core/script/DefaultScriptExecutorUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/script/DefaultScriptExecutorUnitTests.java
@@ -32,6 +32,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 
 /**
  * @author Christoph Strobl
+ * @author won-seoop
  */
 @ExtendWith(MockitoExtension.class)
 class DefaultScriptExecutorUnitTests {
@@ -64,6 +65,17 @@ class DefaultScriptExecutorUnitTests {
 		verify(redisConnectionMock, times(1)).evalSha(anyString(), any(ReturnType.class), anyInt());
 	}
 
+	@Test // GH-2617
+	void executeReadOnlyCheckForPresenceOfScriptViaEvalShaReadOnly() {
+
+		when(redisConnectionMock.evalShaReadOnly(anyString(), any(ReturnType.class), anyInt()))
+				.thenReturn("FOO".getBytes());
+
+		executor.executeReadOnly(SCRIPT, null);
+
+		verify(redisConnectionMock, times(1)).evalShaReadOnly(anyString(), any(ReturnType.class), anyInt());
+	}
+
 	@Test // DATAREDIS-347
 	void excuteShouldNotCallEvalWhenSha1Exists() {
 
@@ -72,6 +84,17 @@ class DefaultScriptExecutorUnitTests {
 		executor.execute(SCRIPT, null);
 
 		verify(redisConnectionMock, never()).eval(any(byte[].class), any(ReturnType.class), anyInt());
+	}
+
+	@Test // GH-2617
+	void executeReadOnlyShouldNotCallEvalReadOnlyWhenSha1Exists() {
+
+		when(redisConnectionMock.evalShaReadOnly(anyString(), any(ReturnType.class), anyInt()))
+				.thenReturn("FOO".getBytes());
+
+		executor.executeReadOnly(SCRIPT, null);
+
+		verify(redisConnectionMock, never()).evalReadOnly(any(byte[].class), any(ReturnType.class), anyInt());
 	}
 
 	@Test // DATAREDIS-347
@@ -83,6 +106,17 @@ class DefaultScriptExecutorUnitTests {
 		executor.execute(SCRIPT, null);
 
 		verify(redisConnectionMock, times(1)).eval(any(byte[].class), any(ReturnType.class), anyInt());
+	}
+
+	@Test // GH-2617
+	void executeReadOnlyShouldUseEvalReadOnlyInCaseNoSha1PresentForGivenScript() {
+
+		when(redisConnectionMock.evalShaReadOnly(anyString(), any(ReturnType.class), anyInt()))
+				.thenThrow(new RedisSystemException("NOSCRIPT No matching script; Please use EVAL.", new Exception()));
+
+		executor.executeReadOnly(SCRIPT, null);
+
+		verify(redisConnectionMock, times(1)).evalReadOnly(any(byte[].class), any(ReturnType.class), anyInt());
 	}
 
 	@Test // DATAREDIS-347


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

This PR adds read-only script execution support so callers can explicitly execute scripts through `EVAL_RO`/`EVALSHA_RO` where supported.

Changes include:

- Add `executeReadOnly(…)` variants to `RedisOperations` and `ScriptExecutor`.
- Add `evalReadOnly(…)` and `evalShaReadOnly(…)` to Redis scripting command APIs, including string-friendly delegates.
- Route Lettuce and Jedis through their read-only scripting APIs.
- Register read-only script method aliases for command classification in connection splitting.
- Add unit coverage for script executor routing, command lookup aliases, and read-only connection splitting.

Closes #2617

Tests:

- `./mvnw -q -DskipITs -DskipDocker -Dtest=DefaultScriptExecutorUnitTests,RedisCommandUnitTests,RedisConnectionUtilsUnitTests test`
- `./mvnw -q -DskipITs -DskipDocker -DskipTests compile test-compile`
- `./mvnw -q -DskipITs -DskipDocker test` fails locally because Redis is not running on `127.0.0.1:6379`.
