### PR TITLE
Add `lengthOfValue` (`HSTRLEN`) to `ReactiveHashOperations`

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveHashOperations.java
@@ -51,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author John Blum
+ * @author Jewoo Shin
  * @since 2.0
  */
 class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations<H, HK, HV> {
@@ -213,6 +214,15 @@ class DefaultReactiveHashOperations<H, HK, HV> implements ReactiveHashOperations
 
 		return createFlux(connection -> connection.hKeys(rawKey(key)) //
 				.map(this::readRequiredHashKey));
+	}
+
+	@Override
+	public Mono<Long> lengthOfValue(H key, HK hashKey) {
+
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(hashKey, "Hash key must not be null");
+
+		return createMono(hashCommands -> hashCommands.hStrLen(rawKey(key), rawHashKey(hashKey)));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveHashOperations.java
@@ -45,6 +45,7 @@ import org.springframework.data.redis.core.types.Expirations;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Viktoriya Kutsarova
+ * @author Jewoo Shin
  * @since 2.0
  */
 public interface ReactiveHashOperations<H, HK, HV> {
@@ -199,6 +200,18 @@ public interface ReactiveHashOperations<H, HK, HV> {
 	 * @return
 	 */
 	Flux<HK> keys(H key);
+
+	/**
+	 * Returns the length of the value associated with {@code hashKey}. If either the {@code key} or the {@code hashKey}
+	 * do not exist, {@code 0} is emitted.
+	 *
+	 * @param key must not be {@literal null}.
+	 * @param hashKey must not be {@literal null}.
+	 * @return {@link Mono} emitting the length of the value associated with {@code hashKey}.
+	 * @since 4.2
+	 * @see <a href="https://redis.io/commands/hstrlen">Redis Documentation: HSTRLEN</a>
+	 */
+	Mono<Long> lengthOfValue(H key, HK hashKey);
 
 	/**
 	 * Get size of hash at {@code key}.

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveHashOperationsIntegrationTests.java
@@ -58,6 +58,7 @@ import org.springframework.data.redis.test.extension.LettuceTestClientResources;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Jewoo Shin
  */
 @ParameterizedClass
 @MethodSource("testParams")
@@ -361,6 +362,26 @@ public class DefaultReactiveHashOperationsIntegrationTests<K, HK, HV> {
 		hashOperations.keys(key).buffer(2) //
 				.as(StepVerifier::create) //
 				.consumeNextWith(list -> assertThat(list).containsExactlyInAnyOrder(hashkey1, hashkey2)) //
+				.verifyComplete();
+	}
+
+	@Test // GH-3376
+	void lengthOfValue() {
+
+		assumeThat(hashValueFactory instanceof StringObjectFactory).isTrue();
+
+		K key = keyFactory.instance();
+		HK hashkey1 = hashKeyFactory.instance();
+		HV hashvalue1 = hashValueFactory.instance();
+
+		HK hashkey2 = hashKeyFactory.instance();
+		HV hashvalue2 = hashValueFactory.instance();
+
+		putAll(key, hashkey1, hashvalue1, hashkey2, hashvalue2);
+
+		hashOperations.lengthOfValue(key, hashkey1) //
+				.as(StepVerifier::create) //
+				.expectNext((long) hashvalue1.toString().length()) //
 				.verifyComplete();
 	}
 


### PR DESCRIPTION
This PR adds `lengthOfValue` to `ReactiveHashOperations`, closing the gap with the imperative `HashOperations.lengthOfValue` that has been available since 2.1. The connection layer already supports the command through `ReactiveHashCommands.hStrLen`, so this change only wires it through the operations API, mirroring the imperative method's contract and Javadoc.

Verified with `DefaultReactiveHashOperationsIntegrationTests` against the Docker Compose test infrastructure:

```
make start
./mvnw test -Dtest=DefaultReactiveHashOperationsIntegrationTests -Pci
```

Closes #3376