### PR TITLE
Fetch hash field TTLs in seconds in `DefaultHashOperations`

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultHashOperations.java
@@ -349,7 +349,7 @@ class DefaultHashOperations<K, HK, HV> extends AbstractOperations<K, Object> imp
 
 		List<Long> raw = execute(
 				connection -> TimeUnit.MILLISECONDS.equals(timeUnit) ? connection.hashCommands().hpTtl(rawKey, rawHashKeys)
-						: connection.hashCommands().hTtl(rawKey, timeUnit, rawHashKeys));
+						: connection.hashCommands().hTtl(rawKey, rawHashKeys));
 
 		if (raw == null) {
 			return null;

--- a/src/test/java/org/springframework/data/redis/core/DefaultHashOperationsUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultHashOperationsUnitTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisHashCommands;
+import org.springframework.data.redis.core.types.Expirations;
+
+/**
+ * Unit tests for {@link DefaultHashOperations}.
+ *
+ * @author Seonghun Lee
+ */
+class DefaultHashOperationsUnitTests {
+
+	RedisConnectionFactory connectionFactory = mock(RedisConnectionFactory.class);
+	RedisConnection connection = mock(RedisConnection.class);
+	RedisHashCommands hashCommands = mock(RedisHashCommands.class);
+
+	StringRedisTemplate template;
+
+	@BeforeEach
+	void setUp() {
+
+		when(connectionFactory.getConnection()).thenReturn(connection);
+		when(connection.hashCommands()).thenReturn(hashCommands);
+
+		template = new StringRedisTemplate(connectionFactory);
+		template.afterPropertiesSet();
+	}
+
+	@Test // GH-3427
+	void getTimeToLiveShouldConsiderTimeUnit() {
+
+		// HTTL returns 120 (seconds); drivers convert to 2 when asked for MINUTES
+		when(hashCommands.hTtl(any(byte[].class), any(byte[][].class))).thenReturn(List.of(120L));
+		when(hashCommands.hTtl(any(byte[].class), eq(TimeUnit.MINUTES), any(byte[][].class))).thenReturn(List.of(2L));
+
+		Expirations<String> expirations = template.<String, String> opsForHash().getTimeToLive("key", TimeUnit.MINUTES,
+				List.of("field"));
+
+		assertThat(expirations.ttlOf("field")).isEqualTo(Duration.ofMinutes(2));
+		assertThat(expirations.expirationOf("field").value()).isEqualTo(2L);
+	}
+}


### PR DESCRIPTION
Closes #3427

`getTimeToLive(key, timeUnit, hashKeys)` called the unit-aware `hTtl(rawKey, timeUnit, rawHashKeys)`, whose driver implementations already convert the server's seconds into the requested `TimeUnit`, but then labeled the returned values as seconds (`Timeouts.of(TimeUnit.SECONDS, rawValues)`), so `Expirations` converted them a second time. Requesting `TimeUnit.MINUTES` for a field with a 120-second TTL yielded an expiration of 2 seconds (`value()` = 0) instead of 2 minutes.

This change uses the unit-less `hTtl` variant and lets `Expirations` convert once, matching `DefaultReactiveHashOperations`. A mock-based regression test added (fails on `main` with `expected: 2M but was: 2S`, passes with the fix); the core unit test sweep passes (1409 tests).