### PR TITLE
Migrate legacy Jedis Cluster API to `UnifiedJedis`

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -69,7 +69,7 @@ import org.springframework.util.Assert;
  * {@link RedisClusterConnection} implementation on top of {@link RedisClusterClient}.
  * <p>
  * Uses the native {@link RedisClusterClient} api where possible and falls back to direct node communication using
- * {@link Jedis} where needed.
+ * {@link UnifiedJedis} where needed.
  * <p>
  * Pipelines and transactions are not supported in cluster mode. This class is not Thread-safe and instances should not
  * be shared across threads.
@@ -322,9 +322,8 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 		Assert.notNull(keys, "Key must not be null");
 		Assert.notNull(args, "Args must not be null");
 
-		JedisMultiKeyClusterCommandCallback<T> commandCallback = (jedis, key) -> (T) jedis
-				.executeCommand(new CommandArguments(JedisClientUtils.getCommand(command))
-						.addObjects(getCommandArguments(key, args)));
+		JedisMultiKeyClusterCommandCallback<T> commandCallback = (jedis, key) -> (T) jedis.executeCommand(
+				new CommandArguments(JedisClientUtils.getCommand(command)).addObjects(getCommandArguments(key, args)));
 
 		return this.clusterCommandExecutor.executeMultiKeyCommand(commandCallback, keys).resultsAsList();
 	}
@@ -483,14 +482,14 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 		String slotId = String.valueOf(slot);
 
 		JedisClusterCommandCallback<Object> command = client -> switch (mode) {
-			case IMPORTING -> client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
-					.add("SETSLOT").add(slotId).add("IMPORTING").add(nodeId));
-			case MIGRATING -> client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
-					.add("SETSLOT").add(slotId).add("MIGRATING").add(nodeId));
-			case STABLE -> client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
-					.add("SETSLOT").add(slotId).add("STABLE"));
-			case NODE -> client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
-					.add("SETSLOT").add(slotId).add("NODE").add(nodeId));
+			case IMPORTING -> client.executeCommand(
+					new CommandArguments(Protocol.Command.CLUSTER).add("SETSLOT").add(slotId).add("IMPORTING").add(nodeId));
+			case MIGRATING -> client.executeCommand(
+					new CommandArguments(Protocol.Command.CLUSTER).add("SETSLOT").add(slotId).add("MIGRATING").add(nodeId));
+			case STABLE ->
+				client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("SETSLOT").add(slotId).add("STABLE"));
+			case NODE -> client.executeCommand(
+					new CommandArguments(Protocol.Command.CLUSTER).add("SETSLOT").add(slotId).add("NODE").add(nodeId));
 		};
 
 		this.clusterCommandExecutor.executeCommandOnSingleNode(command, node);
@@ -601,8 +600,7 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 		RedisClusterNode masterNode = this.topologyProvider.getTopology().lookup(master);
 
 		JedisClusterCommandCallback<Object> command = client -> client
-				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("REPLICATE")
-						.add(masterNode.getId()));
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("REPLICATE").add(masterNode.getId()));
 
 		this.clusterCommandExecutor.executeCommandOnSingleNode(command, replica);
 	}
@@ -610,9 +608,8 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	@Override
 	public Integer clusterGetSlotForKey(byte @NonNull [] key) {
 
-		JedisClusterCommandCallback<Integer> command = client -> ((Long) client
-				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("KEYSLOT")
-						.add(JedisConverters.toString(key)))).intValue();
+		JedisClusterCommandCallback<Integer> command = client -> ((Long) client.executeCommand(
+				new CommandArguments(Protocol.Command.CLUSTER).add("KEYSLOT").add(key))).intValue();
 
 		return this.clusterCommandExecutor.executeCommandOnArbitraryNode(command).getValue();
 	}
@@ -646,9 +643,8 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 
 		RedisClusterNode nodeToUse = this.topologyProvider.getTopology().lookup(master);
 
-		JedisClusterCommandCallback<List<String>> command = client -> JedisConverters
-				.toStrings((List<byte[]>) client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
-						.add("SLAVES").add(nodeToUse.getId())));
+		JedisClusterCommandCallback<List<String>> command = client -> JedisConverters.toStrings((List<byte[]>) client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("SLAVES").add(nodeToUse.getId())));
 
 		List<String> clusterNodes = this.clusterCommandExecutor.executeCommandOnSingleNode(command, master).getValue();
 
@@ -660,10 +656,10 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 
 		JedisClusterCommandCallback<Collection<RedisClusterNode>> command = client -> {
 
-			String myId = JedisConverters.toString((byte[]) client
-					.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("MYID")));
-			List<String> replicas = JedisConverters.toStrings((List<byte[]>) client
-					.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("SLAVES").add(myId)));
+			String myId = JedisConverters
+					.toString((byte[]) client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("MYID")));
+			List<String> replicas = JedisConverters.toStrings(
+					(List<byte[]>) client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("SLAVES").add(myId)));
 
 			return JedisConverters.toSetOfRedisClusterNodes(replicas);
 		};
@@ -684,8 +680,8 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	@Override
 	public ClusterInfo clusterGetClusterInfo() {
 
-		JedisClusterCommandCallback<String> command = client -> JedisConverters.toString((byte[]) client
-				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("INFO")));
+		JedisClusterCommandCallback<String> command = client -> JedisConverters
+				.toString((byte[]) client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("INFO")));
 
 		String source = this.clusterCommandExecutor.executeCommandOnArbitraryNode(command).getValue();
 
@@ -747,7 +743,7 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	}
 
 	/**
-	 * {@link Jedis} specific {@link ClusterCommandCallback}.
+	 * {@link UnifiedJedis} specific {@link ClusterCommandCallback}.
 	 *
 	 * @author Christoph Strobl
 	 * @param <T>
@@ -756,7 +752,7 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	protected interface JedisClusterCommandCallback<T> extends ClusterCommandCallback<UnifiedJedis, T> {}
 
 	/**
-	 * {@link Jedis} specific {@link MultiKeyClusterCommandCallback}.
+	 * {@link UnifiedJedis} specific {@link MultiKeyClusterCommandCallback}.
 	 *
 	 * @author Christoph Strobl
 	 * @param <T>

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -15,18 +15,21 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisClusterInfoCache;
+import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisClusterClient;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.providers.ClusterConnectionProvider;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -35,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -250,8 +254,8 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 		Assert.notNull(command, "Command must not be null");
 		Assert.notNull(args, "Args must not be null");
 
-		JedisClusterCommandCallback<Object> commandCallback = jedis -> jedis
-				.sendCommand(JedisClientUtils.getCommand(command), args);
+		JedisClusterCommandCallback<Object> commandCallback = client -> client
+				.executeCommand(new CommandArguments(JedisClientUtils.getCommand(command)).addObjects(args));
 
 		return this.clusterCommandExecutor.executeCommandOnArbitraryNode(commandCallback).getValue();
 	}
@@ -268,8 +272,8 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 
 		RedisClusterNode keyMaster = this.topologyProvider.getTopology().getKeyServingMasterNode(key);
 
-		JedisClusterCommandCallback<T> commandCallback = jedis -> (T) jedis
-				.sendCommand(JedisClientUtils.getCommand(command), commandArgs);
+		JedisClusterCommandCallback<T> commandCallback = client -> (T) client
+				.executeCommand(new CommandArguments(JedisClientUtils.getCommand(command)).addObjects(commandArgs));
 
 		return this.clusterCommandExecutor.executeCommandOnSingleNode(commandCallback, keyMaster).getValue();
 	}
@@ -318,8 +322,9 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 		Assert.notNull(keys, "Key must not be null");
 		Assert.notNull(args, "Args must not be null");
 
-		JedisMultiKeyClusterCommandCallback<T> commandCallback = (jedis,
-				key) -> (T) jedis.sendCommand(JedisClientUtils.getCommand(command), getCommandArguments(key, args));
+		JedisMultiKeyClusterCommandCallback<T> commandCallback = (jedis, key) -> (T) jedis
+				.executeCommand(new CommandArguments(JedisClientUtils.getCommand(command))
+						.addObjects(getCommandArguments(key, args)));
 
 		return this.clusterCommandExecutor.executeMultiKeyCommand(commandCallback, keys).resultsAsList();
 	}
@@ -450,7 +455,7 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	@Override
 	public String ping() {
 
-		JedisClusterCommandCallback<String> command = Jedis::ping;
+		JedisClusterCommandCallback<String> command = UnifiedJedis::ping;
 
 		return !this.clusterCommandExecutor.executeCommandOnAllNodes(command).resultsAsList().isEmpty() ? "PONG" : null;
 	}
@@ -458,7 +463,7 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	@Override
 	public String ping(@NonNull RedisClusterNode node) {
 
-		JedisClusterCommandCallback<String> command = Jedis::ping;
+		JedisClusterCommandCallback<String> command = UnifiedJedis::ping;
 
 		return this.clusterCommandExecutor.executeCommandOnSingleNode(command, node).getValue();
 	}
@@ -475,12 +480,17 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 
 		RedisClusterNode nodeToUse = this.topologyProvider.getTopology().lookup(node);
 		String nodeId = nodeToUse.getId();
+		String slotId = String.valueOf(slot);
 
-		JedisClusterCommandCallback<String> command = jedis -> switch (mode) {
-			case IMPORTING -> jedis.clusterSetSlotImporting(slot, nodeId);
-			case MIGRATING -> jedis.clusterSetSlotMigrating(slot, nodeId);
-			case STABLE -> jedis.clusterSetSlotStable(slot);
-			case NODE -> jedis.clusterSetSlotNode(slot, nodeId);
+		JedisClusterCommandCallback<Object> command = client -> switch (mode) {
+			case IMPORTING -> client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
+					.add("SETSLOT").add(slotId).add("IMPORTING").add(nodeId));
+			case MIGRATING -> client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
+					.add("SETSLOT").add(slotId).add("MIGRATING").add(nodeId));
+			case STABLE -> client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
+					.add("SETSLOT").add(slotId).add("STABLE"));
+			case NODE -> client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
+					.add("SETSLOT").add(slotId).add("NODE").add(nodeId));
 		};
 
 		this.clusterCommandExecutor.executeCommandOnSingleNode(command, node);
@@ -490,9 +500,11 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	public List<byte[]> clusterGetKeysInSlot(int slot, @NonNull Integer count) {
 
 		RedisClusterNode node = clusterGetNodeForSlot(slot);
+		String slotId = String.valueOf(slot);
 
-		JedisClusterCommandCallback<List<byte[]>> command = jedis -> JedisConverters.stringListToByteList()
-				.convert(jedis.clusterGetKeysInSlot(slot, nullSafeIntValue(count)));
+		JedisClusterCommandCallback<List<byte[]>> command = client -> (List<byte[]>) client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("GETKEYSINSLOT").add(slotId)
+						.add(String.valueOf(nullSafeIntValue(count))));
 
 		NodeResult<List<byte[]>> result = this.clusterCommandExecutor.executeCommandOnSingleNode(command, node);
 
@@ -506,7 +518,11 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	@Override
 	public void clusterAddSlots(@NonNull RedisClusterNode node, int @NonNull... slots) {
 
-		JedisClusterCommandCallback<String> command = jedis -> jedis.clusterAddSlots(slots);
+		String[] args = Stream.concat(Stream.of("ADDSLOTS"), Arrays.stream(slots).mapToObj(String::valueOf))
+				.toArray(String[]::new);
+
+		JedisClusterCommandCallback<Object> command = client -> client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).addObjects(args));
 
 		this.clusterCommandExecutor.executeCommandOnSingleNode(command, node);
 	}
@@ -523,8 +539,10 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	public Long clusterCountKeysInSlot(int slot) {
 
 		RedisClusterNode node = clusterGetNodeForSlot(slot);
+		String slotId = String.valueOf(slot);
 
-		JedisClusterCommandCallback<Long> command = jedis -> jedis.clusterCountKeysInSlot(slot);
+		JedisClusterCommandCallback<Long> command = client -> (Long) client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("COUNTKEYSINSLOT").add(slotId));
 
 		return this.clusterCommandExecutor.executeCommandOnSingleNode(command, node).getValue();
 	}
@@ -532,7 +550,10 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	@Override
 	public void clusterDeleteSlots(@NonNull RedisClusterNode node, int @NonNull... slots) {
 
-		JedisClusterCommandCallback<String> command = jedis -> jedis.clusterDelSlots(slots);
+		String[] args = Stream.concat(Stream.of("DELSLOTS"), Arrays.stream(slots).mapToObj(String::valueOf))
+				.toArray(String[]::new);
+		JedisClusterCommandCallback<Object> command = client -> client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).addObjects(args));
 
 		this.clusterCommandExecutor.executeCommandOnSingleNode(command, node);
 	}
@@ -553,7 +574,8 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 
 		nodes.remove(nodeToRemove);
 
-		JedisClusterCommandCallback<String> command = jedis -> jedis.clusterForget(node.getId());
+		JedisClusterCommandCallback<Object> command = client -> client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("FORGET").add(node.getId()));
 
 		this.clusterCommandExecutor.executeCommandAsyncOnNodes(command, nodes);
 	}
@@ -566,8 +588,9 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 		Assert.hasText(node.getHost(), "Node to meet cluster must have a host");
 		Assert.isTrue(node.getPort() > 0, "Node to meet cluster must have a port greater 0");
 
-		JedisClusterCommandCallback<String> command = jedis -> jedis.clusterMeet(node.getRequiredHost(),
-				node.getRequiredPort());
+		JedisClusterCommandCallback<Object> command = client -> client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("MEET").add(node.getRequiredHost())
+						.add(String.valueOf(node.getRequiredPort())));
 
 		this.clusterCommandExecutor.executeCommandOnAllNodes(command);
 	}
@@ -577,7 +600,9 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 
 		RedisClusterNode masterNode = this.topologyProvider.getTopology().lookup(master);
 
-		JedisClusterCommandCallback<String> command = jedis -> jedis.clusterReplicate(masterNode.getId());
+		JedisClusterCommandCallback<Object> command = client -> client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("REPLICATE")
+						.add(masterNode.getId()));
 
 		this.clusterCommandExecutor.executeCommandOnSingleNode(command, replica);
 	}
@@ -585,8 +610,9 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	@Override
 	public Integer clusterGetSlotForKey(byte @NonNull [] key) {
 
-		JedisClusterCommandCallback<Integer> command = jedis -> Long
-				.valueOf(jedis.clusterKeySlot(JedisConverters.toString(key))).intValue();
+		JedisClusterCommandCallback<Integer> command = client -> ((Long) client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("KEYSLOT")
+						.add(JedisConverters.toString(key)))).intValue();
 
 		return this.clusterCommandExecutor.executeCommandOnArbitraryNode(command).getValue();
 	}
@@ -620,7 +646,9 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 
 		RedisClusterNode nodeToUse = this.topologyProvider.getTopology().lookup(master);
 
-		JedisClusterCommandCallback<List<String>> command = jedis -> jedis.clusterSlaves(nodeToUse.getId());
+		JedisClusterCommandCallback<List<String>> command = client -> JedisConverters
+				.toStrings((List<byte[]>) client.executeCommand(new CommandArguments(Protocol.Command.CLUSTER)
+						.add("SLAVES").add(nodeToUse.getId())));
 
 		List<String> clusterNodes = this.clusterCommandExecutor.executeCommandOnSingleNode(command, master).getValue();
 
@@ -630,8 +658,15 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	@Override
 	public Map<RedisClusterNode, Collection<RedisClusterNode>> clusterGetMasterReplicaMap() {
 
-		JedisClusterCommandCallback<Collection<RedisClusterNode>> command = jedis -> JedisConverters
-				.toSetOfRedisClusterNodes(jedis.clusterSlaves(jedis.clusterMyId()));
+		JedisClusterCommandCallback<Collection<RedisClusterNode>> command = client -> {
+
+			String myId = JedisConverters.toString((byte[]) client
+					.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("MYID")));
+			List<String> replicas = JedisConverters.toStrings((List<byte[]>) client
+					.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("SLAVES").add(myId)));
+
+			return JedisConverters.toSetOfRedisClusterNodes(replicas);
+		};
 
 		Set<RedisClusterNode> activeMasterNodes = this.topologyProvider.getTopology().getActiveMasterNodes();
 
@@ -643,14 +678,14 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 		for (NodeResult<Collection<RedisClusterNode>> nodeResult : nodeResults) {
 			result.put(nodeResult.getNode(), nodeResult.getValue());
 		}
-
 		return result;
 	}
 
 	@Override
 	public ClusterInfo clusterGetClusterInfo() {
 
-		JedisClusterCommandCallback<String> command = Jedis::clusterInfo;
+		JedisClusterCommandCallback<String> command = client -> JedisConverters.toString((byte[]) client
+				.executeCommand(new CommandArguments(Protocol.Command.CLUSTER).add("INFO")));
 
 		String source = this.clusterCommandExecutor.executeCommandOnArbitraryNode(command).getValue();
 
@@ -718,7 +753,7 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	 * @param <T>
 	 * @since 1.7
 	 */
-	protected interface JedisClusterCommandCallback<T> extends ClusterCommandCallback<Jedis, T> {}
+	protected interface JedisClusterCommandCallback<T> extends ClusterCommandCallback<UnifiedJedis, T> {}
 
 	/**
 	 * {@link Jedis} specific {@link MultiKeyClusterCommandCallback}.
@@ -727,7 +762,7 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 	 * @param <T>
 	 * @since 1.7
 	 */
-	protected interface JedisMultiKeyClusterCommandCallback<T> extends MultiKeyClusterCommandCallback<Jedis, T> {}
+	protected interface JedisMultiKeyClusterCommandCallback<T> extends MultiKeyClusterCommandCallback<UnifiedJedis, T> {}
 
 	/**
 	 * Jedis specific implementation of {@link ClusterNodeResourceProvider}.

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterConnection.java
@@ -798,19 +798,19 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 
 		@Override
 		@SuppressWarnings("unchecked")
-		public Jedis getResourceForSpecificNode(RedisClusterNode node) {
+		public UnifiedJedis getResourceForSpecificNode(RedisClusterNode node) {
 
 			Assert.notNull(node, "Cannot get Pool for 'null' node");
 
 			ConnectionPool pool = getResourcePoolForSpecificNode(node);
 			if (pool != null) {
-				return new Jedis(pool.getResource());
+				return new UnifiedJedisAdapter(new Jedis(pool.getResource()));
 			}
 
 			Connection connection = getConnectionForSpecificNode(node);
 
 			if (connection != null) {
-				return new Jedis(connection);
+				return new UnifiedJedisAdapter(new Jedis(connection));
 			}
 
 			throw new DataAccessResourceFailureException("Node %s is unknown to cluster".formatted(node));
@@ -847,7 +847,7 @@ public class JedisClusterConnection extends JedisConnection implements RedisClus
 
 		@Override
 		public void returnResourceForSpecificNode(@NonNull RedisClusterNode node, @NonNull Object client) {
-			((Jedis) client).close();
+			((UnifiedJedisAdapter) client).getJedis().close();
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterJsonCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterJsonCommands.java
@@ -52,10 +52,9 @@ class JedisClusterJsonCommands extends JedisJsonCommands {
 		}
 
 		List<List<byte[]>> results = connection.getClusterCommandExecutor()
-				.executeMultiKeyCommand(
-						(JedisMultiKeyClusterCommandCallback<List<byte[]>>) (client, key) -> toJsonBytes(
-								client.jsonMGet(getPath(path), JedisConverters.toString(key))),
-						Arrays.asList(keys)).resultsAsListSortBy(keys).stream().toList();
+				.executeMultiKeyCommand((JedisMultiKeyClusterCommandCallback<List<byte[]>>) (client,
+						key) -> toJsonBytes(client.jsonMGet(getPath(path), JedisConverters.toString(key))), Arrays.asList(keys))
+				.resultsAsListSortBy(keys).stream().toList();
 
 		List<byte[]> result = new ArrayList<>();
 		for (List<byte[]> list : results) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterJsonCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterJsonCommands.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.springframework.data.redis.connection.ClusterSlotHashUtil;
 import org.springframework.data.redis.connection.RedisJsonCommands;
+import org.springframework.data.redis.connection.jedis.JedisClusterConnection.JedisMultiKeyClusterCommandCallback;
 import org.springframework.data.redis.connection.json.JsonPath;
 import org.springframework.util.Assert;
 
@@ -50,9 +51,11 @@ class JedisClusterJsonCommands extends JedisJsonCommands {
 			return super.jsonMGet(path, keys);
 		}
 
-		List<List<byte[]>> results = connection.getClusterCommandExecutor().executeMultiKeyCommand((client, key) -> {
-			return super.jsonMGet(path, key);
-		}, Arrays.asList(keys)).resultsAsListSortBy(keys).stream().toList();
+		List<List<byte[]>> results = connection.getClusterCommandExecutor()
+				.executeMultiKeyCommand(
+						(JedisMultiKeyClusterCommandCallback<List<byte[]>>) (client, key) -> toJsonBytes(
+								client.jsonMGet(getPath(path), JedisConverters.toString(key))),
+						Arrays.asList(keys)).resultsAsListSortBy(keys).stream().toList();
 
 		List<byte[]> result = new ArrayList<>();
 		for (List<byte[]> list : results) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterScriptingCommands.java
@@ -51,8 +51,8 @@ class JedisClusterScriptingCommands extends JedisScriptingCommands {
 	public void scriptFlush() {
 
 		try {
-			connection.getClusterCommandExecutor()
-					.executeCommandOnAllNodes((JedisClusterConnection.JedisClusterCommandCallback<String>) UnifiedJedis::scriptFlush);
+			connection.getClusterCommandExecutor().executeCommandOnAllNodes(
+					(JedisClusterConnection.JedisClusterCommandCallback<String>) UnifiedJedis::scriptFlush);
 		} catch (Exception ex) {
 			throw connection.convertJedisAccessException(ex);
 		}
@@ -62,8 +62,8 @@ class JedisClusterScriptingCommands extends JedisScriptingCommands {
 	public void scriptKill() {
 
 		try {
-			connection.getClusterCommandExecutor()
-					.executeCommandOnAllNodes((JedisClusterConnection.JedisClusterCommandCallback<String>) UnifiedJedis::scriptKill);
+			connection.getClusterCommandExecutor().executeCommandOnAllNodes(
+					(JedisClusterConnection.JedisClusterCommandCallback<String>) UnifiedJedis::scriptKill);
 		} catch (Exception ex) {
 			throw connection.convertJedisAccessException(ex);
 		}
@@ -76,8 +76,8 @@ class JedisClusterScriptingCommands extends JedisScriptingCommands {
 
 		try {
 			ClusterCommandExecutor.MultiNodeResult<String> multiNodeResult = connection.getClusterCommandExecutor()
-					.executeCommandOnAllNodes(
-							(JedisClusterConnection.JedisClusterCommandCallback<String>) client -> client.scriptLoad(JedisConverters.toString(script)));
+					.executeCommandOnAllNodes((JedisClusterConnection.JedisClusterCommandCallback<String>) client -> client
+							.scriptLoad(JedisConverters.toString(script)));
 
 			return multiNodeResult.getFirstNonNullNotEmptyOrDefault("");
 		} catch (Exception ex) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterScriptingCommands.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
-import redis.clients.jedis.Jedis;
-
 import java.util.List;
 
 import org.jspecify.annotations.NonNull;

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterScriptingCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterScriptingCommands.java
@@ -25,6 +25,7 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.ClusterCommandExecutor;
 import org.springframework.data.redis.connection.RedisScriptingCommands;
 import org.springframework.util.Assert;
+import redis.clients.jedis.UnifiedJedis;
 
 /**
  * Cluster {@link RedisScriptingCommands} implementation for Jedis.
@@ -53,7 +54,7 @@ class JedisClusterScriptingCommands extends JedisScriptingCommands {
 
 		try {
 			connection.getClusterCommandExecutor()
-					.executeCommandOnAllNodes((JedisClusterConnection.JedisClusterCommandCallback<String>) Jedis::scriptFlush);
+					.executeCommandOnAllNodes((JedisClusterConnection.JedisClusterCommandCallback<String>) UnifiedJedis::scriptFlush);
 		} catch (Exception ex) {
 			throw connection.convertJedisAccessException(ex);
 		}
@@ -64,7 +65,7 @@ class JedisClusterScriptingCommands extends JedisScriptingCommands {
 
 		try {
 			connection.getClusterCommandExecutor()
-					.executeCommandOnAllNodes((JedisClusterConnection.JedisClusterCommandCallback<String>) Jedis::scriptKill);
+					.executeCommandOnAllNodes((JedisClusterConnection.JedisClusterCommandCallback<String>) UnifiedJedis::scriptKill);
 		} catch (Exception ex) {
 			throw connection.convertJedisAccessException(ex);
 		}
@@ -76,11 +77,11 @@ class JedisClusterScriptingCommands extends JedisScriptingCommands {
 		Assert.notNull(script, "Script must not be null");
 
 		try {
-			ClusterCommandExecutor.MultiNodeResult<byte[]> multiNodeResult = connection.getClusterCommandExecutor()
+			ClusterCommandExecutor.MultiNodeResult<String> multiNodeResult = connection.getClusterCommandExecutor()
 					.executeCommandOnAllNodes(
-							(JedisClusterConnection.JedisClusterCommandCallback<byte[]>) client -> client.scriptLoad(script));
+							(JedisClusterConnection.JedisClusterCommandCallback<String>) client -> client.scriptLoad(JedisConverters.toString(script)));
 
-			return JedisConverters.toString(multiNodeResult.getFirstNonNullNotEmptyOrDefault(new byte[0]));
+			return multiNodeResult.getFirstNonNullNotEmptyOrDefault("");
 		} catch (Exception ex) {
 			throw connection.convertJedisAccessException(ex);
 		}

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterServerCommands.java
@@ -15,7 +15,10 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.params.MigrateParams;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,30 +60,37 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public void bgReWriteAof(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(Jedis::bgrewriteaof, node);
+		executeCommandOnSingleNode(
+				client -> client.executeCommand(new CommandArguments(Protocol.Command.BGREWRITEAOF)), node);
 	}
 
 	@Override
 	public void bgReWriteAof() {
 		connection.getClusterCommandExecutor()
-				.executeCommandOnAllNodes((JedisClusterCommandCallback<String>) Jedis::bgrewriteaof);
+				.executeCommandOnAllNodes((JedisClusterCommandCallback<Object>) client -> client
+						.executeCommand(new CommandArguments(Protocol.Command.BGREWRITEAOF)));
 	}
 
 	@Override
 	public void bgSave() {
 		connection.getClusterCommandExecutor()
-				.executeCommandOnAllNodes((JedisClusterCommandCallback<String>) Jedis::bgsave);
+				.executeCommandOnAllNodes((JedisClusterCommandCallback<Object>) client -> client
+						.executeCommand(new CommandArguments(Protocol.Command.BGSAVE)));
 	}
 
 	@Override
 	public void bgSave(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(Jedis::bgsave, node);
+		executeCommandOnSingleNode(
+				client -> client.executeCommand(new CommandArguments(Protocol.Command.BGSAVE)), node);
 	}
 
 	@Override
 	public Long lastSave() {
 
-		List<Long> result = new ArrayList<>(executeCommandOnAllNodes(Jedis::lastsave).resultsAsList());
+		JedisClusterCommandCallback<Long> command = client -> (Long) client
+				.executeCommand(new CommandArguments(Protocol.Command.LASTSAVE));
+
+		List<Long> result = new ArrayList<>(executeCommandOnAllNodes(command).resultsAsList());
 
 		if (CollectionUtils.isEmpty(result)) {
 			return null;
@@ -92,23 +102,27 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public Long lastSave(@NonNull RedisClusterNode node) {
-		return executeCommandOnSingleNode(Jedis::lastsave, node).getValue();
+
+		JedisClusterCommandCallback<Long> command = client -> (Long) client
+				.executeCommand(new CommandArguments(Protocol.Command.LASTSAVE));
+
+		return executeCommandOnSingleNode(command, node).getValue();
 	}
 
 	@Override
 	public void save() {
-		executeCommandOnAllNodes(Jedis::save);
+		executeCommandOnAllNodes(client -> client.executeCommand(new CommandArguments(Protocol.Command.SAVE)));
 	}
 
 	@Override
 	public void save(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(Jedis::save, node);
+		executeCommandOnSingleNode(client -> client.executeCommand(new CommandArguments(Protocol.Command.SAVE)), node);
 	}
 
 	@Override
 	public Long dbSize() {
 
-		Collection<Long> dbSizes = executeCommandOnAllNodes(Jedis::dbSize).resultsAsList();
+		Collection<Long> dbSizes = executeCommandOnAllNodes(UnifiedJedis::dbSize).resultsAsList();
 
 		if (CollectionUtils.isEmpty(dbSizes)) {
 			return 0L;
@@ -123,49 +137,54 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public Long dbSize(@NonNull RedisClusterNode node) {
-		return executeCommandOnSingleNode(Jedis::dbSize, node).getValue();
+		return executeCommandOnSingleNode(UnifiedJedis::dbSize, node).getValue();
 	}
 
 	@Override
 	public void flushDb() {
-		executeCommandOnAllNodes(Jedis::flushDB);
+		executeCommandOnAllNodes(UnifiedJedis::flushDB);
 	}
 
 	@Override
 	public void flushDb(@NonNull FlushOption option) {
-		executeCommandOnAllNodes(it -> it.flushDB(JedisConverters.toFlushMode(option)));
+		executeCommandOnAllNodes(client -> client.executeCommand(
+				new CommandArguments(Protocol.Command.FLUSHDB).add(JedisConverters.toFlushMode(option).name())));
 	}
 
 	@Override
 	public void flushDb(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(Jedis::flushDB, node);
+		executeCommandOnSingleNode(UnifiedJedis::flushDB, node);
 	}
 
 	@Override
 	public void flushDb(@NonNull RedisClusterNode node, @NonNull FlushOption option) {
-		executeCommandOnSingleNode(it -> it.flushDB(JedisConverters.toFlushMode(option)), node);
+		executeCommandOnSingleNode(client -> client.executeCommand(
+				new CommandArguments(Protocol.Command.FLUSHDB).add(JedisConverters.toFlushMode(option).name())), node);
 	}
 
 	@Override
 	public void flushAll() {
 		connection.getClusterCommandExecutor()
-				.executeCommandOnAllNodes((JedisClusterCommandCallback<String>) Jedis::flushAll);
+				.executeCommandOnAllNodes((JedisClusterCommandCallback<String>) UnifiedJedis::flushAll);
 	}
 
 	@Override
 	public void flushAll(@NonNull FlushOption option) {
 		connection.getClusterCommandExecutor().executeCommandOnAllNodes(
-				(JedisClusterCommandCallback<String>) it -> it.flushAll(JedisConverters.toFlushMode(option)));
+				(JedisClusterCommandCallback<Object>) client -> client
+						.executeCommand(new CommandArguments(Protocol.Command.FLUSHALL)
+								.add(JedisConverters.toFlushMode(option).name())));
 	}
 
 	@Override
 	public void flushAll(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(Jedis::flushAll, node);
+		executeCommandOnSingleNode(UnifiedJedis::flushAll, node);
 	}
 
 	@Override
 	public void flushAll(@NonNull RedisClusterNode node, @NonNull FlushOption option) {
-		executeCommandOnSingleNode(it -> it.flushAll(JedisConverters.toFlushMode(option)), node);
+		executeCommandOnSingleNode(client -> client.executeCommand(
+				new CommandArguments(Protocol.Command.FLUSHALL).add(JedisConverters.toFlushMode(option).name())), node);
 	}
 
 	@Override
@@ -189,7 +208,7 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public Properties info(@NonNull RedisClusterNode node) {
-		return JedisConverters.toProperties(executeCommandOnSingleNode(Jedis::info, node).getValue());
+		return JedisConverters.toProperties(executeCommandOnSingleNode(UnifiedJedis::info, node).getValue());
 	}
 
 	@Override
@@ -223,18 +242,15 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public void shutdown() {
-		connection.getClusterCommandExecutor().executeCommandOnAllNodes((JedisClusterCommandCallback<String>) jedis -> {
-			jedis.shutdown();
-			return null;
-		});
+		connection.getClusterCommandExecutor().executeCommandOnAllNodes(
+				(JedisClusterCommandCallback<Object>) client -> client.executeCommand(
+						new CommandArguments(Protocol.Command.SHUTDOWN)));
 	}
 
 	@Override
 	public void shutdown(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(jedis -> {
-			jedis.shutdown();
-			return null;
-		}, node);
+		executeCommandOnSingleNode(
+				client -> client.executeCommand(new CommandArguments(Protocol.Command.SHUTDOWN)), node);
 	}
 
 	@Override
@@ -308,41 +324,49 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 	@Override
 	public void resetConfigStats() {
 		connection.getClusterCommandExecutor()
-				.executeCommandOnAllNodes((JedisClusterCommandCallback<String>) Jedis::configResetStat);
+				.executeCommandOnAllNodes((JedisClusterCommandCallback<Object>) client -> client
+						.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("RESETSTAT")));
 	}
 
 	@Override
 	public void rewriteConfig() {
 		connection.getClusterCommandExecutor()
-				.executeCommandOnAllNodes((JedisClusterCommandCallback<String>) Jedis::configRewrite);
+				.executeCommandOnAllNodes((JedisClusterCommandCallback<Object>) client -> client
+						.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("REWRITE")));
 	}
 
 	@Override
 	public void resetConfigStats(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(Jedis::configResetStat, node);
+		executeCommandOnSingleNode(client -> client
+				.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("RESETSTAT")), node);
 	}
 
 	@Override
 	public void rewriteConfig(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(Jedis::configRewrite, node);
+		executeCommandOnSingleNode(client -> client
+				.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("REWRITE")), node);
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public Long time(@NonNull TimeUnit timeUnit) {
 
+		JedisClusterCommandCallback<List<String>> command = client -> JedisConverters
+				.toStrings((List<byte[]>) client.executeCommand(new CommandArguments(Protocol.Command.TIME)));
+
 		return convertListOfStringToTime(
-				connection.getClusterCommandExecutor()
-						.executeCommandOnArbitraryNode((JedisClusterCommandCallback<List<String>>) Jedis::time).getValue(),
-				timeUnit);
+				connection.getClusterCommandExecutor().executeCommandOnArbitraryNode(command).getValue(), timeUnit);
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public Long time(@NonNull RedisClusterNode node, @NonNull TimeUnit timeUnit) {
 
+		JedisClusterCommandCallback<List<String>> command = client -> JedisConverters
+				.toStrings((List<byte[]>) client.executeCommand(new CommandArguments(Protocol.Command.TIME)));
+
 		return convertListOfStringToTime(
-				connection.getClusterCommandExecutor()
-						.executeCommandOnSingleNode((JedisClusterCommandCallback<List<String>>) Jedis::time, node).getValue(),
-				timeUnit);
+				connection.getClusterCommandExecutor().executeCommandOnSingleNode(command, node).getValue(), timeUnit);
 	}
 
 	@Override
@@ -351,7 +375,8 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 		Assert.hasText(host, "Host for 'CLIENT KILL' must not be 'null' or 'empty'");
 		String hostAndPort = "%s:%d".formatted(host, port);
 
-		JedisClusterCommandCallback<String> command = client -> client.clientKill(hostAndPort);
+		JedisClusterCommandCallback<Object> command = client -> client
+				.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("KILL").add(hostAndPort));
 
 		connection.getClusterCommandExecutor().executeCommandOnAllNodes(command);
 	}
@@ -369,8 +394,11 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 	@Override
 	public List<@NonNull RedisClientInfo> getClientList() {
 
-		Collection<String> map = connection.getClusterCommandExecutor()
-				.executeCommandOnAllNodes((JedisClusterCommandCallback<String>) Jedis::clientList).resultsAsList();
+		JedisClusterCommandCallback<String> command = client -> JedisConverters.toString((byte[]) client
+				.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("LIST")));
+
+		Collection<String> map = connection.getClusterCommandExecutor().executeCommandOnAllNodes(command)
+				.resultsAsList();
 
 		ArrayList<RedisClientInfo> result = new ArrayList<>();
 		for (String infos : map) {
@@ -382,8 +410,10 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 	@Override
 	public List<@NonNull RedisClientInfo> getClientList(@NonNull RedisClusterNode node) {
 
-		return JedisConverters
-				.toListOfRedisClientInformation(executeCommandOnSingleNode(Jedis::clientList, node).getValue());
+		JedisClusterCommandCallback<String> command = client -> JedisConverters.toString((byte[]) client
+				.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("LIST")));
+
+		return JedisConverters.toListOfRedisClientInformation(executeCommandOnSingleNode(command, node).getValue());
 	}
 
 	@Override
@@ -414,8 +444,15 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 		RedisClusterNode node = connection.getTopologyProvider().getTopology().lookup(target.getRequiredHost(),
 				target.getRequiredPort());
 
-		executeCommandOnSingleNode(
-				client -> client.migrate(target.getRequiredHost(), target.getRequiredPort(), key, dbIndex, timeoutToUse), node);
+		MigrateParams params = new MigrateParams();
+		if (option == MigrateOption.COPY) {
+			params.copy();
+		} else if (option == MigrateOption.REPLACE) {
+			params.replace();
+		}
+
+		executeCommandOnSingleNode(client -> client.migrate(target.getRequiredHost(), target.getRequiredPort(),
+				timeoutToUse, params, key), node);
 	}
 
 	private Long convertListOfStringToTime(List<@NonNull String> serverTimeInformation, TimeUnit timeUnit) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisClusterServerCommands.java
@@ -60,8 +60,8 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public void bgReWriteAof(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(
-				client -> client.executeCommand(new CommandArguments(Protocol.Command.BGREWRITEAOF)), node);
+		executeCommandOnSingleNode(client -> client.executeCommand(new CommandArguments(Protocol.Command.BGREWRITEAOF)),
+				node);
 	}
 
 	@Override
@@ -80,8 +80,7 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public void bgSave(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(
-				client -> client.executeCommand(new CommandArguments(Protocol.Command.BGSAVE)), node);
+		executeCommandOnSingleNode(client -> client.executeCommand(new CommandArguments(Protocol.Command.BGSAVE)), node);
 	}
 
 	@Override
@@ -158,8 +157,9 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public void flushDb(@NonNull RedisClusterNode node, @NonNull FlushOption option) {
-		executeCommandOnSingleNode(client -> client.executeCommand(
-				new CommandArguments(Protocol.Command.FLUSHDB).add(JedisConverters.toFlushMode(option).name())), node);
+		executeCommandOnSingleNode(client -> client
+				.executeCommand(new CommandArguments(Protocol.Command.FLUSHDB).add(JedisConverters.toFlushMode(option).name())),
+				node);
 	}
 
 	@Override
@@ -170,10 +170,9 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public void flushAll(@NonNull FlushOption option) {
-		connection.getClusterCommandExecutor().executeCommandOnAllNodes(
-				(JedisClusterCommandCallback<Object>) client -> client
-						.executeCommand(new CommandArguments(Protocol.Command.FLUSHALL)
-								.add(JedisConverters.toFlushMode(option).name())));
+		connection.getClusterCommandExecutor()
+				.executeCommandOnAllNodes((JedisClusterCommandCallback<Object>) client -> client.executeCommand(
+						new CommandArguments(Protocol.Command.FLUSHALL).add(JedisConverters.toFlushMode(option).name())));
 	}
 
 	@Override
@@ -242,15 +241,14 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public void shutdown() {
-		connection.getClusterCommandExecutor().executeCommandOnAllNodes(
-				(JedisClusterCommandCallback<Object>) client -> client.executeCommand(
-						new CommandArguments(Protocol.Command.SHUTDOWN)));
+		connection.getClusterCommandExecutor()
+				.executeCommandOnAllNodes((JedisClusterCommandCallback<Object>) client -> client
+						.executeCommand(new CommandArguments(Protocol.Command.SHUTDOWN)));
 	}
 
 	@Override
 	public void shutdown(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(
-				client -> client.executeCommand(new CommandArguments(Protocol.Command.SHUTDOWN)), node);
+		executeCommandOnSingleNode(client -> client.executeCommand(new CommandArguments(Protocol.Command.SHUTDOWN)), node);
 	}
 
 	@Override
@@ -337,14 +335,14 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 
 	@Override
 	public void resetConfigStats(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(client -> client
-				.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("RESETSTAT")), node);
+		executeCommandOnSingleNode(
+				client -> client.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("RESETSTAT")), node);
 	}
 
 	@Override
 	public void rewriteConfig(@NonNull RedisClusterNode node) {
-		executeCommandOnSingleNode(client -> client
-				.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("REWRITE")), node);
+		executeCommandOnSingleNode(
+				client -> client.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("REWRITE")), node);
 	}
 
 	@Override
@@ -394,11 +392,10 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 	@Override
 	public List<@NonNull RedisClientInfo> getClientList() {
 
-		JedisClusterCommandCallback<String> command = client -> JedisConverters.toString((byte[]) client
-				.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("LIST")));
+		JedisClusterCommandCallback<String> command = client -> JedisConverters
+				.toString((byte[]) client.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("LIST")));
 
-		Collection<String> map = connection.getClusterCommandExecutor().executeCommandOnAllNodes(command)
-				.resultsAsList();
+		Collection<String> map = connection.getClusterCommandExecutor().executeCommandOnAllNodes(command).resultsAsList();
 
 		ArrayList<RedisClientInfo> result = new ArrayList<>();
 		for (String infos : map) {
@@ -410,8 +407,8 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 	@Override
 	public List<@NonNull RedisClientInfo> getClientList(@NonNull RedisClusterNode node) {
 
-		JedisClusterCommandCallback<String> command = client -> JedisConverters.toString((byte[]) client
-				.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("LIST")));
+		JedisClusterCommandCallback<String> command = client -> JedisConverters
+				.toString((byte[]) client.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("LIST")));
 
 		return JedisConverters.toListOfRedisClientInformation(executeCommandOnSingleNode(command, node).getValue());
 	}
@@ -451,8 +448,8 @@ class JedisClusterServerCommands implements RedisClusterServerCommands {
 			params.replace();
 		}
 
-		executeCommandOnSingleNode(client -> client.migrate(target.getRequiredHost(), target.getRequiredPort(),
-				timeoutToUse, params, key), node);
+		executeCommandOnSingleNode(
+				client -> client.migrate(target.getRequiredHost(), target.getRequiredPort(), timeoutToUse, params, key), node);
 	}
 
 	private Long convertListOfStringToTime(List<@NonNull String> serverTimeInformation, TimeUnit timeUnit) {

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisConnection.java
@@ -342,7 +342,7 @@ public class JedisConnection extends AbstractRedisConnection {
 				return null;
 			}
 
-			return it.sendCommand(protocolCommand, args);
+			return it.executeCommand(new CommandArguments(protocolCommand).addObjects(args));
 		});
 	}
 
@@ -470,7 +470,7 @@ public class JedisConnection extends AbstractRedisConnection {
 
 		Assert.notNull(message, "Message must not be null");
 
-		return invoke().from(jedis -> jedis.sendCommand(Protocol.Command.ECHO, message))
+		return invoke().from(client -> client.executeCommand(new CommandArguments(Protocol.Command.ECHO).add(message)))
 				.get(response -> (byte[]) response);
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisJsonCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisJsonCommands.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.json.JSONArray;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullUnmarked;
 
@@ -163,7 +164,7 @@ class JedisJsonCommands implements RedisJsonCommands {
 
 		return connection.invoke()
 				.from(UnifiedJedis::jsonMGet, RedisJsonPipelineCommands::jsonMGet, getPath(path), stringKeys)
-				.get(jsonArrList -> jsonArrList.stream().map(arr -> arr != null ? arr.toString().getBytes(StandardCharsets.UTF_8) : null).toList());
+				.get(JedisJsonCommands::toJsonBytes);
 	}
 
 	@Override
@@ -224,6 +225,11 @@ class JedisJsonCommands implements RedisJsonCommands {
 
 	static Path2 getPath(JsonPath path) {
 		return Path2.of(path.asString());
+	}
+
+	static List<byte[]> toJsonBytes(List<JSONArray> jsonArrList) {
+		return jsonArrList.stream().map(arr -> arr != null ? arr.toString().getBytes(StandardCharsets.UTF_8) : null)
+				.toList();
 	}
 
 }

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.args.ExpiryOption;
 import redis.clients.jedis.commands.JedisBinaryCommands;
@@ -327,7 +328,8 @@ class JedisKeyCommands implements RedisKeyCommands {
 
 		Assert.notNull(key, "Key must not be null");
 
-		return connection.invoke().from(j -> j.sendCommand(Protocol.Command.MOVE, key, Protocol.toByteArray(dbIndex)))
+		return connection.invoke().from(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.MOVE).add(key).add(Protocol.toByteArray(dbIndex))))
 				.get(response -> JedisConverters.longToBoolean().convert(((Long) response)));
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisKeyCommands.java
@@ -328,8 +328,8 @@ class JedisKeyCommands implements RedisKeyCommands {
 
 		Assert.notNull(key, "Key must not be null");
 
-		return connection.invoke().from(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.MOVE).add(key).add(Protocol.toByteArray(dbIndex))))
+		return connection.invoke().from(
+				j -> j.executeCommand(new CommandArguments(Protocol.Command.MOVE).add(key).add(Protocol.toByteArray(dbIndex))))
 				.get(response -> JedisConverters.longToBoolean().convert(((Long) response)));
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.redis.connection.jedis;
 
+import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.params.MigrateParams;
@@ -50,23 +51,23 @@ class JedisServerCommands implements RedisServerCommands {
 
 	@Override
 	public void bgReWriteAof() {
-		connection.invoke().just(j -> j.sendCommand(Protocol.Command.BGREWRITEAOF));
+		connection.invoke().just(j -> j.executeCommand(new CommandArguments(Protocol.Command.BGREWRITEAOF)));
 	}
 
 	@Override
 	public void bgSave() {
-		connection.invoke().just(j -> j.sendCommand(Protocol.Command.BGSAVE));
+		connection.invoke().just(j -> j.executeCommand(new CommandArguments(Protocol.Command.BGSAVE)));
 	}
 
 	@Override
 	public Long lastSave() {
-		return connection.invoke().from(j -> j.sendCommand(Protocol.Command.LASTSAVE))
+		return connection.invoke().from(j -> j.executeCommand(new CommandArguments(Protocol.Command.LASTSAVE)))
 				.get(response -> (Long) response);
 	}
 
 	@Override
 	public void save() {
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.SAVE));
+		connection.invokeStatus().just(j -> j.executeCommand(new CommandArguments(Protocol.Command.SAVE)));
 	}
 
 	@Override
@@ -81,7 +82,8 @@ class JedisServerCommands implements RedisServerCommands {
 
 	@Override
 	public void flushDb(@NonNull FlushOption option) {
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.FLUSHDB, JedisConverters.toFlushMode(option).name()));
+		connection.invokeStatus().just(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.FLUSHDB).add(JedisConverters.toFlushMode(option).name())));
 	}
 
 	@Override
@@ -91,7 +93,8 @@ class JedisServerCommands implements RedisServerCommands {
 
 	@Override
 	public void flushAll(@NonNull FlushOption option) {
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.FLUSHALL, JedisConverters.toFlushMode(option).name()));
+		connection.invokeStatus().just(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.FLUSHALL).add(JedisConverters.toFlushMode(option).name())));
 	}
 
 	@Override
@@ -109,7 +112,7 @@ class JedisServerCommands implements RedisServerCommands {
 
 	@Override
 	public void shutdown() {
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.SHUTDOWN));
+		connection.invokeStatus().just(j -> j.executeCommand(new CommandArguments(Protocol.Command.SHUTDOWN)));
 	}
 
 	@Override
@@ -121,7 +124,8 @@ class JedisServerCommands implements RedisServerCommands {
 		}
 
 		String saveOption = (option == ShutdownOption.NOSAVE) ? "NOSAVE" : "SAVE";
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.SHUTDOWN, saveOption));
+		connection.invokeStatus().just(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.SHUTDOWN).add(saveOption)));
 	}
 
 	@Override
@@ -130,7 +134,8 @@ class JedisServerCommands implements RedisServerCommands {
 
 		Assert.notNull(pattern, "Pattern must not be null");
 
-		return connection.invoke().from(j -> j.sendCommand(Protocol.Command.CONFIG, "GET", pattern))
+		return connection.invoke().from(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.CONFIG).add("GET").add(pattern)))
 				.get(response -> {
 					List<Object> list = (List<Object>) response;
 					Properties props = new Properties();
@@ -166,12 +171,14 @@ class JedisServerCommands implements RedisServerCommands {
 
 	@Override
 	public void resetConfigStats() {
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.CONFIG, "RESETSTAT"));
+		connection.invokeStatus().just(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.CONFIG).add("RESETSTAT")));
 	}
 
 	@Override
 	public void rewriteConfig() {
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.CONFIG, "REWRITE"));
+		connection.invokeStatus().just(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.CONFIG).add("REWRITE")));
 	}
 
 	@Override
@@ -180,7 +187,7 @@ class JedisServerCommands implements RedisServerCommands {
 
 		Assert.notNull(timeUnit, "TimeUnit must not be null");
 
-		return connection.invoke().from(j -> j.sendCommand(Protocol.Command.TIME))
+		return connection.invoke().from(j -> j.executeCommand(new CommandArguments(Protocol.Command.TIME)))
 				.get(response -> {
 					List<Object> list = (List<Object>) response;
 					List<String> timeList = new ArrayList<>();
@@ -196,7 +203,8 @@ class JedisServerCommands implements RedisServerCommands {
 
 		Assert.hasText(host, "Host for 'CLIENT KILL' must not be 'null' or 'empty'");
 
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.CLIENT, "KILL", "%s:%s".formatted(host, port)));
+		connection.invokeStatus().just(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.CLIENT).add("KILL").add("%s:%s".formatted(host, port))));
 	}
 
 	@Override
@@ -204,18 +212,21 @@ class JedisServerCommands implements RedisServerCommands {
 
 		Assert.notNull(name, "Name must not be null");
 
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.CLIENT, "SETNAME".getBytes(), name));
+		connection.invokeStatus().just(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.CLIENT).add("SETNAME".getBytes()).add(name)));
 	}
 
 	@Override
 	public String getClientName() {
-		return connection.invokeStatus().from(j -> j.sendCommand(Protocol.Command.CLIENT, "GETNAME"))
+		return connection.invokeStatus().from(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.CLIENT).add("GETNAME")))
 				.get(response -> new String((byte[]) response));
 	}
 
 	@Override
 	public List<@NonNull RedisClientInfo> getClientList() {
-		return connection.invokeStatus().from(j -> j.sendCommand(Protocol.Command.CLIENT, "LIST"))
+		return connection.invokeStatus().from(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.CLIENT).add("LIST")))
 				.get(response -> JedisConverters.toListOfRedisClientInformation(new String((byte[]) response)));
 	}
 
@@ -224,12 +235,14 @@ class JedisServerCommands implements RedisServerCommands {
 
 		Assert.hasText(host, "Host must not be null for 'REPLICAOF' command");
 
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.REPLICAOF, host, String.valueOf(port)));
+		connection.invokeStatus().just(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.REPLICAOF).add(host).add(String.valueOf(port))));
 	}
 
 	@Override
 	public void replicaOfNoOne() {
-		connection.invokeStatus().just(j -> j.sendCommand(Protocol.Command.REPLICAOF, "NO", "ONE"));
+		connection.invokeStatus().just(j -> j.executeCommand(
+				new CommandArguments(Protocol.Command.REPLICAOF).add("NO").add("ONE")));
 
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisServerCommands.java
@@ -124,8 +124,8 @@ class JedisServerCommands implements RedisServerCommands {
 		}
 
 		String saveOption = (option == ShutdownOption.NOSAVE) ? "NOSAVE" : "SAVE";
-		connection.invokeStatus().just(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.SHUTDOWN).add(saveOption)));
+		connection.invokeStatus()
+				.just(j -> j.executeCommand(new CommandArguments(Protocol.Command.SHUTDOWN).add(saveOption)));
 	}
 
 	@Override
@@ -134,8 +134,8 @@ class JedisServerCommands implements RedisServerCommands {
 
 		Assert.notNull(pattern, "Pattern must not be null");
 
-		return connection.invoke().from(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.CONFIG).add("GET").add(pattern)))
+		return connection.invoke()
+				.from(j -> j.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("GET").add(pattern)))
 				.get(response -> {
 					List<Object> list = (List<Object>) response;
 					Properties props = new Properties();
@@ -171,14 +171,13 @@ class JedisServerCommands implements RedisServerCommands {
 
 	@Override
 	public void resetConfigStats() {
-		connection.invokeStatus().just(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.CONFIG).add("RESETSTAT")));
+		connection.invokeStatus()
+				.just(j -> j.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("RESETSTAT")));
 	}
 
 	@Override
 	public void rewriteConfig() {
-		connection.invokeStatus().just(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.CONFIG).add("REWRITE")));
+		connection.invokeStatus().just(j -> j.executeCommand(new CommandArguments(Protocol.Command.CONFIG).add("REWRITE")));
 	}
 
 	@Override
@@ -203,8 +202,8 @@ class JedisServerCommands implements RedisServerCommands {
 
 		Assert.hasText(host, "Host for 'CLIENT KILL' must not be 'null' or 'empty'");
 
-		connection.invokeStatus().just(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.CLIENT).add("KILL").add("%s:%s".formatted(host, port))));
+		connection.invokeStatus().just(j -> j
+				.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("KILL").add("%s:%s".formatted(host, port))));
 	}
 
 	@Override
@@ -212,21 +211,21 @@ class JedisServerCommands implements RedisServerCommands {
 
 		Assert.notNull(name, "Name must not be null");
 
-		connection.invokeStatus().just(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.CLIENT).add("SETNAME".getBytes()).add(name)));
+		connection.invokeStatus()
+				.just(j -> j.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("SETNAME".getBytes()).add(name)));
 	}
 
 	@Override
 	public String getClientName() {
-		return connection.invokeStatus().from(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.CLIENT).add("GETNAME")))
+		return connection.invokeStatus()
+				.from(j -> j.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("GETNAME")))
 				.get(response -> new String((byte[]) response));
 	}
 
 	@Override
 	public List<@NonNull RedisClientInfo> getClientList() {
-		return connection.invokeStatus().from(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.CLIENT).add("LIST")))
+		return connection.invokeStatus()
+				.from(j -> j.executeCommand(new CommandArguments(Protocol.Command.CLIENT).add("LIST")))
 				.get(response -> JedisConverters.toListOfRedisClientInformation(new String((byte[]) response)));
 	}
 
@@ -235,14 +234,14 @@ class JedisServerCommands implements RedisServerCommands {
 
 		Assert.hasText(host, "Host must not be null for 'REPLICAOF' command");
 
-		connection.invokeStatus().just(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.REPLICAOF).add(host).add(String.valueOf(port))));
+		connection.invokeStatus().just(
+				j -> j.executeCommand(new CommandArguments(Protocol.Command.REPLICAOF).add(host).add(String.valueOf(port))));
 	}
 
 	@Override
 	public void replicaOfNoOne() {
-		connection.invokeStatus().just(j -> j.executeCommand(
-				new CommandArguments(Protocol.Command.REPLICAOF).add("NO").add("ONE")));
+		connection.invokeStatus()
+				.just(j -> j.executeCommand(new CommandArguments(Protocol.Command.REPLICAOF).add("NO").add("ONE")));
 
 	}
 


### PR DESCRIPTION
Follow-up to #3315, completing the `UnifiedJedis` migration for the cluster path.

The cluster command callbacks were still typed over `Jedis`, and the node resource provider still handed out `Jedis` instances, which is not a `UnifiedJedis` subtype. This PR moves the remaining cluster internals to `UnifiedJedis` and removes the last uses of the deprecated `sendCommand` API.

## Changes

- `JedisClusterCommandCallback` / `JedisMultiKeyClusterCommandCallback` now extend `ClusterCommandCallback<UnifiedJedis, T>` / `MultiKeyClusterCommandCallback<UnifiedJedis, T>`. Source-incompatible for subclasses that implemented callbacks against `Jedis`.
- `JedisClusterNodeResourceProvider` returns a `UnifiedJedisAdapter` wrapping the node `Connection` instead of `Jedis`.
- Commands missing on `UnifiedJedis` (`CLUSTER *`, `BGREWRITEAOF`, `BGSAVE`, `SAVE`, `LASTSAVE`, `CONFIG RESETSTAT`/`REWRITE`, `TIME`, `CLIENT LIST`/`KILL`, `SHUTDOWN`) use `executeCommand(new CommandArguments(...))`; all remaining `sendCommand` calls (deprecated since Jedis 7.4.0) are migrated as well.
- Raw command replies are decoded through `JedisConverters`.
- Cluster `migrate` now applies `MigrateOption` (`COPY`/`REPLACE`) via `MigrateParams`.
- Cluster `jsonMGet` routes through the typed multi-key callback using the per-node client.

## Testing

Existing integration suite passes against local cluster infrastructure; no new tests.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
