### PR TITLE
Fix inconsistent Javadoc parameter references

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveHashCommands.java
@@ -50,6 +50,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Tihomir Mateev
+ * @author JaeGeun Lee
  * @since 2.0
  */
 public interface ReactiveHashCommands {
@@ -793,7 +794,7 @@ public interface ReactiveHashCommands {
 		}
 
 		/**
-		 * Specify the {@code field} within the hash to get the length of the {@code value} of.ø
+		 * Specify the {@code field} within the hash to get the length of the {@code value} of.
 		 *
 		 * @param field must not be {@literal null}.
 		 * @return new instance of {@link HStrLenCommand}.

--- a/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisHashCommands.java
@@ -38,6 +38,7 @@ import org.springframework.util.ObjectUtils;
  * @author Mark Paluch
  * @author Tihomir Mateev
  * @author Viktoriya Kutsarova
+ * @author JaeGeun Lee
  * @see RedisCommands
  */
 @NullUnmarked
@@ -156,7 +157,7 @@ public interface RedisHashCommands {
 	Set<byte @NonNull []> hKeys(byte @NonNull [] key);
 
 	/**
-	 * Get entry set (values) of hash at {@code field}.
+	 * Get entry set (values) of hash at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return empty {@link List} if key does not exist. {@literal null} when used in pipeline / transaction.
@@ -312,7 +313,7 @@ public interface RedisHashCommands {
 	 * Set time to live for given {@code fields} in seconds.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param seconds the amount of time after which the fields will be expired in seconds, must not be {@literal null}.
+	 * @param seconds the amount of time after which the fields will be expired in seconds.
 	 * @param fields must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 2} indicating the specific field is
 	 *         deleted already due to expiration, or provided expiry interval is 0; {@code 1} indicating expiration time
@@ -348,7 +349,7 @@ public interface RedisHashCommands {
 	 * Set time to live for given {@code fields} in seconds.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param seconds the amount of time after which the fields will be expired in seconds, must not be {@literal null}.
+	 * @param seconds the amount of time after which the fields will be expired in seconds.
 	 * @param fields must not be {@literal null}.
 	 * @param condition the condition for expiration, must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 2} indicating the specific field is
@@ -366,8 +367,7 @@ public interface RedisHashCommands {
 	 * Set time to live for given {@code fields} in milliseconds.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param millis the amount of time after which the fields will be expired in milliseconds, must not be
-	 *          {@literal null}.
+	 * @param millis the amount of time after which the fields will be expired in milliseconds.
 	 * @param fields must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 2} indicating the specific field is
 	 *         deleted already due to expiration, or provided expiry interval is 0; {@code 1} indicating expiration time
@@ -403,8 +403,7 @@ public interface RedisHashCommands {
 	 * Set time to live for given {@code fields} in milliseconds.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param millis the amount of time after which the fields will be expired in milliseconds, must not be
-	 *          {@literal null}.
+	 * @param millis the amount of time after which the fields will be expired in milliseconds.
 	 * @param condition the condition for expiration, must not be {@literal null}.
 	 * @param fields must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 2} indicating the specific field is
@@ -419,10 +418,10 @@ public interface RedisHashCommands {
 			byte @NonNull [] @NonNull... fields);
 
 	/**
-	 * Set the expiration for given {@code field} as a {@literal UNIX} timestamp.
+	 * Set the expiration for given {@code fields} as a {@literal UNIX} timestamp.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param unixTime the moment in time in which the field expires, must not be {@literal null}.
+	 * @param unixTime the Unix timestamp in seconds at which the fields expire.
 	 * @param fields must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 2} indicating the specific field is
 	 *         deleted already due to expiration, or provided expiry interval is in the past; {@code 1} indicating
@@ -436,10 +435,10 @@ public interface RedisHashCommands {
 	}
 
 	/**
-	 * Set the expiration for given {@code field} as a {@literal UNIX} timestamp.
+	 * Set the expiration for given {@code fields} as a {@literal UNIX} timestamp.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param unixTime the moment in time in which the field expires, must not be {@literal null}.
+	 * @param unixTime the Unix timestamp in seconds at which the fields expire.
 	 * @param condition the condition for expiration, must not be {@literal null}.
 	 * @param fields must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 2} indicating the specific field is
@@ -454,10 +453,10 @@ public interface RedisHashCommands {
 			byte @NonNull [] @NonNull... fields);
 
 	/**
-	 * Set the expiration for given {@code field} as a {@literal UNIX} timestamp in milliseconds.
+	 * Set the expiration for given {@code fields} as a {@literal UNIX} timestamp in milliseconds.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param unixTimeInMillis the moment in time in which the field expires in milliseconds, must not be {@literal null}.
+	 * @param unixTimeInMillis the Unix timestamp in milliseconds at which the fields expire.
 	 * @param fields must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 2} indicating the specific field is
 	 *         deleted already due to expiration, or provided expiry interval is in the past; {@code 1} indicating
@@ -472,10 +471,10 @@ public interface RedisHashCommands {
 	}
 
 	/**
-	 * Set the expiration for given {@code field} as a {@literal UNIX} timestamp in milliseconds.
+	 * Set the expiration for given {@code fields} as a {@literal UNIX} timestamp in milliseconds.
 	 *
 	 * @param key must not be {@literal null}.
-	 * @param unixTimeInMillis the moment in time in which the field expires in milliseconds, must not be {@literal null}.
+	 * @param unixTimeInMillis the Unix timestamp in milliseconds at which the fields expire.
 	 * @param condition the condition for expiration, must not be {@literal null}.
 	 * @param fields must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 2} indicating the specific field is
@@ -490,14 +489,13 @@ public interface RedisHashCommands {
 			ExpirationOptions.@NonNull Condition condition, byte @NonNull [] @NonNull... fields);
 
 	/**
-	 * Remove the expiration from given {@code field}.
+	 * Remove the expiration from given {@code fields}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param fields must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 1} indicating expiration time is
 	 *         removed; {@code -1} field has no expiration time to be removed; {@code -2} indicating there is no such
-	 *         field; {@literal null} when used in pipeline / transaction.{@literal null} when used in pipeline /
-	 *         transaction.
+	 *         field; {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/docs/latest/commands/hpersist/">Redis Documentation: HPERSIST</a>
 	 * @since 3.5
 	 */

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -76,6 +76,7 @@ import org.springframework.util.CollectionUtils;
  * @author Jeonggyu Choi
  * @author Mingi Lee
  * @author Yordan Tsintsov
+ * @author JaeGeun Lee
  * @see RedisCallback
  * @see RedisSerializer
  * @see StringRedisTemplate
@@ -2386,7 +2387,7 @@ public interface StringRedisConnection extends RedisConnection {
 	Set<String> hKeys(@NonNull String key);
 
 	/**
-	 * Get entry set (values) of hash at {@code field}.
+	 * Get entry set (values) of hash at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @return
@@ -2571,8 +2572,7 @@ public interface StringRedisConnection extends RedisConnection {
 	 * @param fields must not be {@literal null}.
 	 * @return a list of {@link Long} values for each of the fields provided: {@code 1} indicating expiration time is
 	 *         removed; {@code -1} field has no expiration time to be removed; {@code -2} indicating there is no such
-	 *         field; {@literal null} when used in pipeline / transaction.{@literal null} when used in pipeline /
-	 *         transaction.
+	 *         field; {@literal null} when used in pipeline / transaction.
 	 * @see <a href="https://redis.io/docs/latest/commands/hpersist/">Redis Documentation: HPERSIST</a>
 	 * @since 3.5
 	 */

--- a/src/main/java/org/springframework/data/redis/core/BoundListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundListOperations.java
@@ -29,12 +29,13 @@ import org.springframework.util.Assert;
  *
  * @author Costin Leau
  * @author Mark Paluch
+ * @author JaeGeun Lee
  */
 @NullUnmarked
 public interface BoundListOperations<K, V> extends BoundKeyOperations<K> {
 
 	/**
-	 * Get elements between {@code begin} and {@code end} from list at the bound key.
+	 * Get elements between {@code start} and {@code end} from list at the bound key.
 	 *
 	 * @param start
 	 * @param end

--- a/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/BoundValueOperations.java
@@ -33,6 +33,7 @@ import org.springframework.data.redis.core.types.Expiration;
  * @author Christoph Strobl
  * @author Marcin Grzejszczak
  * @author Yordan Tsintsov
+ * @author JaeGeun Lee
  */
 @NullUnmarked
 public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
@@ -376,7 +377,7 @@ public interface BoundValueOperations<K, V> extends BoundKeyOperations<K> {
 	Integer append(@NonNull String value);
 
 	/**
-	 * Get a substring of value of the bound key between {@code begin} and {@code end}.
+	 * Get a substring of value of the bound key between {@code start} and {@code end}.
 	 *
 	 * @param start
 	 * @param end

--- a/src/main/java/org/springframework/data/redis/core/ListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ListOperations.java
@@ -38,12 +38,13 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author dengliming
  * @author Lee Jaeheon
+ * @author JaeGeun Lee
  */
 @NullUnmarked
 public interface ListOperations<K, V> {
 
 	/**
-	 * Get elements between {@code begin} and {@code end} from list at {@code key}.
+	 * Get elements between {@code start} and {@code end} from list at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param start

--- a/src/main/java/org/springframework/data/redis/core/ReactiveListOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveListOperations.java
@@ -40,13 +40,14 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author John Blum
+ * @author JaeGeun Lee
  * @see <a href="https://redis.io/commands#list">Redis Documentation: List Commands</a>
  * @since 2.0
  */
 public interface ReactiveListOperations<K, V> {
 
 	/**
-	 * Get elements between {@code begin} and {@code end} from list at {@code key}.
+	 * Get elements between {@code start} and {@code end} from list at {@code key}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param start

--- a/src/main/java/org/springframework/data/redis/core/ReactiveValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveValueOperations.java
@@ -38,6 +38,7 @@ import org.springframework.data.redis.core.types.Expiration;
  * @author Mark Paluch
  * @author Jiahe Cai
  * @author Yordan Tsintsov
+ * @author JaeGeun Lee
  * @since 2.0
  */
 public interface ReactiveValueOperations<K, V> {
@@ -340,7 +341,7 @@ public interface ReactiveValueOperations<K, V> {
 	Mono<Long> append(K key, String value);
 
 	/**
-	 * Get a substring of value of {@code key} between {@code begin} and {@code end}.
+	 * Get a substring of value of {@code key} between {@code start} and {@code end}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param start

--- a/src/main/java/org/springframework/data/redis/core/ValueOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ValueOperations.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  * @author Marcin Grzejszczak
  * @author Chris Bono
  * @author Yordan Tsintsov
+ * @author JaeGeun Lee
  */
 @NullUnmarked
 public interface ValueOperations<K, V> {
@@ -480,7 +481,7 @@ public interface ValueOperations<K, V> {
 	Integer append(@NonNull K key, @NonNull String value);
 
 	/**
-	 * Get a substring of value of {@code key} between {@code begin} and {@code end}.
+	 * Get a substring of value of {@code key} between {@code start} and {@code end}.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param start


### PR DESCRIPTION
## Summary

This PR fixes several small Javadoc inconsistencies where the documentation does not match the corresponding method signatures.

Changes include:

* Replacing outdated parameter references such as `begin` with `start`
* Correcting `field` references where methods use `key` or varargs `fields`
* Removing `must not be null` descriptions from primitive parameters
* Removing a duplicated pipeline/transaction return note

These are documentation-only changes and do not affect runtime behavior.

## Testing

No tests were added because this change only updates Javadocs. I verified that the updated parameter references match the corresponding method signatures.

Closes #3400 


---

* [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
* [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
* [ ] You submit test cases (unit or integration tests) that back your changes.
* [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

