### PR TITLE
Fix typos in Javadoc and assertion messages

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -56,7 +56,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
- * Default implementation of {@link ListOperations}.
+ * Default implementation of {@link StreamOperations}.
  *
  * @author Mark Paluch
  * @author Christoph Strobl

--- a/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJackson2JsonRedisSerializer.java
@@ -502,7 +502,7 @@ public class GenericJackson2JsonRedisSerializer implements RedisSerializer<Objec
 		 */
 		public GenericJackson2JsonRedisSerializerBuilder typeHintPropertyName(String typeHintPropertyName) {
 
-			Assert.hasText(typeHintPropertyName, "Type hint property name must bot be null or empty");
+			Assert.hasText(typeHintPropertyName, "Type hint property name must not be null or empty");
 
 			this.typeHintPropertyName = typeHintPropertyName;
 			return this;

--- a/src/main/java/org/springframework/data/redis/serializer/RedisMessageConverters.java
+++ b/src/main/java/org/springframework/data/redis/serializer/RedisMessageConverters.java
@@ -101,7 +101,7 @@ public interface RedisMessageConverters {
 	interface Builder {
 
 		/**
-		 * Configure the default {@link MimeType} that is provieded through
+		 * Configure the default {@link MimeType} that is provided through
 		 * {@link org.springframework.messaging.converter.DefaultContentTypeResolver} to message converters when using
 		 * {@link #registerDefaults(boolean) default registrations}.
 		 *


### PR DESCRIPTION
## Summary
- Fix typo "provieded" -> "provided" in `RedisMessageConverters` Javadoc
- Fix typo "bot" -> "not" in the assertion message of `GenericJackson2JsonRedisSerializer.typeHintPropertyName(...)`
- Fix stale class-level Javadoc in `DefaultStreamOperations` that referenced `{@link ListOperations}` (copy-pasted) instead of `{@link StreamOperations}`

## Test plan
- Doc/message-only changes, no behavior change; verified with `./mvnw compile`.