### PR TITLE
GH-3099: Parse Redis INFO output without using Properties.load()

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/Converters.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.redis.connection.convert;
 
-import java.io.StringReader;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.*;
@@ -30,7 +29,6 @@ import org.springframework.data.geo.GeoResult;
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Metrics;
-import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.connection.RedisClusterNode;
@@ -106,10 +104,15 @@ public abstract class Converters {
 
 		Properties info = new Properties();
 
-		try (StringReader stringReader = new StringReader(source)) {
-			info.load(stringReader);
-		} catch (Exception ex) {
-			throw new RedisSystemException("Cannot read Redis info", ex);
+		for (String line : source.split("\\r?\\n")) {
+			String trimmed = line.trim();
+			if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+				continue;
+			}
+			int colonIndex = trimmed.indexOf(':');
+			if (colonIndex > 0) {
+				info.setProperty(trimmed.substring(0, colonIndex).trim(), trimmed.substring(colonIndex + 1).trim());
+			}
 		}
 
 		return info;

--- a/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
+++ b/src/main/java/org/springframework/data/redis/connection/convert/StringToPropertiesConverter.java
@@ -15,14 +15,15 @@
  */
 package org.springframework.data.redis.connection.convert;
 
-import java.io.StringReader;
 import java.util.Properties;
 
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.redis.RedisSystemException;
 
 /**
- * Converts Strings to {@link Properties}
+ * Converts Strings in Redis {@code INFO} / {@code CLUSTER INFO} key:value format to {@link Properties}.
+ * <p>
+ * Unlike {@link Properties#load}, this converter does not interpret escape sequences (e.g. {@code \u}) so that values
+ * containing backslashes — such as Windows-style file paths emitted by Redis on Windows — are preserved verbatim.
  *
  * @author Jennifer Hickey
  * @author Christoph Strobl
@@ -31,13 +32,6 @@ public class StringToPropertiesConverter implements Converter<String, Properties
 
 	@Override
 	public Properties convert(String source) {
-
-		Properties info = new Properties();
-		try (StringReader stringReader = new StringReader(source)) {
-			info.load(stringReader);
-		} catch (Exception ex) {
-			throw new RedisSystemException("Cannot read Redis info", ex);
-		}
-		return info;
+		return Converters.toProperties(source);
 	}
 }


### PR DESCRIPTION
## Summary

Closes #3099. Closes #3020.

`Properties.load()` interprets `\u` sequences as Unicode escapes. Redis INFO output can contain Windows-style paths in fields like `exe_path`, `config_file`, `rdb_filename`, and `aof_filename` that include sequences such as `c:\users\...`. When these paths pass through `Properties.load()`, the `\u` prefix triggers a Unicode parsing error (or silently corrupts the value).

The Redis INFO format is a simple `key:value` text format — it is **not** a Java `.properties` file and should not be parsed as one.

## Changes

**Fixes #3099:** Replaced the `Properties.load()`-based implementation in `Converters.toProperties(String)` with a direct line-by-line parser that:
- Skips blank lines and section-header comments (`# Server`, `# Memory`, etc.)
- Splits each line on the **first** colon only (matching Redis INFO's `key:value` format)
- Does **not** interpret any escape sequences, preserving values exactly as Redis emits them

**Fixes #3020:** `StringToPropertiesConverter` now delegates to `Converters.toProperties(String)` rather than duplicating the parsing logic, eliminating the duplication flagged in that issue.

## Test plan

- [ ] Existing tests pass (no behaviour change for normal INFO output)
- [ ] Manually verify that INFO output containing `c:\users\...` paths (Windows Redis) is parsed without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)