### PR TITLE
Jedis fails on TTL parameters exceeding integer range

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -63,6 +63,7 @@ import org.springframework.util.ObjectUtils;
  * @author Yordan Tsintsov
  * @author Tihomir Mateev
  * @author Tiefang Hu
+ * @author Dongliang Xie
  * @since 2.0
  */
 @NullUnmarked
@@ -411,16 +412,12 @@ class JedisKeyCommands implements RedisKeyCommands {
 		if (replace) {
 
 			connection.invokeStatus().just(KeyBinaryCommands::restore, KeyPipelineBinaryCommands::restore, key,
-					(int) ttlInMillis, serializedValue, RestoreParams.restoreParams().replace());
+					ttlInMillis, serializedValue, RestoreParams.restoreParams().replace());
 			return;
 		}
 
-		if (ttlInMillis > Integer.MAX_VALUE) {
-			throw new IllegalArgumentException("TtlInMillis must be less than Integer.MAX_VALUE for restore in Jedis");
-		}
-
 		connection.invokeStatus().just(KeyBinaryCommands::restore, KeyPipelineBinaryCommands::restore, key,
-				(int) ttlInMillis, serializedValue);
+				ttlInMillis, serializedValue);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -63,6 +63,7 @@ import org.springframework.util.ObjectUtils;
  * @author Yordan Tsintsov
  * @author Tihomir Mateev
  * @author Tiefang Hu
+ * @author Dongliang Xie
  * @since 2.0
  */
 @NullUnmarked
@@ -408,19 +409,15 @@ class JedisKeyCommands implements RedisKeyCommands {
 		Assert.notNull(key, "Key must not be null");
 		Assert.notNull(serializedValue, "Serialized value must not be null");
 
-		if (ttlInMillis > Integer.MAX_VALUE) {
-			throw new IllegalArgumentException("TtlInMillis must be less than Integer.MAX_VALUE for restore in Jedis");
-		}
-
 		if (replace) {
 
 			connection.invokeStatus().just(KeyBinaryCommands::restore, KeyPipelineBinaryCommands::restore, key,
-					(int) ttlInMillis, serializedValue, RestoreParams.restoreParams().replace());
+					ttlInMillis, serializedValue, RestoreParams.restoreParams().replace());
 			return;
 		}
 
 		connection.invokeStatus().just(KeyBinaryCommands::restore, KeyPipelineBinaryCommands::restore, key,
-				(int) ttlInMillis, serializedValue);
+				ttlInMillis, serializedValue);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import redis.clients.jedis.AbstractTransaction;
+import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.CommandObject;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.args.Rawable;
 
 import java.io.IOException;
 
@@ -47,6 +49,7 @@ import org.springframework.data.redis.connection.RedisServerCommands.ShutdownOpt
  * @author Christoph Strobl
  * @author Tihomir Mateev
  * @author Tiefang Hu
+ * @author Dongliang Xie
  */
 class JedisConnectionUnitTests {
 
@@ -96,21 +99,40 @@ class JedisConnectionUnitTests {
 		}
 
 		/**
-		 * Captures the CommandObject sent via executeCommand and returns a string containing
-		 * the command name and all arguments.
+		 * Captures the command sent to the mock connection and returns a string containing the
+		 * command name and all arguments.
 		 */
 		@SuppressWarnings("unchecked")
 		private String captureCommand() {
+
+			if (connection.isPipelined()) {
+				ArgumentCaptor<CommandArguments> captor = ArgumentCaptor.forClass(CommandArguments.class);
+				verify(connectionMock, atLeastOnce()).sendCommand(captor.capture());
+				return commandToString(captor.getValue());
+			}
+
 			ArgumentCaptor<CommandObject<?>> captor = ArgumentCaptor.forClass(CommandObject.class);
 			verify(connectionMock, atLeastOnce()).executeCommand(captor.capture());
-			CommandObject<?> lastCommand = captor.getValue();
-			// Build a string from all raw arguments
+			return commandToString(captor.getValue().getArguments());
+		}
+
+		private String commandToString(Iterable<? extends Rawable> arguments) {
+
 			StringBuilder sb = new StringBuilder();
-			for (var arg : lastCommand.getArguments()) {
-				if (sb.length() > 0) sb.append(" ");
+
+			for (Rawable arg : arguments) {
+				if (sb.length() > 0) {
+					sb.append(" ");
+				}
 				sb.append(new String(arg.getRaw()));
 			}
+
 			return sb.toString();
+		}
+
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		private void returnOkForCommands() {
+			when(connectionMock.executeCommand(any(CommandObject.class))).thenReturn("OK");
 		}
 
 		@Test // DATAREDIS-184, GH-2153
@@ -201,10 +223,30 @@ class JedisConnectionUnitTests {
 					.isThrownBy(() -> connection.getSentinelConnection());
 		}
 
-		@Test // DATAREDIS-472
-		void restoreShouldThrowExceptionWhenTtlInMillisExceedsIntegerRange() {
-			assertThatIllegalArgumentException()
-					.isThrownBy(() -> connection.restore("foo".getBytes(), (long) Integer.MAX_VALUE + 1L, "bar".getBytes()));
+		@Test // GH-3386
+		void restoreShouldPassLongTtlToJedis() {
+
+			long ttlInMillis = (long) Integer.MAX_VALUE + 1L;
+
+			returnOkForCommands();
+
+			connection.restore("foo".getBytes(), ttlInMillis, "bar".getBytes());
+
+			String command = captureCommand();
+			assertThat(command).contains("RESTORE").contains(Long.toString(ttlInMillis));
+		}
+
+		@Test // GH-3386
+		void restoreWithReplaceShouldPassLongTtlToJedis() {
+
+			long ttlInMillis = (long) Integer.MAX_VALUE + 1L;
+
+			returnOkForCommands();
+
+			connection.restore("foo".getBytes(), ttlInMillis, "bar".getBytes(), true);
+
+			String command = captureCommand();
+			assertThat(command).contains("RESTORE").contains(Long.toString(ttlInMillis)).contains("REPLACE");
 		}
 
 		@Test // DATAREDIS-472

--- a/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/JedisConnectionUnitTests.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import redis.clients.jedis.AbstractTransaction;
+import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.CommandObject;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.args.Rawable;
 
 import java.io.IOException;
 
@@ -47,6 +49,7 @@ import org.springframework.data.redis.connection.RedisServerCommands.ShutdownOpt
  * @author Christoph Strobl
  * @author Tihomir Mateev
  * @author Tiefang Hu
+ * @author Dongliang Xie
  */
 class JedisConnectionUnitTests {
 
@@ -96,21 +99,40 @@ class JedisConnectionUnitTests {
 		}
 
 		/**
-		 * Captures the CommandObject sent via executeCommand and returns a string containing
-		 * the command name and all arguments.
+		 * Captures the command sent to the mock connection and returns a string containing the
+		 * command name and all arguments.
 		 */
 		@SuppressWarnings("unchecked")
 		private String captureCommand() {
+
+			if (connection.isPipelined()) {
+				ArgumentCaptor<CommandArguments> captor = ArgumentCaptor.forClass(CommandArguments.class);
+				verify(connectionMock, atLeastOnce()).sendCommand(captor.capture());
+				return commandToString(captor.getValue());
+			}
+
 			ArgumentCaptor<CommandObject<?>> captor = ArgumentCaptor.forClass(CommandObject.class);
 			verify(connectionMock, atLeastOnce()).executeCommand(captor.capture());
-			CommandObject<?> lastCommand = captor.getValue();
-			// Build a string from all raw arguments
+			return commandToString(captor.getValue().getArguments());
+		}
+
+		private String commandToString(Iterable<? extends Rawable> arguments) {
+
 			StringBuilder sb = new StringBuilder();
-			for (var arg : lastCommand.getArguments()) {
-				if (sb.length() > 0) sb.append(" ");
+
+			for (Rawable arg : arguments) {
+				if (sb.length() > 0) {
+					sb.append(" ");
+				}
 				sb.append(new String(arg.getRaw()));
 			}
+
 			return sb.toString();
+		}
+
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		private void returnOkForCommands() {
+			when(connectionMock.executeCommand(any(CommandObject.class))).thenReturn("OK");
 		}
 
 		@Test // DATAREDIS-184, GH-2153
@@ -201,16 +223,30 @@ class JedisConnectionUnitTests {
 					.isThrownBy(() -> connection.getSentinelConnection());
 		}
 
-		@Test // DATAREDIS-472
-		void restoreShouldThrowExceptionWhenTtlInMillisExceedsIntegerRange() {
-			assertThatIllegalArgumentException()
-					.isThrownBy(() -> connection.restore("foo".getBytes(), (long) Integer.MAX_VALUE + 1L, "bar".getBytes()));
+		@Test // GH-3386
+		void restoreShouldPassLongTtlToJedis() {
+
+			long ttlInMillis = (long) Integer.MAX_VALUE + 1L;
+
+			returnOkForCommands();
+
+			connection.restore("foo".getBytes(), ttlInMillis, "bar".getBytes());
+
+			String command = captureCommand();
+			assertThat(command).isEqualTo("RESTORE foo " + ttlInMillis + " bar");
 		}
 
-		@Test // GH-3437
-		void restoreWithReplaceShouldThrowExceptionWhenTtlInMillisExceedsIntegerRange() {
-			assertThatIllegalArgumentException().isThrownBy(
-					() -> connection.restore("foo".getBytes(), (long) Integer.MAX_VALUE + 1L, "bar".getBytes(), true));
+		@Test // GH-3386
+		void restoreWithReplaceShouldPassLongTtlToJedis() {
+
+			long ttlInMillis = (long) Integer.MAX_VALUE + 1L;
+
+			returnOkForCommands();
+
+			connection.restore("foo".getBytes(), ttlInMillis, "bar".getBytes(), true);
+
+			String command = captureCommand();
+			assertThat(command).isEqualTo("RESTORE foo " + ttlInMillis + " bar REPLACE");
 		}
 
 		@Test // GH-3438


### PR DESCRIPTION
Closes #3386.

Jedis supports `long` TTL values for `RESTORE`. Pass `ttlInMillis` without narrowing in both the normal and `REPLACE` paths, and remove the obsolete integer-range guard.

A focused parameterized test covers both variants with a TTL above `Integer.MAX_VALUE`.

Verification:
- `./mvnw --no-transfer-progress --quiet clean test -Pci` (12,156 tests, 0 failures/errors, using the Redis environment from `make start`)
- `git diff --check`

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
