### PR TITLE
Compare raw TTL values as long in `Expirations.TimeToLive`

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/types/Expirations.java
+++ b/src/main/java/org/springframework/data/redis/core/types/Expirations.java
@@ -234,11 +234,17 @@ public class Expirations<K> {
 		 */
 		public static TimeToLive of(Number value, TimeUnit timeUnit) {
 
-			return switch (value.intValue()) {
-				case -2 -> MISSING;
-				case -1 -> PERSISTENT;
-				default -> new TimeToLive(value.longValue(), timeUnit);
-			};
+			long raw = value.longValue();
+
+			if (raw == MISSING.raw()) {
+				return MISSING;
+			}
+
+			if (raw == PERSISTENT.raw()) {
+				return PERSISTENT;
+			}
+
+			return new TimeToLive(raw, timeUnit);
 		}
 
 		/**
@@ -320,11 +326,15 @@ public class Expirations<K> {
 		@Override
 		public String toString() {
 
-			return switch ((int) raw()) {
-				case -2 -> "MISSING";
-				case -1 -> "PERSISTENT";
-				default -> "%d %s".formatted(raw(), sourceUnit);
-			};
+			if (isMissing()) {
+				return "MISSING";
+			}
+
+			if (isPersistent()) {
+				return "PERSISTENT";
+			}
+
+			return "%d %s".formatted(raw(), sourceUnit);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/types/ExpirationsUnitTest.java
+++ b/src/test/java/org/springframework/data/redis/core/types/ExpirationsUnitTest.java
@@ -97,6 +97,16 @@ class ExpirationsUnitTest {
 		assertThat(Expirations.TimeToLive.of(1, TimeUnit.SECONDS)).hasToString("1 SECONDS");
 	}
 
+	@Test // GH-3425
+	void largeTimeToLiveValuesShouldNotBeMisclassified() {
+
+		assertThat(Expirations.TimeToLive.of(4294967294L, TimeUnit.MILLISECONDS).isMissing()).isFalse();
+		assertThat(Expirations.TimeToLive.of(4294967295L, TimeUnit.MILLISECONDS).isPersistent()).isFalse();
+		assertThat(Expirations.TimeToLive.of(4294967294L, TimeUnit.MILLISECONDS).raw()).isEqualTo(4294967294L);
+		assertThat(Expirations.TimeToLive.of(4294967294L, TimeUnit.MILLISECONDS))
+				.hasToString("4294967294 MILLISECONDS");
+	}
+
 	static Expirations<String> createExpirations(Timeouts timeouts) {
 
 		List<String> keys = IntStream.range(1, timeouts.raw().size() + 1).mapToObj("key-%s"::formatted).toList();


### PR DESCRIPTION
Closes #3425

`TimeToLive.of(Number, TimeUnit)` classified the raw TTL by `value.intValue()`, so any 64-bit TTL whose low 32 bits equal -2 or -1 — e.g. an `HPTTL` of 4294967294 ms (≈ 49.7 days) — was misclassified as the `MISSING`/`PERSISTENT` sentinel. `TimeToLive#toString` had the same `(int) raw()` truncation.

The sentinel comparison now uses the full `long` value, and `toString` uses `isMissing()`/`isPersistent()`. Regression test added (fails on `main`, passes with the fix); `ExpirationsUnitTest` passes 13/13.