### PR TITLE
Release reactive connection that arrives after close

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnection.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
 /**
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author sywu14
  * @since 2.0
  */
 @NullUnmarked
@@ -324,7 +325,9 @@ class LettuceReactiveRedisConnection implements ReactiveRedisConnection {
 			this.connectionPublisher = defer.doOnNext(it -> {
 
 				if (isClosing(STATE.get(this))) {
-					it.closeAsync();
+					// Connection arrived after close() was initiated. Release it back to the connection provider so a
+					// pooled connection is returned to the pool instead of being closed without releasing the pool slot.
+					connectionProvider.releaseAsync(it);
 				} else {
 					connection = it;
 				}

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveRedisConnectionUnitTests.java
@@ -50,6 +50,7 @@ import org.springframework.data.redis.connection.stream.MapRecord;
  * Unit tests for {@link LettuceReactiveRedisConnection}.
  *
  * @author Mark Paluch
+ * @author sywu14
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -194,6 +195,32 @@ class LettuceReactiveRedisConnectionUnitTests {
 		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(connectionProvider);
 
 		connection.getConnection().as(StepVerifier::create).expectError(RedisConnectionFailureException.class).verify();
+	}
+
+	@Test // GH-3371
+	@SuppressWarnings("unchecked")
+	void shouldReleaseConnectionArrivingAfterClose() throws Exception {
+
+		CompletableFuture<StatefulConnection<?, ?>> connectionFuture = new CompletableFuture<>();
+		reset(connectionProvider);
+		when(connectionProvider.getConnectionAsync(any())).thenReturn(connectionFuture);
+		when(connectionProvider.releaseAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
+
+		LettuceReactiveRedisConnection connection = new LettuceReactiveRedisConnection(connectionProvider);
+
+		// connection request is in-flight, the connection has not arrived yet
+		CompletableFuture<StatefulConnection<ByteBuffer, ByteBuffer>> inFlight = (CompletableFuture) connection
+				.getConnection().toFuture();
+		assertThat(inFlight).isNotDone();
+
+		// the connection gets closed while the acquisition is still in progress
+		connection.close();
+
+		// the connection finally arrives from the provider
+		connectionFuture.complete(sharedConnection);
+
+		// the late-arriving connection must be released back to the provider (returned to the pool), not leaked
+		verify(connectionProvider, times(1)).releaseAsync(sharedConnection);
 	}
 
 	@Test // DATAREDIS-720, DATAREDIS-721


### PR DESCRIPTION
Closes #3371

### Problem

`LettuceReactiveRedisConnection.AsyncConnect` leaks a pooled connection when the connection acquisition is cancelled (request timeout, client disconnect, subscription cancellation) **before** the connection has arrived from the `LettuceConnectionProvider`.

The late-arriving connection is closed via `it.closeAsync()` but never released back to the provider, so a pooled provider keeps counting it as active (Lettuce's `BoundedAsyncPool` never decrements `objectCount` / removes it from the `all` queue). Over time the pool is exhausted and throws `PoolException` / `Pool exhausted`, even though the physical connections are already closed.

Race scenario:

1. Subscriber subscribes to `getConnection()`; a connection is requested from the pool. `this.connection` is still `null`.
2. The subscription is cancelled, so `close()` runs. Because `this.connection` is still `null`, `releaseAsync(...)` is skipped and the state becomes `CLOSED`.
3. The pool finally yields the connection. `doOnNext` sees the closing state and calls `it.closeAsync()`.
4. `releaseAsync(it)` is never called, so the pool never reclaims the slot. Leak.

### Fix

Release the late-arriving connection through `connectionProvider.releaseAsync(it)` instead of `it.closeAsync()`, mirroring what `close()` already does for an already-arrived connection. For non-pooled providers this is equivalent to closing (the default `releaseAsync` delegates to `closeAsync()`); for pooled providers it correctly returns the connection to the pool.

### Tests

New unit test `shouldReleaseConnectionArrivingAfterClose` reproduces the race using a deferred connection future: it subscribes, closes while the acquisition is in-flight, then completes the future and verifies `releaseAsync` is invoked for the late-arriving connection. The test fails on `main` (`Wanted but not invoked: releaseAsync`) and passes with this change.

This issue was originally reported against Lettuce as redis/lettuce#3609, but the root cause is here in `AsyncConnect`.

---

- [x] You have read the Spring Data contribution guidelines.
- [x] You use the code formatters provided and have them applied to your changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched.