### PR TITLE
Fix broken links in Redis reference documentation

### DIFF
--- a/src/main/antora/modules/ROOT/pages/redis/drivers.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/drivers.adoc
@@ -47,11 +47,11 @@ The following overview explains features that are supported by the individual Re
 | X
 | X
 
-| xref:redis.adoc#redis:write-to-master-read-from-replica[Master/Replica Connections]
+| xref:redis/connection-modes.adoc#redis:write-to-master-read-from-replica[Master/Replica Connections]
 | X
 |
 
-| xref:redis.adoc#redis:sentinel[Redis Sentinel]
+| xref:redis/connection-modes.adoc#redis:sentinel[Redis Sentinel]
 | Master Lookup, Sentinel Authentication, Replica Reads
 | Master Lookup
 

--- a/src/main/antora/modules/ROOT/pages/redis/hash-mappers.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/hash-mappers.adoc
@@ -6,7 +6,7 @@ Ideally, JSON can be stored as a value by using plain keys.
 You can achieve a more sophisticated mapping of structured objects by using Redis hashes.
 Spring Data Redis offers various strategies for mapping data to hashes (depending on the use case):
 
-* Direct mapping, by using javadoc:org.springframework.data.redis.core.HashOperations[] and a xref:redis.adoc#redis:serializer[serializer]
+* Direct mapping, by using javadoc:org.springframework.data.redis.core.HashOperations[] and a xref:redis/template.adoc#redis:serializer[serializer]
 * Using xref:repositories.adoc[Redis Repositories]
 * Using javadoc:org.springframework.data.redis.hash.HashMapper[] and javadoc:org.springframework.data.redis.core.HashOperations[]
 

--- a/src/main/antora/modules/ROOT/pages/redis/pubsub-receiving.adoc
+++ b/src/main/antora/modules/ROOT/pages/redis/pubsub-receiving.adoc
@@ -11,7 +11,7 @@ To change the subscription of a connection or query whether it is listening, `Re
 NOTE: Subscription commands in Spring Data Redis are blocking.
 That is, calling subscribe on a connection causes the current thread to block as it starts waiting for messages.
 The thread is released only if the subscription is canceled, which happens when another thread invokes `unsubscribe` or `pUnsubscribe` on the *same* connection.
-See "`xref:redis/pubsub.adoc#redis:pubsub:subscribe:containers[Message Listener Containers]`" (later in this document) for a solution to this problem.
+See "`xref:redis/pubsub-receiving.adoc#container[Message Listener Containers]`" (later in this document) for a solution to this problem.
 
 As mentioned earlier, once subscribed, a connection starts waiting for messages.
 Only commands that add new subscriptions, modify existing subscriptions, and cancel existing subscriptions are allowed.


### PR DESCRIPTION
## Summary

- Fix the Master/Replica and Redis Sentinel links to point to the Connection Modes documentation.
- Fix the serializer link in the Hash Mapping documentation.
- Fix the Message Listener Containers link in the Pub/Sub documentation.

## Test plan

- Ran `git diff --check`.
- Verified that each referenced target file and anchor exists.
