### PR TITLE
Resolve type hint without parsing the entire payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-redis</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-GH-3012-SNAPSHOT</version>
 
 	<name>Spring Data Redis</name>
 	<description>Spring Data module for Redis</description>

--- a/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
+++ b/src/main/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializer.java
@@ -23,16 +23,12 @@ import tools.jackson.core.TreeNode;
 import tools.jackson.core.Version;
 import tools.jackson.databind.DefaultTyping;
 import tools.jackson.databind.DeserializationConfig;
-import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JacksonModule;
 import tools.jackson.databind.JavaType;
-import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.cfg.MapperBuilder;
-import tools.jackson.databind.deser.jackson.BaseNodeDeserializer;
-import tools.jackson.databind.deser.jackson.JsonNodeDeserializer;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import tools.jackson.databind.jsontype.PolymorphicTypeValidator;
@@ -68,6 +64,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * {@link JacksonObjectWriter}.
  *
  * @author Christoph Strobl
+ * @author Moritz Halbritter
  * @see JacksonObjectReader
  * @see JacksonObjectWriter
  * @see ObjectMapper
@@ -209,7 +206,7 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 		try {
 			return (T) reader.read(mapper, source, resolveType(source, type));
 		} catch (Exception ex) {
-			throw new SerializationException("Could not read JSON:%s ".formatted(ex.getMessage()), ex);
+			throw new SerializationException("Could not read JSON: %s".formatted(ex.getMessage()), ex);
 		}
 	}
 
@@ -482,41 +479,55 @@ public class GenericJacksonJsonRedisSerializer implements RedisSerializer<Object
 			return typeFactory.get().constructType(type);
 		}
 
+		/**
+		 * Resolve the {@link JavaType} to deserialize the given source into by inspecting its type hint property. Falls back
+		 * to the given {@link Class type} if the source does not declare a usable type hint. If the type hint property is
+		 * declared more than once, only its first occurrence is considered, as it is by Jackson's own type id handling.
+		 * Resolution is lenient in that it considers the type hint regardless of whether the {@link ObjectMapper} is
+		 * configured with a default typer for deserialization.
+		 *
+		 * @param source the JSON to inspect.
+		 * @param type the type to fall back to.
+		 * @return the resolved {@link JavaType}.
+		 */
 		protected JavaType resolveType(byte[] source, Class<?> type) throws IOException {
 
-			JsonNode root = readTree(source);
-			JsonNode jsonNode = root.get(hintName.get());
+			String typeHint = readTypeHint(source);
 
-			if (jsonNode != null && jsonNode.isString() && jsonNode.asString() != null) {
-				return typeFactory.get().constructFromCanonical(jsonNode.asString());
-			}
-
-			return constructType(type);
+			return typeHint != null ? typeFactory.get().constructFromCanonical(typeHint) : constructType(type);
 		}
 
 		/**
-		 * Lenient variant of ObjectMapper._readTreeAndClose using a strict {@link JsonNodeDeserializer}.
+		 * Read the type hint property of the top-level JSON object using a shallow scan of the token stream. Property values
+		 * are skipped without materializing them and the scan stops as soon as the type hint is found, so resolving the type
+		 * hint does not require parsing the entire payload.
+		 *
+		 * @param source the JSON to inspect.
+		 * @return the type hint value, or {@literal null} if the source does not declare a usable one.
 		 */
-		private JsonNode readTree(byte[] source) {
-
-			BaseNodeDeserializer<?> deserializer = JsonNodeDeserializer.getDeserializer(JsonNode.class);
-			DeserializationConfig cfg = mapper.deserializationConfig();
+		private @Nullable String readTypeHint(byte[] source) {
 
 			try (JsonParser parser = mapper.createParser(source)) {
 
-				JsonToken t = parser.currentToken();
-				if (t == null) {
-					t = parser.nextToken();
-					if (t == null) {
-						return cfg.getNodeFactory().missingNode();
-					}
+				if (parser.nextToken() != JsonToken.START_OBJECT) {
+					return null;
 				}
 
-				if (t == JsonToken.VALUE_NULL) {
-					return cfg.getNodeFactory().nullNode();
-				} else {
-					return deserializer.deserialize(parser, (DeserializationContext) parser.objectReadContext());
+				String hint = hintName.get();
+
+				for (String property = parser.nextName(); property != null; property = parser.nextName()) {
+
+					if (hint.equals(property)) {
+						// only the first type hint counts, as it does for Jackson's own AsPropertyTypeDeserializer
+						return parser.nextToken() == JsonToken.VALUE_STRING ? parser.getString() : null;
+					}
+
+					// not the type hint: skip the value, structured values included
+					parser.nextToken();
+					parser.skipChildren();
 				}
+
+				return null;
 			}
 		}
 	}

--- a/src/test/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializerUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/serializer/GenericJacksonJsonRedisSerializerUnitTests.java
@@ -27,6 +27,7 @@ import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonReadFeature;
 import tools.jackson.databind.DefaultTyping;
 import tools.jackson.databind.DeserializationConfig;
+import tools.jackson.databind.JavaType;
 import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.annotation.JsonDeserialize;
@@ -40,9 +41,12 @@ import tools.jackson.databind.jsontype.TypeResolverBuilder;
 import tools.jackson.databind.type.TypeFactory;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -62,6 +66,7 @@ import com.fasterxml.jackson.annotation.JsonView;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author John Blum
+ * @author Moritz Halbritter
  */
 class GenericJacksonJsonRedisSerializerUnitTests {
 
@@ -441,6 +446,119 @@ class GenericJacksonJsonRedisSerializerUnitTests {
 		assertThat(serializer.resolveType(source, Object.class).getRawClass()).isEqualTo(SimpleObject.class);
 	}
 
+	@Test // GH-3012
+	void resolvesTypeHintWithoutParsingEntirePayload() throws IOException {
+
+		// the payload is malformed after the type hint, so it can only be resolved without parsing the remainder
+		byte[] source = "{\"@class\":\"%s\",\"longValue\":}".formatted(SimpleObject.class.getName())
+				.getBytes(StandardCharsets.UTF_8);
+
+		assertThat(serializer.resolveType(source, Object.class).getRawClass()).isEqualTo(SimpleObject.class);
+	}
+
+	@Test // GH-3012
+	void resolvesTypeHintDeclaredAfterOtherProperties() throws IOException {
+
+		byte[] source = "{\"longValue\":1,\"nested\":{\"a\":[1,2]},\"@class\":\"%s\"}"
+				.formatted(SimpleObject.class.getName()).getBytes(StandardCharsets.UTF_8);
+
+		assertThat(serializer.resolveType(source, Object.class).getRawClass()).isEqualTo(SimpleObject.class);
+		assertThat(serializer.deserialize(source)).isEqualTo(SIMPLE_OBJECT);
+	}
+
+	@Test // GH-3012
+	void doesNotResolveTypeHintDeclaredWithinNestedValue() throws IOException {
+
+		byte[] source = "{\"nested\":{\"@class\":\"%s\"},\"longValue\":1}".formatted(SimpleObject.class.getName())
+				.getBytes(StandardCharsets.UTF_8);
+
+		assertThat(serializer.resolveType(source, Object.class).getRawClass()).isEqualTo(Object.class);
+	}
+
+	@Test // GH-3012
+	void fallsBackToGivenTypeWithoutResolvableTypeHint() throws IOException {
+
+		assertThat(resolvedRawType("{\"longValue\":1}")).isEqualTo(Object.class);
+		assertThat(resolvedRawType("{\"@class\":42}")).isEqualTo(Object.class);
+		assertThat(resolvedRawType("{\"@class\":null,\"@class\":\"%s\"}".formatted(SimpleObject.class.getName())))
+				.isEqualTo(Object.class);
+		assertThat(resolvedRawType("{}")).isEqualTo(Object.class);
+		assertThat(resolvedRawType("[1,2]")).isEqualTo(Object.class);
+		assertThat(resolvedRawType("\"just-a-string\"")).isEqualTo(Object.class);
+		assertThat(resolvedRawType("null")).isEqualTo(Object.class);
+	}
+
+	@Test // GH-3396
+	void deserializesPayloadWithDuplicateProperties() {
+
+		byte[] source = "{\"@class\":\"java.util.LinkedHashMap\",\"a\":1,\"a\":2}".getBytes(StandardCharsets.UTF_8);
+
+		assertThat(serializer.deserialize(source)).isEqualTo(Map.of("a", 2));
+	}
+
+	@Test // GH-3012
+	void resolvesCustomTypeHintPropertyName() throws IOException {
+
+		GenericJacksonJsonRedisSerializer serializer = GenericJacksonJsonRedisSerializer.create(configHelper -> {
+			configHelper.customize(mapperBuilder -> mapperBuilder.activateDefaultTypingAsProperty(
+					BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build(), DefaultTyping.NON_FINAL,
+					"_woot"));
+		});
+
+		byte[] source = "{\"@class\":\"java.lang.Void\",\"_woot\":\"%s\",\"longValue\":1}"
+				.formatted(SimpleObject.class.getName()).getBytes(StandardCharsets.UTF_8);
+
+		assertThat(serializer.resolveType(source, Object.class).getRawClass()).isEqualTo(SimpleObject.class);
+	}
+
+	@Test // GH-3012, GH-3396
+	void resolvesFirstOfDuplicateTypeHints() throws IOException {
+
+		// Jackson's own AsPropertyTypeDeserializer consumes the first type id it encounters
+		byte[] json = "{\"@class\":\"%s\",\"@class\":\"%s\",\"longValue\":1}"
+				.formatted(TypeHintSubtype.class.getName(), TypeHintSupertype.class.getName()).getBytes(StandardCharsets.UTF_8);
+
+		AtomicReference<JavaType> typeHandedToReader = new AtomicReference<>();
+
+		GenericJacksonJsonRedisSerializer serializer = GenericJacksonJsonRedisSerializer.create(configHelper -> {
+			configHelper.enableUnsafeDefaultTyping();
+			configHelper.reader((mapper, source, type) -> {
+				typeHandedToReader.set(type);
+				return mapper.readValue(source, type);
+			});
+		});
+
+		assertThat(serializer.resolveType(json, Object.class).getRawClass()).isEqualTo(TypeHintSubtype.class);
+
+		Object deserializedValue = serializer.deserialize(json);
+
+		assertThat(deserializedValue).isExactlyInstanceOf(TypeHintSubtype.class);
+		assertThat(typeHandedToReader.get().getRawClass()).isEqualTo(deserializedValue.getClass());
+
+		// resolving the type hint must agree with Jackson reading the very same payload on its own
+		ObjectMapper mapper = (ObjectMapper) getField(serializer, "mapper");
+		assertThat(mapper.readValue(json, Object.class)).hasSameClassAs(deserializedValue);
+	}
+
+	@Test // GH-3012
+	void deserializeRetainsNumberFidelity() {
+
+		BigDecimal bigDecimal = new BigDecimal("1.0000000000000000000000001");
+		BigInteger bigInteger = new BigInteger("123456789012345678901234567890");
+
+		Map<String, Object> value = new LinkedHashMap<>();
+		value.put("bigDecimal", bigDecimal);
+		value.put("bigInteger", bigInteger);
+		value.put("doubleValue", 1.1d);
+		value.put("longValue", Long.MAX_VALUE);
+
+		assertThat(serializer.deserialize(serializer.serialize(value))).isEqualTo(value);
+	}
+
+	private Class<?> resolvedRawType(String json) throws IOException {
+		return serializer.resolveType(json.getBytes(StandardCharsets.UTF_8), Object.class).getRawClass();
+	}
+
 	private static void serializeAndDeserializeNullValue(GenericJacksonJsonRedisSerializer serializer) {
 
 		NullValue nv = BeanUtils.instantiateClass(NullValue.class);
@@ -542,6 +660,13 @@ class GenericJacksonJsonRedisSerializerUnitTests {
 			return Objects.hash(getLongValue(), getMyArray(), getSimpleObject());
 		}
 	}
+
+	static class TypeHintSupertype {
+
+		public Long longValue;
+	}
+
+	static class TypeHintSubtype extends TypeHintSupertype {}
 
 	static class SimpleObject {
 


### PR DESCRIPTION
This is my take at solving https://github.com/spring-projects/spring-data-redis/issues/3012.

I implemented it only for the Jackson 3 case, as the Jackson 2 class is deprecated.

It works by using the parser to get tokens until we reach the first `@class` and use that as the class name instead of parsing the whole JSON in a `JsonNode`.

We don't reuse the parsed `JsonNode`, (as the spike in 8aaf501b73a8c74df7db839793d55b6e83720835 does) as this breaks number handling with `double` and `BigDecimal`, see the `org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializerUnitTests#deserializeRetainsNumberFidelity()` test.

> the loss happens at tree-build time, before any type information is applied. That's precisely why "parse once into a tree, then convert" cannot be made correct by being smarter about types, and why the commit went with a shallow token scan plus a full re-read instead.

That's also the reason why https://github.com/spring-projects/spring-data-redis/pull/3366 is not suitable for us - this was the PR which sent me down this rabbit hole.

When we merge this, we should clarify that #3012 is about Jackson 3, not Jackson 2.