### PR TITLE
Return converted StringRedisConnection results during MULTI.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -85,6 +85,7 @@ import org.springframework.util.ObjectUtils;
  * @author Jeonggyu Choi
  * @author Mingi Lee
  * @author Yordan Tsintsov
+ * @author arimu1
  */
 @NullUnmarked
 @SuppressWarnings({ "ConstantConditions", "deprecation" })
@@ -3226,7 +3227,11 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 		if (isFutureConversion()) {
 
 			addResultConverter(converter);
-			return null;
+			if (value == null) {
+				return null;
+			}
+			// Delegate already produced a result (for example a ConnectionSplittingInterceptor
+			// unbound read during MULTI). Convert it now instead of discarding it.
 		}
 
 		if (!(converter instanceof ListConverter) && value instanceof List list) {

--- a/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTxTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/DefaultStringRedisConnectionTxTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
@@ -35,6 +36,7 @@ import org.springframework.data.redis.connection.stream.StreamRecords;
  * @author Christoph Strobl
  * @author Ninad Divadkar
  * @author Viktoriya Kutsarova
+ * @author arimu1
  */
 public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConnectionTests {
 
@@ -199,6 +201,15 @@ public class DefaultStringRedisConnectionTxTests extends DefaultStringRedisConne
 	public void testGet() {
 		doReturn(Arrays.asList(new Object[] { barBytes })).when(nativeConnection).exec();
 		super.testGet();
+	}
+
+	@Test // GH-2953
+	void getReturnsConvertedValueWhenDelegateProducesResultDuringTransaction() {
+
+		doReturn(barBytes).when(nativeConnection).get(fooBytes);
+
+		assertThat(connection.get(foo)).isEqualTo(bar);
+		assertThat(connection.get(fooBytes)).isEqualTo(barBytes);
 	}
 
 	@Test


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

`DefaultStringRedisConnection.convertAndReturn` discarded already-available delegate results when `isFutureConversion()` was true. Transactional reads that wrap a `ConnectionSplittingInterceptor` unbound connection therefore returned `null` instead of the converted value.

Queued commands that still return `null` from the driver are unchanged (converter registered, `exec()` / `closePipeline()` convert later).

Fixes #2953