### PR TITLE
Use Parser-bound `DeserializationContext` for parsing type hints in `TypeResolver`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-GH-3396-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
@@ -244,11 +244,14 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 
 			DeserializationConfig deserializationConfig = mapper.deserializationConfig();
 
+			var typer = deserializationConfig.getDefaultTyper(null);
+			if (typer instanceof StdTypeResolverBuilder std) {
+				return std.getTypeProperty();
+			}
+
 			JavaType objectType = mapper.getTypeFactory().constructType(Object.class);
-
-			TypeDeserializer typeDeserializer = deserializationConfig.getDefaultTyper(null)
+			TypeDeserializer typeDeserializer = typer
 					.buildTypeDeserializer(mapper._deserializationContext(), objectType, Collections.emptyList());
-
 			return typeDeserializer.getPropertyName();
 		});
 	}
@@ -488,7 +491,7 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 		/**
 		 * Lenient variant of ObjectMapper._readTreeAndClose using a strict {@link JsonNodeDeserializer}.
 		 */
-		private JsonNode readTree(byte[] source) throws IOException {
+		private JsonNode readTree(byte[] source) {
 
 			BaseNodeDeserializer<?> deserializer = JsonNodeDeserializer.getDeserializer(JsonNode.class);
 			DeserializationConfig cfg = mapper.deserializationConfig();

--- a/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
@@ -230,7 +230,8 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 
 	private static Lazy<String> newLazyTypeHintPropertyName(ObjectMapper mapper, Lazy<Boolean> defaultTypingEnabled) {
 
-		Lazy<String> configuredTypeDeserializationPropertyName = getConfiguredTypeDeserializationPropertyName(mapper);
+		Supplier<@Nullable String> configuredTypeDeserializationPropertyName = getConfiguredTypeDeserializationPropertyName(
+				mapper);
 
 		Lazy<String> resolvedLazyTypeHintPropertyName = Lazy
 				.of(() -> defaultTypingEnabled.get() ? configuredTypeDeserializationPropertyName.get() : null);
@@ -238,13 +239,16 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 		return resolvedLazyTypeHintPropertyName.or("@class");
 	}
 
-	private static Lazy<String> getConfiguredTypeDeserializationPropertyName(ObjectMapper mapper) {
+	private static Supplier<@Nullable String> getConfiguredTypeDeserializationPropertyName(ObjectMapper mapper) {
 
-		return Lazy.of(() -> {
+		Lazy<String> lazy = Lazy.of(() -> {
 
 			DeserializationConfig deserializationConfig = mapper.deserializationConfig();
-
 			var typer = deserializationConfig.getDefaultTyper(null);
+			if (typer == null) {
+				return null;
+			}
+
 			if (typer instanceof StdTypeResolverBuilder std) {
 				return std.getTypeProperty();
 			}
@@ -254,6 +258,8 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 					.buildTypeDeserializer(mapper._deserializationContext(), objectType, Collections.emptyList());
 			return typeDeserializer.getPropertyName();
 		});
+
+		return lazy::getNullable;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
@@ -493,7 +493,7 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 			BaseNodeDeserializer<?> deserializer = JsonNodeDeserializer.getDeserializer(JsonNode.class);
 			DeserializationConfig cfg = mapper.deserializationConfig();
 
-			try (JsonParser parser = createParser(source)) {
+			try (JsonParser parser = mapper.createParser(source)) {
 
 				JsonToken t = parser.currentToken();
 				if (t == null) {
@@ -503,21 +503,12 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 					}
 				}
 
-				/*
-				 * Hokey pokey! Oh my.
-				 */
-				DeserializationContext ctxt = mapper._deserializationContext();
-
 				if (t == JsonToken.VALUE_NULL) {
 					return cfg.getNodeFactory().nullNode();
 				} else {
-					return deserializer.deserialize(parser, ctxt);
+					return deserializer.deserialize(parser, (DeserializationContext) parser.objectReadContext());
 				}
 			}
-		}
-
-		private JsonParser createParser(byte[] source) throws IOException {
-			return mapper.createParser(source);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializerUnitTests.java
@@ -514,6 +514,16 @@ class GenericJackson2JsonRedisSerializerUnitTests {
 		serializeAndDeserializeNullValue(serializer);
 	}
 
+	@Test // GH-3396
+	void deserializesJsonWithDuplicatePropertyNames() {
+
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+
+		byte[] source = "{\"@class\":\"java.util.LinkedHashMap\",\"a\":1,\"a\":2}".getBytes(StandardCharsets.UTF_8);
+
+		assertThat(serializer.deserialize(source)).isEqualTo(Map.of("a", 2));
+	}
+
 	private static void serializeAndDeserializeNullValue(GenericJackson2JsonRedisSerializer serializer) {
 
 		NullValue nv = BeanUtils.instantiateClass(NullValue.class);

--- a/src/test/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializerUnitTests.java
@@ -26,6 +26,7 @@ import tools.jackson.core.exc.JacksonIOException;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonReadFeature;
 import tools.jackson.databind.DefaultTyping;
+import tools.jackson.databind.DeserializationConfig;
 import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.annotation.JsonDeserialize;
@@ -414,6 +415,30 @@ class GenericJacksonJsonRedisSerializerUnitTests {
 		byte[] source = "{\"@class\":\"java.util.LinkedHashMap\",\"a\":1,\"a\":2}".getBytes(StandardCharsets.UTF_8);
 
 		assertThat(serializer.deserialize(source)).isEqualTo(Map.of("a", 2));
+	}
+
+	@Test // GH-3396
+	void resolvesTypeHintWithoutDeserializationTyper() throws IOException {
+
+		PolymorphicTypeValidator validator = BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
+		JsonMapper.Builder builder = JsonMapper.builder();
+		DeserializationConfig untypedConfig = builder.build().deserializationConfig();
+
+		// deserialization config without a default typer
+		ObjectMapper mapper = new JsonMapper(
+				builder.activateDefaultTypingAsProperty(validator, DefaultTyping.NON_FINAL, "@class")) {
+
+			@Override
+			public DeserializationConfig deserializationConfig() {
+				return untypedConfig;
+			}
+		};
+
+		GenericJacksonJsonRedisSerializer serializer = new GenericJacksonJsonRedisSerializer(mapper);
+		byte[] source = "{\"@class\":\"org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializerUnitTests$SimpleObject\",\"longValue\":1}"
+				.getBytes(StandardCharsets.UTF_8);
+
+		assertThat(serializer.resolveType(source, Object.class).getRawClass()).isEqualTo(SimpleObject.class);
 	}
 
 	private static void serializeAndDeserializeNullValue(GenericJacksonJsonRedisSerializer serializer) {

--- a/src/test/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializerUnitTests.java
@@ -34,6 +34,7 @@ import tools.jackson.databind.ext.javatime.deser.LocalDateDeserializer;
 import tools.jackson.databind.ext.javatime.ser.LocalDateSerializer;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import tools.jackson.databind.jsontype.PolymorphicTypeValidator;
 import tools.jackson.databind.jsontype.TypeResolverBuilder;
 import tools.jackson.databind.type.TypeFactory;
 
@@ -401,6 +402,18 @@ class GenericJacksonJsonRedisSerializerUnitTests {
 		});
 
 		assertThat(serializer).isNotNull();
+	}
+
+	@Test // GH-3396
+	void deserializesJsonWithDuplicatePropertyNames() {
+
+		PolymorphicTypeValidator validator = BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
+		GenericJacksonJsonRedisSerializer serializer = GenericJacksonJsonRedisSerializer.builder()
+				.enableDefaultTyping(validator).build();
+
+		byte[] source = "{\"@class\":\"java.util.LinkedHashMap\",\"a\":1,\"a\":2}".getBytes(StandardCharsets.UTF_8);
+
+		assertThat(serializer.deserialize(source)).isEqualTo(Map.of("a", 2));
 	}
 
 	private static void serializeAndDeserializeNullValue(GenericJacksonJsonRedisSerializer serializer) {


### PR DESCRIPTION
We now use the deserialization context bound to the JSON parser instead of using the unbound and generic Mapper `DeserializationContext` that is actually only visible for testing.

Also, use `StdTypeResolverBuilder` if possible to defer `_deserializationContext()` access.

Closes #3396