### PR TITLE
Add support for XAUTOCLAIM to stream operations.

### DIFF
--- a/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultStringRedisConnection.java
@@ -38,6 +38,8 @@ import org.springframework.data.redis.connection.convert.ListConverter;
 import org.springframework.data.redis.connection.convert.MapConverter;
 import org.springframework.data.redis.connection.convert.SetConverter;
 import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -85,6 +87,7 @@ import org.springframework.util.ObjectUtils;
  * @author Jeonggyu Choi
  * @author Mingi Lee
  * @author Yordan Tsintsov
+ * @author big-cir
  */
 @NullUnmarked
 @SuppressWarnings({ "ConstantConditions", "deprecation" })
@@ -115,6 +118,9 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 
 	private ListConverter<ByteRecord, StringRecord> listByteMapRecordToStringMapRecordConverter = new ListConverter<>(
 			byteMapRecordToStringMapRecordConverter);
+
+	private Converter<ClaimedRecords<ByteRecord>, ClaimedRecords<StringRecord>> claimedByteRecordsToClaimedStringRecordsConverter = source -> source
+			.mapRecords(byteMapRecordToStringMapRecordConverter::convert);
 
 	@SuppressWarnings("rawtypes") private Queue<Converter> pipelineConverters = new LinkedList<>();
 	@SuppressWarnings("rawtypes") private Queue<Converter> txConverters = new LinkedList<>();
@@ -2950,6 +2956,19 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	}
 
 	@Override
+	public ClaimedRecordIds xAutoClaimJustId(String key, String group, String consumer, XAutoClaimOptions options) {
+		return convertAndReturn(delegate.xAutoClaimJustId(serialize(key), group, consumer, options),
+				Converters.identityConverter());
+	}
+
+	@Override
+	public ClaimedRecords<StringRecord> xAutoClaim(String key, String group, String consumer,
+			XAutoClaimOptions options) {
+		return convertAndReturn(delegate.xAutoClaim(serialize(key), group, consumer, options),
+				claimedByteRecordsToClaimedStringRecordsConverter);
+	}
+
+	@Override
 	public Long xDel(String key, RecordId... recordIds) {
 		return convertAndReturn(delegate.xDel(serialize(key), recordIds), Converters.identityConverter());
 	}
@@ -3105,6 +3124,17 @@ public class DefaultStringRedisConnection implements StringRedisConnection, Deco
 	@Override
 	public List<ByteRecord> xClaim(byte[] key, String group, String newOwner, XClaimOptions options) {
 		return delegate.xClaim(key, group, newOwner, options);
+	}
+
+	@Override
+	public ClaimedRecordIds xAutoClaimJustId(byte[] key, String group, String newOwner, XAutoClaimOptions options) {
+		return delegate.xAutoClaimJustId(key, group, newOwner, options);
+	}
+
+	@Override
+	public ClaimedRecords<ByteRecord> xAutoClaim(byte[] key, String group, String newOwner,
+			XAutoClaimOptions options) {
+		return delegate.xAutoClaim(key, group, newOwner, options);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/DefaultedRedisConnection.java
@@ -36,6 +36,8 @@ import org.springframework.data.redis.connection.json.JsonSetCondition;
 import org.springframework.data.redis.connection.json.JsonType;
 import org.springframework.data.redis.connection.json.JsonValue;
 import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -74,6 +76,7 @@ import org.springframework.data.redis.domain.geo.GeoShape;
  * @author Tihomir Mateev
  * @author Mingi Lee
  * @author Yordan Tsintsov
+ * @author big-cir
  * @since 2.0
  */
 @Deprecated
@@ -560,6 +563,21 @@ public interface DefaultedRedisConnection extends RedisCommands, RedisCommandsPr
 	@Deprecated
 	default List<ByteRecord> xClaim(byte[] key, String group, String newOwner, XClaimOptions options) {
 		return streamCommands().xClaim(key, group, newOwner, options);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
+	@Override
+	@Deprecated
+	default ClaimedRecordIds xAutoClaimJustId(byte[] key, String group, String newOwner, XAutoClaimOptions options) {
+		return streamCommands().xAutoClaimJustId(key, group, newOwner, options);
+	}
+
+	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */
+	@Override
+	@Deprecated
+	default ClaimedRecords<ByteRecord> xAutoClaim(byte[] key, String group, String newOwner,
+			XAutoClaimOptions options) {
+		return streamCommands().xAutoClaim(key, group, newOwner, options);
 	}
 
 	/** @deprecated in favor of {@link RedisConnection#streamCommands()}}. */

--- a/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/ReactiveStreamCommands.java
@@ -39,11 +39,14 @@ import org.springframework.data.redis.connection.RedisStreamCommands.TrimOperato
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimStrategy;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XPendingOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
 import org.springframework.data.redis.connection.stream.ByteBufferRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.PendingMessage;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -68,6 +71,7 @@ import org.springframework.util.Assert;
  * @author Mark John Moreno
  * @author jinkshower
  * @author Jeonggyu Choi
+ * @author big-cir
  * @since 2.2
  */
 public interface ReactiveStreamCommands {
@@ -519,6 +523,88 @@ public interface ReactiveStreamCommands {
 	Flux<CommandResponse<XClaimCommand, Flux<ByteBufferRecord>>> xClaim(Publisher<XClaimCommand> commands);
 
 	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@literal min-idle-time} to the
+	 * given new {@literal consumer} without fetching the message bodies. Scanning starts at the
+	 * {@link XAutoClaimOptions#getStart() start} id and the returned {@link ClaimedRecordIds#getCursor() cursor} is to
+	 * be used as start for the next call.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param options must not be {@literal null}.
+	 * @return a {@link Mono} emitting the next cursor along with the {@link RecordId ids} that changed user.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	default Mono<ClaimedRecordIds> xAutoClaimJustId(ByteBuffer key, String group, String newOwner,
+			XAutoClaimOptions options) {
+
+		return xAutoClaimJustId(Mono.just(new XAutoClaimCommand(key, group, newOwner, options))).next()
+				.map(CommandResponse::getOutput);
+	}
+
+	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@literal min-idle-time} to the
+	 * given new {@literal consumer} without fetching the message bodies.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return a {@link Flux} emitting the next cursor along with the {@link RecordId ids} that changed user.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	Flux<CommandResponse<XAutoClaimCommand, ClaimedRecordIds>> xAutoClaimJustId(
+			Publisher<XAutoClaimCommand> commands);
+
+	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@link Duration minimum idle
+	 * time} to the given new {@literal consumer}, scanning the pending entries list from the beginning.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param minIdleTime must not be {@literal null}.
+	 * @return a {@link Mono} emitting the next cursor along with the {@link ByteBufferRecord records} that changed user.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	default Mono<ClaimedRecords<ByteBufferRecord>> xAutoClaim(ByteBuffer key, String group, String newOwner,
+			Duration minIdleTime) {
+		return xAutoClaim(key, group, newOwner, XAutoClaimOptions.minIdle(minIdleTime));
+	}
+
+	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@literal min-idle-time} to the
+	 * given new {@literal consumer}. Scanning starts at the {@link XAutoClaimOptions#getStart() start} id and the
+	 * returned {@link ClaimedRecords#getCursor() cursor} is to be used as start for the next call.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param options must not be {@literal null}.
+	 * @return a {@link Mono} emitting the next cursor along with the {@link ByteBufferRecord records} that changed user.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	default Mono<ClaimedRecords<ByteBufferRecord>> xAutoClaim(ByteBuffer key, String group, String newOwner,
+			XAutoClaimOptions options) {
+
+		return xAutoClaim(Mono.just(new XAutoClaimCommand(key, group, newOwner, options))).next()
+				.map(CommandResponse::getOutput);
+	}
+
+	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@literal min-idle-time} to the
+	 * given new {@literal consumer}.
+	 *
+	 * @param commands must not be {@literal null}.
+	 * @return a {@link Flux} emitting the next cursor along with the {@link ByteBufferRecord records} that changed user.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	Flux<CommandResponse<XAutoClaimCommand, ClaimedRecords<ByteBufferRecord>>> xAutoClaim(
+			Publisher<XAutoClaimCommand> commands);
+
+	/**
 	 * {@code XCLAIM} command parameters.
 	 *
 	 * @see <a href="https://redis.io/commands/xclaim">Redis Documentation: XCLAIM</a>
@@ -539,6 +625,61 @@ public interface ReactiveStreamCommands {
 		}
 
 		public XClaimOptions getOptions() {
+			return options;
+		}
+
+		public String getNewOwner() {
+			return newOwner;
+		}
+
+		public String getGroupName() {
+			return groupName;
+		}
+	}
+
+	/**
+	 * {@code XAUTOCLAIM} command parameters.
+	 *
+	 * @author big-cir
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	class XAutoClaimCommand extends KeyCommand {
+
+		private final String groupName;
+		private final String newOwner;
+		private final XAutoClaimOptions options;
+
+		private XAutoClaimCommand(@Nullable ByteBuffer key, String groupName, String newOwner,
+				XAutoClaimOptions options) {
+
+			super(key);
+			this.groupName = groupName;
+			this.newOwner = newOwner;
+			this.options = options;
+		}
+
+		/**
+		 * Creates a new {@link XAutoClaimCommand} given a {@literal key}.
+		 *
+		 * @param key must not be {@literal null}.
+		 * @param groupName must not be {@literal null}.
+		 * @param newOwner must not be {@literal null}.
+		 * @param options must not be {@literal null}.
+		 * @return a new {@link XAutoClaimCommand}.
+		 */
+		public static XAutoClaimCommand autoClaim(ByteBuffer key, String groupName, String newOwner,
+				XAutoClaimOptions options) {
+
+			Assert.notNull(key, "Key must not be null");
+			Assert.notNull(groupName, "Group name must not be null");
+			Assert.notNull(newOwner, "New owner must not be null");
+			Assert.notNull(options, "Options must not be null");
+
+			return new XAutoClaimCommand(key, groupName, newOwner, options);
+		}
+
+		public XAutoClaimOptions getOptions() {
 			return options;
 		}
 

--- a/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/RedisStreamCommands.java
@@ -47,6 +47,7 @@ import org.springframework.util.StringUtils;
  * @author Mark John Moreno
  * @author Jeonggyu Choi
  * @author Viktoriya Kutsarova
+ * @author big-cir
  * @since 2.2
  * @see RedisCommands
  * @see <a href="https://redis.io/topics/streams-intro">Redis Documentation - Streams</a>
@@ -700,6 +701,59 @@ public interface RedisStreamCommands {
 			@NonNull XClaimOptions options);
 
 	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@literal min-idle-time} to the
+	 * given new {@literal consumer} without fetching the message bodies. Scanning starts at the
+	 * {@link XAutoClaimOptions#getStart() start} id and the returned {@link ClaimedRecordIds#getCursor() cursor} is to
+	 * be used as start for the next call.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param options must not be {@literal null}.
+	 * @return the next cursor along with the {@link RecordId ids} that changed user. {@literal null} when used in
+	 *         pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	ClaimedRecordIds xAutoClaimJustId(byte @NonNull [] key, @NonNull String group, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options);
+
+	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@link Duration minimum idle
+	 * time} to the given new {@literal consumer}, scanning the pending entries list from the beginning.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param minIdleTime must not be {@literal null}.
+	 * @return the next cursor along with the {@link ByteRecord records} that changed user. {@literal null} when used in
+	 *         pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	default ClaimedRecords<ByteRecord> xAutoClaim(byte @NonNull [] key, @NonNull String group,
+			@NonNull String newOwner, @NonNull Duration minIdleTime) {
+		return xAutoClaim(key, group, newOwner, XAutoClaimOptions.minIdle(minIdleTime));
+	}
+
+	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@literal min-idle-time} to the
+	 * given new {@literal consumer}. Scanning starts at the {@link XAutoClaimOptions#getStart() start} id and the
+	 * returned {@link ClaimedRecords#getCursor() cursor} is to be used as start for the next call.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param options must not be {@literal null}.
+	 * @return the next cursor along with the {@link ByteRecord records} that changed user. {@literal null} when used in
+	 *         pipeline / transaction.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	ClaimedRecords<ByteRecord> xAutoClaim(byte @NonNull [] key, @NonNull String group, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options);
+
+	/**
 	 * @author Christoph Strobl
 	 * @since 2.3
 	 */
@@ -897,6 +951,130 @@ public interface RedisStreamCommands {
 			public XClaimOptions ids(String... ids) {
 				return ids(Arrays.asList(ids));
 			}
+		}
+	}
+
+	/**
+	 * Options for {@literal XAUTOCLAIM}.
+	 *
+	 * @author big-cir
+	 * @since 4.2
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 */
+	@NullMarked
+	class XAutoClaimOptions {
+
+		private static final RecordId INITIAL_CURSOR = RecordId.of("0-0");
+
+		private final Duration minIdleTime;
+		private final RecordId start;
+		private final @Nullable Long count;
+
+		private XAutoClaimOptions(Duration minIdleTime, RecordId start, @Nullable Long count) {
+
+			this.minIdleTime = minIdleTime;
+			this.start = start;
+			this.count = count;
+		}
+
+		/**
+		 * Create new {@link XAutoClaimOptions} limiting the command to messages that have been idle for at least the given
+		 * {@link Duration}. Scanning starts at the beginning of the pending entries list ({@code 0-0}).
+		 *
+		 * @param minIdleTime must not be {@literal null}.
+		 * @return new instance of {@link XAutoClaimOptions}.
+		 */
+		public static XAutoClaimOptions minIdle(Duration minIdleTime) {
+
+			Assert.notNull(minIdleTime, "Min idle time must not be null");
+
+			return new XAutoClaimOptions(minIdleTime, INITIAL_CURSOR, null);
+		}
+
+		/**
+		 * Create new {@link XAutoClaimOptions} limiting the command to messages that have been idle for at least the given
+		 * {@literal milliseconds}. Scanning starts at the beginning of the pending entries list ({@code 0-0}).
+		 *
+		 * @param millis
+		 * @return new instance of {@link XAutoClaimOptions}.
+		 */
+		public static XAutoClaimOptions minIdleMs(long millis) {
+			return minIdle(Duration.ofMillis(millis));
+		}
+
+		/**
+		 * Set the {@literal start} id to scan the pending entries list from. Typically the cursor returned by a previous
+		 * call.
+		 *
+		 * @param start must not be {@literal null}.
+		 * @return new instance of {@link XAutoClaimOptions}.
+		 */
+		public XAutoClaimOptions from(RecordId start) {
+
+			Assert.notNull(start, "Start id must not be null");
+
+			return new XAutoClaimOptions(minIdleTime, start, count);
+		}
+
+		/**
+		 * Set the {@literal start} id to scan the pending entries list from. Typically the cursor returned by a previous
+		 * call.
+		 *
+		 * @param start must not be {@literal null}.
+		 * @return new instance of {@link XAutoClaimOptions}.
+		 */
+		public XAutoClaimOptions from(String start) {
+
+			Assert.hasText(start, "Start id must not be null or empty");
+
+			return from(RecordId.of(start));
+		}
+
+		/**
+		 * Limit the number of messages to claim per call ({@literal COUNT}).
+		 *
+		 * @param count must be greater than zero.
+		 * @return new instance of {@link XAutoClaimOptions}.
+		 */
+		public XAutoClaimOptions count(long count) {
+
+			Assert.isTrue(count > 0, "Count must be greater than zero");
+
+			return new XAutoClaimOptions(minIdleTime, start, count);
+		}
+
+		/**
+		 * Get the {@literal min-idle-time}.
+		 *
+		 * @return never {@literal null}.
+		 */
+		public Duration getMinIdleTime() {
+			return minIdleTime;
+		}
+
+		/**
+		 * Get the {@literal start} id.
+		 *
+		 * @return never {@literal null}.
+		 */
+		public RecordId getStart() {
+			return start;
+		}
+
+		/**
+		 * Get the {@literal COUNT}.
+		 *
+		 * @return can be {@literal null}.
+		 */
+		public @Nullable Long getCount() {
+			return count;
+		}
+
+		/**
+		 * @return {@literal true} if {@literal COUNT} is set.
+		 */
+		public boolean isLimited() {
+			return count != null;
 		}
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
+++ b/src/main/java/org/springframework/data/redis/connection/StringRedisConnection.java
@@ -31,6 +31,8 @@ import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Metric;
 import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.PendingMessage;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -77,6 +79,7 @@ import org.springframework.util.CollectionUtils;
  * @author Mingi Lee
  * @author Yordan Tsintsov
  * @author JaeGeun Lee
+ * @author big-cir
  * @see RedisCallback
  * @see RedisSerializer
  * @see StringRedisTemplate
@@ -3135,6 +3138,53 @@ public interface StringRedisConnection extends RedisConnection {
 	 */
 	List<StringRecord> xClaim(@NonNull String key, @NonNull String group, @NonNull String newOwner,
 			@NonNull XClaimOptions options);
+
+	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@literal min-idle-time} to the
+	 * given new {@literal consumer} without fetching the message bodies.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param options must not be {@literal null}.
+	 * @return the next cursor along with the {@link RecordId ids} that changed user.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	ClaimedRecordIds xAutoClaimJustId(@NonNull String key, @NonNull String group, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options);
+
+	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@link Duration minimum idle
+	 * time} to the given new {@literal consumer}, scanning the pending entries list from the beginning.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param minIdleTime must not be {@literal null}.
+	 * @return the next cursor along with the {@link StringRecord records} that changed user.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	default ClaimedRecords<StringRecord> xAutoClaim(@NonNull String key, @NonNull String group,
+			@NonNull String newOwner, @NonNull Duration minIdleTime) {
+		return xAutoClaim(key, group, newOwner, XAutoClaimOptions.minIdle(minIdleTime));
+	}
+
+	/**
+	 * Transfer ownership of pending messages that have been idle for at least the given {@literal min-idle-time} to the
+	 * given new {@literal consumer}.
+	 *
+	 * @param key the {@literal key} the stream is stored at.
+	 * @param group the name of the {@literal consumer group}.
+	 * @param newOwner the name of the new {@literal consumer}.
+	 * @param options must not be {@literal null}.
+	 * @return the next cursor along with the {@link StringRecord records} that changed user.
+	 * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+	 * @since 4.2
+	 */
+	ClaimedRecords<StringRecord> xAutoClaim(@NonNull String key, @NonNull String group, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options);
 
 	/**
 	 * Removes the specified entries from the stream. Returns the number of items deleted, that may be different from the

--- a/src/main/java/org/springframework/data/redis/connection/jedis/JedisStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/JedisStreamCommands.java
@@ -20,6 +20,7 @@ import redis.clients.jedis.commands.JedisBinaryCommands;
 import redis.clients.jedis.commands.PipelineBinaryCommands;
 import redis.clients.jedis.commands.StreamPipelineBinaryCommands;
 import redis.clients.jedis.params.XAddParams;
+import redis.clients.jedis.params.XAutoClaimParams;
 import redis.clients.jedis.params.XClaimParams;
 import redis.clients.jedis.params.XPendingParams;
 import redis.clients.jedis.params.XReadGroupParams;
@@ -41,6 +42,8 @@ import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisStreamCommands;
 import org.springframework.data.redis.connection.jedis.JedisInvoker.ResponseCommands;
 import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -57,6 +60,7 @@ import org.springframework.util.Assert;
  *
  * @author Dengliming
  * @author Tihomir Mateev
+ * @author big-cir
  * @since 2.3
  */
 @NullUnmarked
@@ -131,6 +135,42 @@ class JedisStreamCommands implements RedisStreamCommands {
 						JedisConverters.toBytes(newOwner), options.getMinIdleTime().toMillis(), params,
 						StreamConverters.entryIdsToBytes(options.getIds()))
 				.get(r -> StreamConverters.convertToByteRecord(key, r));
+	}
+
+	@Override
+	public ClaimedRecordIds xAutoClaimJustId(byte @NonNull [] key, @NonNull String group, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options) {
+
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(group, "Group must not be null");
+		Assert.notNull(newOwner, "NewOwner must not be null");
+		Assert.notNull(options, "Options must not be null");
+
+		XAutoClaimParams params = StreamConverters.toXAutoClaimParams(options);
+
+		return connection.invoke()
+				.from(JedisBinaryCommands::xautoclaimJustId, ResponseCommands::xautoclaimJustId, key,
+						JedisConverters.toBytes(group), JedisConverters.toBytes(newOwner), options.getMinIdleTime().toMillis(),
+						JedisConverters.toBytes(options.getStart().getValue()), params)
+				.get(StreamConverters::toClaimedRecordIds);
+	}
+
+	@Override
+	public ClaimedRecords<ByteRecord> xAutoClaim(byte @NonNull [] key, @NonNull String group, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options) {
+
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(group, "Group must not be null");
+		Assert.notNull(newOwner, "NewOwner must not be null");
+		Assert.notNull(options, "Options must not be null");
+
+		XAutoClaimParams params = StreamConverters.toXAutoClaimParams(options);
+
+		return connection.invoke()
+				.from(JedisBinaryCommands::xautoclaim, ResponseCommands::xautoclaim, key, JedisConverters.toBytes(group),
+						JedisConverters.toBytes(newOwner), options.getMinIdleTime().toMillis(),
+						JedisConverters.toBytes(options.getStart().getValue()), params)
+				.get(r -> StreamConverters.toClaimedRecords(key, r));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/jedis/StreamConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/jedis/StreamConverters.java
@@ -19,6 +19,7 @@ import redis.clients.jedis.BuilderFactory;
 import redis.clients.jedis.StreamEntryID;
 import redis.clients.jedis.args.StreamDeletionPolicy;
 import redis.clients.jedis.params.XAddParams;
+import redis.clients.jedis.params.XAutoClaimParams;
 import redis.clients.jedis.params.XClaimParams;
 import redis.clients.jedis.params.XPendingParams;
 import redis.clients.jedis.params.XReadGroupParams;
@@ -35,12 +36,15 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.RedisStreamCommands;
 import org.springframework.data.redis.connection.RedisStreamCommands.*;
 import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.PendingMessage;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -60,6 +64,7 @@ import org.springframework.data.redis.connection.stream.StreamRecords;
  * @author Mark Paluch
  * @author Jeonggyu Choi
  * @author Viktoriya Kutsarova
+ * @author big-cir
  * @since 2.3
  */
 class StreamConverters {
@@ -319,6 +324,68 @@ class StreamConverters {
 		}
 
 		return params;
+	}
+
+	/**
+	 * Convert {@link XAutoClaimOptions} to Jedis' {@link XAutoClaimParams}.
+	 *
+	 * @param options must not be {@literal null}.
+	 * @return the converted {@link XAutoClaimParams}.
+	 * @since 4.2
+	 */
+	public static XAutoClaimParams toXAutoClaimParams(XAutoClaimOptions options) {
+
+		XAutoClaimParams params = XAutoClaimParams.xAutoClaimParams();
+
+		if (options.isLimited()) {
+			params.count(Math.toIntExact(options.getCount()));
+		}
+
+		return params;
+	}
+
+	/**
+	 * Convert the raw Jedis {@literal XAUTOCLAIM} response ({@code [cursor, entries, ...]}) to {@link ClaimedRecords}.
+	 *
+	 * @param key the stream key.
+	 * @param source the raw Jedis response.
+	 * @return the converted {@link ClaimedRecords}.
+	 * @since 4.2
+	 */
+	@SuppressWarnings("unchecked")
+	static ClaimedRecords<ByteRecord> toClaimedRecords(byte[] key, Object source) {
+
+		List<Object> response = (List<Object>) source;
+		RecordId cursor = RecordId.of(JedisConverters.toString((byte[]) response.get(0)));
+
+		// Redis < 7.0 reports pending entries that no longer exist in the stream as nil entries.
+		List<ByteRecord> records = convertToByteRecord(key, response.get(1));
+		records.removeIf(Objects::isNull);
+
+		return new ClaimedRecords<>(cursor, records);
+	}
+
+	/**
+	 * Convert the raw Jedis {@literal XAUTOCLAIM ... JUSTID} response ({@code [cursor, ids, ...]}) to
+	 * {@link ClaimedRecordIds}.
+	 *
+	 * @param source the raw Jedis response.
+	 * @return the converted {@link ClaimedRecordIds}.
+	 * @since 4.2
+	 */
+	@SuppressWarnings("unchecked")
+	static ClaimedRecordIds toClaimedRecordIds(Object source) {
+
+		List<Object> response = (List<Object>) source;
+		RecordId cursor = RecordId.of(JedisConverters.toString((byte[]) response.get(0)));
+
+		List<byte[]> rawIds = (List<byte[]>) response.get(1);
+		List<RecordId> ids = new ArrayList<>(rawIds.size());
+		for (byte[] rawId : rawIds) {
+			ids.add(RecordId.of(JedisConverters.toString(rawId)));
+		}
+
+		return new ClaimedRecordIds(cursor, ids);
 	}
 
 	@SuppressWarnings("NullAway")

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommands.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
 import io.lettuce.core.XClaimArgs;
 import io.lettuce.core.XGroupCreateArgs;
 import io.lettuce.core.XPendingArgs;
@@ -41,6 +42,8 @@ import org.springframework.data.redis.connection.ReactiveStreamCommands.DeleteEx
 import org.springframework.data.redis.connection.ReactiveStreamCommands.GroupCommand.GroupCommandAction;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamEntryDeletionResult;
 import org.springframework.data.redis.connection.stream.ByteBufferRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.PendingMessages;
 import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
@@ -61,6 +64,7 @@ import org.springframework.util.Assert;
  * @author Dengliming
  * @author Mark John Moreno
  * @author Jeonggyu Choi
+ * @author big-cir
  * @since 2.2
  */
 class LettuceReactiveStreamCommands implements ReactiveStreamCommands {
@@ -136,6 +140,44 @@ class LettuceReactiveStreamCommands implements ReactiveStreamCommands {
 			Flux<ByteBufferRecord> result = cmd.xclaim(command.getKey(), from, args, ids)
 					.map(it -> StreamRecords.newRecord().in(it.getStream()).withId(it.getId()).ofBuffer(it.getBody()));
 			return new CommandResponse<>(command, result);
+		}));
+	}
+
+	@Override
+	public Flux<CommandResponse<XAutoClaimCommand, ClaimedRecordIds>> xAutoClaimJustId(
+			Publisher<XAutoClaimCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null");
+			Assert.notNull(command.getOptions(), "Options must not be null");
+
+			io.lettuce.core.Consumer<ByteBuffer> consumer = io.lettuce.core.Consumer
+					.from(ByteUtils.getByteBuffer(command.getGroupName()), ByteUtils.getByteBuffer(command.getNewOwner()));
+			XAutoClaimArgs<ByteBuffer> args = StreamConverters.toXAutoClaimArgs(consumer, command.getOptions()).justid();
+
+			// Lettuce < 7.8 reports ids of pending entries that no longer exist in the stream (the third XAUTOCLAIM reply
+			// element introduced with Redis 7.0) as claimed ids when using JUSTID. See redis/lettuce#3901.
+			return cmd.xautoclaim(command.getKey(), args).map(StreamConverters::toClaimedRecordIds)
+					.map(value -> new CommandResponse<>(command, value));
+		}));
+	}
+
+	@Override
+	public Flux<CommandResponse<XAutoClaimCommand, ClaimedRecords<ByteBufferRecord>>> xAutoClaim(
+			Publisher<XAutoClaimCommand> commands) {
+
+		return connection.execute(cmd -> Flux.from(commands).concatMap(command -> {
+
+			Assert.notNull(command.getKey(), "Key must not be null");
+			Assert.notNull(command.getOptions(), "Options must not be null");
+
+			io.lettuce.core.Consumer<ByteBuffer> consumer = io.lettuce.core.Consumer
+					.from(ByteUtils.getByteBuffer(command.getGroupName()), ByteUtils.getByteBuffer(command.getNewOwner()));
+			XAutoClaimArgs<ByteBuffer> args = StreamConverters.toXAutoClaimArgs(consumer, command.getOptions());
+
+			return cmd.xautoclaim(command.getKey(), args).map(StreamConverters::toClaimedByteBufferRecords)
+					.map(value -> new CommandResponse<>(command, value));
 		}));
 	}
 

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/LettuceStreamCommands.java
@@ -16,6 +16,7 @@
 package org.springframework.data.redis.connection.lettuce;
 
 import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
 import io.lettuce.core.XClaimArgs;
 import io.lettuce.core.XGroupCreateArgs;
 import io.lettuce.core.XPendingArgs;
@@ -35,6 +36,8 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisStreamCommands;
 import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -55,6 +58,7 @@ import org.springframework.util.Assert;
  * @author Dengliming
  * @author Mark John Moreno
  * @author Jeonggyu Choi
+ * @author big-cir
  * @since 2.2
  */
 @NullUnmarked
@@ -115,6 +119,32 @@ class LettuceStreamCommands implements RedisStreamCommands {
 
 		return connection.invoke().fromMany(RedisStreamAsyncCommands::xclaim, key, from, args, ids)
 				.toList(StreamConverters.byteRecordConverter());
+	}
+
+	@Override
+	public ClaimedRecordIds xAutoClaimJustId(byte @NonNull [] key, @NonNull String group, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options) {
+
+		io.lettuce.core.Consumer<byte[]> consumer = io.lettuce.core.Consumer.from(LettuceConverters.toBytes(group),
+				LettuceConverters.toBytes(newOwner));
+		XAutoClaimArgs<byte[]> args = StreamConverters.toXAutoClaimArgs(consumer, options).justid();
+
+		// Lettuce < 7.8 reports ids of pending entries that no longer exist in the stream (the third XAUTOCLAIM reply
+		// element introduced with Redis 7.0) as claimed ids when using JUSTID. See redis/lettuce#3901.
+		return connection.invoke().from(RedisStreamAsyncCommands::xautoclaim, key, args)
+				.get(StreamConverters::toClaimedRecordIds);
+	}
+
+	@Override
+	public ClaimedRecords<ByteRecord> xAutoClaim(byte @NonNull [] key, @NonNull String group, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options) {
+
+		io.lettuce.core.Consumer<byte[]> consumer = io.lettuce.core.Consumer.from(LettuceConverters.toBytes(group),
+				LettuceConverters.toBytes(newOwner));
+		XAutoClaimArgs<byte[]> args = StreamConverters.toXAutoClaimArgs(consumer, options);
+
+		return connection.invoke().from(RedisStreamAsyncCommands::xautoclaim, key, args)
+				.get(StreamConverters::toClaimedRecords);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/connection/lettuce/StreamConverters.java
+++ b/src/main/java/org/springframework/data/redis/connection/lettuce/StreamConverters.java
@@ -18,13 +18,16 @@ package org.springframework.data.redis.connection.lettuce;
 import io.lettuce.core.StreamDeletionPolicy;
 import io.lettuce.core.StreamMessage;
 import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
 import io.lettuce.core.XClaimArgs;
 import io.lettuce.core.XReadArgs;
 import io.lettuce.core.XTrimArgs;
+import io.lettuce.core.models.stream.ClaimedMessages;
 import io.lettuce.core.models.stream.PendingMessage;
 import io.lettuce.core.models.stream.PendingMessages;
 import io.lettuce.core.models.stream.StreamEntryDeletionResult;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
 import org.springframework.core.convert.converter.Converter;
@@ -35,10 +38,14 @@ import org.springframework.data.redis.connection.RedisStreamCommands.TrimOperato
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimStrategy;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
+import org.springframework.data.redis.connection.stream.ByteBufferRecord;
 import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import org.springframework.data.redis.connection.stream.RecordId;
@@ -55,6 +62,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Viktoriya Kutsarova
+ * @author big-cir
  * @since 2.2
  */
 @SuppressWarnings({ "rawtypes" })
@@ -79,6 +87,69 @@ class StreamConverters {
 	 */
 	static XClaimArgs toXClaimArgs(XClaimOptions options) {
 		return XClaimOptionsToXClaimArgsConverter.INSTANCE.convert(options);
+	}
+
+	/**
+	 * Convert {@link XAutoClaimOptions} to Lettuce's {@link XAutoClaimArgs}.
+	 *
+	 * @param consumer the consumer claiming the messages. Must not be {@literal null}.
+	 * @param options must not be {@literal null}.
+	 * @return the converted {@link XAutoClaimArgs}.
+	 * @since 4.2
+	 */
+	static <K> XAutoClaimArgs<K> toXAutoClaimArgs(io.lettuce.core.Consumer<K> consumer, XAutoClaimOptions options) {
+
+		XAutoClaimArgs<K> args = XAutoClaimArgs.Builder.xautoclaim(consumer, options.getMinIdleTime(),
+				options.getStart().getValue());
+
+		if (options.isLimited()) {
+			args.count(options.getCount());
+		}
+
+		return args;
+	}
+
+	/**
+	 * Convert Lettuce's {@link ClaimedMessages} to {@link ClaimedRecords}.
+	 *
+	 * @param source the raw Lettuce response.
+	 * @return the converted {@link ClaimedRecords}.
+	 * @since 4.2
+	 */
+	static ClaimedRecords<ByteRecord> toClaimedRecords(ClaimedMessages<byte[], byte[]> source) {
+
+		List<ByteRecord> records = source.getMessages().stream().map(byteRecordConverter()::convert).toList();
+
+		return new ClaimedRecords<>(RecordId.of(source.getId()), records);
+	}
+
+	/**
+	 * Convert Lettuce's {@link ClaimedMessages} to {@link ClaimedRecords} holding {@link ByteBufferRecord}.
+	 *
+	 * @param source the raw Lettuce response.
+	 * @return the converted {@link ClaimedRecords}.
+	 * @since 4.2
+	 */
+	static ClaimedRecords<ByteBufferRecord> toClaimedByteBufferRecords(ClaimedMessages<ByteBuffer, ByteBuffer> source) {
+
+		List<ByteBufferRecord> records = source.getMessages().stream()
+				.map(it -> StreamRecords.newRecord().in(it.getStream()).withId(it.getId()).ofBuffer(it.getBody())).toList();
+
+		return new ClaimedRecords<>(RecordId.of(source.getId()), records);
+	}
+
+	/**
+	 * Convert Lettuce's {@link ClaimedMessages} of a {@literal JUSTID} call to {@link ClaimedRecordIds}.
+	 *
+	 * @param source the raw Lettuce response.
+	 * @return the converted {@link ClaimedRecordIds}.
+	 * @since 4.2
+	 */
+	static ClaimedRecordIds toClaimedRecordIds(ClaimedMessages<?, ?> source) {
+
+		List<RecordId> ids = source.getMessages().stream().map(it -> RecordId.of(it.getId())).toList();
+
+		return new ClaimedRecordIds(RecordId.of(source.getId()), ids);
 	}
 
 	@SuppressWarnings("NullAway")

--- a/src/main/java/org/springframework/data/redis/connection/stream/ClaimedRecordIds.java
+++ b/src/main/java/org/springframework/data/redis/connection/stream/ClaimedRecordIds.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.stream;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.data.util.Streamable;
+import org.springframework.util.Assert;
+
+/**
+ * Value object holding the result of an {@literal XAUTOCLAIM ... JUSTID} call: the {@link RecordId cursor} to use as
+ * start argument for the next call along with the {@link RecordId ids} of the records whose ownership has been
+ * transferred.
+ * <p>
+ * A cursor of {@code 0-0} indicates that the scan of the pending entries list has been completed.
+ *
+ * @author big-cir
+ * @since 4.2
+ * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+ */
+public class ClaimedRecordIds implements Streamable<RecordId> {
+
+	private final RecordId cursor;
+	private final List<RecordId> ids;
+
+	/**
+	 * Create new {@link ClaimedRecordIds}.
+	 *
+	 * @param cursor the {@link RecordId} to be used as start argument for the next call. Must not be {@literal null}.
+	 * @param ids the ids of the claimed records. Must not be {@literal null}.
+	 */
+	public ClaimedRecordIds(RecordId cursor, List<RecordId> ids) {
+
+		Assert.notNull(cursor, "Cursor must not be null");
+		Assert.notNull(ids, "Ids must not be null");
+
+		this.cursor = cursor;
+		this.ids = ids;
+	}
+
+	/**
+	 * The {@link RecordId} to be used as the start argument for the next {@literal XAUTOCLAIM} call. {@code 0-0}
+	 * indicates that the scan is complete.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public RecordId getCursor() {
+		return cursor;
+	}
+
+	/**
+	 * The {@link RecordId ids} of the records that were claimed.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public List<RecordId> getIds() {
+		return ids;
+	}
+
+	/**
+	 * @return {@literal true} if no records were claimed.
+	 */
+	public boolean isEmpty() {
+		return ids.isEmpty();
+	}
+
+	/**
+	 * @return the number of claimed records.
+	 */
+	public int size() {
+		return ids.size();
+	}
+
+	/**
+	 * Get the {@link RecordId} at the given position.
+	 *
+	 * @param index
+	 * @return the {@link RecordId} at the given index.
+	 * @throws IndexOutOfBoundsException if the index is out of range.
+	 */
+	public RecordId get(int index) {
+		return ids.get(index);
+	}
+
+	@Override
+	public Iterator<RecordId> iterator() {
+		return ids.iterator();
+	}
+
+	@Override
+	public String toString() {
+		return "ClaimedRecordIds{" + "cursor=" + cursor + ", ids=" + ids + '}';
+	}
+}

--- a/src/main/java/org/springframework/data/redis/connection/stream/ClaimedRecords.java
+++ b/src/main/java/org/springframework/data/redis/connection/stream/ClaimedRecords.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.redis.connection.stream;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+import org.springframework.data.util.Streamable;
+import org.springframework.util.Assert;
+
+/**
+ * Value object holding the result of an {@literal XAUTOCLAIM} call: the {@link RecordId cursor} to use as start
+ * argument for the next call along with the {@link Record records} whose ownership has been transferred.
+ * <p>
+ * A cursor of {@code 0-0} indicates that the scan of the pending entries list has been completed.
+ *
+ * @param <R> the {@link Record} type.
+ * @author big-cir
+ * @since 4.2
+ * @see <a href="https://redis.io/commands/xautoclaim">Redis Documentation: XAUTOCLAIM</a>
+ */
+public class ClaimedRecords<R extends Record<?, ?>> implements Streamable<R> {
+
+	private final RecordId cursor;
+	private final List<R> records;
+
+	/**
+	 * Create new {@link ClaimedRecords}.
+	 *
+	 * @param cursor the {@link RecordId} to be used as start argument for the next call. Must not be {@literal null}.
+	 * @param records the claimed records. Must not be {@literal null}.
+	 */
+	public ClaimedRecords(RecordId cursor, List<R> records) {
+
+		Assert.notNull(cursor, "Cursor must not be null");
+		Assert.notNull(records, "Records must not be null");
+
+		this.cursor = cursor;
+		this.records = records;
+	}
+
+	/**
+	 * The {@link RecordId} to be used as the start argument for the next {@literal XAUTOCLAIM} call. {@code 0-0}
+	 * indicates that the scan is complete.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public RecordId getCursor() {
+		return cursor;
+	}
+
+	/**
+	 * The {@link Record records} that were claimed.
+	 *
+	 * @return never {@literal null}.
+	 */
+	public List<R> getRecords() {
+		return records;
+	}
+
+	/**
+	 * @return {@literal true} if no records were claimed.
+	 */
+	public boolean isEmpty() {
+		return records.isEmpty();
+	}
+
+	/**
+	 * @return the number of claimed records.
+	 */
+	public int size() {
+		return records.size();
+	}
+
+	/**
+	 * Get the {@link Record} at the given position.
+	 *
+	 * @param index
+	 * @return the {@link Record} at the given index.
+	 * @throws IndexOutOfBoundsException if the index is out of range.
+	 */
+	public R get(int index) {
+		return records.get(index);
+	}
+
+	/**
+	 * Create a new {@link ClaimedRecords} instance by applying the given {@link Function mapper} to each record while
+	 * retaining the cursor.
+	 *
+	 * @param mapper must not be {@literal null}.
+	 * @param <T> the target {@link Record} type.
+	 * @return new instance of {@link ClaimedRecords}.
+	 */
+	public <T extends Record<?, ?>> ClaimedRecords<T> mapRecords(Function<? super R, ? extends T> mapper) {
+
+		Assert.notNull(mapper, "Mapping function must not be null");
+
+		List<T> mapped = new ArrayList<>(records.size());
+		for (R record : records) {
+			mapped.add(mapper.apply(record));
+		}
+
+		return new ClaimedRecords<>(cursor, mapped);
+	}
+
+	@Override
+	public Iterator<R> iterator() {
+		return records.iterator();
+	}
+
+	@Override
+	public String toString() {
+		return "ClaimedRecords{" + "cursor=" + cursor + ", records=" + records + '}';
+	}
+}

--- a/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultReactiveStreamOperations.java
@@ -35,12 +35,15 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.ReactiveStreamCommands;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamEntryDeletionResult;
 import org.springframework.data.redis.connection.convert.Converters;
 import org.springframework.data.redis.connection.stream.ByteBufferRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -66,6 +69,7 @@ import org.springframework.util.ClassUtils;
  * @author Marcin Zielinski
  * @author John Blum
  * @author jinkshower
+ * @author big-cir
  * @since 2.2
  */
 @NullUnmarked
@@ -172,6 +176,32 @@ class DefaultReactiveStreamOperations<K, HK, HV> implements ReactiveStreamOperat
 
 		return createFlux(streamCommands -> streamCommands.xClaim(rawKey(key), consumerGroup, newOwner, xClaimOptions)
 				.map(this::deserializeRecord));
+	}
+
+	@Override
+	public Mono<ClaimedRecords<MapRecord<K, HK, HV>>> autoClaim(@NonNull K key, @NonNull String consumerGroup,
+			@NonNull String newOwner, @NonNull XAutoClaimOptions options) {
+
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(consumerGroup, "Consumer group must not be null");
+		Assert.notNull(newOwner, "New owner must not be null");
+		Assert.notNull(options, "Options must not be null");
+
+		return createMono(streamCommands -> streamCommands.xAutoClaim(rawKey(key), consumerGroup, newOwner, options)
+				.map(claimed -> claimed.mapRecords(this::deserializeRecord)));
+	}
+
+	@Override
+	public Mono<ClaimedRecordIds> autoClaimJustId(@NonNull K key, @NonNull String consumerGroup,
+			@NonNull String newOwner, @NonNull XAutoClaimOptions options) {
+
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(consumerGroup, "Consumer group must not be null");
+		Assert.notNull(newOwner, "New owner must not be null");
+		Assert.notNull(options, "Options must not be null");
+
+		return createMono(
+				streamCommands -> streamCommands.xAutoClaimJustId(rawKey(key), consumerGroup, newOwner, options));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/DefaultStreamOperations.java
@@ -32,11 +32,14 @@ import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisStreamCommands;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamEntryDeletionResult;
 import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -64,6 +67,7 @@ import org.springframework.util.ClassUtils;
  * @author John Blum
  * @author jinkshower
  * @author Jeonggyu Choi
+ * @author big-cir
  * @since 2.2
  */
 @NullUnmarked
@@ -172,6 +176,31 @@ class DefaultStreamOperations<K, HK, HV> extends AbstractOperations<K, Object> i
 				return connection.streamCommands().xClaim(rawKey(key), consumerGroup, newOwner, xClaimOptions);
 			}
 		}));
+	}
+
+	@Override
+	public ClaimedRecords<MapRecord<K, HK, HV>> autoClaim(@NonNull K key, @NonNull String consumerGroup,
+			@NonNull String newOwner, @NonNull XAutoClaimOptions options) {
+
+		byte[] rawKey = rawKey(key);
+
+		return execute(connection -> {
+
+			ClaimedRecords<ByteRecord> raw = connection.streamCommands().xAutoClaim(rawKey, consumerGroup, newOwner,
+					options);
+
+			return raw != null ? raw.mapRecords(this::deserializeRecord) : null;
+		});
+	}
+
+	@Override
+	public ClaimedRecordIds autoClaimJustId(@NonNull K key, @NonNull String consumerGroup, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options) {
+
+		byte[] rawKey = rawKey(key);
+
+		return execute(connection -> connection.streamCommands().xAutoClaimJustId(rawKey, consumerGroup, newOwner,
+				options));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/ReactiveStreamOperations.java
@@ -32,6 +32,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamEntryDeletionResult;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
@@ -52,6 +53,7 @@ import org.springframework.util.Assert;
  * @author Marcin Zielinski
  * @author John Blum
  * @author jinkshower
+ * @author big-cir
  * @since 2.2
  */
 @NullUnmarked
@@ -224,6 +226,59 @@ public interface ReactiveStreamOperations<K, HK, HV> extends HashMapperProvider<
 	 */
 	Flux<MapRecord<K, HK, HV>> claim(@NonNull K key, @NonNull String consumerGroup, @NonNull String newOwner,
 			@NonNull XClaimOptions xClaimOptions);
+
+	/**
+	 * Transfers ownership of pending messages that have been idle for at least the given {@link Duration minimum idle
+	 * time} to the given new owner, scanning the pending entries list from the beginning.
+	 *
+	 * @param key {@link K key} of the stream.
+	 * @param consumerGroup {@link String name} of the consumer group.
+	 * @param newOwner {@link String name} of the consumer claiming the messages.
+	 * @param minIdleTime {@link Duration minimum idle time} required for a message to be claimed.
+	 * @return a {@link Mono} emitting the next cursor along with the claimed {@link MapRecord MapRecords}.
+	 * @see <a href="https://redis.io/commands/xautoclaim/">Redis Documentation: XAUTOCLAIM</a>
+	 * @see #autoClaim(Object, String, String, XAutoClaimOptions)
+	 * @since 4.2
+	 */
+	default Mono<ClaimedRecords<MapRecord<K, HK, HV>>> autoClaim(@NonNull K key, @NonNull String consumerGroup,
+			@NonNull String newOwner, @NonNull Duration minIdleTime) {
+		return autoClaim(key, consumerGroup, newOwner, XAutoClaimOptions.minIdle(minIdleTime));
+	}
+
+	/**
+	 * Transfers ownership of pending messages that have been idle for at least the given
+	 * {@link XAutoClaimOptions#getMinIdleTime() minimum idle time} to the given new owner. Scanning starts at the
+	 * {@link XAutoClaimOptions#getStart() start} id and the returned {@link ClaimedRecords#getCursor() cursor} is to be
+	 * used as start for the next call.
+	 *
+	 * @param key {@link K key} of the stream.
+	 * @param consumerGroup {@link String name} of the consumer group.
+	 * @param newOwner {@link String name} of the consumer claiming the messages.
+	 * @param options additional parameters for the {@literal XAUTOCLAIM} call.
+	 * @return a {@link Mono} emitting the next cursor along with the claimed {@link MapRecord MapRecords}.
+	 * @see <a href="https://redis.io/commands/xautoclaim/">Redis Documentation: XAUTOCLAIM</a>
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions
+	 * @since 4.2
+	 */
+	Mono<ClaimedRecords<MapRecord<K, HK, HV>>> autoClaim(@NonNull K key, @NonNull String consumerGroup,
+			@NonNull String newOwner, @NonNull XAutoClaimOptions options);
+
+	/**
+	 * Transfers ownership of pending messages that have been idle for at least the given
+	 * {@link XAutoClaimOptions#getMinIdleTime() minimum idle time} to the given new owner without fetching the message
+	 * bodies.
+	 *
+	 * @param key {@link K key} of the stream.
+	 * @param consumerGroup {@link String name} of the consumer group.
+	 * @param newOwner {@link String name} of the consumer claiming the messages.
+	 * @param options additional parameters for the {@literal XAUTOCLAIM} call.
+	 * @return a {@link Mono} emitting the next cursor along with the {@link RecordId ids} of the claimed records.
+	 * @see <a href="https://redis.io/commands/xautoclaim/">Redis Documentation: XAUTOCLAIM</a>
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions
+	 * @since 4.2
+	 */
+	Mono<ClaimedRecordIds> autoClaimJustId(@NonNull K key, @NonNull String consumerGroup, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options);
 
 	/**
 	 * Removes the specified records from the stream. Returns the number of records deleted, that may be different from

--- a/src/main/java/org/springframework/data/redis/core/StreamOperations.java
+++ b/src/main/java/org/springframework/data/redis/core/StreamOperations.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.NullUnmarked;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
@@ -50,6 +51,7 @@ import org.springframework.util.Assert;
  * @author John Blum
  * @author jinkshower
  * @author Jeonggyu Choi
+ * @author big-cir
  * @since 2.2
  */
 @NullUnmarked
@@ -209,6 +211,59 @@ public interface StreamOperations<K, HK, HV> extends HashMapperProvider<HK, HV> 
 	 */
 	List<@NonNull MapRecord<K, HK, HV>> claim(@NonNull K key, @NonNull String consumerGroup, @NonNull String newOwner,
 			@NonNull XClaimOptions xClaimOptions);
+
+	/**
+	 * Transfers ownership of pending messages that have been idle for at least the given {@link Duration minimum idle
+	 * time} to the given new owner, scanning the pending entries list from the beginning.
+	 *
+	 * @param key {@link K key} of the stream.
+	 * @param consumerGroup {@link String name} of the consumer group.
+	 * @param newOwner {@link String name} of the consumer claiming the messages.
+	 * @param minIdleTime {@link Duration minimum idle time} required for a message to be claimed.
+	 * @return the next cursor along with the claimed {@link MapRecord MapRecords}.
+	 * @see <a href="https://redis.io/commands/xautoclaim/">Redis Documentation: XAUTOCLAIM</a>
+	 * @see #autoClaim(Object, String, String, XAutoClaimOptions)
+	 * @since 4.2
+	 */
+	default ClaimedRecords<MapRecord<K, HK, HV>> autoClaim(@NonNull K key, @NonNull String consumerGroup,
+			@NonNull String newOwner, @NonNull Duration minIdleTime) {
+		return autoClaim(key, consumerGroup, newOwner, XAutoClaimOptions.minIdle(minIdleTime));
+	}
+
+	/**
+	 * Transfers ownership of pending messages that have been idle for at least the given
+	 * {@link XAutoClaimOptions#getMinIdleTime() minimum idle time} to the given new owner. Scanning starts at the
+	 * {@link XAutoClaimOptions#getStart() start} id and the returned {@link ClaimedRecords#getCursor() cursor} is to be
+	 * used as start for the next call.
+	 *
+	 * @param key {@link K key} of the stream.
+	 * @param consumerGroup {@link String name} of the consumer group.
+	 * @param newOwner {@link String name} of the consumer claiming the messages.
+	 * @param options additional parameters for the {@literal XAUTOCLAIM} call.
+	 * @return the next cursor along with the claimed {@link MapRecord MapRecords}.
+	 * @see <a href="https://redis.io/commands/xautoclaim/">Redis Documentation: XAUTOCLAIM</a>
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions
+	 * @since 4.2
+	 */
+	ClaimedRecords<MapRecord<K, HK, HV>> autoClaim(@NonNull K key, @NonNull String consumerGroup,
+			@NonNull String newOwner, @NonNull XAutoClaimOptions options);
+
+	/**
+	 * Transfers ownership of pending messages that have been idle for at least the given
+	 * {@link XAutoClaimOptions#getMinIdleTime() minimum idle time} to the given new owner without fetching the message
+	 * bodies.
+	 *
+	 * @param key {@link K key} of the stream.
+	 * @param consumerGroup {@link String name} of the consumer group.
+	 * @param newOwner {@link String name} of the consumer claiming the messages.
+	 * @param options additional parameters for the {@literal XAUTOCLAIM} call.
+	 * @return the next cursor along with the {@link RecordId ids} of the claimed records.
+	 * @see <a href="https://redis.io/commands/xautoclaim/">Redis Documentation: XAUTOCLAIM</a>
+	 * @see org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions
+	 * @since 4.2
+	 */
+	ClaimedRecordIds autoClaimJustId(@NonNull K key, @NonNull String consumerGroup, @NonNull String newOwner,
+			@NonNull XAutoClaimOptions options);
 
 	/**
 	 * Removes the specified records from the stream. Returns the number of records deleted, that may be different from

--- a/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/AbstractConnectionIntegrationTests.java
@@ -65,6 +65,7 @@ import org.springframework.data.redis.connection.RedisListCommands.Position;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamDeletionPolicy;
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
 import org.springframework.data.redis.connection.RedisStringCommands.BitOperation;
@@ -77,6 +78,8 @@ import org.springframework.data.redis.connection.json.JsonPath;
 import org.springframework.data.redis.connection.json.JsonSetCondition;
 import org.springframework.data.redis.connection.json.JsonType;
 import org.springframework.data.redis.connection.json.JsonValue;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessages;
@@ -127,6 +130,7 @@ import org.springframework.util.ObjectUtils;
  * @author Jeonggyu Choi
  * @author Viktoriya Kutsarova
  * @author Yordan Tsintsov
+ * @author big-cir
  */
 public abstract class AbstractConnectionIntegrationTests {
 
@@ -4950,6 +4954,44 @@ public abstract class AbstractConnectionIntegrationTests {
 
 		List<MapRecord<String, String, String>> claimed = (List<MapRecord<String, String, String>>) getResults().get(3);
 		assertThat(claimed).containsAll(messages);
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	public void xAutoClaim() {
+
+		actual.add(connection.xAdd(KEY_1, Collections.singletonMap(KEY_2, VALUE_2)));
+		actual.add(connection.xGroupCreate(KEY_1, ReadOffset.from("0"), "my-group"));
+		actual.add(connection.xReadGroupAsString(Consumer.from("my-group", "my-consumer"),
+				StreamOffset.create(KEY_1, ReadOffset.lastConsumed())));
+		actual.add(connection.xAutoClaim(KEY_1, "my-group", "new-owner", Duration.ZERO));
+
+		List<Object> results = getResults();
+		List<MapRecord<String, String, String>> messages = (List<MapRecord<String, String, String>>) results.get(2);
+		ClaimedRecords<StringRecord> claimed = (ClaimedRecords<StringRecord>) results.get(3);
+
+		assertThat(claimed.getCursor()).isEqualTo(RecordId.of("0-0"));
+		assertThat(claimed.size()).isOne();
+		assertThat(claimed.get(0)).isEqualTo(messages.get(0));
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	public void xAutoClaimJustId() {
+
+		actual.add(connection.xAdd(KEY_1, Collections.singletonMap(KEY_2, VALUE_2)));
+		actual.add(connection.xGroupCreate(KEY_1, ReadOffset.from("0"), "my-group"));
+		actual.add(connection.xReadGroupAsString(Consumer.from("my-group", "my-consumer"),
+				StreamOffset.create(KEY_1, ReadOffset.lastConsumed())));
+		actual.add(connection.xAutoClaimJustId(KEY_1, "my-group", "new-owner",
+				XAutoClaimOptions.minIdle(Duration.ZERO).count(10)));
+
+		List<Object> results = getResults();
+		List<MapRecord<String, String, String>> messages = (List<MapRecord<String, String, String>>) results.get(2);
+		ClaimedRecordIds claimed = (ClaimedRecordIds) results.get(3);
+
+		assertThat(claimed.getCursor()).isEqualTo(RecordId.of("0-0"));
+		assertThat(claimed.getIds()).containsExactly(messages.get(0).getId());
 	}
 
 	@Test // DATAREDIS-1119

--- a/src/test/java/org/springframework/data/redis/connection/jedis/StreamConvertersUnitTest.java
+++ b/src/test/java/org/springframework/data/redis/connection/jedis/StreamConvertersUnitTest.java
@@ -23,6 +23,9 @@ import redis.clients.jedis.params.XPendingParams;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -36,15 +39,20 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamDeletionPolicy;
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XPendingOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
+import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.RecordId;
 
 /**
  * @author Jeonggyu Choi
  * @author Christoph Strobl
  * @author Viktoriya Kutsarova
+ * @author big-cir
  */
 class StreamConvertersUnitTest {
 
@@ -125,6 +133,60 @@ class StreamConvertersUnitTest {
 				argumentSet("withDeleteReferencesPolicy", XDelOptions.deletionPolicy(StreamDeletionPolicy.delete()), redis.clients.jedis.args.StreamDeletionPolicy.DELETE_REFERENCES),
 				argumentSet("withRemoveAcknowledgedPolicy", XDelOptions.deletionPolicy(StreamDeletionPolicy.removeAcknowledged()), redis.clients.jedis.args.StreamDeletionPolicy.ACKNOWLEDGED)
 		);
+	}
+
+	@Test // GH-3434
+	void toXAutoClaimParamsShouldConvertCount() {
+
+		assertThat(StreamConverters.toXAutoClaimParams(XAutoClaimOptions.minIdleMs(1000).count(10)))
+				.hasFieldOrPropertyWithValue("count", 10);
+	}
+
+	@Test // GH-3434
+	void toXAutoClaimParamsShouldOmitCountByDefault() {
+
+		assertThat(StreamConverters.toXAutoClaimParams(XAutoClaimOptions.minIdleMs(1000)))
+				.hasFieldOrPropertyWithValue("count", null);
+	}
+
+	@Test // GH-3434
+	void toClaimedRecordsShouldConvertRawResponse() {
+
+		byte[] key = "key".getBytes();
+		List<Object> entry = Arrays.asList("1-0".getBytes(), Arrays.asList("field".getBytes(), "value".getBytes()));
+		List<Object> response = Arrays.asList("2-0".getBytes(), Collections.singletonList(entry));
+
+		ClaimedRecords<ByteRecord> claimed = StreamConverters.toClaimedRecords(key, response);
+
+		assertThat(claimed.getCursor()).isEqualTo(RecordId.of("2-0"));
+		assertThat(claimed.size()).isOne();
+		assertThat(claimed.get(0).getId()).isEqualTo(RecordId.of("1-0"));
+		assertThat(claimed.get(0).getStream()).isEqualTo(key);
+		assertThat(claimed.get(0).getValue()).hasSize(1);
+	}
+
+	@Test // GH-3434
+	void toClaimedRecordsShouldSkipNilEntries() {
+
+		byte[] key = "key".getBytes();
+		List<Object> entry = Arrays.asList("2-0".getBytes(), Arrays.asList("field".getBytes(), "value".getBytes()));
+		List<Object> response = Arrays.asList("0-0".getBytes(), Arrays.asList(null, entry));
+
+		ClaimedRecords<ByteRecord> claimed = StreamConverters.toClaimedRecords(key, response);
+
+		assertThat(claimed.size()).isOne();
+		assertThat(claimed.get(0).getId()).isEqualTo(RecordId.of("2-0"));
+	}
+
+	@Test // GH-3434
+	void toClaimedRecordIdsShouldConvertRawResponse() {
+
+		List<Object> response = Arrays.asList("0-0".getBytes(), Arrays.asList("1-0".getBytes(), "2-0".getBytes()));
+
+		ClaimedRecordIds claimed = StreamConverters.toClaimedRecordIds(response);
+
+		assertThat(claimed.getCursor()).isEqualTo(RecordId.of("0-0"));
+		assertThat(claimed.getIds()).containsExactly(RecordId.of("1-0"), RecordId.of("2-0"));
 	}
 
 }

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceConvertersUnitTests.java
@@ -26,12 +26,15 @@ import io.lettuce.core.GetExArgs;
 import io.lettuce.core.Limit;
 import io.lettuce.core.RedisCredentials;
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.StreamMessage;
 import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
 import io.lettuce.core.XTrimArgs;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode.NodeFlag;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.models.stream.ClaimedMessages;
 import io.lettuce.core.protocol.CommandArgs;
 
 import java.nio.ByteBuffer;
@@ -60,10 +63,14 @@ import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamDeletionPolicy;
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
 import org.springframework.data.redis.connection.SetCondition;
 import org.springframework.data.redis.connection.json.JsonSetCondition;
+import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.data.redis.core.types.RedisClientInfo;
@@ -76,6 +83,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @author Vikas Garg
  * @author Yordan Tsintsov
  * @author Mark Paluch
+ * @author big-cir
  */
 class LettuceConvertersUnitTests {
 
@@ -538,6 +546,73 @@ class LettuceConvertersUnitTests {
 			XTrimArgs args = StreamConverters.toXTrimArgs(options);
 
 			assertThat(args).extracting("trimmingMode").isEqualTo(io.lettuce.core.StreamDeletionPolicy.KEEP_REFERENCES);
+		}
+	}
+
+	@Nested // GH-3434
+	class ToXAutoClaimArgsShould {
+
+		@Test
+		void convertMinIdleTimeAndStart() {
+
+			XAutoClaimArgs<String> args = StreamConverters.toXAutoClaimArgs(io.lettuce.core.Consumer.from("group", "owner"),
+					XAutoClaimOptions.minIdleMs(1000).from("1234-0"));
+
+			assertThat(args).extracting("minIdleTime").isEqualTo(1000L);
+			assertThat(args).extracting("startId").isEqualTo("1234-0");
+			assertThat(args).extracting("count").isNull();
+			assertThat(args.isJustid()).isFalse();
+		}
+
+		@Test
+		void defaultToInitialCursor() {
+
+			XAutoClaimArgs<String> args = StreamConverters.toXAutoClaimArgs(io.lettuce.core.Consumer.from("group", "owner"),
+					XAutoClaimOptions.minIdleMs(1000));
+
+			assertThat(args).extracting("startId").isEqualTo("0-0");
+		}
+
+		@Test
+		void convertCount() {
+
+			XAutoClaimArgs<String> args = StreamConverters.toXAutoClaimArgs(io.lettuce.core.Consumer.from("group", "owner"),
+					XAutoClaimOptions.minIdleMs(1000).count(10));
+
+			assertThat(args).extracting("count").isEqualTo(10L);
+		}
+	}
+
+	@Nested // GH-3434
+	class ToClaimedRecordsShould {
+
+		@Test
+		void convertClaimedMessages() {
+
+			byte[] key = "key".getBytes();
+			StreamMessage<byte[], byte[]> message = new StreamMessage<>(key, "1-0",
+					Collections.singletonMap("field".getBytes(), "value".getBytes()));
+			ClaimedMessages<byte[], byte[]> source = new ClaimedMessages<>("2-0", Collections.singletonList(message));
+
+			ClaimedRecords<ByteRecord> claimed = StreamConverters.toClaimedRecords(source);
+
+			assertThat(claimed.getCursor()).isEqualTo(RecordId.of("2-0"));
+			assertThat(claimed.size()).isOne();
+			assertThat(claimed.get(0).getId()).isEqualTo(RecordId.of("1-0"));
+			assertThat(claimed.get(0).getStream()).isEqualTo(key);
+			assertThat(claimed.get(0).getValue()).hasSize(1);
+		}
+
+		@Test
+		void convertClaimedMessageIds() {
+
+			StreamMessage<byte[], byte[]> message = new StreamMessage<>("key".getBytes(), "1-0", null);
+			ClaimedMessages<byte[], byte[]> source = new ClaimedMessages<>("0-0", Collections.singletonList(message));
+
+			ClaimedRecordIds claimed = StreamConverters.toClaimedRecordIds(source);
+
+			assertThat(claimed.getCursor()).isEqualTo(RecordId.of("0-0"));
+			assertThat(claimed.getIds()).containsExactly(RecordId.of("1-0"));
 		}
 	}
 

--- a/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommandsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/connection/lettuce/LettuceReactiveStreamCommandsIntegrationTests.java
@@ -34,6 +34,7 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.Limit;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamEntryDeletionResult;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
 import org.springframework.data.redis.connection.stream.Consumer;
@@ -50,6 +51,7 @@ import org.springframework.data.redis.test.condition.EnabledOnCommand;
  * @author Tugdual Grall
  * @author Dengliming
  * @author Jeonggyu Choi
+ * @author big-cir
  */
 @ParameterizedClass
 @EnabledOnCommand("XADD")
@@ -660,6 +662,96 @@ public class LettuceReactiveStreamCommandsIntegrationTests extends LettuceReacti
 						XClaimOptions.minIdle(Duration.ofMillis(1)).ids(record.getId())))
 				.as(StepVerifier::create) //
 				.assertNext(it -> assertThat(it.getValue()).isEqualTo(expected)) //
+				.verifyComplete();
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	void xAutoClaimShouldClaimPendingMessages() {
+
+		String initialMessage = nativeCommands.xadd(KEY_1, KEY_1, VALUE_1);
+		nativeCommands.xgroupCreate(XReadArgs.StreamOffset.from(KEY_1, initialMessage), "my-group");
+
+		String expected = nativeCommands.xadd(KEY_1, KEY_2, VALUE_2);
+
+		connection.streamCommands()
+				.xReadGroup(Consumer.from("my-group", "my-consumer"),
+						StreamOffset.create(KEY_1_BBUFFER, ReadOffset.lastConsumed())) //
+				.then().as(StepVerifier::create) //
+				.verifyComplete();
+
+		connection.streamCommands().xAutoClaim(KEY_1_BBUFFER, "my-group", "new-owner", Duration.ZERO) //
+				.as(StepVerifier::create) //
+				.assertNext(it -> {
+
+					assertThat(it.getCursor()).isEqualTo(RecordId.of("0-0"));
+					assertThat(it.size()).isOne();
+					assertThat(it.get(0).getId().getValue()).isEqualTo(expected);
+					assertThat(it.get(0).getValue()).containsEntry(KEY_2_BBUFFER, VALUE_2_BBUFFER);
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	void xAutoClaimShouldIterateUsingCursor() {
+
+		String initialMessage = nativeCommands.xadd(KEY_1, KEY_1, VALUE_1);
+		nativeCommands.xgroupCreate(XReadArgs.StreamOffset.from(KEY_1, initialMessage), "my-group");
+
+		String first = nativeCommands.xadd(KEY_1, KEY_2, VALUE_2);
+		String second = nativeCommands.xadd(KEY_1, KEY_3, VALUE_3);
+
+		connection.streamCommands()
+				.xReadGroup(Consumer.from("my-group", "my-consumer"),
+						StreamOffset.create(KEY_1_BBUFFER, ReadOffset.lastConsumed())) //
+				.then().as(StepVerifier::create) //
+				.verifyComplete();
+
+		connection.streamCommands()
+				.xAutoClaim(KEY_1_BBUFFER, "my-group", "new-owner", XAutoClaimOptions.minIdle(Duration.ZERO).count(1)) //
+				.flatMap(firstPage -> {
+
+					assertThat(firstPage.size()).isOne();
+					assertThat(firstPage.get(0).getId().getValue()).isEqualTo(first);
+					assertThat(firstPage.getCursor()).isNotEqualTo(RecordId.of("0-0"));
+
+					return connection.streamCommands().xAutoClaim(KEY_1_BBUFFER, "my-group", "new-owner",
+							XAutoClaimOptions.minIdle(Duration.ZERO).count(1).from(firstPage.getCursor()));
+				}) //
+				.as(StepVerifier::create) //
+				.assertNext(secondPage -> {
+
+					assertThat(secondPage.size()).isOne();
+					assertThat(secondPage.get(0).getId().getValue()).isEqualTo(second);
+					assertThat(secondPage.getCursor()).isEqualTo(RecordId.of("0-0"));
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	void xAutoClaimJustIdShouldReturnIdsOnly() {
+
+		String initialMessage = nativeCommands.xadd(KEY_1, KEY_1, VALUE_1);
+		nativeCommands.xgroupCreate(XReadArgs.StreamOffset.from(KEY_1, initialMessage), "my-group");
+
+		String expected = nativeCommands.xadd(KEY_1, KEY_2, VALUE_2);
+
+		connection.streamCommands()
+				.xReadGroup(Consumer.from("my-group", "my-consumer"),
+						StreamOffset.create(KEY_1_BBUFFER, ReadOffset.lastConsumed())) //
+				.then().as(StepVerifier::create) //
+				.verifyComplete();
+
+		connection.streamCommands()
+				.xAutoClaimJustId(KEY_1_BBUFFER, "my-group", "new-owner", XAutoClaimOptions.minIdle(Duration.ZERO)) //
+				.as(StepVerifier::create) //
+				.assertNext(it -> {
+
+					assertThat(it.getCursor()).isEqualTo(RecordId.of("0-0"));
+					assertThat(it.getIds()).containsExactly(RecordId.of(expected));
+				}) //
 				.verifyComplete();
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultReactiveStreamOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultReactiveStreamOperationsIntegrationTests.java
@@ -43,7 +43,10 @@ import org.springframework.data.redis.connection.RedisStreamCommands.StreamDelet
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamEntryDeletionResult;
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.ReadOffset;
@@ -70,6 +73,7 @@ import org.springframework.data.redis.test.condition.EnabledOnCommand;
  * @author Christoph Strobl
  * @author Marcin Zielinski
  * @author jinkshower
+ * @author big-cir
  */
 @ParameterizedClass
 @MethodSource("testParams")
@@ -596,6 +600,96 @@ public class DefaultReactiveStreamOperationsIntegrationTests<K, HK, HV> {
 					assertThat(claimed.getStream()).isEqualTo(key);
 					assertThat(claimed.getValue()).isEqualTo(content);
 					assertThat(claimed.getId()).isEqualTo(messageId);
+				}).verifyComplete();
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	void autoClaimShouldClaimPendingMessages() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = valueFactory.instance();
+
+		Map<HK, HV> content = Collections.singletonMap(hashKey, value);
+		RecordId messageId = streamOperations.add(key, content).block();
+
+		streamOperations.createGroup(key, ReadOffset.from("0-0"), "my-group").then().as(StepVerifier::create)
+				.verifyComplete();
+
+		streamOperations.read(Consumer.from("my-group", "my-consumer"), StreamOffset.create(key, ReadOffset.lastConsumed()))
+				.then().as(StepVerifier::create).verifyComplete();
+
+		streamOperations.autoClaim(key, "my-group", "new-owner", Duration.ZERO).as(StepVerifier::create)
+				.assertNext(claimed -> {
+
+					assertThat(claimed.getCursor()).isEqualTo(RecordId.of("0-0"));
+					assertThat(claimed.size()).isOne();
+					assertThat(claimed.get(0).getStream()).isEqualTo(key);
+					assertThat(claimed.get(0).getValue()).isEqualTo(content);
+					assertThat(claimed.get(0).getId()).isEqualTo(messageId);
+				}).verifyComplete();
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	void autoClaimShouldIterateUsingCursor() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = valueFactory.instance();
+
+		RecordId first = streamOperations.add(key, Collections.singletonMap(hashKey, value)).block();
+		RecordId second = streamOperations.add(key, Collections.singletonMap(hashKey, value)).block();
+
+		streamOperations.createGroup(key, ReadOffset.from("0-0"), "my-group").then().as(StepVerifier::create)
+				.verifyComplete();
+
+		streamOperations.read(Consumer.from("my-group", "my-consumer"), StreamOffset.create(key, ReadOffset.lastConsumed()))
+				.then().as(StepVerifier::create).verifyComplete();
+
+		streamOperations
+				.autoClaim(key, "my-group", "new-owner", XAutoClaimOptions.minIdle(Duration.ZERO).count(1)) //
+				.flatMap(firstPage -> {
+
+					assertThat(firstPage.size()).isOne();
+					assertThat(firstPage.get(0).getId()).isEqualTo(first);
+					assertThat(firstPage.getCursor()).isNotEqualTo(RecordId.of("0-0"));
+
+					return streamOperations.autoClaim(key, "my-group", "new-owner",
+							XAutoClaimOptions.minIdle(Duration.ZERO).count(1).from(firstPage.getCursor()));
+				}) //
+				.as(StepVerifier::create) //
+				.assertNext(secondPage -> {
+
+					assertThat(secondPage.size()).isOne();
+					assertThat(secondPage.get(0).getId()).isEqualTo(second);
+					assertThat(secondPage.getCursor()).isEqualTo(RecordId.of("0-0"));
+				}) //
+				.verifyComplete();
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	void autoClaimJustIdShouldReturnIdsOnly() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = valueFactory.instance();
+
+		RecordId messageId = streamOperations.add(key, Collections.singletonMap(hashKey, value)).block();
+
+		streamOperations.createGroup(key, ReadOffset.from("0-0"), "my-group").then().as(StepVerifier::create)
+				.verifyComplete();
+
+		streamOperations.read(Consumer.from("my-group", "my-consumer"), StreamOffset.create(key, ReadOffset.lastConsumed()))
+				.then().as(StepVerifier::create).verifyComplete();
+
+		streamOperations.autoClaimJustId(key, "my-group", "new-owner", XAutoClaimOptions.minIdle(Duration.ZERO))
+				.as(StepVerifier::create).assertNext(claimed -> {
+
+					assertThat(claimed.getCursor()).isEqualTo(RecordId.of("0-0"));
+					assertThat(claimed.getIds()).containsExactly(messageId);
 				}).verifyComplete();
 	}
 

--- a/src/test/java/org/springframework/data/redis/core/DefaultStreamOperationsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/redis/core/DefaultStreamOperationsIntegrationTests.java
@@ -40,12 +40,15 @@ import org.springframework.data.redis.connection.RedisStreamCommands;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamEntryDeletionResult;
 import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
+import org.springframework.data.redis.connection.RedisStreamCommands.XAutoClaimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XDelOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XTrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.StreamDeletionPolicy;
 import org.springframework.data.redis.connection.jedis.extension.JedisConnectionFactoryExtension;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.extension.LettuceConnectionFactoryExtension;
+import org.springframework.data.redis.connection.stream.ClaimedRecordIds;
+import org.springframework.data.redis.connection.stream.ClaimedRecords;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.ObjectRecord;
@@ -70,6 +73,7 @@ import org.springframework.data.redis.test.extension.RedisStandalone;
  * @author Christoph Strobl
  * @author Marcin Zielinski
  * @author jinkshower
+ * @author big-cir
  */
 @ParameterizedClass
 @MethodSource("testParams")
@@ -781,6 +785,80 @@ public class DefaultStreamOperationsIntegrationTests<K, HK, HV> {
 		if (!(key instanceof byte[] || value instanceof byte[])) {
 			assertThat(message.getValue()).containsEntry(hashKey, value);
 		}
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	void autoClaimShouldClaimPendingMessages() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = hashValueFactory.instance();
+
+		RecordId messageId = streamOps.add(key, Collections.singletonMap(hashKey, value));
+		streamOps.createGroup(key, ReadOffset.from("0-0"), "my-group");
+		streamOps.read(Consumer.from("my-group", "name"), StreamOffset.create(key, ReadOffset.lastConsumed()));
+
+		ClaimedRecords<MapRecord<K, HK, HV>> claimed = streamOps.autoClaim(key, "my-group", "new-owner", Duration.ZERO);
+
+		assertThat(claimed.getCursor()).isEqualTo(RecordId.of("0-0"));
+		assertThat(claimed).hasSize(1);
+
+		MapRecord<K, HK, HV> message = claimed.get(0);
+
+		assertThat(message.getId()).isEqualTo(messageId);
+		assertThat(message.getStream()).isEqualTo(key);
+
+		if (!(key instanceof byte[] || value instanceof byte[])) {
+			assertThat(message.getValue()).containsEntry(hashKey, value);
+		}
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	void autoClaimShouldIterateUsingCursor() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = hashValueFactory.instance();
+
+		RecordId first = streamOps.add(key, Collections.singletonMap(hashKey, value));
+		RecordId second = streamOps.add(key, Collections.singletonMap(hashKey, value));
+		streamOps.createGroup(key, ReadOffset.from("0-0"), "my-group");
+		streamOps.read(Consumer.from("my-group", "name"), StreamOffset.create(key, ReadOffset.lastConsumed()));
+
+		ClaimedRecords<MapRecord<K, HK, HV>> firstPage = streamOps.autoClaim(key, "my-group", "new-owner",
+				XAutoClaimOptions.minIdle(Duration.ZERO).count(1));
+
+		assertThat(firstPage).hasSize(1);
+		assertThat(firstPage.get(0).getId()).isEqualTo(first);
+		assertThat(firstPage.getCursor()).isNotEqualTo(RecordId.of("0-0"));
+
+		ClaimedRecords<MapRecord<K, HK, HV>> secondPage = streamOps.autoClaim(key, "my-group", "new-owner",
+				XAutoClaimOptions.minIdle(Duration.ZERO).count(1).from(firstPage.getCursor()));
+
+		assertThat(secondPage).hasSize(1);
+		assertThat(secondPage.get(0).getId()).isEqualTo(second);
+		assertThat(secondPage.getCursor()).isEqualTo(RecordId.of("0-0"));
+	}
+
+	@Test // GH-3434
+	@EnabledOnCommand("XAUTOCLAIM")
+	void autoClaimJustIdShouldReturnIdsOnly() {
+
+		K key = keyFactory.instance();
+		HK hashKey = hashKeyFactory.instance();
+		HV value = hashValueFactory.instance();
+
+		RecordId messageId = streamOps.add(key, Collections.singletonMap(hashKey, value));
+		streamOps.createGroup(key, ReadOffset.from("0-0"), "my-group");
+		streamOps.read(Consumer.from("my-group", "name"), StreamOffset.create(key, ReadOffset.lastConsumed()));
+
+		ClaimedRecordIds claimed = streamOps.autoClaimJustId(key, "my-group", "new-owner",
+				XAutoClaimOptions.minIdle(Duration.ZERO));
+
+		assertThat(claimed.getCursor()).isEqualTo(RecordId.of("0-0"));
+		assertThat(claimed.getIds()).containsExactly(messageId);
 	}
 
 	@Nested // GH-3232


### PR DESCRIPTION
Spring Data Redis exposes `XCLAIM` but not `XAUTOCLAIM`. Recovering unacknowledged messages from a failed consumer currently requires either issuing `XPENDING` first and passing the ids to `claim`, or unwrapping `RedisConnection#getNativeConnection()` to call the underlying driver directly. The latter ties the recovery logic to a specific driver and bypasses the serializers configured on the template.

Both driver versions declared in `pom.xml` already support the command, so this change is only about exposing it: Lettuce 7.7.0 through `xautoclaim(K, XAutoClaimArgs<K>)` returning `ClaimedMessages`, and Jedis 8.0.1 through `xautoclaim` and `xautoclaimJustId`.

`XAutoClaimOptions` holds the min-idle-time, the start id and an optional `COUNT`, mirroring how `XClaimOptions` sits next to `xClaim`.

### Return type

`XAUTOCLAIM` returns a cursor in addition to the claimed entries, and a cursor of `0-0` is what tells the caller the scan is finished. Returning a bare `List` or `Flux` the way `claim` does would discard that, so the command returns `ClaimedRecords` (cursor plus records) and `ClaimedRecordIds` for the `JUSTID` variant. Both implement `Streamable`, like `PendingMessages`. For the same reason the reactive methods return `Mono<ClaimedRecords<...>>` rather than a `Flux` of records. This was the open design question in #3434, so feedback on the shape is welcome.

### Out of scope

The third reply element added in Redis 7.0, the ids of pending entries that no longer exist in the stream, is not exposed. Neither driver reports it today. The Lettuce side is fixed in redis/lettuce#3901 and ships in 7.8, so I left it out rather than add an accessor that is always empty. `ClaimedRecords` and `ClaimedRecordIds` can take the extra list later without changing the existing signatures.

### Driver coverage

Both Lettuce and Jedis, imperative and reactive: `LettuceStreamCommands`, `LettuceReactiveStreamCommands`, and `JedisStreamCommands` (inherited by `JedisClusterStreamCommands`), with conversion handled in the respective `StreamConverters`. The Jedis converter filters out nil entries, which Redis versions before 7.0 return in place of pending entries whose message was deleted.

### Backward compatibility

`xAutoClaim` and `xAutoClaimJustId` are declared as abstract methods on `RedisStreamCommands`, `ReactiveStreamCommands` and `StringRedisConnection`, following the pattern set by `xAckDel` and `xDelEx` in #3247. Custom implementations of those interfaces will need to implement the new methods.

### Documentation and commits

No update to `appendix.adoc` is necessary, as `XAUTOCLAIM` is already listed there as supported, which this change makes true.

Split into two commits, the connection contract first and the template API that builds on it second, to make review easier. Each commit carries its own tests and compiles on its own. Happy to squash if you prefer a single commit.

### Verification

Verified locally against Redis 8.6.2 via `make start` across both drivers, standalone and cluster, imperative and reactive, including the pipeline and transaction paths. 3003 tests across `DefaultStreamOperationsIntegrationTests`, `DefaultReactiveStreamOperationsIntegrationTests`, `LettuceReactiveStreamCommandsIntegrationTests`, the `AbstractConnectionIntegrationTests` subclasses, the converter unit tests and the `DefaultStringRedisConnection` unit tests.

The two failures observed, `xAckDelShouldAcknowledgeAndDeleteEntries` and `xAckDelWithStringIdsShouldWork`, reproduce on unmodified `main` in the same environment and are unrelated to this change. New tests cover the claim itself, cursor pagination with `COUNT` across two calls until the cursor returns to `0-0`, the `JUSTID` variant, and the raw reply shapes of both drivers. Since this introduces new API, those tests do not compile before the change rather than failing against it.

Closes #3434

---
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
---
