### PR TITLE
getExpirationDuration and getExpirationInstant return wrong result if asked for milliseconds

### DIFF
--- a/src/main/java/org/springframework/data/redis/core/types/Expiration.java
+++ b/src/main/java/org/springframework/data/redis/core/types/Expiration.java
@@ -17,7 +17,6 @@ package org.springframework.data.redis.core.types;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.jspecify.annotations.Nullable;
@@ -31,6 +30,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author John Blum
+ * @author Rene Choi
  * @see java.time.Duration
  * @see java.util.concurrent.TimeUnit
  * @since 1.7
@@ -171,7 +171,7 @@ public class Expiration {
 	public Instant getExpirationInstant(TimeUnit precision) {
 
 		assertPrecision(precision);
-		return precision == TimeUnit.MILLISECONDS ? Instant.ofEpochMilli(getExpirationTime())
+		return precision == TimeUnit.MILLISECONDS ? Instant.ofEpochMilli(getExpirationTimeInMilliseconds())
 				: Instant.ofEpochSecond(getExpirationTimeInSeconds());
 	}
 
@@ -203,7 +203,7 @@ public class Expiration {
 
 		assertPrecision(precision);
 
-		return precision == TimeUnit.MILLISECONDS ? Duration.ofMillis(getExpirationTime())
+		return precision == TimeUnit.MILLISECONDS ? Duration.ofMillis(getExpirationTimeInMilliseconds())
 				: Duration.ofSeconds(getExpirationTimeInSeconds());
 	}
 
@@ -288,7 +288,7 @@ public class Expiration {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(getExpirationTime(), getTimeUnit());
+		return Long.hashCode(getTimeUnit().toMillis(getExpirationTime()));
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/redis/core/types/ExpirationUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/core/types/ExpirationUnitTests.java
@@ -18,6 +18,9 @@ package org.springframework.data.redis.core.types;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +30,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mark Paluch
  * @author John Blum
+ * @author Rene Choi
  */
 class ExpirationUnitTests {
 
@@ -89,5 +93,35 @@ class ExpirationUnitTests {
 		assertThat(expiration).doesNotHaveSameHashCodeAs(60L);
 		assertThat(expiration).doesNotHaveSameHashCodeAs(Duration.ofSeconds(60L));
 		assertThat(expiration).doesNotHaveSameHashCodeAs(Expiration.from(60L, TimeUnit.MINUTES));
+	}
+
+	@Test
+	void equalValuedExpirationsHaveTheSameHashCode() {
+
+		Expiration sixtyThousandMilliseconds = Expiration.milliseconds(60_000L);
+		Expiration sixtySeconds = Expiration.seconds(60L);
+
+		assertThat(sixtyThousandMilliseconds).hasSameHashCodeAs(sixtySeconds);
+		assertThat(new HashSet<>(List.of(sixtyThousandMilliseconds, sixtySeconds))).hasSize(1);
+	}
+
+	@Test
+	void convertsTheExpirationToTheRequestedPrecision() {
+
+		Expiration sixtySeconds = Expiration.seconds(60L);
+
+		assertThat(sixtySeconds.getExpirationDuration(TimeUnit.MILLISECONDS)).isEqualTo(Duration.ofSeconds(60L));
+		assertThat(sixtySeconds.getExpirationDuration(TimeUnit.SECONDS)).isEqualTo(Duration.ofSeconds(60L));
+		assertThat(Expiration.milliseconds(60_000L).getExpirationDuration(TimeUnit.MILLISECONDS))
+				.isEqualTo(Duration.ofSeconds(60L));
+	}
+
+	@Test
+	void convertsTheUnixTimestampToTheRequestedPrecision() {
+
+		Expiration timestamp = Expiration.unixTimestamp(1700000000L, TimeUnit.SECONDS);
+
+		assertThat(timestamp.getExpirationInstant(TimeUnit.MILLISECONDS)).isEqualTo(Instant.ofEpochSecond(1700000000L));
+		assertThat(timestamp.getExpirationInstant(TimeUnit.SECONDS)).isEqualTo(Instant.ofEpochSecond(1700000000L));
 	}
 }


### PR DESCRIPTION
`getExpirationInstant` and `getExpirationDuration` convert on the `SECONDS` branch but pass the
raw `getExpirationTime()` on the `MILLISECONDS` one.
`seconds(60).getExpirationDuration(MILLISECONDS)` is `PT0.06S`;
`unixTimestamp(1700000000, SECONDS).getExpirationInstant(MILLISECONDS)` is `1970-01-20T16:13:20Z`.
Both now use `getExpirationTimeInMilliseconds()`.

`equals` normalises to millis, so `milliseconds(60_000)` equals `seconds(60)`, but `hashCode`
hashed the raw time and unit, so a `HashSet` of the two keeps both. `hashCode` now hashes what
`equals` compares.

The only in-tree caller derives precision from `isPrecise()` and never hits that branch.

The three new tests fail on the parent commit with the values above; the other six pass.
431 tests across the unit classes touching `Expiration` are green.
