### PR TITLE
Fix inverted equals in `RedisStreamCommands.TrimOptions`

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
@@ -141,6 +141,22 @@ public interface RedisStreamCommands {
 			return threshold;
 		}
 
+		@Override
+		public boolean equals(@Nullable Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof MaxLenTrimStrategy that)) {
+				return false;
+			}
+			return this.threshold == that.threshold;
+		}
+
+		@Override
+		public int hashCode() {
+			return Long.hashCode(threshold);
+		}
+
 	}
 
 	/**
@@ -162,6 +178,22 @@ public interface RedisStreamCommands {
 		 */
 		public RecordId threshold() {
 			return threshold;
+		}
+
+		@Override
+		public boolean equals(@Nullable Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof MinIdTrimStrategy that)) {
+				return false;
+			}
+			return this.threshold.equals(that.threshold);
+		}
+
+		@Override
+		public int hashCode() {
+			return threshold.hashCode();
 		}
 	}
 
@@ -325,10 +357,13 @@ public interface RedisStreamCommands {
 			if (!(o instanceof TrimOptions that)) {
 				return false;
 			}
-			if (this.trimStrategy.equals(that.trimStrategy)) {
+			if (!this.trimStrategy.equals(that.trimStrategy)) {
 				return false;
 			}
-			if (this.trimOperator.equals(that.trimOperator)) {
+			if (!this.trimOperator.equals(that.trimOperator)) {
+				return false;
+			}
+			if (!ObjectUtils.nullSafeEquals(limit, that.limit)) {
 				return false;
 			}
 			return ObjectUtils.nullSafeEquals(deletionPolicy, that.deletionPolicy);

--- a/src/test/java/org/springframework/data/redis/connection/RedisStreamCommandsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/RedisStreamCommandsUnitTests.java
@@ -20,7 +20,10 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XPendingOptions;
+import org.springframework.data.redis.connection.stream.RecordId;
 
 /**
  * Unit tests for {@link RedisStreamCommands}.
@@ -53,5 +56,30 @@ class RedisStreamCommandsUnitTests {
 		XPendingOptions xPendingOptions = XPendingOptions.unbounded();
 
 		assertThatIllegalArgumentException().isThrownBy(() -> xPendingOptions.minIdleTime(null));
+	}
+
+	@Test // GH-3426
+	void trimOptionsEqualsShouldConsiderEqualOptions() {
+
+		assertThat(TrimOptions.maxLen(10)).isEqualTo(TrimOptions.maxLen(10));
+		assertThat(TrimOptions.maxLen(10)).hasSameHashCodeAs(TrimOptions.maxLen(10));
+		assertThat(TrimOptions.minId(RecordId.of("5-0")).approximate())
+				.isEqualTo(TrimOptions.minId(RecordId.of("5-0")).approximate());
+	}
+
+	@Test // GH-3426
+	void trimOptionsEqualsShouldConsiderDifferentOptions() {
+
+		assertThat(TrimOptions.maxLen(10).approximate()).isNotEqualTo(TrimOptions.minId(RecordId.of("5-0")).exact());
+		assertThat(TrimOptions.maxLen(10)).isNotEqualTo(TrimOptions.maxLen(10).limit(5));
+		assertThat(TrimOptions.maxLen(10)).isNotEqualTo(TrimOptions.maxLen(11));
+	}
+
+	@Test // GH-3426
+	void xAddOptionsEqualsShouldConsiderTrimOptions() {
+
+		assertThat(XAddOptions.maxlen(10)).isEqualTo(XAddOptions.maxlen(10));
+		assertThat(XAddOptions.maxlen(10)).hasSameHashCodeAs(XAddOptions.maxlen(10));
+		assertThat(XAddOptions.maxlen(10)).isNotEqualTo(XAddOptions.maxlen(11));
 	}
 }


### PR DESCRIPTION
Closes #3426

`TrimOptions.equals` returned `false` when the trim strategies or operators were **equal** (inverted conditions), never compared `limit` (though it participates in `hashCode`), and `MaxLenTrimStrategy`/`MinIdTrimStrategy` lacked value-based `equals`/`hashCode`, so equality effectively fell back to identity. `XAddOptions.equals` delegates to `TrimOptions` and was broken the same way: `XAddOptions.maxlen(10)` did not equal `XAddOptions.maxlen(10)`, while `TrimOptions.maxLen(10).approximate()` equaled `TrimOptions.minId("5-0").exact()`.

This change negates the comparisons, includes `limit`, and adds value-based `equals`/`hashCode` to both trim strategies. Three regression tests added (all fail on `main`, pass with the fix); the connection package unit tests pass (119 tests).