### PR TITLE
Fix NullPointerException resolving type hints for JSON with duplicate properties

### DIFF
--- a/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
@@ -23,7 +23,6 @@ import tools.jackson.core.TreeNode;
 import tools.jackson.core.Version;
 import tools.jackson.databind.DefaultTyping;
 import tools.jackson.databind.DeserializationConfig;
-import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JacksonModule;
 import tools.jackson.databind.JavaType;
@@ -31,6 +30,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.deser.DeserializationContextExt;
 import tools.jackson.databind.deser.jackson.BaseNodeDeserializer;
 import tools.jackson.databind.deser.jackson.JsonNodeDeserializer;
 import tools.jackson.databind.json.JsonMapper;
@@ -68,6 +68,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * {@link JacksonObjectWriter}.
  *
  * @author Christoph Strobl
+ * @author Tomaz Cerar
  * @see JacksonObjectReader
  * @see JacksonObjectWriter
  * @see ObjectMapper
@@ -503,10 +504,12 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 					}
 				}
 
-				/*
-				 * Hokey pokey! Oh my.
-				 */
-				DeserializationContext ctxt = mapper._deserializationContext();
+				// Bind the parser to the context so its stream-read capabilities are initialized: the node
+				// deserializer consults them (e.g. StreamReadCapability.DUPLICATE_PROPERTIES when a duplicate
+				// field name is encountered) and would otherwise throw a NullPointerException. This mirrors the
+				// way ObjectMapper._readTreeAndClose(...) binds the parser via assignAndReturnParser(...).
+				DeserializationContextExt ctxt = mapper._deserializationContext();
+				ctxt.assignParser(parser);
 
 				if (t == JsonToken.VALUE_NULL) {
 					return cfg.getNodeFactory().nullNode();

--- a/src/test/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializerUnitTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.redis.serializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
@@ -60,6 +61,7 @@ import com.fasterxml.jackson.annotation.JsonView;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author John Blum
+ * @author Tomaz Cerar
  */
 class GenericJacksonJsonRedisSerializerUnitTests {
 
@@ -176,6 +178,19 @@ class GenericJacksonJsonRedisSerializerUnitTests {
 
 		assertThat(result.getCount()).isEqualTo(1);
 		assertThat(result.getAvailable()).containsExactly(0, 1);
+	}
+
+	@Test // GH-3396
+	void deserializeShouldHandleDuplicatePropertyWithDefaultTyping() {
+
+		// Duplicate property names are valid JSON (RFC 8259) and can appear in cached values written by an
+		// earlier serializer (e.g. Jackson 2). Resolving the type hint scans the JSON tree, which must not
+		// fail on a duplicate field (previously a NullPointerException from an unbound DeserializationContext).
+		byte[] source = "{\"@class\":\"java.util.LinkedHashMap\",\"a\":1,\"a\":2}".getBytes(StandardCharsets.UTF_8);
+
+		Object result = serializer.deserialize(source);
+
+		assertThat(result).asInstanceOf(map(String.class, Object.class)).containsEntry("a", 2);
 	}
 
 	@Test // GH-2322


### PR DESCRIPTION
## Problem

`GenericJacksonJsonRedisSerializer` (Jackson 3, default typing enabled) throws a `NullPointerException` when deserializing any value whose JSON contains a duplicate property name.

`TypeResolver.readTree(byte[])` builds the JSON node tree with a `DeserializationContext` obtained from `ObjectMapper._deserializationContext()`, which is never bound to the parser. Its stream-read capabilities therefore stay `null`, and the first time `BaseNodeDeserializer._handleDuplicateProperty` consults `StreamReadCapability.DUPLICATE_PROPERTIES` it fails:

```
java.lang.NullPointerException: Cannot invoke
"tools.jackson.core.util.JacksonFeatureSet.isEnabled(...)" because "this._readCapabilities" is null
    at tools.jackson.databind.DeserializationContext.isEnabled(DeserializationContext.java:470)
    at tools.jackson.databind.deser.jackson.BaseNodeDeserializer._handleDuplicateProperty(BaseNodeDeserializer.java:148)
    at ...GenericJacksonJsonRedisSerializer$TypeResolver.readTree(GenericJacksonJsonRedisSerializer.java:509)
```

Duplicate property names are valid JSON (RFC 8259) and occur in practice — for example in cache entries written by the Jackson 2 serializer, or by a polymorphic type whose `@JsonTypeInfo(include = As.PROPERTY)` type-id name coincides with a bean property of the same name (Jackson 2 emitted both as duplicate keys). Such entries can no longer be read back under the Jackson 3 serializer — not even to be evicted.

Reported in #3396, with a minimal reproduction there.

## Fix

Bind the parser to the context before deserializing, so its stream-read capabilities are initialized. This mirrors how `ObjectMapper._readTreeAndClose(...)` binds the parser via `assignAndReturnParser(...)`. The tree scan then applies Jackson's normal duplicate-property handling (last value wins) instead of dereferencing a `null`.

## Test

`GenericJacksonJsonRedisSerializerUnitTests.deserializeShouldHandleDuplicatePropertyWithDefaultTyping` deserializes a value containing a duplicate property. It reproduces the `NullPointerException` above without the fix and passes with it.

---

- [x] I have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a test case backing the change; no formatting-only changes are included.
- [x] I added myself as an author in the headers of the classes I touched.

Closes #3396
