### PR TITLE
Resolve `@RedisListener` topic placeholders

### DIFF
--- a/src/main/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessor.java
+++ b/src/main/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessor.java
@@ -69,6 +69,7 @@ import org.springframework.util.StringValueResolver;
  * @author Ilyass Bougati
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Dongliang Xie
  * @since 4.1
  * @see RedisListener
  */
@@ -248,7 +249,7 @@ public class RedisListenerAnnotationBeanPostProcessor
 		MethodRedisListenerEndpoint endpoint = new MethodRedisListenerEndpoint(bean, method);
 		endpoint.setMessageHandlerMethodFactory(this.messageHandlerMethodFactory);
 		endpoint.setId(getEndpointId(redisListener));
-		endpoint.setTopic(redisListener.topic());
+		endpoint.setTopic(resolve(redisListener.topic()));
 		endpoint.setConsumes(redisListener.consumes());
 
 		return endpoint;

--- a/src/test/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessorIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/annotation/RedisListenerAnnotationBeanPostProcessorIntegrationTests.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -30,6 +32,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.data.redis.config.RedisListenerConfigUtils;
 import org.springframework.data.redis.config.RedisListenerEndpointRegistry;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -40,6 +43,7 @@ import org.springframework.data.redis.listener.Topic;
  *
  * @author Ilyass Bougati
  * @author Mark Paluch
+ * @author Dongliang Xie
  */
 class RedisListenerAnnotationBeanPostProcessorIntegrationTests {
 
@@ -60,6 +64,24 @@ class RedisListenerAnnotationBeanPostProcessorIntegrationTests {
 		}, DefaultConfig.class, SimpleService.class);
 
 		assertThat(registryRef.get().isRunning()).isFalse();
+	}
+
+	@Test // GH-3393
+	void resolvesListenerTopicPlaceholder() {
+
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.getEnvironment().getPropertySources()
+					.addFirst(new MapPropertySource("redis-listener-test", Map.of("app.my-channel", "my-channel")));
+			context.register(DefaultConfig.class, PlaceholderTopicService.class);
+			context.refresh();
+
+			RedisMessageListenerContainer container = context.getBean("redisMessageListenerContainer",
+					RedisMessageListenerContainer.class);
+			ArgumentCaptor<Topic> topicCaptor = ArgumentCaptor.forClass(Topic.class);
+
+			verify(container).addMessageListener(any(), topicCaptor.capture());
+			assertThat(topicCaptor.getValue().getTopic()).isEqualTo("my-channel");
+		}
 	}
 
 	@Test // GH-3340
@@ -136,6 +158,13 @@ class RedisListenerAnnotationBeanPostProcessorIntegrationTests {
 	static class SimpleService {
 
 		@RedisListener(topic = "test-topic")
+		public void handle(String msg) {}
+
+	}
+
+	static class PlaceholderTopicService {
+
+		@RedisListener(topic = "${app.my-channel}")
 		public void handle(String msg) {}
 
 	}


### PR DESCRIPTION
Closes #3393

This resolves embedded property placeholders in the `@RedisListener` topic attribute before registering the listener endpoint.

Tests: `./mvnw -Dtest=RedisListenerAnnotationBeanPostProcessorIntegrationTests,RedisListenerAnnotationBeanPostProcessorUnitTests test`

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).