### PR TITLE
Fix argument validation in RedisData.setTimeToLive(Long, TimeUnit)

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/convert/RedisData.java
+++ b/src/main/java/org/springframework/data/redis/core/convert/RedisData.java
@@ -161,7 +161,7 @@ public class RedisData {
 	public void setTimeToLive(Long timeToLive, TimeUnit timeUnit) {
 
 		Assert.notNull(timeToLive, "TTL must not be null when used with TimeUnit");
-		Assert.notNull(timeToLive, "TimeUnit must not be null");
+		Assert.notNull(timeUnit, "TimeUnit must not be null");
 
 		setTimeToLive(TimeUnit.SECONDS.convert(timeToLive, timeUnit));
 	}

--- a/src/test/java/org/springframework/data/redis/core/convert/RedisDataUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/convert/RedisDataUnitTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RedisData}.
+ */
+class RedisDataUnitTests {
+
+	@Test
+	void setTimeToLiveWithTimeUnitConvertsToSeconds() {
+
+		RedisData redisData = new RedisData(Collections.emptyMap());
+
+		redisData.setTimeToLive(2L, TimeUnit.MINUTES);
+
+		assertThat(redisData.getTimeToLive()).isEqualTo(120L);
+	}
+
+	@Test
+	void setTimeToLiveWithNullTimeToLiveThrowsIllegalArgumentException() {
+
+		RedisData redisData = new RedisData(Collections.emptyMap());
+
+		assertThatIllegalArgumentException().isThrownBy(() -> redisData.setTimeToLive(null, TimeUnit.SECONDS))
+				.withMessageContaining("TTL");
+	}
+
+	@Test
+	void setTimeToLiveWithNullTimeUnitThrowsIllegalArgumentException() {
+
+		RedisData redisData = new RedisData(Collections.emptyMap());
+
+		assertThatIllegalArgumentException().isThrownBy(() -> redisData.setTimeToLive(1L, null))
+				.withMessageContaining("TimeUnit");
+	}
+
+}


### PR DESCRIPTION
## Summary
- `RedisData.setTimeToLive(Long, TimeUnit)` had a copy/paste bug: the second `Assert.notNull(...)` call re-checked `timeToLive` instead of validating `timeUnit`.
- As a result, passing a `null` `TimeUnit` skipped the intended fail-fast `IllegalArgumentException` and instead threw an unguarded `NullPointerException` from `TimeUnit.SECONDS.convert(...)`.
- Fixed the check to validate `timeUnit` as the message already stated.
- Added `RedisDataUnitTests` covering: null `TimeUnit` (new behavior), null `timeToLive` (existing behavior), and the regular seconds-conversion path (regression guard).

## Test plan
- [x] New unit tests in `RedisDataUnitTests` pass (`./mvnw test -Dtest=RedisDataUnitTests`)
- [x] `./mvnw compile` / `test-compile` succeed