### PR TITLE
Remove duplicated "the" in JavaDoc

### DIFF
--- a/src/main/antora/modules/ROOT/pages/redis/redis-repositories/anatomy.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/redis-repositories/anatomy.adoc
@@ -96,7 +96,7 @@ GEOADD "people:hometown:location" "13.361389" "38.115556" "76900e94-b057-44bc-ab
 SADD   "people:76900e94-b057-44bc-abcf-8126d51a621b:idx" "people:hometown:location"               <2>
 ----
 
-<1> Add the key of the saved entry to the the geo index.
+<1> Add the key of the saved entry to the geo index.
 <2> Keep track of the index structure.
 ====
 

--- a/src/main/java/org/springframework/data/redis/connection/stream/PendingMessage.java
+++ b/src/main/java/org/springframework/data/redis/connection/stream/PendingMessage.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 
 /**
  * Value object representing a single pending message containing its {@literal ID}, the {@literal consumer} that fetched
- * the message and has still to acknowledge it, the time elapsed since the messages last delivery and the the total
+ * the message and has still to acknowledge it, the time elapsed since the messages last delivery and the total
  * number of times delivered.
  *
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/core/ScanOptions.java
+++ b/src/main/java/org/springframework/data/redis/core/ScanOptions.java
@@ -151,7 +151,7 @@ public class ScanOptions {
 
 		/**
 		 * Returns the current {@link ScanOptionsBuilder} configured with the given {@code type}. <br />
-		 * Please verify the the targeted command supports the
+		 * Please verify the targeted command supports the
 		 * <a href="https://redis.io/commands/SCAN#the-type-option">TYPE</a> option before use.
 		 *
 		 * @param type must not be {@literal null}. Either do not set or use {@link DataType#NONE}.


### PR DESCRIPTION
This PR fixes typos of "the the" to "the".