### PR TITLE
Fix typos and a malformed anchor in the preface

### DIFF
--- a/src/main/antora/modules/ROOT/pages/preface.adoc
+++ b/src/main/antora/modules/ROOT/pages/preface.adoc
@@ -37,9 +37,9 @@ In general, this should be the starting point for developers wanting to try Spri
 == Learning NoSQL and Key Value Stores
 
 NoSQL stores have taken the storage world by storm.
-It is a vast domain with a plethora of solutions, terms, and patterns (to make things worse, even the term itself has multiple https://www.google.com/search?q=nosoql+acronym[meanings]).
+It is a vast domain with a plethora of solutions, terms, and patterns (to make things worse, even the term itself has multiple https://www.google.com/search?q=nosql+acronym[meanings]).
 While some of the principles are common, it is crucial that you be familiar to some degree with the stores supported by SDR. The best way to get acquainted with these solutions is to read their documentation and follow their examples.
-It usually does not take more then five to ten minutes to go through them and, if you come from an RDMBS-only background, many times these exercises can be eye-openers.
+It usually does not take more than five to ten minutes to go through them and, if you come from an RDBMS-only background, many times these exercises can be eye-openers.
 
 [[get-started:first-steps:samples]]
 === Trying out the Samples
@@ -61,12 +61,12 @@ Learning a new framework is not always straightforward.
 In this section, we try to provide what we think is an easy-to-follow guide for starting with the Spring Data Redis module.
 However, if you encounter issues or you need advice, feel free to use one of the following links:
 
-[get-started:help:community]]
+[[get-started:help:community]]
 Community Forum :: Spring Data on https://stackoverflow.com/questions/tagged/spring-data[Stack Overflow] is a tag for all Spring Data (not just Document) users to share information and help each other.
 Note that registration is needed only for posting.
 
 [[get-started:help:professional]]
-Professional Support :: Professional, from-the-source support, with guaranteed response time, is available from https://pivotal.io/[Pivotal Sofware, Inc.], the company behind Spring Data and Spring.
+Professional Support :: Professional, from-the-source support, with guaranteed response time, is available from https://pivotal.io/[Pivotal Software, Inc.], the company behind Spring Data and Spring.
 
 [[get-started:up-to-date]]
 == Following Development


### PR DESCRIPTION
A few small issues in the preface:

- `more then` → `more than`
- `RDMBS` → `RDBMS` (spelled correctly elsewhere in the docs)
- the search URL query `nosoql` → `nosql`
- a malformed block anchor `[get-started:help:community]]` → `[[get-started:help:community]]` (all sibling anchors use `[[...]]`)
- `Pivotal Sofware, Inc.` → `Pivotal Software, Inc.`

Docs only.
